### PR TITLE
Fix GitHub dependency vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <testcontainers.version>2.0.5</testcontainers.version>
     <micrometer.version>1.14.4</micrometer.version>
     <micrometer.tracing.version>1.4.4</micrometer.tracing.version>
-    <opentelemetry.version>1.48.0</opentelemetry.version>
+    <opentelemetry.version>1.62.0</opentelemetry.version>
     <mockito.version>5.23.0</mockito.version>
     <awaitility.version>4.3.0</awaitility.version>
     <shrinkwrap-resolver.version>3.3.6</shrinkwrap-resolver.version>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1212,9 +1212,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -9985,9 +9985,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -31,8 +31,10 @@
     "typescript": "~6.0.3"
   },
   "overrides": {
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
     "copy-webpack-plugin": "^14.0.0",
     "css-minimizer-webpack-plugin": "^8.0.0",
+    "fast-uri": "^3.1.2",
     "follow-redirects": "^1.16.0",
     "http-proxy-middleware": "^3.0.5",
     "lodash": "^4.18.1",


### PR DESCRIPTION
## Summary

- Bump OpenTelemetry Java from `1.48.0` to `1.62.0` so `ratchet-otel` and the testsuite no longer resolve the vulnerable `opentelemetry-api` range for GHSA-rcgg-9c38-7xpx / CVE-2026-45292.
- Add npm overrides for `@babel/plugin-transform-modules-systemjs` and `fast-uri`, then regenerate the website lockfile so it resolves `@babel/plugin-transform-modules-systemjs@7.29.4` and `fast-uri@3.1.2`.
- Covers the five open Dependabot alerts currently shown on the default branch: alerts #2, #3, #4, #5, and #6.

## Validation

- `npm install --package-lock-only`
- `npm audit --audit-level=moderate`
- `npm ls fast-uri @babel/plugin-transform-modules-systemjs --all`
- `npm run typecheck`
- `npm run build`
- `mvn -pl ratchet-otel -am dependency:tree -Dincludes=io.opentelemetry:opentelemetry-api,io.opentelemetry:opentelemetry-context -DskipTests`
- `mvn -pl ratchet-testsuite -am dependency:tree -Dincludes=io.opentelemetry:opentelemetry-api -DskipTests`
- `mvn -pl ratchet-otel,ratchet-testsuite -am test -DskipITs`
