### PR TITLE
Clear 14 Qodana SARIF warnings

### DIFF
--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
@@ -29,8 +29,8 @@ final class MysqlArchiveOperations implements ArchiveStore {
       original_created_at, first_execution_time, completion_time,
       total_execution_time_ms, queue_wait_ms, archived_at, archived_by, archive_reason,
       job_result, result_type, final_error, payload_summary, depended_on, superseded_by,
-	      tags
-	      """;
+      tags
+      """;
 
   private static final String ARCHIVE_VALUE_PLACEHOLDERS =
       "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
@@ -228,7 +228,10 @@ final class MysqlArchiveOperations implements ArchiveStore {
     }
   }
 
+  // SQL template is assembled from a compile-time-constant column list and AND-clauses defined in
+  // this package; runtime values are bound as JDBC parameters via setParameter.
   @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
   public List<ArchivedJobEntity> findArchivedJobs(
       String targetClass, String businessKey, Instant from, Instant to, int limit) {
     try {

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
@@ -133,8 +133,10 @@ final class MysqlJobClaimOperations implements JobClaimStore {
     return query.getResultList();
   }
 
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "SqlSourceToSinkFlow"})
   public List<JobClaimDto> claimNextBatchOptimized(
       JobExecutionType jobType, int limit, String nodeId, NodeTagFilter tagFilter) {
     if (limit <= 0 || !MysqlJobRowMapper.isPollerExecutable(jobType)) {
@@ -175,8 +177,10 @@ final class MysqlJobClaimOperations implements JobClaimStore {
     }
   }
 
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "SqlSourceToSinkFlow"})
   public List<JobEntity> claimDueRecurring(int limit, String nodeId, NodeTagFilter tagFilter) {
     if (limit <= 0) {
       return List.of();

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlStoreContext.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlStoreContext.java
@@ -50,6 +50,9 @@ final class MysqlStoreContext {
    * Executes a trusted, package-local SQL count query. Callers must pass hard-coded SQL templates
    * only; runtime values belong in {@code params}.
    */
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
+  @SuppressWarnings("SqlSourceToSinkFlow")
   long countByNative(String sql, Object... params) {
     var query = em.createNativeQuery(sql);
     for (int i = 0; i < params.length; i++) {
@@ -62,6 +65,9 @@ final class MysqlStoreContext {
    * Executes a trusted, package-local SQL scalar query. Callers must pass hard-coded SQL templates
    * only; runtime values belong in {@code params}.
    */
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
+  @SuppressWarnings("SqlSourceToSinkFlow")
   double doubleByNativeOrZero(String sql, Object... params) {
     var query = em.createNativeQuery(sql);
     for (int i = 0; i < params.length; i++) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
@@ -206,7 +206,10 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
     return ctx.countByNative(sql, Timestamp.from(olderThan));
   }
 
+  // SQL template is assembled from a compile-time-constant column list and AND-clauses defined in
+  // this package; runtime values are bound as JDBC parameters via setParameter.
   @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
   public List<ArchivedJobEntity> findArchivedJobs(
       String targetClass, String businessKey, Instant from, Instant to, int limit) {
     var searchQuery =

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
@@ -113,7 +113,10 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
         : "q.priority DESC, " + timeColumn + " ASC, q.job_id ASC";
   }
 
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
   @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
   public List<JobEntity> claimNextBatch(int limit, String nodeId, NodeTagFilter tagFilter) {
     if (limit <= 0) {
       return List.of();
@@ -159,7 +162,10 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
     }
   }
 
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
   @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
   public List<JobClaimDto> claimNextBatchOptimized(
       JobExecutionType jobType, int limit, String nodeId, NodeTagFilter tagFilter) {
     if (limit <= 0 || !PostgresqlStoreContext.isPollerExecutable(jobType)) {
@@ -326,8 +332,10 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
     }
   }
 
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
   @Override
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings({"unchecked", "SqlSourceToSinkFlow"})
   public List<JobEntity> claimDueRecurring(int limit, String nodeId, NodeTagFilter tagFilter) {
     if (limit <= 0) {
       return List.of();

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobCancelContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobCancelContract.java
@@ -113,9 +113,11 @@ public abstract class AbstractJobCancelContract {
     return Duration.ofSeconds(5);
   }
 
+  @SuppressWarnings("BusyWait")
   private void assertNoChainEventsWithin(Duration quietWindow) throws InterruptedException {
     // The API does not expose handles for child chain jobs. After the parent cancellation event is
     // visible, observe a short, bounded quiet window and fail fast if a child records execution.
+    // No event is available to wait on, so polling at CHAIN_CHILD_POLL_INTERVAL is intentional.
     long deadlineNanos = System.nanoTime() + quietWindow.toNanos();
     while (System.nanoTime() < deadlineNanos) {
       assertTrue(

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSchemaMigratorContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSchemaMigratorContract.java
@@ -53,6 +53,7 @@ public abstract class AbstractSchemaMigratorContract {
   }
 
   @Test
+  @SuppressWarnings("AutoCloseableResource")
   void parallelMigratorsConvergeUnderAdvisoryLock() throws Exception {
     resetDatabase();
 
@@ -64,6 +65,8 @@ public abstract class AbstractSchemaMigratorContract {
           go.await();
           return newMigrator().migrate();
         };
+    // Java 17 ExecutorService is not AutoCloseable; the finally block below already shuts the
+    // pool down and awaits termination.
     ExecutorService pool = Executors.newFixedThreadPool(2);
     List<Future<SchemaMigrator.MigrationResult>> futures = new ArrayList<>();
     int totalApplied = 0;

--- a/ratchet/src/main/java/run/ratchet/ri/core/RetryBufferManager.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/RetryBufferManager.java
@@ -232,29 +232,22 @@ public class RetryBufferManager {
   private boolean forceOffer(BufferedClaim claim) {
     Queue<BufferedClaim> buffer = retryBuffers.get(claim.jobType());
     ReentrantLock lock = bufferLocks.get(claim.jobType());
-    boolean moveToDlq;
 
     lock.lock();
     try {
-      if (buffer.size() >= HARD_CAP_PER_TYPE) {
-        moveToDlq = true;
-      } else {
+      if (buffer.size() < HARD_CAP_PER_TYPE) {
         if (buffer.size() >= MAX_BUFFER_SIZE_PER_TYPE) {
           log.warnf(
               "Retry buffer exceeding normal limit (%d) for job type %s. "
                   + "Current size: %d. Force-buffering job %s.",
               MAX_BUFFER_SIZE_PER_TYPE, claim.jobType(), buffer.size(), claim.jobId());
         }
-
         return buffer.offer(claim);
       }
     } finally {
       lock.unlock();
     }
-    if (moveToDlq) {
-      return moveHardCapOverflow(claim, buffer, lock);
-    }
-    return false;
+    return moveHardCapOverflow(claim, buffer, lock);
   }
 
   private boolean moveHardCapOverflow(

--- a/ratchet/src/main/java/run/ratchet/ri/payload/JobPayloadFactory.java
+++ b/ratchet/src/main/java/run/ratchet/ri/payload/JobPayloadFactory.java
@@ -343,6 +343,11 @@ public final class JobPayloadFactory {
         });
   }
 
+  // All callers pass either VISIBILITY_CACHE or FUNCTIONAL_INTERFACE_METHOD_CACHE — both static
+  // final fields — so the parameter holds a stable identity. External sync is required because
+  // the LinkedHashMap LRU promotion in get() makes get-then-put non-atomic on the underlying
+  // synchronizedMap.
+  @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
   private static <V> V cached(
       Map<MethodLookupKey, V> cache, MethodLookupKey key, Function<MethodLookupKey, V> resolver) {
     synchronized (cache) {


### PR DESCRIPTION
## Summary

Clears the 14 warnings reported in `qodana.sarif.json`. Mix of small refactors and narrow inspection suppressions with rationale at each site.

**Real fixes**

- `RetryBufferManager.forceOffer` — drop dead `moveToDlq` flag and the unreachable `return false`. Call `moveHardCapOverflow` directly when the buffer overflows the hard cap.
- `MysqlArchiveOperations.ARCHIVE_COLUMNS` — replace mixed tab+space indent in the text block with spaces only.

**Suppressions with rationale**

- `AbstractSchemaMigratorContract.parallelMigratorsConvergeUnderAdvisoryLock` — `ExecutorService` is not `AutoCloseable` on Java 17. The existing `finally` block already shuts the pool down and awaits termination.
- `AbstractJobCancelContract.assertNoChainEventsWithin` — bounded quiet-window assertion has no event to wait on; polling at `CHAIN_CHILD_POLL_INTERVAL` is intentional.
- `JobPayloadFactory.cached` — all callers pass `VISIBILITY_CACHE` or `FUNCTIONAL_INTERFACE_METHOD_CACHE` (static final fields), so the parameter holds a stable identity. External `synchronized` is required because the `LinkedHashMap` LRU promotion in `get()` makes get-then-put non-atomic on the underlying `synchronizedMap`.
- 9 `SqlSourceToSinkFlow` sites across the MySQL and PostgreSQL stores — every flagged SQL string is assembled from a compile-time-constant template defined in the same package; runtime values are bound as JDBC parameters via `setParameter`.

## Testing

List the validation you actually ran.

- [x] `mvn -pl ratchet -am test` — 699 / 699 pass
- [x] `mvn -pl ratchet-store-mysql,ratchet-store-postgresql,ratchet-tck/api,ratchet-tck/store -am test` — green
- [x] `mvn spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am` — not run locally; CI will exercise

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

**Follow-up surfaced during peer review (not in this PR):** the input validators `JobClaimSqlSupport.requireSafeSqlFragment` (regex `[A-Za-z0-9_().,\s+\-*/]+`) and `ArchiveQuerySupport.ARCHIVE_COLUMNS_PATTERN` (`[A-Za-z0-9_.,\s]+`) admit SQL comment tokens and bare keywords respectively. Neither is a live injection vector today (every caller passes a compile-time constant), but the validator names overstate their guarantees. Worth tightening + adding a unit test in a dedicated PR.

## Additional Context

Plan was peer-reviewed via Codex (APPROVE-WITH-CHANGES). The two requested changes were applied:
1. SqlSourceToSinkFlow suppression rationale does not cite the regex validators as the safety mechanism.
2. The `JobPayloadFactory.cached` suppression comment names the two specific static cache fields all callers pass.