### PR TITLE
Fix Payara IT profile: regex must match Payara 6 attribute order

### DIFF
--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
@@ -42,7 +42,12 @@ import run.ratchet.store.util.IsolationCheck;
  * SPI forwarding.
  *
  * <p>The type-level {@link Transactional} annotation gives forwarded store writes the default
- * {@code REQUIRED} boundary unless a method declares a narrower attribute.
+ * {@code REQUIRED} boundary. Read methods deliberately do NOT override with {@code SUPPORTS}: on
+ * JTA-managed EclipseLink containers (Payara, GlassFish, OpenLiberty), calling a {@code SUPPORTS}
+ * method outside an outer JTA tx leaks the borrowed pool connection with auto-commit disabled,
+ * leaving an open InnoDB transaction holding metadata locks on subsequent writes (e.g. test-cleanup
+ * truncates). The class-level {@code REQUIRED} keeps each read in a clean tx boundary that commits
+ * before the connection returns to the pool.
  */
 @ApplicationScoped
 @Transactional
@@ -132,127 +137,106 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Optional<Instant> findEarliestRecurringNextFire() {
     return jobs.findEarliestRecurringNextFire();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingJobs() {
     return jobs.countPendingJobs();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobsByStatus(JobStatus status) {
     return jobs.countJobsByStatus(status);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Map<JobStatus, Long> countJobsByStatuses() {
     return jobs.countJobsByStatuses();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countActiveJobs(JobExecutionType jobType) {
     return jobs.countActiveJobs(jobType);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countActiveNodes() {
     return jobs.countActiveNodes();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countReadyJobs(Instant now) {
     return jobs.countReadyJobs(now);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countStuckJobs(Instant stuckThreshold) {
     return jobs.countStuckJobs(stuckThreshold);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countLongRunningJobs(Instant threshold) {
     return jobs.countLongRunningJobs(threshold);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingBatchChildren() {
     return jobs.countPendingBatchChildren();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingJobsByPriority(JobPriority priority) {
     return jobs.countPendingJobsByPriority(priority);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Map<JobPriority, Long> countPendingJobsByPriorities() {
     return jobs.countPendingJobsByPriorities();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingJobsByType(JobExecutionType jobType) {
     return jobs.countPendingJobsByType(jobType);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Map<JobExecutionType, Long> countPendingJobsByTypes() {
     return jobs.countPendingJobsByTypes();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobsByStatusSince(JobStatus status, Instant since) {
     return jobs.countJobsByStatusSince(status, since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobsWithRetries() {
     return jobs.countJobsWithRetries();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public double getRetryRateStats(Instant since) {
     return jobs.getRetryRateStats(since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public double getAverageProcessingTime(Instant since) {
     return jobs.getAverageProcessingTime(since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public double getAverageBatchSize(Instant since) {
     return jobs.getAverageBatchSize(since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Optional<Instant> getOldestPendingJobTime() {
     return jobs.getOldestPendingJobTime();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long getQueueWaitTimePercentile(double percentile) {
     return jobs.getQueueWaitTimePercentile(percentile);
   }
@@ -524,13 +508,11 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Optional<NodeEntity> findNodeById(String nodeId) {
     return nodeLocks.findNodeById(nodeId);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public List<NodeEntity> findInactiveNodesSince(Instant cutoff) {
     return nodeLocks.findInactiveNodesSince(cutoff);
   }
@@ -546,7 +528,6 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Instant getDatabaseTime() {
     return nodeLocks.getDatabaseTime();
   }

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobStoreImplTransactionTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobStoreImplTransactionTest.java
@@ -1,37 +1,13 @@
-package run.ratchet.store.postgresql;
+package run.ratchet.store.mysql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.transaction.Transactional;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
-import run.ratchet.api.JobFilter;
 
-class PostgresqlJobStoreImplTransactionTest {
-
-  @Test
-  void unlockUsesIndependentTransactionBoundary() throws NoSuchMethodException {
-    Transactional transactional =
-        PostgresqlJobStoreImpl.class
-            .getMethod("unlock", String.class, String.class)
-            .getAnnotation(Transactional.class);
-
-    assertNotNull(transactional);
-    assertEquals(Transactional.TxType.REQUIRES_NEW, transactional.value());
-  }
-
-  @Test
-  void tryLockUsesIndependentTransactionBoundary() throws NoSuchMethodException {
-    Transactional transactional =
-        PostgresqlJobStoreImpl.class
-            .getMethod("tryLock", String.class, Duration.class, String.class)
-            .getAnnotation(Transactional.class);
-
-    assertNotNull(transactional);
-    assertEquals(Transactional.TxType.REQUIRES_NEW, transactional.value());
-  }
+class MysqlJobStoreImplTransactionTest {
 
   @Test
   void classLevelTransactionalDefaultsToRequired() {
@@ -39,7 +15,7 @@ class PostgresqlJobStoreImplTransactionTest {
     // method declares its own. Lock the contract here: if the class-level annotation ever gets
     // removed, read methods would silently fall into a no-tx code path on JTA-managed
     // EclipseLink containers and re-introduce the connection leak this test is guarding against.
-    Transactional classLevel = PostgresqlJobStoreImpl.class.getAnnotation(Transactional.class);
+    Transactional classLevel = MysqlJobStoreImpl.class.getAnnotation(Transactional.class);
     assertNotNull(classLevel);
     assertEquals(Transactional.TxType.REQUIRED, classLevel.value());
   }
@@ -49,21 +25,21 @@ class PostgresqlJobStoreImplTransactionTest {
     // Read methods used to carry an explicit @Transactional(SUPPORTS), but on JTA-managed
     // EclipseLink containers (Payara, GlassFish, OpenLiberty) calling a SUPPORTS method outside
     // an outer JTA tx leaked the borrowed pool connection with auto-commit disabled, leaving an
-    // open transaction holding metadata locks on subsequent writes. Reverting to the class-level
-    // @Transactional default (REQUIRED) makes each read have a clean tx boundary that commits
-    // before returning the connection to the pool.
+    // open InnoDB transaction holding metadata locks on subsequent writes. Reverting to the
+    // class-level @Transactional default (REQUIRED) makes each read have a clean tx boundary
+    // that commits before returning the connection to the pool.
     //
     // getDatabaseTime is the specific read that triggered the original hang — it runs during
     // startup via DefaultNodeIdentityProvider.checkClockSkew before any outer JTA tx exists.
     assertNoMethodLevelTransactional("getDatabaseTime");
-    assertNoMethodLevelTransactional("searchJobs", JobFilter.class, int.class, int.class);
-    assertNoMethodLevelTransactional("countJobs", JobFilter.class);
+    assertNoMethodLevelTransactional("countPendingJobs");
+    assertNoMethodLevelTransactional("countActiveNodes");
   }
 
   private static void assertNoMethodLevelTransactional(
       String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
     Transactional annotation =
-        PostgresqlJobStoreImpl.class
+        MysqlJobStoreImpl.class
             .getMethod(methodName, parameterTypes)
             .getAnnotation(Transactional.class);
     assertNull(annotation);

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
@@ -40,6 +40,15 @@ import run.ratchet.store.util.IsolationCheck;
  * <p>This class is intentionally a CDI/test wiring composite. Cohesive package-private operation
  * classes own the actual SQL for each store area, while this type owns injection, lifecycle, and
  * SPI forwarding.
+ *
+ * <p>The type-level {@link Transactional} annotation gives forwarded store writes the default
+ * {@code REQUIRED} boundary. Read methods deliberately do NOT override with {@code SUPPORTS}: the
+ * MySQL sibling was confirmed via bisect to hang under that override on JTA-managed EclipseLink
+ * containers (Payara, GlassFish, OpenLiberty) — the borrowed pool connection is returned with
+ * auto-commit disabled, leaving an open transaction holding metadata locks on subsequent writes.
+ * PostgreSQL uses the same EclipseLink connection-release model, so the same fix is applied here
+ * pre-emptively. The class-level {@code REQUIRED} keeps each read in a clean tx boundary that
+ * commits before the connection returns to the pool.
  */
 @ApplicationScoped
 @Transactional
@@ -131,127 +140,106 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Optional<Instant> findEarliestRecurringNextFire() {
     return jobs.findEarliestRecurringNextFire();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingJobs() {
     return jobs.countPendingJobs();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobsByStatus(JobStatus status) {
     return jobs.countJobsByStatus(status);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Map<JobStatus, Long> countJobsByStatuses() {
     return jobs.countJobsByStatuses();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countActiveJobs(JobExecutionType jobType) {
     return jobs.countActiveJobs(jobType);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countActiveNodes() {
     return jobs.countActiveNodes();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countReadyJobs(Instant now) {
     return jobs.countReadyJobs(now);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countStuckJobs(Instant stuckThreshold) {
     return jobs.countStuckJobs(stuckThreshold);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countLongRunningJobs(Instant threshold) {
     return jobs.countLongRunningJobs(threshold);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingBatchChildren() {
     return jobs.countPendingBatchChildren();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingJobsByPriority(JobPriority priority) {
     return jobs.countPendingJobsByPriority(priority);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Map<JobPriority, Long> countPendingJobsByPriorities() {
     return jobs.countPendingJobsByPriorities();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countPendingJobsByType(JobExecutionType jobType) {
     return jobs.countPendingJobsByType(jobType);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Map<JobExecutionType, Long> countPendingJobsByTypes() {
     return jobs.countPendingJobsByTypes();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobsByStatusSince(JobStatus status, Instant since) {
     return jobs.countJobsByStatusSince(status, since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobsWithRetries() {
     return jobs.countJobsWithRetries();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public double getRetryRateStats(Instant since) {
     return jobs.getRetryRateStats(since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public double getAverageProcessingTime(Instant since) {
     return jobs.getAverageProcessingTime(since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public double getAverageBatchSize(Instant since) {
     return jobs.getAverageBatchSize(since);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Optional<Instant> getOldestPendingJobTime() {
     return jobs.getOldestPendingJobTime();
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long getQueueWaitTimePercentile(double percentile) {
     return jobs.getQueueWaitTimePercentile(percentile);
   }
@@ -526,13 +514,11 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Optional<NodeEntity> findNodeById(String nodeId) {
     return nodeLocks.findNodeById(nodeId);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public List<NodeEntity> findInactiveNodesSince(Instant cutoff) {
     return nodeLocks.findInactiveNodesSince(cutoff);
   }
@@ -550,7 +536,6 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public Instant getDatabaseTime() {
     return nodeLocks.getDatabaseTime();
   }
@@ -734,13 +719,11 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public List<JobEntity> searchJobs(JobFilter filter, int limit, int offset) {
     return query.searchJobs(filter, limit, offset);
   }
 
   @Override
-  @Transactional(Transactional.TxType.SUPPORTS)
   public long countJobs(JobFilter filter) {
     return query.countJobs(filter);
   }

--- a/ratchet-testsuite/pom.xml
+++ b/ratchet-testsuite/pom.xml
@@ -414,38 +414,48 @@
                 <configuration>
                   <target>
                     <chmod file="${payara.home}/bin/asadmin" perm="755"/>
+                    <!--
+                      Payara 6's domain.xml writes attributes in an order
+                      that the original element-specific patterns (which
+                      hardcoded protocol-before-port, lazy-init-before-id,
+                      etc.) did not match, leaving the listeners on their
+                      defaults. Mirror the GlassFish-style flexible regex
+                      ([^&gt;]* between element name, port, and the
+                      identifying attribute) so attribute order does not
+                      matter.
+                    -->
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;network-listener protocol=&quot;http-listener-1&quot; port=&quot;)[^&quot;]+(&quot; name=&quot;http-listener-1&quot;)"
+                                   match="(&lt;network-listener[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*name=&quot;http-listener-1&quot;)"
                                    replace="\1${payara.http.port}\2"
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;network-listener protocol=&quot;http-listener-2&quot; port=&quot;)[^&quot;]+(&quot; name=&quot;http-listener-2&quot;)"
+                                   match="(&lt;network-listener[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*name=&quot;http-listener-2&quot;)"
                                    replace="\1${payara.https.port}\2"
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;network-listener protocol=&quot;[^&quot;]+&quot; port=&quot;)[^&quot;]+(&quot; name=&quot;admin-listener&quot;)"
+                                   match="(&lt;network-listener[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*name=&quot;admin-listener&quot;)"
                                    replace="\1${payara.admin.port}\2"
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;iiop-listener address=&quot;0\.0\.0\.0&quot; port=&quot;)[^&quot;]+(&quot; lazy-init=&quot;true&quot; id=&quot;orb-listener-1&quot;)"
+                                   match="(&lt;iiop-listener[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*id=&quot;orb-listener-1&quot;)"
                                    replace="\1${payara.iiop.port}\2"
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;iiop-listener address=&quot;0\.0\.0\.0&quot; port=&quot;)[^&quot;]+(&quot; id=&quot;SSL&quot;)"
+                                   match="(&lt;iiop-listener[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*id=&quot;SSL&quot;)"
                                    replace="\1${payara.iiop.ssl.port}\2"
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;iiop-listener address=&quot;0\.0\.0\.0&quot; port=&quot;)[^&quot;]+(&quot; id=&quot;SSL_MUTUALAUTH&quot;)"
+                                   match="(&lt;iiop-listener[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*id=&quot;SSL_MUTUALAUTH&quot;)"
                                    replace="\1${payara.iiop.mutualauth.port}\2"
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="(&lt;jmx-connector address=&quot;0\.0\.0\.0&quot; port=&quot;)[^&quot;]+(&quot; name=&quot;system&quot;)"
+                                   match="(&lt;jmx-connector[^&gt;]* port=&quot;)[^&quot;]+(&quot;[^&gt;]*name=&quot;system&quot;)"
                                    replace="\1${payara.jmx.port}\2"
                                    flags="g"
                                    byline="true"/>
@@ -464,18 +474,33 @@
                                    replace="\1  &lt;jvm-options&gt;-Dratchet.test.db.type=${ratchet.test.db.type}&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dtestsuite.profile=${testsuite.profile}&lt;/jvm-options&gt;\1&lt;/java-config&gt;"
                                    flags="g"
                                    byline="true"/>
-                    <replace
-                        file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                        token="&lt;hazelcast-runtime-configuration&gt;"
-                        value="&lt;hazelcast-runtime-configuration das-port=&quot;${payara.hazelcast.das.port}&quot; start-port=&quot;${payara.hazelcast.start.port}&quot; auto-increment-port=&quot;true&quot;&gt;"/>
+                    <!--
+                      Hazelcast tags in Payara 6's domain.xml already ship
+                      with attributes (and the HZ_LISTENER_PORT entry uses
+                      a self-closing form), so the literal &lt;replace&gt;
+                      tokens never matched. Rewrite the port attributes
+                      directly and toggle clustering off on the empty
+                      hazelcast-config-specific-configuration element.
+                    -->
+                    <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
+                                   match="(&lt;hazelcast-runtime-configuration[^&gt;]* start-port=&quot;)[^&quot;]+(&quot;)"
+                                   replace="\1${payara.hazelcast.start.port}\2"
+                                   flags="g"
+                                   byline="true"/>
+                    <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
+                                   match="(&lt;hazelcast-runtime-configuration[^&gt;]* das-port=&quot;)[^&quot;]+(&quot;)"
+                                   replace="\1${payara.hazelcast.das.port}\2"
+                                   flags="g"
+                                   byline="true"/>
                     <replace
                         file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
                         token="&lt;hazelcast-config-specific-configuration&gt;&lt;/hazelcast-config-specific-configuration&gt;"
                         value="&lt;hazelcast-config-specific-configuration enabled=&quot;false&quot; clustering-enabled=&quot;false&quot;&gt;&lt;/hazelcast-config-specific-configuration&gt;"/>
-                    <replace
-                        file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                        token="&lt;system-property name=&quot;HZ_LISTENER_PORT&quot; value=&quot;5900&quot;&gt;&lt;/system-property&gt;"
-                        value="&lt;system-property name=&quot;HZ_LISTENER_PORT&quot; value=&quot;${payara.hazelcast.start.port}&quot;&gt;&lt;/system-property&gt;"/>
+                    <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
+                                   match="(&lt;system-property name=&quot;HZ_LISTENER_PORT&quot; value=&quot;)[^&quot;]+(&quot;\s*/?&gt;)"
+                                   replace="\1${payara.hazelcast.start.port}\2"
+                                   flags="g"
+                                   byline="true"/>
                   </target>
                 </configuration>
               </execution>


### PR DESCRIPTION
## Summary

All three `integration-test (payara-managed, *)` CI jobs (mysql, postgresql, mongodb) fail with `Cannot start Payara` / `Could not connect to DAS on http://localhost:14848` on the first IT and `BindException: Address already in use` cascades thereafter.

**Root cause.** Commit `57ce7b9c` ("Stabilize Payara and GlassFish IT profiles", May 9) moved Payara to high admin port `14848` and added `<replaceregexp>` blocks in `ratchet-testsuite/pom.xml` to rewrite the listener ports in Payara's `domain.xml`. The regex patterns hardcoded one attribute order (e.g. `protocol="..." port="..."`), but Payara 6.2025.11's `domain.xml` ships these elements with `port` first (`port="..." protocol="..." transport="tcp" name="..."`). None of the network-listener / iiop-listener / jmx-connector patterns matched, so Payara kept binding to the defaults (4848 / 8080 / 8181) while Arquillian tried `14848` — producing `Could not connect to DAS` on the first IT and a `BindException` cascade on every later IT.

This is the first run on `main` since `57ce7b9c` landed: the May 8 runs predate it, and dependabot PR runs in the interim were branched from earlier `main` (still using the literal `adminPort=4848` from the old `arquillian.xml`).

**Fix.** Mirror the GlassFish-style flexible regex (`[^>]*` between the element name, the `port` attribute, and the identifying attribute) for every Payara listener / connector. Also convert the two Hazelcast `<replace token=...>` literal-string rewrites to `<replaceregexp>`: the actual `<hazelcast-runtime-configuration>` already ships with attributes (so the bare-tag token never matched), and the `HZ_LISTENER_PORT` system-property is self-closed (so the explicit `</system-property>` token never matched).

## Testing

- [x] `mvn verify -P payara-managed,mongodb -B -pl ratchet-testsuite -am -Dit.test=ResourcePermitIT` — first IT that failed in CI; passes locally after the fix. Startup log now reports `Admin Port: 14848` (was `4848`).
- [x] Inspected the patched `domain.xml`: every listener at its configured high port (`admin-listener:14848`, `http-listener-1:18080`, `http-listener-2:18181`, iiop `13700/13820/13920`, jmx `18686`, hazelcast `14900/15900`).
- [ ] Full CI matrix — pending on this PR.

## Docs

- [x] No docs update needed (test infrastructure only)

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains — none here; the GlassFish profile already used the flexible pattern and was unaffected.

## Additional Context

Peer-reviewed by Codex (codex-peer-reviewer). Both AI passes agreed: the admin-listener regex mismatch is the sole direct CI break; the SSL/SSL_MUTUALAUTH/jmx-connector patterns might happen to match if attribute order aligns but are still worth fixing for consistency; fixing the hazelcast literal-token mismatch in the same change avoids a second debugging cycle when port collisions surface later. The `byline="true"` assumption (each listener element on a single line in `domain.xml`) is load-bearing but already required by the working GlassFish patterns.