### PR TITLE
Retry Eclipse Dash license check on transient API failure

### DIFF
--- a/.github/workflows/eclipse_dash.yml
+++ b/.github/workflows/eclipse_dash.yml
@@ -42,5 +42,16 @@ jobs:
           EOF
 
       - name: Eclipse Dash license check
-        run: >
-          mvn org.eclipse.dash:license-tool-plugin:1.1.0:license-check -Ddash.summary=target/dash-DEPENDENCIES
+        # api.eclipse.org occasionally times out under load. Retry once
+        # after 60s to absorb transient failures without masking real
+        # outages. Inline loop is used instead of a third-party retry
+        # action to avoid pinning a mutable tag on a PR-trigger workflow.
+        run: |
+          for attempt in 1 2; do
+            mvn org.eclipse.dash:license-tool-plugin:1.1.0:license-check \
+              -Ddash.summary=target/dash-DEPENDENCIES && exit 0
+            echo "Attempt $attempt failed; sleeping 60s before retry..."
+            sleep 60
+          done
+          echo "Eclipse Dash license check failed after 2 attempts."
+          exit 1


### PR DESCRIPTION
## Summary
- Wraps the `mvn ... license-check` invocation in an inline 2-attempt shell loop with 60s backoff to absorb transient `api.eclipse.org` timeouts.
- Historical failure rate: ~1 in 10 runs, all timeouts, all isolated — consistent with the well-known flakiness of the Eclipse license-tool-plugin's API dependency.
- Uses an inline shell loop rather than `nick-fields/retry@v3` to avoid pinning a mutable third-party action tag on a PR-trigger workflow (supply-chain hygiene).

## Why not bump `-Ddash.timeout`?
The `dash.timeout` property isn't in the documented parameter list for `license-tool-plugin:1.1.0`, and Maven silently ignores unknown `-D` flags. Verified during peer review that this would be a no-op and was dropped from the proposal.

## Test plan
- [ ] `build`, `Analyze (Java)`, `DCO` all pass on this PR
- [ ] Eclipse Dash check passes here (will execute the new wrapper at least once on the happy path)
- [ ] Confirm in next ~10 runs that any transient timeout is now caught by the retry, not surfaced as a job failure