### PR TITLE
order startup lifecycle hooks

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/spi/SchedulerLifecycleHook.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/SchedulerLifecycleHook.java
@@ -5,6 +5,15 @@ import run.ratchet.api.Incubating;
 /**
  * Optional CDI hook around Ratchet startup and shutdown.
  *
+ * <p>Hooks run in ascending {@code jakarta.annotation.Priority} order when a priority annotation is
+ * present, then by implementation class name for deterministic tie-breaking. Unprioritized hooks
+ * run after prioritized hooks.
+ *
+ * <p>Lifecycle phases are paired per hook. A hook receives {@link #afterStart()} only when its
+ * {@link #beforeStart()} completed successfully, receives {@link #beforeStop()} only when it
+ * completed startup, and receives {@link #afterStop()} only when its {@link #beforeStop()}
+ * completed successfully.
+ *
  * <p>Exceptions thrown from {@link #beforeStart()}, {@link #afterStart()}, {@link #beforeStop()},
  * or {@link #afterStop()} are logged at {@code WARN} and swallowed by the lifecycle observer so a
  * single misbehaving hook does not block deployment. The one exception is {@code

--- a/ratchet-store-core/src/main/java/module-info.java
+++ b/ratchet-store-core/src/main/java/module-info.java
@@ -1,8 +1,10 @@
 module run.ratchet.store.core {
   requires transitive run.ratchet.api;
   requires transitive jakarta.persistence;
+  requires jakarta.annotation;
   requires jakarta.cdi;
   requires jakarta.inject;
+  requires jakarta.interceptor;
   requires jakarta.json;
   requires jakarta.json.bind;
   requires java.sql;

--- a/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationLifecycleHook.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationLifecycleHook.java
@@ -1,8 +1,10 @@
 package run.ratchet.store.migration;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import jakarta.interceptor.Interceptor;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
@@ -38,6 +40,7 @@ import run.ratchet.spi.SchedulerLifecycleHook;
  * queries (correctness-critical, not operational).
  */
 @ApplicationScoped
