### PR TITLE
Clear remaining Qodana warnings

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobOptions.java
@@ -23,9 +23,9 @@ public record JobOptions(
     int timeoutSec) {
 
   public JobOptions {
-    priority = Objects.requireNonNull(priority, "priority must not be null");
-    backoffPolicy = Objects.requireNonNull(backoffPolicy, "backoffPolicy must not be null");
-    backoffParam = Objects.requireNonNull(backoffParam, "backoffParam must not be null");
+    Objects.requireNonNull(priority, "priority must not be null");
+    Objects.requireNonNull(backoffPolicy, "backoffPolicy must not be null");
+    Objects.requireNonNull(backoffParam, "backoffParam must not be null");
     if (maxRetries < 0) {
       throw new IllegalArgumentException("maxRetries must be >= 0");
     }

--- a/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationLifecycleHook.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationLifecycleHook.java
@@ -5,6 +5,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Objects;
 import javax.sql.DataSource;
 import org.jboss.logging.Logger;
 import run.ratchet.api.RatchetOptions;
@@ -58,7 +59,8 @@ public class SchemaMigrationLifecycleHook implements SchedulerLifecycleHook {
 
   @Override
   public void beforeStart() {
-    RatchetOptions.SchemaOptions schemaOptions = options.schema();
+    RatchetOptions.SchemaOptions schemaOptions =
+        Objects.requireNonNull(options, "options must be injected").schema();
     if (!schemaOptions.autoMigrate()) {
       log.info(
           "Ratchet schema auto-migration disabled (default). Manage ratchet_* and scheduler_*"

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -62,7 +62,7 @@ final class MongoArchiveOperations {
           () -> {
             ctx.archives().insertOne(session, doc);
             ctx.jobs().deleteOne(session, eq(ID, job.getId()));
-            return null;
+            return Boolean.TRUE;
           });
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("archive job", e);

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
@@ -236,7 +236,10 @@ final class MongoJobCrudOperations {
     for (Document doc : ctx.jobs().aggregate(pipeline)) {
       Object rawStatus = doc.get(ID);
       if (rawStatus instanceof String status) {
-        counts.put(JobStatus.valueOf(status), numberField(doc, "count").longValue());
+        Number count = numberField(doc, "count");
+        if (count != null) {
+          counts.put(JobStatus.valueOf(status), count.longValue());
+        }
       }
     }
     return counts;
@@ -296,7 +299,10 @@ final class MongoJobCrudOperations {
       if (rawPriority instanceof Number priority) {
         int ordinal = priority.intValue();
         if (ordinal >= 0 && ordinal < values.length) {
-          counts.put(values[ordinal], numberField(doc, "count").longValue());
+          Number count = numberField(doc, "count");
+          if (count != null) {
+            counts.put(values[ordinal], count.longValue());
+          }
         }
       }
     }
@@ -318,7 +324,10 @@ final class MongoJobCrudOperations {
     for (Document doc : ctx.jobs().aggregate(pipeline)) {
       Object rawType = doc.get(ID);
       if (rawType instanceof String type) {
-        counts.put(JobExecutionType.valueOf(type), numberField(doc, "count").longValue());
+        Number count = numberField(doc, "count");
+        if (count != null) {
+          counts.put(JobExecutionType.valueOf(type), count.longValue());
+        }
       }
     }
     return counts;

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobHandle;
 import run.ratchet.api.JobOptions;
+import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.Recurring;
@@ -362,11 +363,11 @@ public class RecurringJobProcessor {
         return Optional.empty();
       }
 
-      RecurringAnnotationParser.mapPriority(annotation.priority());
+      JobPriority priority = RecurringAnnotationParser.mapPriority(annotation.priority());
 
       return Optional.of(
           new RecurringMethodRegistration(
-              beanClass, methodName, hasJobContextParam, annotation, jobId, zone));
+              beanClass, methodName, hasJobContextParam, annotation, jobId, zone, priority));
     } catch (Exception e) {
       log.errorf(e, "@Recurring registration error: %s.%s", beanClass.getName(), methodName);
       return Optional.empty();
@@ -389,7 +390,7 @@ public class RecurringJobProcessor {
 
     JobOptions options =
         JobOptions.defaults()
-            .withPriority(RecurringAnnotationParser.mapPriority(annotation.priority()))
+            .withPriority(registration.priority())
             .withMaxRetries(annotation.maxRetries())
             .withBackoff(annotation.backoffPolicy(), Duration.ofMillis(annotation.backoffDelayMs()))
             .withTimeout(Duration.ofSeconds(annotation.timeoutSeconds()));
@@ -439,5 +440,6 @@ public class RecurringJobProcessor {
       boolean hasJobContextParam,
       Recurring annotation,
       String jobId,
-      ZoneId zone) {}
+      ZoneId zone,
+      JobPriority priority) {}
 }


### PR DESCRIPTION
## Summary

Qodana still flagged a few places where the code was correct but too implicit for data-flow analysis: Mongo aggregate counts, CDI proxy-only constructors, Mongo transaction callbacks, and recurring priority parsing.

This keeps behavior unchanged. Mongo aggregate counts now check the untyped value before reading it, the schema lifecycle hook fails fast if CDI calls the proxy constructor path, the Mongo archive transaction returns a real value, and recurring job registration reuses the priority parsed during validation.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [x] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Additional validation run:

- `mvn -B -pl ratchet-api,ratchet-store-core,ratchet-store-mongodb,ratchet -am test`
- `qodana scan --linter qodana-jvm-community --within-docker=false --save-report=false --print-problems --timeout=600000 --results-dir /tmp/qodana-ratchet-current --fail-threshold=1`

Local Qodana reported 0 active problems for the configured profile. It also showed 11 suggested-inspection items, which are outside the active cloud report problem set.

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

This PR addresses the current Qodana report for `https://qodana.cloud/projects/9kM7M/reports/bQOYLD`. The old `fix/qodana-warnings` branch from the report was already merged into `main`, so this branch starts from `origin/main`.