### PR TITLE
Widen JobRetryIT backoff to absorb CI event-emission lag

### DIFF
--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/core/JobRetryIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/core/JobRetryIT.java
@@ -25,8 +25,13 @@ import run.ratchet.testsuite.util.RatchetArchiveBuilder;
 /** Validates retry behavior: failure → retry with backoff, configurable retry count. */
 class JobRetryIT extends BaseRatchetIT {
 
-  private static final Duration FIXED_BACKOFF = Duration.ofMillis(100);
-  private static final Duration BACKOFF_TOLERANCE = Duration.ofMillis(75);
+  // The gap assertion measures scheduledTime − event.timestamp. Emission-lag between scheduling
+  // the retry and publishing the event eats into the gap, so the backoff must be large enough
+  // that a slow CI runner (GC pause, DB write latency) can't push the gap below the floor. 100ms
+  // was too tight — observed −42ms gap on a CI runner, i.e. ~142ms of emission lag. 500ms with a
+  // 150ms tolerance gives ~350ms of headroom while still catching real backoff regressions.
+  private static final Duration FIXED_BACKOFF = Duration.ofMillis(500);
+  private static final Duration BACKOFF_TOLERANCE = Duration.ofMillis(150);
 
   @Inject private TestJobService jobService;
 


### PR DESCRIPTION
## Summary

Fix a CI flake on \`failingJob_withRetries_shouldRetryAndFail\`. The test asserts that the retry gap — \`event.scheduledTime − event.timestamp\` — lands within \`FIXED_BACKOFF ± BACKOFF_TOLERANCE\` (= \`100ms ± 75ms\` → floor \`25ms\`). On a contended CI runner that floor isn't reliable: observed \`gap = −41.5ms\` on \`main\` immediately after the SQL IT hang fix landed, i.e. ~141ms of emission lag between the retry being scheduled and the \`JobRetryingEvent\` being published+timestamped. That's environmental (GC pause, DB-write latency), not a backoff regression.

Bump \`FIXED_BACKOFF\` to \`500ms\` and \`BACKOFF_TOLERANCE\` to \`150ms\`. New range \`[350ms, 650ms]\` keeps the symmetric ceiling assertion from \`8fc709bb\` meaningful (still catches "scheduled arbitrarily far in the future" regressions) while leaving ~350ms of headroom for emission lag. Test runtime grows by ~800ms (two retries × 400ms extra backoff).

## Testing

- [x] \`mvn verify -P glassfish-managed,mysql -pl ratchet-testsuite -am -Dit.test='JobRetryIT'\` → \`Tests run: 2, Failures: 0, Errors: 0\` in 18.60s.
- [ ] \`mvn clean test -B\` — pending CI.
- [ ] \`mvn spotless:check -B\` — pending CI (pre-commit hook ran spotless:apply locally).
- [ ] Full IT matrix — pending CI.

## Docs

- [x] No docs update needed (test-only constant change, comment in source explains the rationale)

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

Discovered after PR #9 merged to main. Not caused by either fix in PR #9 — the floor assertion has been there since the original \`JobRetryIT\` (commit \`0d43b491\`); \`8fc709bb\` only added the symmetric ceiling. The 100ms baseline was always tight for this measurement model. The real root cause is that the gap base is \`event.getTimestamp()\` (emission time) rather than the retry's actual computation time — a cleaner fix would be a separate accessor on \`JobRetryingEvent\` for the retry-scheduled-at moment, but that's an SPI change for a different PR.