### PR TITLE
preserve terminal failure metadata

### DIFF
--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
@@ -88,6 +88,25 @@ final class MongoJobLifecycleOperations
   public boolean compareAndSwapStatus(
       UUID id, JobStatus expected, JobStatus newStatus, String error) {
     try {
+      if ((newStatus == JobStatus.FAILED || newStatus == JobStatus.CANCELED)
+          && expected == JobStatus.RUNNING) {
+        Instant now = Instant.now();
+        UpdateResult result =
+            ctx.jobs()
+                .updateOne(
+                    and(eq(ID, id), eq(STATUS, expected.name())),
+                    combine(
+                        set(STATUS, newStatus.name()),
+                        set(LAST_ERROR, error),
+                        set(EXECUTION_START_TIME, DocumentMapper.toDate(now)),
+                        set(EXECUTION_END_TIME, DocumentMapper.toDate(now)),
+                        set(EXECUTION_DURATION_MS, 0L),
+                        set(PICKED_BY, null),
+                        set(PICKED_AT, null),
+                        set(UPDATED_AT, DocumentMapper.toDate(now)),
+                        inc(VERSION, 1)));
+        return result.getModifiedCount() > 0;
+      }
       UpdateResult result =
           ctx.jobs()
               .updateOne(
@@ -303,6 +322,7 @@ final class MongoJobLifecycleOperations
     return booleanMutation(
         "mark job failed terminal",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateOne(
@@ -311,9 +331,12 @@ final class MongoJobLifecycleOperations
                           set(STATUS, "FAILED"),
                           set(LAST_ERROR, terminalError),
                           set(ATTEMPTS, totalAttempts),
+                          set(EXECUTION_START_TIME, DocumentMapper.toDate(now)),
+                          set(EXECUTION_END_TIME, DocumentMapper.toDate(now)),
+                          set(EXECUTION_DURATION_MS, 0L),
                           set(PICKED_BY, null),
                           set(PICKED_AT, null),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return result.getModifiedCount() > 0;
         });
@@ -324,12 +347,27 @@ final class MongoJobLifecycleOperations
     return booleanMutation(
         "cancel job",
         () -> {
+          Instant now = Instant.now();
+          UpdateResult runningResult =
+              ctx.jobs()
+                  .updateOne(
+                      and(eq(ID, id), eq(STATUS, "RUNNING")),
+                      combine(
+                          set(STATUS, "CANCELED"),
+                          set(EXECUTION_START_TIME, DocumentMapper.toDate(now)),
+                          set(EXECUTION_END_TIME, DocumentMapper.toDate(now)),
+                          set(EXECUTION_DURATION_MS, 0L),
+                          set(PICKED_BY, null),
+                          set(PICKED_AT, null),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          inc(VERSION, 1)));
+          if (runningResult.getModifiedCount() > 0) {
+            return true;
+          }
           UpdateResult result =
               ctx.jobs()
                   .updateOne(
-                      and(
-                          eq(ID, id),
-                          in(STATUS, List.of("PENDING", "RUNNING", "PAUSED", "WAITING"))),
+                      and(eq(ID, id), in(STATUS, List.of("PENDING", "PAUSED", "WAITING"))),
                       combine(
                           set(STATUS, "CANCELED"),
                           set(PICKED_BY, null),

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobTerminalOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobTerminalOperations.java
@@ -102,7 +102,7 @@ final class MysqlJobTerminalOperations {
               if (expected != JobStatus.RUNNING && expected != JobStatus.WAITING) {
                 return false;
               }
-              return markJobFailedTerminalFromStatus(id, error, 0, expected);
+              return markJobFailedTerminalFromStatus(id, error, null, expected);
             }
             throw new IllegalArgumentException("Unsupported CAS target newStatus: " + newStatus);
           } catch (RuntimeException e) {
@@ -275,9 +275,27 @@ final class MysqlJobTerminalOperations {
     // language=MySQL
     String cancelNonRecurringSql =
         """
-        UPDATE scheduler_job
-        SET terminal_status = 'CANCELED', terminated_at = NOW(3)
-        WHERE job_id = ? AND job_type <> 'RECURRING' AND terminal_status IS NULL
+        UPDATE scheduler_job c
+        JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        SET c.terminal_status = 'CANCELED',
+            c.terminated_at = NOW(3),
+            c.execution_start_time =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN COALESCE(c.execution_start_time, q.picked_at, NOW(3))
+                     ELSE c.execution_start_time END,
+            c.execution_end_time =
+                CASE WHEN q.status = 'RUNNING' THEN NOW(3) ELSE c.execution_end_time END,
+            c.execution_duration_ms =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN GREATEST(
+                         0,
+                         TIMESTAMPDIFF(
+                             MICROSECOND,
+                             COALESCE(c.execution_start_time, q.picked_at, NOW(3)),
+                             NOW(3)) DIV 1000)
+                     ELSE c.execution_duration_ms END
+        WHERE c.job_id = ? AND c.job_type <> 'RECURRING' AND c.terminal_status IS NULL
+          AND q.status IN ('PENDING','RUNNING','PAUSED','WAITING')
         """;
     int nonRecurringUpdated =
         ctx.em()
@@ -291,10 +309,15 @@ final class MysqlJobTerminalOperations {
           DELETE FROM scheduler_job_queue
           WHERE job_id = ? AND status IN ('PENDING','RUNNING','PAUSED','WAITING')
           """;
-      ctx.em()
-          .createNativeQuery(deleteHotSql)
-          .setParameter(1, UuidByteArrayConverter.toBytes(id))
-          .executeUpdate();
+      int hotDeleted =
+          ctx.em()
+              .createNativeQuery(deleteHotSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .executeUpdate();
+      if (hotDeleted == 0) {
+        throw new IllegalStateException(
+            "cancel updated cold row but did not remove hot row for job " + id);
+      }
       reservations.deleteReservationByOwner(id);
       return true;
     }
@@ -427,7 +450,48 @@ final class MysqlJobTerminalOperations {
   }
 
   private boolean markJobFailedTerminalFromStatus(
-      UUID id, String terminalError, int totalAttempts, JobStatus expectedStatus) {
+      UUID id, String terminalError, Integer totalAttempts, JobStatus expectedStatus) {
+    String attemptsExpression = totalAttempts == null ? "q.attempts" : "?";
+    // language=MySQL
+    String updateColdSql =
+        """
+        UPDATE scheduler_job c
+        JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        SET c.terminal_status = 'FAILED',
+            c.terminal_error = ?,
+            c.total_attempts = %s,
+            c.terminated_at = NOW(3),
+            c.execution_start_time =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN COALESCE(c.execution_start_time, q.picked_at, NOW(3))
+                     ELSE c.execution_start_time END,
+            c.execution_end_time =
+                CASE WHEN q.status = 'RUNNING' THEN NOW(3) ELSE c.execution_end_time END,
+            c.execution_duration_ms =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN GREATEST(
+                         0,
+                         TIMESTAMPDIFF(
+                             MICROSECOND,
+                             COALESCE(c.execution_start_time, q.picked_at, NOW(3)),
+                             NOW(3)) DIV 1000)
+                     ELSE c.execution_duration_ms END
+        WHERE c.job_id = ? AND c.terminal_status IS NULL AND q.status = ?
+        """
+            .formatted(attemptsExpression);
+    var query = ctx.em().createNativeQuery(updateColdSql).setParameter(1, terminalError);
+    int parameter = 2;
+    if (totalAttempts != null) {
+      query.setParameter(parameter++, totalAttempts);
+    }
+    int coldUpdated =
+        query
+            .setParameter(parameter++, UuidByteArrayConverter.toBytes(id))
+            .setParameter(parameter, expectedStatus.name())
+            .executeUpdate();
+    if (coldUpdated == 0) {
+      return false;
+    }
     // language=MySQL
     String deleteHotSql = "DELETE FROM scheduler_job_queue WHERE job_id = ? AND status = ?";
     int hotDeleted =
@@ -437,37 +501,8 @@ final class MysqlJobTerminalOperations {
             .setParameter(2, expectedStatus.name())
             .executeUpdate();
     if (hotDeleted == 0) {
-      return false;
-    }
-    // WAITING jobs never started executing, so execution_end_time must stay null to avoid a
-    // non-null end with a null start, which would produce negative or null duration metrics.
-    // language=MySQL
-    String updateColdSql =
-        expectedStatus == JobStatus.WAITING
-            ? """
-              UPDATE scheduler_job
-              SET terminal_status = 'FAILED', terminal_error = ?, total_attempts = ?,
-                  terminated_at = NOW(3)
-              WHERE job_id = ? AND terminal_status IS NULL
-              """
-            : """
-              UPDATE scheduler_job
-              SET terminal_status = 'FAILED', terminal_error = ?, total_attempts = ?,
-                  terminated_at = NOW(3), execution_end_time = NOW(3)
-              WHERE job_id = ? AND terminal_status IS NULL
-              """;
-    int coldUpdated =
-        ctx.em()
-            .createNativeQuery(updateColdSql)
-            .setParameter(1, terminalError)
-            .setParameter(2, totalAttempts)
-            .setParameter(3, UuidByteArrayConverter.toBytes(id))
-            .executeUpdate();
-    if (coldUpdated == 0) {
-      // Invariant violation: the hot row was deleted in this transaction, but the cold row no
-      // longer matched the expected non-terminal state.
       throw new IllegalStateException(
-          "terminal failure removed hot row but did not update cold row for job " + id);
+          "terminal failure updated cold row but did not remove hot row for job " + id);
     }
     reservations.deleteReservationByOwner(id);
     return true;

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobTerminalOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobTerminalOperations.java
@@ -94,7 +94,7 @@ final class PostgresqlJobTerminalOperations {
         if (expected != JobStatus.RUNNING && expected != JobStatus.WAITING) {
           return false;
         }
-        return markJobFailedTerminalFromStatus(id, error, 0, expected);
+        return markJobFailedTerminalFromStatus(id, error, null, expected);
       }
       throw new IllegalArgumentException("Unsupported CAS target newStatus: " + newStatus);
     } catch (RuntimeException e) {
@@ -268,22 +268,47 @@ final class PostgresqlJobTerminalOperations {
           DELETE FROM scheduler_job_queue
           WHERE job_id = ? AND status IN ('PENDING','RUNNING','PAUSED','WAITING')
           """;
-      int hotDeleted = ctx.em().createNativeQuery(deleteHotSql).setParameter(1, id).executeUpdate();
-      if (hotDeleted == 0) {
-        return false;
-      }
       // language=PostgreSQL
       String updateColdSql =
           """
-          UPDATE scheduler_job
-          SET terminal_status = 'CANCELED', terminated_at = statement_timestamp()
-          WHERE job_id = ? AND terminal_status IS NULL
+          UPDATE scheduler_job c
+          SET terminal_status = 'CANCELED',
+              terminated_at = statement_timestamp(),
+              execution_start_time =
+                  CASE WHEN q.status = 'RUNNING'
+                       THEN COALESCE(c.execution_start_time, q.picked_at, statement_timestamp())
+                       ELSE c.execution_start_time END,
+              execution_end_time =
+                  CASE WHEN q.status = 'RUNNING'
+                       THEN statement_timestamp()
+                       ELSE c.execution_end_time END,
+              execution_duration_ms =
+                  CASE WHEN q.status = 'RUNNING'
+                       THEN GREATEST(
+                           0,
+                           FLOOR(
+                               EXTRACT(
+                                   EPOCH FROM statement_timestamp()
+                                     - COALESCE(
+                                         c.execution_start_time,
+                                         q.picked_at,
+                                         statement_timestamp()))
+                               * 1000)::bigint)
+                       ELSE c.execution_duration_ms END
+          FROM scheduler_job_queue q
+          WHERE c.job_id = ? AND q.job_id = c.job_id
+            AND c.terminal_status IS NULL
+            AND q.status IN ('PENDING','RUNNING','PAUSED','WAITING')
           """;
       int coldUpdated =
           ctx.em().createNativeQuery(updateColdSql).setParameter(1, id).executeUpdate();
       if (coldUpdated == 0) {
+        return false;
+      }
+      int hotDeleted = ctx.em().createNativeQuery(deleteHotSql).setParameter(1, id).executeUpdate();
+      if (hotDeleted == 0) {
         throw new IllegalStateException(
-            "cancel removed hot row but did not update cold row for job " + id);
+            "cancel updated cold row but did not remove hot row for job " + id);
       }
       reservations.deleteReservationByOwner(id);
       return coldUpdated > 0;
@@ -370,7 +395,55 @@ final class PostgresqlJobTerminalOperations {
   }
 
   private boolean markJobFailedTerminalFromStatus(
-      UUID id, String terminalError, int totalAttempts, JobStatus expectedStatus) {
+      UUID id, String terminalError, Integer totalAttempts, JobStatus expectedStatus) {
+    String attemptsExpression = totalAttempts == null ? "q.attempts" : "?";
+    // language=PostgreSQL
+    String updateColdSql =
+        """
+        UPDATE scheduler_job c
+        SET terminal_status = 'FAILED',
+            terminal_error = ?,
+            total_attempts = %s,
+            terminated_at = statement_timestamp(),
+            execution_start_time =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN COALESCE(c.execution_start_time, q.picked_at, statement_timestamp())
+                     ELSE c.execution_start_time END,
+            execution_end_time =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN statement_timestamp()
+                     ELSE c.execution_end_time END,
+            execution_duration_ms =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN GREATEST(
+                         0,
+                         FLOOR(
+                             EXTRACT(
+                                 EPOCH FROM statement_timestamp()
+                                   - COALESCE(
+                                       c.execution_start_time,
+                                       q.picked_at,
+                                       statement_timestamp()))
+                             * 1000)::bigint)
+                     ELSE c.execution_duration_ms END
+        FROM scheduler_job_queue q
+        WHERE c.job_id = ? AND q.job_id = c.job_id
+          AND c.terminal_status IS NULL AND q.status = ?
+        """
+            .formatted(attemptsExpression);
+    var query = ctx.em().createNativeQuery(updateColdSql).setParameter(1, terminalError);
+    int parameter = 2;
+    if (totalAttempts != null) {
+      query.setParameter(parameter++, totalAttempts);
+    }
+    int coldUpdated =
+        query
+            .setParameter(parameter++, id)
+            .setParameter(parameter, expectedStatus.name())
+            .executeUpdate();
+    if (coldUpdated == 0) {
+      return false;
+    }
     // language=PostgreSQL
     String deleteHotSql = "DELETE FROM scheduler_job_queue WHERE job_id = ? AND status = ?";
     int hotDeleted =
@@ -380,36 +453,8 @@ final class PostgresqlJobTerminalOperations {
             .setParameter(2, expectedStatus.name())
             .executeUpdate();
     if (hotDeleted == 0) {
-      return false;
-    }
-    // WAITING jobs never started executing, so execution_end_time must stay null to avoid a
-    // non-null end with a null start, which would produce negative or null duration metrics.
-    // language=PostgreSQL
-    String updateColdSql =
-        expectedStatus == JobStatus.WAITING
-            ? """
-              UPDATE scheduler_job
-              SET terminal_status = 'FAILED', terminal_error = ?, total_attempts = ?,
-                  terminated_at = statement_timestamp()
-              WHERE job_id = ? AND terminal_status IS NULL
-              """
-            : """
-              UPDATE scheduler_job
-              SET terminal_status = 'FAILED', terminal_error = ?, total_attempts = ?,
-                  terminated_at = statement_timestamp(),
-                  execution_end_time = statement_timestamp()
-              WHERE job_id = ? AND terminal_status IS NULL
-              """;
-    int coldUpdated =
-        ctx.em()
-            .createNativeQuery(updateColdSql)
-            .setParameter(1, terminalError)
-            .setParameter(2, totalAttempts)
-            .setParameter(3, id)
-            .executeUpdate();
-    if (coldUpdated == 0) {
       throw new IllegalStateException(
-          "terminal failure removed hot row but did not update cold row for job " + id);
+          "terminal failure updated cold row but did not remove hot row for job " + id);
     }
     reservations.deleteReservationByOwner(id);
     return true;

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobTerminalStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobTerminalStoreContract.java
@@ -52,4 +52,99 @@ public abstract class AbstractJobTerminalStoreContract implements JobStoreContra
     assertEquals(JobStatus.SUCCEEDED, reloaded.getStatus());
     assertNull(reloaded.getJobResult(), "Minimal success should not persist result JSON");
   }
+
+  @Test
+  void markJobSucceededAndUpdateBatch_updatesJobAndBatchAtomically() {
+    var parent = persist(newBatchParentJob());
+    persistBatch(parent.getId(), 1);
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+
+    Instant start = Instant.now().minusSeconds(5);
+    Instant end = Instant.now();
+    boolean marked =
+        store()
+            .markJobSucceededAndUpdateBatch(
+                saved.getId(),
+                "{\"ok\":true}",
+                "java.lang.String",
+                start,
+                end,
+                5000L,
+                100L,
+                parent.getId());
+
+    assertTrue(marked, "markJobSucceededAndUpdateBatch should return true for a running job");
+    var reloaded = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.SUCCEEDED, reloaded.getStatus());
+    assertNotNull(reloaded.getJobResult(), "Result JSON should be persisted");
+    assertEquals(1, store().findBatchById(parent.getId()).orElseThrow().getCompletedItems());
+  }
+
+  @Test
+  void markJobFailedTerminal_usesCallerAttemptsAndPersistsTimingFields() {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+
+    boolean marked = store().markJobFailedTerminal(saved.getId(), "permanent", 3);
+
+    assertTrue(marked, "markJobFailedTerminal should return true for a running job");
+    var reloaded = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.FAILED, reloaded.getStatus());
+    assertEquals(3, reloaded.getAttempts(), "Caller totalAttempts must be persisted");
+    assertTerminalTiming(reloaded.getExecutionStartTime(), reloaded.getExecutionEndTime());
+    assertNotNull(reloaded.getExecutionDurationMs(), "Terminal duration should be persisted");
+  }
+
+  @Test
+  void compareAndSwapStatus_runningToFailedPreservesHotAttemptsAndTimingFields() {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    assertEquals(1, store().incrementRetryAttempt(saved.getId()));
+
+    boolean marked =
+        store().compareAndSwapStatus(saved.getId(), JobStatus.RUNNING, JobStatus.FAILED, "boom");
+
+    assertTrue(marked, "RUNNING to FAILED CAS should succeed");
+    var reloaded = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.FAILED, reloaded.getStatus());
+    assertEquals(1, reloaded.getAttempts(), "Terminal row must preserve hot-row attempts");
+    assertTerminalTiming(reloaded.getExecutionStartTime(), reloaded.getExecutionEndTime());
+    assertNotNull(reloaded.getExecutionDurationMs(), "Terminal duration should be persisted");
+  }
+
+  @Test
+  void cancelJob_runningJobPersistsTimingFields() {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+
+    boolean canceled = store().cancelJob(saved.getId());
+
+    assertTrue(canceled, "cancelJob should return true for a running job");
+    var reloaded = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.CANCELED, reloaded.getStatus());
+    assertTerminalTiming(reloaded.getExecutionStartTime(), reloaded.getExecutionEndTime());
+    assertNotNull(reloaded.getExecutionDurationMs(), "Terminal duration should be persisted");
+  }
+
+  @Test
+  void compareAndSwapStatus_runningToCanceledPersistsTimingFields() {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+
+    boolean canceled =
+        store().compareAndSwapStatus(saved.getId(), JobStatus.RUNNING, JobStatus.CANCELED, null);
+
+    assertTrue(canceled, "RUNNING to CANCELED CAS should succeed");
+    var reloaded = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.CANCELED, reloaded.getStatus());
+    assertTerminalTiming(reloaded.getExecutionStartTime(), reloaded.getExecutionEndTime());
+    assertNotNull(reloaded.getExecutionDurationMs(), "Terminal duration should be persisted");
+  }
+
+  private static void assertTerminalTiming(Instant start, Instant end) {
+    assertNotNull(start, "Terminal start time should be persisted");
+    assertNotNull(end, "Terminal end time should be persisted");
+    assertTrue(!end.isBefore(start), "Terminal end time should not precede start time");
+  }
 }


### PR DESCRIPTION
## Summary

v5 found terminal-state writes that lost failure metadata. The SQL stores were hardcoding failed terminal rows with `totalAttempts = 0`, and Mongo cancellation paths could disagree on terminal timing fields.

This preserves attempts from the hot row during failure moves, tightens canceled/failed terminal metadata, and adds TCK coverage so the stores keep those fields intact.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet-store-mysql,ratchet-store-postgresql,ratchet-store-mongodb,ratchet-tck/store spotless:apply`
- `mvn -pl ratchet-store-mysql,ratchet-store-postgresql,ratchet-store-mongodb -am -DskipTests compile`
- MySQL terminal store contract tests
- PostgreSQL terminal store contract tests
- Mongo terminal store contract tests

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

The hot-row update is intentionally done before the cold-row delete so attempts and timing fields are still available while the terminal row is written.
