### PR TITLE
Add /website to Dependabot with directory-scoped auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,3 +61,14 @@ updates:
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    groups:
+      website-minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs that touch only the /website directory.
+# Scope is enforced by matching dependabot/fetch-metadata's `directory`
+# output against the value configured in .github/dependabot.yml.
+# Major updates are excluded so breaking changes still require human review.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for /website non-major updates
+        if: >-
+          steps.meta.outputs.directory == '/website' &&
+          steps.meta.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
## Summary
- Adds an `npm` ecosystem entry to `.github/dependabot.yml` for `/website` (Docusaurus site, `package-lock.json`). Grouped minor + patch to keep PR volume down.
- Adds `.github/workflows/dependabot-auto-merge.yml` that auto-merges Dependabot PRs **only** when `dependabot/fetch-metadata@v2` reports `directory == /website` and the update is non-major. Maven and github-actions PRs still require a human merge.
- Uses `--merge` (not `--squash`) because the repo's `allow_squash_merge` is `false`.

## How the scoping works
The `dependabot/fetch-metadata@v2` action exposes the `directory` value Dependabot used to open the PR — pulled directly from the matched `updates[].directory` in `dependabot.yml`. We match `/website` exactly, so the workflow can never auto-merge a maven or github-actions update.

## Test plan
- [ ] Lint passes (`build`, `Analyze (Java)`)
- [ ] `DCO` check passes
- [ ] After merge, confirm a Dependabot PR opens against `/website` within 24h
- [ ] Confirm a Dependabot PR against any maven module does **not** auto-merge