+@Priority(Interceptor.Priority.LIBRARY_BEFORE)
 public class SchemaMigrationLifecycleHook implements SchedulerLifecycleHook {
 
   private static final Logger log = Logger.getLogger(SchemaMigrationLifecycleHook.class);

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -28,6 +28,7 @@ import org.bson.conversions.Bson;
 import run.ratchet.store.entity.ArchivedJobEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
+import run.ratchet.store.spi.ArchiveStore;
 
 /**
  * Archive operations over {@code scheduler_job_archive}. Terminal-state jobs matching the retention
@@ -35,7 +36,7 @@ import run.ratchet.store.id.UuidV7Factory;
  * inside one Mongo transaction because the Jakarta transaction on the caller cannot enlist this
  * driver session.
  */
-final class MongoArchiveOperations {
+final class MongoArchiveOperations implements ArchiveStore {
 
   private final MongoStoreContext ctx;
   private final Clock clock;
@@ -53,7 +54,8 @@ final class MongoArchiveOperations {
    * Archives one terminal job and atomically deletes it from the active collection. Consistent with
    * the batch variant: both insert and delete succeed together or neither does.
    */
-  ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy) {
+  @Override
+  public ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy) {
     ArchivedJobEntity archive = buildArchive(job, reason, archivedBy);
     archive.setId(UuidV7Factory.create());
     Document doc = DocumentMapper.toDocument(archive);
@@ -70,7 +72,8 @@ final class MongoArchiveOperations {
     return archive;
   }
 
-  int archiveJobsBatch(List<JobEntity> jobList, String reason, String archivedBy) {
+  @Override
+  public int archiveJobsBatch(List<JobEntity> jobList, String reason, String archivedBy) {
     if (jobList.isEmpty()) {
       return 0;
     }
@@ -104,7 +107,8 @@ final class MongoArchiveOperations {
     return docs.size();
   }
 
-  List<JobEntity> findJobsForArchiving(Instant olderThan, int limit) {
+  @Override
+  public List<JobEntity> findJobsForArchiving(Instant olderThan, int limit) {
     List<JobEntity> results = new ArrayList<>();
     for (Document doc :
         ctx.jobs()
@@ -119,7 +123,8 @@ final class MongoArchiveOperations {
     return results;
   }
 
-  long countJobsForArchiving(Instant olderThan) {
+  @Override
+  public long countJobsForArchiving(Instant olderThan) {
     return ctx.jobs()
         .countDocuments(
             and(
@@ -127,7 +132,8 @@ final class MongoArchiveOperations {
                 lt(UPDATED_AT, DocumentMapper.toDate(olderThan))));
   }
 
-  List<ArchivedJobEntity> findArchivedJobs(
+  @Override
+  public List<ArchivedJobEntity> findArchivedJobs(
       String targetClass, String businessKey, Instant from, Instant to, int limit) {
     List<Bson> filters = new ArrayList<>();
     if (targetClass != null) {
@@ -151,7 +157,8 @@ final class MongoArchiveOperations {
     return results;
   }
 
-  int purgeArchivedJobs(Instant olderThan) {
+  @Override
+  public int purgeArchivedJobs(Instant olderThan) {
     DeleteResult result =
         ctx.archives().deleteMany(lt(ARCHIVED_AT, DocumentMapper.toDate(olderThan)));
     return (int) result.getDeletedCount();

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoBatchOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoBatchOperations.java
@@ -40,12 +40,14 @@ import org.bson.Document;
 import run.ratchet.store.dto.BatchProgress;
 import run.ratchet.store.entity.BatchEntity;
 import run.ratchet.store.entity.BatchMetricsEntity;
+import run.ratchet.store.spi.BatchMetricsStore;
+import run.ratchet.store.spi.BatchStore;
 
 /**
  * Batch and batch-metrics collection operations. Batches drive fan-out/fan-in accounting for {@code
  * BATCH_CHILD} jobs; metrics accumulate overhead/execution splits for dashboards.
  */
-final class MongoBatchOperations {
+final class MongoBatchOperations implements BatchStore, BatchMetricsStore {
 
   private final MongoStoreContext ctx;
   private final Clock clock;
@@ -59,18 +61,21 @@ final class MongoBatchOperations {
     this.clock = Objects.requireNonNull(clock, "clock");
   }
 
-  BatchEntity saveBatch(BatchEntity batch) {
+  @Override
+  public BatchEntity saveBatch(BatchEntity batch) {
     Document doc = DocumentMapper.toDocument(batch);
     ctx.batches().replaceOne(eq(ID, batch.getId()), doc, new ReplaceOptions().upsert(true));
     return batch;
   }
 
-  Optional<BatchEntity> findBatchById(UUID batchId) {
+  @Override
+  public Optional<BatchEntity> findBatchById(UUID batchId) {
     Document doc = ctx.batches().find(eq(ID, batchId)).first();
     return doc == null ? Optional.empty() : Optional.of(DocumentMapper.toBatchEntity(doc));
   }
 
-  List<BatchEntity> findBatchesByIds(List<UUID> batchIds) {
+  @Override
+  public List<BatchEntity> findBatchesByIds(List<UUID> batchIds) {
     if (batchIds == null || batchIds.isEmpty()) {
       return List.of();
     }
@@ -81,7 +86,8 @@ final class MongoBatchOperations {
     return result;
   }
 
-  BatchProgress incrementCompletedAtomic(UUID batchId) {
+  @Override
+  public BatchProgress incrementCompletedAtomic(UUID batchId) {
     return incrementCompletedAtomic(null, batchId);
   }
 
@@ -99,7 +105,8 @@ final class MongoBatchOperations {
     return DocumentMapper.toBatchProgress(doc, batchId);
   }
 
-  BatchProgress incrementFailedAtomic(UUID batchId) {
+  @Override
+  public BatchProgress incrementFailedAtomic(UUID batchId) {
     Document doc =
         ctx.batches()
             .findOneAndUpdate(
@@ -112,7 +119,8 @@ final class MongoBatchOperations {
     return DocumentMapper.toBatchProgress(doc, batchId);
   }
 
-  boolean markBatchCompleteIfReady(UUID batchId) {
+  @Override
+  public boolean markBatchCompleteIfReady(UUID batchId) {
     UpdateResult result =
         ctx.batches()
             .updateOne(
@@ -131,7 +139,8 @@ final class MongoBatchOperations {
     return result.getModifiedCount() > 0;
   }
 
-  List<UUID> findRecoverableBatchIds(int limit) {
+  @Override
+  public List<UUID> findRecoverableBatchIds(int limit) {
     List<UUID> ids = new ArrayList<>();
     FindIterable<Document> results =
         ctx.batches()
@@ -154,30 +163,35 @@ final class MongoBatchOperations {
     return ids;
   }
 
-  boolean updateBatchTotalItems(UUID batchId, int totalItems) {
+  @Override
+  public boolean updateBatchTotalItems(UUID batchId, int totalItems) {
     UpdateResult result = ctx.batches().updateOne(eq(ID, batchId), set(TOTAL_ITEMS, totalItems));
     return result.getModifiedCount() > 0;
   }
 
-  BatchMetricsEntity saveBatchMetrics(BatchMetricsEntity metrics) {
+  @Override
+  public BatchMetricsEntity saveBatchMetrics(BatchMetricsEntity metrics) {
     Document doc = DocumentMapper.toDocument(metrics);
     ctx.batchMetrics()
         .replaceOne(eq(ID, metrics.getBatchId()), doc, new ReplaceOptions().upsert(true));
     return metrics;
   }
 
-  Optional<BatchMetricsEntity> findBatchMetrics(UUID batchId) {
+  @Override
+  public Optional<BatchMetricsEntity> findBatchMetrics(UUID batchId) {
     Document doc = ctx.batchMetrics().find(eq(ID, batchId)).first();
     return doc == null ? Optional.empty() : Optional.of(DocumentMapper.toBatchMetricsEntity(doc));
   }
 
-  void addChildExecutionTime(UUID batchId, long durationMs) {
+  @Override
+  public void addChildExecutionTime(UUID batchId, long durationMs) {
     ctx.batchMetrics()
         .updateOne(
             eq(ID, batchId), combine(inc(CHILD_EXECUTION_MS, durationMs), inc(SUCCESS_COUNT, 1)));
   }
 
-  void finalizeBatchMetrics(UUID batchId) {
+  @Override
+  public void finalizeBatchMetrics(UUID batchId) {
     Document doc = ctx.batchMetrics().find(eq(ID, batchId)).first();
     if (doc == null) {
       return;
@@ -204,7 +218,8 @@ final class MongoBatchOperations {
                 set(OVERHEAD_MS, overheadMs)));
   }
 
-  void updateBatchMetricsChildCount(UUID batchId, int childCount) {
+  @Override
+  public void updateBatchMetricsChildCount(UUID batchId, int childCount) {
     ctx.batchMetrics().updateOne(eq(ID, batchId), set(CHILD_COUNT, childCount));
   }
 }

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractIdempotencyContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractIdempotencyContract.java
@@ -147,8 +147,9 @@ public abstract class AbstractIdempotencyContract {
 
     JobHandle survivor = handleA.get() != null ? handleA.get() : handleB.get();
     assertNotNull(survivor, "Surviving handle must be observable");
+    Duration completionTimeout = defaultTimeout().plus(Duration.ofSeconds(10));
     assertTrue(
-        runtime().probe().awaitCompleted(survivor, defaultTimeout()),
+        runtime().probe().awaitCompleted(survivor, completionTimeout),
         "Survivor handle must complete within timeout");
 
     int invocationsOnA =

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetLifecycle.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetLifecycle.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import org.jboss.logging.Logger;
@@ -53,6 +54,12 @@ public class RatchetLifecycle {
   private final JobExecutionCoordinator jobExecutionCoordinator;
   private final Instance<SchedulerLifecycleHook> lifecycleHooks;
   private volatile List<SchedulerLifecycleHook> resolvedHooks;
+  private volatile List<SchedulerLifecycleHook> startedHooks = List.of();
+  private volatile boolean shutdownComplete;
+
+  private static final Comparator<SchedulerLifecycleHook> HOOK_ORDER =
+      Comparator.comparingInt(RatchetLifecycle::priorityValue)
+          .thenComparing(RatchetLifecycle::hookSortName);
 
   protected RatchetLifecycle() {
     this.poller = null;
@@ -139,7 +146,8 @@ public class RatchetLifecycle {
           @Priority(Interceptor.Priority.APPLICATION + 500)
           @Initialized(ApplicationScoped.class) Object init) {
     log.info("Ratchet starting");
-    notifyHooks("beforeStart", SchedulerLifecycleHook::beforeStart, true);
+    List<SchedulerLifecycleHook> beforeStartSucceeded =
+        notifyHooks("beforeStart", hooks(), SchedulerLifecycleHook::beforeStart, true);
 
     recurringScheduler.configure(
         options.recurring().pollMs(),
@@ -174,14 +182,25 @@ public class RatchetLifecycle {
     pollerWakeupListener.init();
     jobExecutionCoordinator.initRetryBufferDrainer();
 
-    notifyHooks("afterStart", SchedulerLifecycleHook::afterStart, false);
+    startedHooks =
+        notifyHooks("afterStart", beforeStartSucceeded, SchedulerLifecycleHook::afterStart, false);
     log.info("Ratchet started");
   }
 
   @PreDestroy
   void onShutdown() {
+    List<SchedulerLifecycleHook> hooksToStop;
+    synchronized (this) {
+      if (shutdownComplete) {
+        return;
+      }
+      shutdownComplete = true;
+      hooksToStop = startedHooks;
+    }
+
     log.info("Ratchet stopping");
-    notifyHooks("beforeStop", SchedulerLifecycleHook::beforeStop, false);
+    List<SchedulerLifecycleHook> beforeStopSucceeded =
+        notifyHooks("beforeStop", hooksToStop, SchedulerLifecycleHook::beforeStop, false);
     // Drain before stop to prevent new claims
     drainController.setDraining(true);
 
@@ -201,7 +220,7 @@ public class RatchetLifecycle {
 
     JobTask.clearCaches();
     JobPayloadFactory.clearCaches();
-    notifyHooks("afterStop", SchedulerLifecycleHook::afterStop, false);
+    notifyHooks("afterStop", beforeStopSucceeded, SchedulerLifecycleHook::afterStop, false);
     destroyHooks();
   }
 
@@ -212,16 +231,22 @@ public class RatchetLifecycle {
     if (resolvedHooks == null) {
       List<SchedulerLifecycleHook> resolved = new ArrayList<>();
       lifecycleHooks.forEach(resolved::add);
+      resolved.sort(HOOK_ORDER);
       resolvedHooks = List.copyOf(resolved);
     }
     return resolvedHooks;
   }
 
-  private void notifyHooks(
-      String phase, Consumer<SchedulerLifecycleHook> callback, boolean abortOnSchemaFailure) {
-    for (SchedulerLifecycleHook hook : hooks()) {
+  private List<SchedulerLifecycleHook> notifyHooks(
+      String phase,
+      List<SchedulerLifecycleHook> phaseHooks,
+      Consumer<SchedulerLifecycleHook> callback,
+      boolean abortOnSchemaFailure) {
+    List<SchedulerLifecycleHook> succeeded = new ArrayList<>(phaseHooks.size());
+    for (SchedulerLifecycleHook hook : phaseHooks) {
       try {
         callback.accept(hook);
+        succeeded.add(hook);
       } catch (SchemaInitializationException e) {
         if (abortOnSchemaFailure) {
           // Schema initialization failures must abort startup so the scheduler does not begin
@@ -236,6 +261,46 @@ public class RatchetLifecycle {
         log.warnf(e, "Scheduler lifecycle hook failed during %s: %s", phase, e.getMessage());
       }
     }
+    return List.copyOf(succeeded);
+  }
+
+  private static int priorityValue(SchedulerLifecycleHook hook) {
+    Priority priority = findPriority(hook.getClass());
+    return priority == null ? Integer.MAX_VALUE : priority.value();
+  }
+
+  private static Priority findPriority(Class<?> type) {
+    for (Class<?> current = type;
+        current != null && current != Object.class;
+        current = current.getSuperclass()) {
+      Priority priority = current.getAnnotation(Priority.class);
+      if (priority != null) {
+        return priority;
+      }
+      priority = findInterfacePriority(current);
+      if (priority != null) {
+        return priority;
+      }
+    }
+    return null;
+  }
+
+  private static Priority findInterfacePriority(Class<?> type) {
+    for (Class<?> iface : type.getInterfaces()) {
+      Priority priority = iface.getAnnotation(Priority.class);
+      if (priority != null) {
+        return priority;
+      }
+      priority = findInterfacePriority(iface);
+      if (priority != null) {
+        return priority;
+      }
+    }
+    return null;
+  }
+
+  private static String hookSortName(SchedulerLifecycleHook hook) {
+    return hook.getClass().getName();
   }
 
   private void stopService(String name, Runnable stopAction) {

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/RatchetLifecycleHookTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/RatchetLifecycleHookTest.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Instance.Handle;
 import jakarta.enterprise.util.TypeLiteral;
@@ -72,6 +74,84 @@ class RatchetLifecycleHookTest {
   }
 
   @Test
+  void hooksRunInPriorityThenClassNameOrder() {
+    List<String> events = new ArrayList<>();
+    SchedulerLifecycleHook zulu = new ZuluFallbackHook(events);
+    SchedulerLifecycleHook lowPriority = new LowPriorityHook(events);
+    SchedulerLifecycleHook alpha = new AlphaFallbackHook(events);
+    SchedulerLifecycleHook highPriority = new HighPriorityHook(events);
+
+    RatchetLifecycle lifecycle =
+        newLifecycle(new RecordingInstance<>(List.of(zulu, lowPriority, alpha, highPriority)));
+
+    lifecycle.onStartup(new Object());
+
+    assertEquals(
+        List.of(
+            "high.beforeStart",
+            "low.beforeStart",
+            "alpha.beforeStart",
+            "zulu.beforeStart",
+            "high.afterStart",
+            "low.afterStart",
+            "alpha.afterStart",
+            "zulu.afterStart"),
+        events);
+  }
+
+  @Test
+  void failedBeforeStartHookDoesNotReceivePairedLifecyclePhases() {
+    List<String> events = new ArrayList<>();
+    SchedulerLifecycleHook failing = new FailingBeforeStartHook(events);
+    SchedulerLifecycleHook successful = new SuccessfulHook(events);
+
+    RatchetLifecycle lifecycle =
+        newLifecycle(new RecordingInstance<>(List.of(successful, failing)));
+
+    assertDoesNotThrow(() -> lifecycle.onStartup(new Object()));
+    lifecycle.onShutdown();
+
+    assertEquals(
+        List.of(
+            "failing.beforeStart",
+            "successful.beforeStart",
+            "successful.afterStart",
+            "successful.beforeStop",
+            "successful.afterStop"),
+        events);
+  }
+
+  @Test
+  void failedBeforeStopHookDoesNotReceiveAfterStop() {
+    List<String> events = new ArrayList<>();
+    SchedulerLifecycleHook hook = new FailingBeforeStopHook(events);
+
+    RatchetLifecycle lifecycle = newLifecycle(new RecordingInstance<>(List.of(hook)));
+
+    lifecycle.onStartup(new Object());
+    assertDoesNotThrow(lifecycle::onShutdown);
+
+    assertEquals(
+        List.of("failingStop.beforeStart", "failingStop.afterStart", "failingStop.beforeStop"),
+        events);
+  }
+
+  @Test
+  void onShutdown_isIdempotent() {
+    SchedulerLifecycleHook hook = mock(SchedulerLifecycleHook.class);
+    RecordingInstance<SchedulerLifecycleHook> hookInstance = new RecordingInstance<>(List.of(hook));
+
+    RatchetLifecycle lifecycle = newLifecycle(hookInstance);
+    lifecycle.onStartup(new Object());
+    lifecycle.onShutdown();
+    lifecycle.onShutdown();
+
+    verify(hook, times(1)).beforeStop();
+    verify(hook, times(1)).afterStop();
+    assertEquals(List.of(hook), hookInstance.destroyed);
+  }
+
+  @Test
   void onShutdown_withNullInstance_doesNotThrow() {
     // Non-CDI construction path — no Instance available; destroyHooks must be a safe no-op.
     RatchetLifecycle lifecycle = newLifecycleNoCdi();
@@ -96,25 +176,34 @@ class RatchetLifecycleHookTest {
 
   @Test
   void nonStartupPhases_swallowSchemaInitializationExceptionLikeOtherHookFailures() {
-    SchedulerLifecycleHook hook =
+    SchedulerLifecycleHook afterStartFailure =
         new SchedulerLifecycleHook() {
           @Override
           public void afterStart() {
             throw new SchemaInitializationException("late hook failure");
           }
+        };
 
+    SchedulerLifecycleHook beforeStopFailure =
+        new SchedulerLifecycleHook() {
           @Override
           public void beforeStop() {
             throw new SchemaInitializationException("shutdown hook failure");
           }
+        };
 
+    SchedulerLifecycleHook afterStopFailure =
+        new SchedulerLifecycleHook() {
           @Override
           public void afterStop() {
             throw new SchemaInitializationException("post-shutdown hook failure");
           }
         };
 
-    RatchetLifecycle lifecycle = newLifecycle(new RecordingInstance<>(List.of(hook)));
+    RatchetLifecycle lifecycle =
+        newLifecycle(
+            new RecordingInstance<>(
+                List.of(afterStartFailure, beforeStopFailure, afterStopFailure)));
 
     assertDoesNotThrow(() -> lifecycle.onStartup(new Object()));
     assertDoesNotThrow(lifecycle::onShutdown);
@@ -238,6 +327,168 @@ class RatchetLifecycleHookTest {
     @Override
     public Stream<Handle<T>> handlesStream() {
       throw new UnsupportedOperationException();
+    }
+  }
+
+  private static final class AlphaFallbackHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    AlphaFallbackHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("alpha.beforeStart");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("alpha.afterStart");
+    }
+  }
+
+  private static final class ZuluFallbackHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    ZuluFallbackHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("zulu.beforeStart");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("zulu.afterStart");
+    }
+  }
+
+  @Priority(10)
+  private static final class HighPriorityHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    HighPriorityHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("high.beforeStart");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("high.afterStart");
+    }
+  }
+
+  @Priority(20)
+  private static final class LowPriorityHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    LowPriorityHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("low.beforeStart");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("low.afterStart");
+    }
+  }
+
+  @Priority(10)
+  private static final class FailingBeforeStartHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    FailingBeforeStartHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("failing.beforeStart");
+      throw new IllegalStateException("hook failed");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("failing.afterStart");
+    }
+
+    @Override
+    public void beforeStop() {
+      events.add("failing.beforeStop");
+    }
+
+    @Override
+    public void afterStop() {
+      events.add("failing.afterStop");
+    }
+  }
+
+  @Priority(20)
+  private static final class SuccessfulHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    SuccessfulHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("successful.beforeStart");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("successful.afterStart");
+    }
+
+    @Override
+    public void beforeStop() {
+      events.add("successful.beforeStop");
+    }
+
+    @Override
+    public void afterStop() {
+      events.add("successful.afterStop");
+    }
+  }
+
+  private static final class FailingBeforeStopHook implements SchedulerLifecycleHook {
+    private final List<String> events;
+
+    FailingBeforeStopHook(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void beforeStart() {
+      events.add("failingStop.beforeStart");
+    }
+
+    @Override
+    public void afterStart() {
+      events.add("failingStop.afterStart");
+    }
+
+    @Override
+    public void beforeStop() {
+      events.add("failingStop.beforeStop");
+      throw new IllegalStateException("stop hook failed");
+    }
+
+    @Override
+    public void afterStop() {
+      events.add("failingStop.afterStop");
     }
   }
 }


### PR DESCRIPTION
## Summary

v5 found a startup ordering hole: schema migration could run after other lifecycle hooks, so a stale store schema might fail in the wrong place. This sorts `SchedulerLifecycleHook` beans by `@Priority`, gives `SchemaMigrationLifecycleHook` an early priority, and makes the Mongo archive/batch operation classes explicitly implement their store SPIs.

The Mongo change is deliberately small. It turns interface drift into a compile error instead of another audit finding.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet,ratchet-store-core,ratchet-store-mongodb spotless:apply`
- `mvn -pl ratchet -am -Dtest=RatchetLifecycleHookTest,RatchetLifecycleShutdownTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl ratchet-store-mongodb -am -DskipTests compile`
- `git diff --check`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

This is the v5 prerequisite PR. I did not run the full integration suite or container-backed Mongo tests here.
