### PR TITLE
fix store data edge cases

### DIFF
--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/ResourcePermitStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/ResourcePermitStore.java
@@ -40,7 +40,12 @@ public interface ResourcePermitStore {
    */
   void releaseAllPermits(UUID jobId);
 
-  /** Reads the retry delay for a resource. Transaction attribute: {@code SUPPORTS}. */
+  /**
+   * Reads the retry delay for a resource.
+   *
+   * @return the configured delay, or the store default delay when {@code resource} is unknown
+   *     <p>Transaction attribute: {@code SUPPORTS}.
+   */
   int getPermitRetryDelay(String resource);
 
   /** Creates or updates a resource limit. Transaction attribute: {@code REQUIRED}. */

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -2,10 +2,12 @@ package run.ratchet.store.mongodb;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.exists;
 import static com.mongodb.client.model.Filters.gte;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lt;
 import static com.mongodb.client.model.Filters.lte;
+import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Sorts.ascending;
 import static com.mongodb.client.model.Sorts.descending;
 import static run.ratchet.store.mongodb.MongoFieldNames.ARCHIVED_AT;
@@ -13,6 +15,7 @@ import static run.ratchet.store.mongodb.MongoFieldNames.BUSINESS_KEY;
 import static run.ratchet.store.mongodb.MongoFieldNames.ID;
 import static run.ratchet.store.mongodb.MongoFieldNames.STATUS;
 import static run.ratchet.store.mongodb.MongoFieldNames.TARGET_CLASS;
+import static run.ratchet.store.mongodb.MongoFieldNames.TERMINATED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.UPDATED_AT;
 
 import com.mongodb.client.ClientSession;
@@ -108,11 +111,8 @@ final class MongoArchiveOperations {
     List<JobEntity> results = new ArrayList<>();
     for (Document doc :
         ctx.jobs()
-            .find(
-                and(
-                    in(STATUS, MongoStoreContext.TERMINAL_STATUSES),
-                    lt(UPDATED_AT, DocumentMapper.toDate(olderThan))))
-            .sort(ascending(UPDATED_AT))
+            .find(terminalOlderThan(olderThan))
+            .sort(ascending(TERMINATED_AT, UPDATED_AT))
             .limit(limit)) {
       results.add(DocumentMapper.toJobEntity(doc));
     }
@@ -120,11 +120,7 @@ final class MongoArchiveOperations {
   }
 
   long countJobsForArchiving(Instant olderThan) {
-    return ctx.jobs()
-        .countDocuments(
-            and(
-                in(STATUS, MongoStoreContext.TERMINAL_STATUSES),
-                lt(UPDATED_AT, DocumentMapper.toDate(olderThan))));
+    return ctx.jobs().countDocuments(terminalOlderThan(olderThan));
   }
 
   List<ArchivedJobEntity> findArchivedJobs(
@@ -155,6 +151,13 @@ final class MongoArchiveOperations {
     DeleteResult result =
         ctx.archives().deleteMany(lt(ARCHIVED_AT, DocumentMapper.toDate(olderThan)));
     return (int) result.getDeletedCount();
+  }
+
+  static Bson terminalOlderThan(Instant olderThan) {
+    var cutoff = DocumentMapper.toDate(olderThan);
+    return and(
+        in(STATUS, MongoStoreContext.TERMINAL_STATUSES),
+        or(lt(TERMINATED_AT, cutoff), and(exists(TERMINATED_AT, false), lt(UPDATED_AT, cutoff))));
   }
 
   private ArchivedJobEntity buildArchive(JobEntity job, String reason, String archivedBy) {

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoAuxiliaryOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoAuxiliaryOperations.java
@@ -219,6 +219,13 @@ final class MongoAuxiliaryOperations {
     try (ClientSession session = ctx.startSession()) {
       return session.withTransaction(
           () -> {
+            if (ctx.resourcePermits()
+                    .find(session, and(eq(RESOURCE_NAME, resource), eq(JOB_ID, jobId)))
+                    .first()
+                != null) {
+              return true;
+            }
+
             Document result =
                 ctx.resourceLimits()
                     .findOneAndUpdate(

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoCollectionInitializer.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoCollectionInitializer.java
@@ -124,6 +124,7 @@ class MongoCollectionInitializer {
     createIndex(coll, Indexes.ascending(METHOD_NAME), "idx_job_method_name");
     createIndex(coll, Indexes.ascending(CREATED_AT), "idx_job_created_at");
     createIndex(coll, Indexes.ascending(UPDATED_AT), "idx_job_updated_at");
+    createIndex(coll, Indexes.ascending(TERMINATED_AT), "idx_job_terminated_at");
     createIndex(coll, Indexes.ascending(JOB_TYPE), "idx_job_type");
     createIndex(coll, Indexes.ascending(SUPERSEDED_BY), "idx_job_superseded_by");
 

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoFieldNames.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoFieldNames.java
@@ -23,6 +23,7 @@ final class MongoFieldNames {
   static final String CREATED_AT = "created_at";
   static final String CALLER_PRINCIPAL = "caller_principal";
   static final String UPDATED_AT = "updated_at";
+  static final String TERMINATED_AT = "terminated_at";
   // Scheduling
   static final String SCHEDULED_TIME = "scheduled_time";
   static final String NEXT_FIRE = "next_fire";

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
@@ -2,12 +2,14 @@ package run.ratchet.store.mongodb;
 
 import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.exists;
 import static com.mongodb.client.model.Filters.gte;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lt;
 import static com.mongodb.client.model.Filters.lte;
 import static com.mongodb.client.model.Filters.ne;
 import static com.mongodb.client.model.Filters.nin;
+import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Sorts.ascending;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.inc;
@@ -30,6 +32,7 @@ import static run.ratchet.store.mongodb.MongoFieldNames.PRIORITY;
 import static run.ratchet.store.mongodb.MongoFieldNames.QUEUE_WAIT_MS;
 import static run.ratchet.store.mongodb.MongoFieldNames.SCHEDULED_TIME;
 import static run.ratchet.store.mongodb.MongoFieldNames.STATUS;
+import static run.ratchet.store.mongodb.MongoFieldNames.TERMINATED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.TOTAL_ITEMS;
 import static run.ratchet.store.mongodb.MongoFieldNames.UPDATED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.VERSION;
@@ -536,7 +539,11 @@ final class MongoJobCrudOperations {
                     eq(STATUS, STATUS_FAILED),
                     new Document(
                         "$expr", new Document("$gte", List.of("$" + ATTEMPTS, "$" + MAX_RETRIES))),
-                    lt(UPDATED_AT, DocumentMapper.toDate(cutoff))));
+                    or(
+                        lt(TERMINATED_AT, DocumentMapper.toDate(cutoff)),
+                        and(
+                            exists(TERMINATED_AT, false),
+                            lt(UPDATED_AT, DocumentMapper.toDate(cutoff))))));
     return (int) result.getDeletedCount();
   }
 

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
@@ -9,6 +9,7 @@ import static com.mongodb.client.model.Filters.nin;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.inc;
 import static com.mongodb.client.model.Updates.set;
+import static com.mongodb.client.model.Updates.unset;
 import static run.ratchet.store.mongodb.MongoFieldNames.ATTEMPTS;
 import static run.ratchet.store.mongodb.MongoFieldNames.BUSINESS_KEY;
 import static run.ratchet.store.mongodb.MongoFieldNames.CREATED_AT;
@@ -27,6 +28,7 @@ import static run.ratchet.store.mongodb.MongoFieldNames.RESULT_TYPE;
 import static run.ratchet.store.mongodb.MongoFieldNames.SCHEDULED_TIME;
 import static run.ratchet.store.mongodb.MongoFieldNames.STATUS;
 import static run.ratchet.store.mongodb.MongoFieldNames.TAGS;
+import static run.ratchet.store.mongodb.MongoFieldNames.TERMINATED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.UPDATED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.VERSION;
 
@@ -73,21 +75,25 @@ final class MongoJobLifecycleOperations
   public void updateJobStatus(UUID id, JobStatus status, String errorMessage) {
     runMutation(
         "update job status",
-        () ->
-            ctx.jobs()
-                .updateOne(
-                    eq(ID, id),
-                    combine(
-                        set(STATUS, status.name()),
-                        set(LAST_ERROR, errorMessage),
-                        set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
-                        inc(VERSION, 1))));
+        () -> {
+          Instant now = Instant.now();
+          ctx.jobs()
+              .updateOne(
+                  eq(ID, id),
+                  combine(
+                      set(STATUS, status.name()),
+                      set(LAST_ERROR, errorMessage),
+                      set(UPDATED_AT, DocumentMapper.toDate(now)),
+                      set(TERMINATED_AT, terminalDate(status, now)),
+                      inc(VERSION, 1)));
+        });
   }
 
   @Override
   public boolean compareAndSwapStatus(
       UUID id, JobStatus expected, JobStatus newStatus, String error) {
     try {
+      Instant now = Instant.now();
       UpdateResult result =
           ctx.jobs()
               .updateOne(
@@ -95,7 +101,8 @@ final class MongoJobLifecycleOperations
                   combine(
                       set(STATUS, newStatus.name()),
                       set(LAST_ERROR, error),
-                      set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                      set(UPDATED_AT, DocumentMapper.toDate(now)),
+                      set(TERMINATED_AT, terminalDate(newStatus, now)),
                       inc(VERSION, 1)));
       return result.getModifiedCount() > 0;
     } catch (RuntimeException e) {
@@ -156,6 +163,7 @@ final class MongoJobLifecycleOperations
       Long durationMs,
       Long queueWaitMs) {
     try {
+      Instant now = Instant.now();
       UpdateResult result =
           ctx.jobs()
               .updateOne(
@@ -166,10 +174,11 @@ final class MongoJobLifecycleOperations
                       set(RESULT_TYPE, resultType),
                       set(EXECUTION_START_TIME, DocumentMapper.toDate(start)),
                       set(EXECUTION_END_TIME, DocumentMapper.toDate(end)),
+                      set(TERMINATED_AT, DocumentMapper.toDate(now)),
                       set(EXECUTION_DURATION_MS, durationMs),
                       set(QUEUE_WAIT_MS, queueWaitMs),
                       set(LAST_ERROR, null),
-                      set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                      set(UPDATED_AT, DocumentMapper.toDate(now)),
                       inc(VERSION, 1)));
       return result.getModifiedCount() > 0;
     } catch (RuntimeException e) {
@@ -181,6 +190,7 @@ final class MongoJobLifecycleOperations
   public boolean markJobSucceededMinimal(
       UUID id, Instant start, Instant end, Long durationMs, Long queueWaitMs) {
     try {
+      Instant now = Instant.now();
       UpdateResult result =
           ctx.jobs()
               .updateOne(
@@ -189,10 +199,11 @@ final class MongoJobLifecycleOperations
                       set(STATUS, "SUCCEEDED"),
                       set(EXECUTION_START_TIME, DocumentMapper.toDate(start)),
                       set(EXECUTION_END_TIME, DocumentMapper.toDate(end)),
+                      set(TERMINATED_AT, DocumentMapper.toDate(now)),
                       set(EXECUTION_DURATION_MS, durationMs),
                       set(QUEUE_WAIT_MS, queueWaitMs),
                       set(LAST_ERROR, null),
-                      set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                      set(UPDATED_AT, DocumentMapper.toDate(now)),
                       inc(VERSION, 1)));
       return result.getModifiedCount() > 0;
     } catch (RuntimeException e) {
@@ -213,6 +224,7 @@ final class MongoJobLifecycleOperations
     try (ClientSession session = ctx.startSession()) {
       return session.withTransaction(
           () -> {
+            Instant now = Instant.now();
             UpdateResult result =
                 ctx.jobs()
                     .updateOne(
@@ -224,10 +236,11 @@ final class MongoJobLifecycleOperations
                             set(RESULT_TYPE, resultType),
                             set(EXECUTION_START_TIME, DocumentMapper.toDate(start)),
                             set(EXECUTION_END_TIME, DocumentMapper.toDate(end)),
+                            set(TERMINATED_AT, DocumentMapper.toDate(now)),
                             set(EXECUTION_DURATION_MS, durationMs),
                             set(QUEUE_WAIT_MS, queueWaitMs),
                             set(LAST_ERROR, null),
-                            set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                            set(UPDATED_AT, DocumentMapper.toDate(now)),
                             inc(VERSION, 1)));
             if (result.getModifiedCount() == 0) {
               return false;
@@ -256,6 +269,7 @@ final class MongoJobLifecycleOperations
                           set(LAST_ERROR, error),
                           set(PICKED_BY, null),
                           set(PICKED_AT, null),
+                          unset(TERMINATED_AT),
                           set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
                           inc(VERSION, 1)));
           return result.getModifiedCount() > 0;
@@ -303,6 +317,7 @@ final class MongoJobLifecycleOperations
     return booleanMutation(
         "mark job failed terminal",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateOne(
@@ -313,7 +328,8 @@ final class MongoJobLifecycleOperations
                           set(ATTEMPTS, totalAttempts),
                           set(PICKED_BY, null),
                           set(PICKED_AT, null),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return result.getModifiedCount() > 0;
         });
@@ -324,6 +340,7 @@ final class MongoJobLifecycleOperations
     return booleanMutation(
         "cancel job",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateOne(
@@ -334,7 +351,8 @@ final class MongoJobLifecycleOperations
                           set(STATUS, "CANCELED"),
                           set(PICKED_BY, null),
                           set(PICKED_AT, null),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return result.getModifiedCount() > 0;
         });
@@ -383,6 +401,7 @@ final class MongoJobLifecycleOperations
     return intMutation(
         "cancel jobs by tag",
         () -> {
+          Instant now = Instant.now();
           // Explicit 3-status filter: ACTIVE_STATUSES includes RUNNING.
           UpdateResult result =
               ctx.jobs()
@@ -395,7 +414,8 @@ final class MongoJobLifecycleOperations
                           set(STATUS, "CANCELED"),
                           set(PICKED_BY, null),
                           set(PICKED_AT, null),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return (int) result.getModifiedCount();
         });
@@ -406,6 +426,7 @@ final class MongoJobLifecycleOperations
     return intMutation(
         "cancel recurring jobs by tag",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateMany(
@@ -415,7 +436,8 @@ final class MongoJobLifecycleOperations
                           in(STATUS, MongoStoreContext.ACTIVE_STATUSES)),
                       combine(
                           set(STATUS, "CANCELED"),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return (int) result.getModifiedCount();
         });
@@ -426,6 +448,7 @@ final class MongoJobLifecycleOperations
     return intMutation(
         "cancel recurring job by business key",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateMany(
@@ -435,7 +458,8 @@ final class MongoJobLifecycleOperations
                           in(STATUS, MongoStoreContext.ACTIVE_STATUSES)),
                       combine(
                           set(STATUS, "CANCELED"),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return (int) result.getModifiedCount();
         });
@@ -449,6 +473,7 @@ final class MongoJobLifecycleOperations
     return intMutation(
         "cancel recurring jobs by business keys",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateMany(
@@ -458,7 +483,8 @@ final class MongoJobLifecycleOperations
                           in(STATUS, MongoStoreContext.ACTIVE_STATUSES)),
                       combine(
                           set(STATUS, "CANCELED"),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return (int) result.getModifiedCount();
         });
@@ -473,6 +499,7 @@ final class MongoJobLifecycleOperations
     return intMutation(
         "cancel orphaned recurring annotation jobs",
         () -> {
+          Instant now = Instant.now();
           UpdateResult result =
               ctx.jobs()
                   .updateMany(
@@ -484,7 +511,8 @@ final class MongoJobLifecycleOperations
                           nin(BUSINESS_KEY, registeredIds)),
                       combine(
                           set(STATUS, "CANCELED"),
-                          set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
+                          set(UPDATED_AT, DocumentMapper.toDate(now)),
+                          set(TERMINATED_AT, DocumentMapper.toDate(now)),
                           inc(VERSION, 1)));
           return (int) result.getModifiedCount();
         });
@@ -506,6 +534,7 @@ final class MongoJobLifecycleOperations
                           set(SCHEDULED_TIME, DocumentMapper.toDate(Instant.now())),
                           set(PICKED_BY, null),
                           set(PICKED_AT, null),
+                          unset(TERMINATED_AT),
                           set(UPDATED_AT, DocumentMapper.toDate(Instant.now())),
                           inc(VERSION, 1)));
           return result.getModifiedCount() > 0;
@@ -612,5 +641,11 @@ final class MongoJobLifecycleOperations
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException(operation, e);
     }
+  }
+
+  private static Date terminalDate(JobStatus status, Instant now) {
+    return MongoStoreContext.TERMINAL_STATUSES.contains(status.name())
+        ? DocumentMapper.toDate(now)
+        : null;
   }
 }

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoNodeLockOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoNodeLockOperations.java
@@ -4,6 +4,7 @@ import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
 import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Filters.lt;
+import static com.mongodb.client.model.Filters.or;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
 import static com.mongodb.client.model.Updates.setOnInsert;
@@ -66,7 +67,7 @@ final class MongoNodeLockOperations implements LockStore, NodeStore {
       Document result =
           ctx.locks()
               .findOneAndUpdate(
-                  and(eq(ID, name), lt(EXPIRES_AT, now)),
+                  and(eq(ID, name), or(lt(EXPIRES_AT, now), eq(OWNER_NODE, nodeId))),
                   combine(
                       set(OWNER_NODE, nodeId),
                       set(LOCKED_AT, now),

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoArchiveStoreContractTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoArchiveStoreContractTest.java
@@ -1,6 +1,10 @@
 package run.ratchet.store.mongodb;
 
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.combine;
+import static com.mongodb.client.model.Updates.set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -56,5 +60,29 @@ class MongoArchiveStoreContractTest extends AbstractArchiveStoreContract {
             .archiveJob(completed, "test", "tck");
 
     assertEquals(ARCHIVE_NOW, archived.getArchivedAt());
+  }
+
+  @Test
+  void findJobsForArchiving_usesTerminatedAtInsteadOfUpdatedAt() {
+    var job = persist(newPendingJob());
+    store().compareAndSwapStatus(job.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store()
+        .markJobSucceeded(
+            job.getId(), null, null, ARCHIVE_NOW, ARCHIVE_NOW.plusSeconds(1), 100L, 50L);
+
+    fixture
+        .database()
+        .getCollection("scheduler_job")
+        .updateOne(
+            eq("_id", job.getId()),
+            combine(
+                set("updated_at", DocumentMapper.toDate(ARCHIVE_NOW.minusSeconds(3600))),
+                set("terminated_at", DocumentMapper.toDate(ARCHIVE_NOW))));
+
+    var candidates = store().findJobsForArchiving(ARCHIVE_NOW.minusSeconds(1800), 10);
+
+    assertTrue(
+        candidates.isEmpty(),
+        "Mongo archiving must use terminated_at, not an older updated_at value");
   }
 }

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoTestFixture.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoTestFixture.java
@@ -85,6 +85,10 @@ public class MongoTestFixture implements JobStoreContractFixture, AutoCloseable 
     return new MongoArchiveOperations(ctx, clock);
   }
 
+  MongoDatabase database() {
+    return database;
+  }
+
   @Override
   public JobStore store() {
     return store;

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlAuxiliaryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlAuxiliaryOperations.java
@@ -12,6 +12,7 @@ import run.ratchet.api.WorkflowCondition;
 import run.ratchet.store.entity.DlqAlertEntity;
 import run.ratchet.store.entity.JobExecutionEntity;
 import run.ratchet.store.entity.JobLogEntity;
+import run.ratchet.store.entity.ResourceLimitEntity;
 import run.ratchet.store.entity.ResourcePermitEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
 import run.ratchet.store.id.UuidV7Factory;
@@ -312,7 +313,7 @@ final class MysqlAuxiliaryOperations
       return ((Number) ctx.em().createNativeQuery(sql).setParameter(1, resource).getSingleResult())
           .intValue();
     } catch (NoResultException e) {
-      throw new IllegalArgumentException("Resource is not configured: " + resource, e);
+      return ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS;
     }
   }
 

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlBatchOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlBatchOperations.java
@@ -1,5 +1,6 @@
 package run.ratchet.store.mysql;
 
+import jakarta.persistence.NoResultException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -138,6 +139,8 @@ final class MysqlBatchOperations implements BatchStore, BatchMetricsStore {
           .executeUpdate();
 
       return counter.progressAfterIncrement(batchId, locked, this::parseProgressHook);
+    } catch (NoResultException e) {
+      throw new IllegalStateException("Batch not found: " + batchId, e);
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("increment batch counter", e);
     }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
@@ -197,6 +197,16 @@ final class MysqlJobQueryOperations {
     };
   }
 
+  private static String archiveSortColumn(JobQuerySortField field) {
+    return switch (field) {
+      case CREATED_AT -> "a.original_created_at";
+      case SCHEDULED_TIME -> "a.original_scheduled_time";
+      case UPDATED_AT -> "a.archived_at";
+      case PRIORITY -> "a.priority";
+      case STATUS -> "a.final_status";
+    };
+  }
+
   private static int unionSortColumnPosition(JobFilter filter) {
     JobQuerySortField field =
         (filter == null || filter.sortField() == null)
@@ -362,6 +372,7 @@ final class MysqlJobQueryOperations {
     appendInstantGte("a.original_scheduled_time", filter.scheduledAfter(), where, params);
     appendInstantLt("a.original_scheduled_time", filter.scheduledBefore(), where, params);
     appendInstantGte("a.archived_at", filter.updatedAfter(), where, params);
+    appendArchiveCursorCondition(filter, where, params);
 
     return where.length() == 0 ? "" : " WHERE " + where;
   }
@@ -571,6 +582,28 @@ final class MysqlJobQueryOperations {
       params.add(UuidByteArrayConverter.toBytes(c.jobId()));
     } catch (IllegalArgumentException e) {
       log.warnf(e, "Ignoring malformed job-query cursor; falling back to offset pagination");
+    }
+  }
+
+  private void appendArchiveCursorCondition(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    if (filter == null || filter.cursor() == null) {
+      return;
+    }
+    try {
+      JobQueryCursor c = JobQueryCursor.decode(filter.cursor());
+      String sortCol = archiveSortColumn(c.sortField());
+      String op = filter.sortAscending() ? ">" : "<";
+      and(
+          where,
+          "(" + sortCol + " " + op + " ? OR (" + sortCol + " = ? AND a.original_job_id > ?))");
+      Object sortVal = parseSortValue(c);
+      params.add(sortVal);
+      params.add(sortVal);
+      params.add(UuidByteArrayConverter.toBytes(c.jobId()));
+    } catch (IllegalArgumentException e) {
+      log.warnf(
+          e, "Ignoring malformed archive job-query cursor; falling back to offset pagination");
     }
   }
 }

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlAuxiliaryOperationsTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlAuxiliaryOperationsTest.java
@@ -1,6 +1,6 @@
 package run.ratchet.store.mysql;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.persistence.EntityManager;
@@ -10,6 +10,7 @@ import java.lang.reflect.Proxy;
 import java.util.Collections;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.ResourceLimitEntity;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 
 class MysqlAuxiliaryOperationsTest {
@@ -24,11 +25,12 @@ class MysqlAuxiliaryOperationsTest {
   }
 
   @Test
-  void getPermitRetryDelayRejectsMissingResource() {
+  void getPermitRetryDelayUsesDefaultForMissingResource() {
     MysqlAuxiliaryOperations operations =
         new MysqlAuxiliaryOperations(new MysqlStoreContext(entityManagerWithNoResult(), null));
 
-    assertThrows(IllegalArgumentException.class, () -> operations.getPermitRetryDelay("missing"));
+    assertEquals(
+        ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS, operations.getPermitRetryDelay("missing"));
   }
 
   private static EntityManager entityManagerWithNoResult() {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
@@ -12,6 +12,7 @@ import run.ratchet.api.WorkflowCondition;
 import run.ratchet.store.entity.DlqAlertEntity;
 import run.ratchet.store.entity.JobExecutionEntity;
 import run.ratchet.store.entity.JobLogEntity;
+import run.ratchet.store.entity.ResourceLimitEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.DlqAlertStore;
@@ -232,6 +233,22 @@ final class PostgresqlAuxiliaryOperations
       throw new IllegalArgumentException("Resource is not configured: " + resource);
     }
 
+    // language=PostgreSQL
+    String existingSql =
+        """
+        SELECT COUNT(*) FROM scheduler_resource_permit
+        WHERE resource_name = ? AND job_id = ?
+        """;
+    Object existing =
+        ctx.em()
+            .createNativeQuery(existingSql)
+            .setParameter(1, resource)
+            .setParameter(2, jobId)
+            .getSingleResult();
+    if (((Number) existing).intValue() > 0) {
+      return true;
+    }
+
     // PostgreSQL uses one statement snapshot even after waiting on FOR UPDATE. Keep the lock
     // acquisition as its own statement, then count and insert together with a fresh snapshot.
     // language=PostgreSQL
@@ -286,7 +303,7 @@ final class PostgresqlAuxiliaryOperations
       Object result = ctx.em().createNativeQuery(sql).setParameter(1, resource).getSingleResult();
       return ((Number) result).intValue();
     } catch (NoResultException e) {
-      throw new IllegalArgumentException("Resource is not configured: " + resource, e);
+      return ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS;
     }
   }
 

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
@@ -351,6 +351,7 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
           LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
           WHERE c.job_type = 'RECURRING'
             AND c.rec_status = 'P'
+            AND q.job_id IS NULL
             AND c.next_fire <= statement_timestamp()%s
           ORDER BY %s
           LIMIT ?

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlNodeLockOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlNodeLockOperations.java
@@ -27,17 +27,17 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     requireLockName(name);
     requirePositiveDuration(ttl, "ttl");
     Objects.requireNonNull(nodeId, "nodeId");
-    long ttlSeconds = ttl.toSeconds();
+    long ttlMicros = durationMicros(ttl);
     // language=PostgreSQL
     String sql =
         """
         INSERT INTO scheduler_lock (lock_name, owner_node, locked_at, expires_at)
         VALUES (?, ?, statement_timestamp(),
-                statement_timestamp() + ? * interval '1 second')
+                statement_timestamp() + ? * interval '1 microsecond')
         ON CONFLICT (lock_name) DO UPDATE SET
           owner_node = EXCLUDED.owner_node,
           locked_at = statement_timestamp(),
-          expires_at = statement_timestamp() + ? * interval '1 second'
+          expires_at = statement_timestamp() + ? * interval '1 microsecond'
         WHERE scheduler_lock.expires_at < statement_timestamp()
            OR scheduler_lock.owner_node = ?
         """;
@@ -46,8 +46,8 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
             .createNativeQuery(sql)
             .setParameter(1, name)
             .setParameter(2, nodeId)
-            .setParameter(3, ttlSeconds)
-            .setParameter(4, ttlSeconds)
+            .setParameter(3, ttlMicros)
+            .setParameter(4, ttlMicros)
             .setParameter(5, nodeId)
             .executeUpdate();
     return updated > 0;
@@ -67,18 +67,18 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     requireLockName(name);
     requirePositiveDuration(extension, "extension");
     Objects.requireNonNull(nodeId, "nodeId");
-    long extensionSeconds = extension.toSeconds();
+    long extensionMicros = durationMicros(extension);
     // language=PostgreSQL
     String sql =
         """
         UPDATE scheduler_lock
-        SET expires_at = statement_timestamp() + ? * interval '1 second'
+        SET expires_at = statement_timestamp() + ? * interval '1 microsecond'
         WHERE lock_name = ? AND owner_node = ?
         """;
     int updated =
         ctx.em()
             .createNativeQuery(sql)
-            .setParameter(1, extensionSeconds)
+            .setParameter(1, extensionMicros)
             .setParameter(2, name)
             .setParameter(3, nodeId)
             .executeUpdate();
@@ -97,6 +97,15 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     if (duration.isZero() || duration.isNegative()) {
       throw new IllegalArgumentException(parameterName + " must be positive");
     }
+  }
+
+  private static long durationMicros(Duration duration) {
+    long seconds = duration.getSeconds();
+    long microsFromNanos = (duration.getNano() + 999L) / 1_000L;
+    if (seconds > (Long.MAX_VALUE - microsFromNanos) / 1_000_000L) {
+      return Long.MAX_VALUE;
+    }
+    return Math.max(1L, seconds * 1_000_000L + microsFromNanos);
   }
 
   @Override

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperationsTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperationsTest.java
@@ -1,30 +1,25 @@
 package run.ratchet.store.postgresql;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.Query;
 import java.lang.reflect.Proxy;
 import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.ResourceLimitEntity;
 
 class PostgresqlAuxiliaryOperationsTest {
 
   @Test
-  void getPermitRetryDelayRejectsUnknownResource() {
+  void getPermitRetryDelayUsesDefaultForMissingResource() {
     PostgresqlAuxiliaryOperations operations =
         new PostgresqlAuxiliaryOperations(
             new PostgresqlStoreContext(entityManagerThrowingNoResult()));
 
-    IllegalArgumentException thrown =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> operations.getPermitRetryDelay("missing-resource"));
-
-    assertTrue(thrown.getMessage().contains("Resource is not configured"));
-    assertInstanceOf(NoResultException.class, thrown.getCause());
+    assertEquals(
+        ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS,
+        operations.getPermitRetryDelay("missing-resource"));
   }
 
   private static EntityManager entityManagerThrowingNoResult() {

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractBatchStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractBatchStoreContract.java
@@ -2,6 +2,7 @@ package run.ratchet.tck.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -60,6 +61,14 @@ public abstract class AbstractBatchStoreContract implements JobStoreContractFixt
     assertEquals(2, progress.totalItems());
     assertEquals(0, progress.completedItems());
     assertEquals(1, progress.failedItems());
+  }
+
+  @Test
+  void incrementCompletedAtomic_unknownBatch_throwsIllegalStateException() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> store().incrementCompletedAtomic(new UUID(0L, Long.MAX_VALUE)),
+        "Missing batch increments should fail with the BatchStore contract exception");
   }
 
   @Test

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractLockStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractLockStoreContract.java
@@ -43,6 +43,34 @@ public abstract class AbstractLockStoreContract implements JobStoreContractFixtu
   }
 
   @Test
+  void tryLock_sameOwnerLiveLock_reacquiresIdempotently() {
+    assertTrue(
+        store().tryLock("same-owner-lock", Duration.ofMinutes(5), "node-A"),
+        "First tryLock should succeed");
+
+    assertTrue(
+        store().tryLock("same-owner-lock", Duration.ofMinutes(5), "node-A"),
+        "Same owner should be able to refresh a live lock");
+  }
+
+  @Test
+  void tryLock_subSecondTtlRemainsLiveUntilExpiry() throws InterruptedException {
+    assertTrue(
+        store().tryLock("subsecond-lock", Duration.ofMillis(500), "node-A"),
+        "Sub-second tryLock should succeed");
+
+    assertFalse(
+        store().tryLock("subsecond-lock", Duration.ofMinutes(5), "node-B"),
+        "Sub-second TTL must not be rounded down to an immediately expired lease");
+
+    Thread.sleep(800);
+
+    assertTrue(
+        store().tryLock("subsecond-lock", Duration.ofMinutes(5), "node-B"),
+        "Lock should be reacquirable after the sub-second TTL expires");
+  }
+
+  @Test
   void tryLock_rejectsNullParameters() {
     Duration ttl = Duration.ofMinutes(5);
 

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractResourcePermitStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractResourcePermitStoreContract.java
@@ -99,6 +99,13 @@ public abstract class AbstractResourcePermitStoreContract implements JobStoreCon
   }
 
   @Test
+  void getPermitRetryDelay_unknownResource_returnsDefaultDelay() {
+    int delay = store().getPermitRetryDelay("missing-resource");
+
+    assertEquals(5000, delay, "Unknown resources should use the default retry delay");
+  }
+
+  @Test
   void tryAcquirePermit_concurrent_respectsCapacity() {
     int capacity = 3;
     store().configureResource("res-cap", capacity, 1000, "capacity test");
@@ -162,13 +169,11 @@ public abstract class AbstractResourcePermitStoreContract implements JobStoreCon
     boolean second = store().tryAcquirePermit("res-idem", job.getId(), "node-1");
 
     assertTrue(first, "First acquire should succeed");
-    // Second acquire for same job should either succeed (idempotent) or fail,
-    // but must not consume an additional permit slot
+    assertTrue(second, "Second acquire for the same job should be idempotent");
+
     var otherJob = persist(newPendingJob());
-    // If capacity is 1 and same-job re-acquire is idempotent, this should fail
-    // If same-job re-acquire consumed a slot, the resource would be at capacity
     assertFalse(
         store().tryAcquirePermit("res-idem", otherJob.getId(), "node-1"),
-        "Resource capacity should still be exhausted — same-job re-acquire must not free a slot");
+        "Resource capacity should remain exhausted by the one idempotent permit");
   }
 }

--- a/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DocumentStoreTestDataManipulator.java
+++ b/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DocumentStoreTestDataManipulator.java
@@ -1,6 +1,8 @@
 package run.ratchet.testsuite.app;
 
+import static com.mongodb.client.model.Filters.and;
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.in;
 import static com.mongodb.client.model.Updates.set;
 
 import com.mongodb.client.MongoDatabase;
@@ -9,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -25,6 +28,7 @@ public class DocumentStoreTestDataManipulator implements TestDataManipulator {
 
   private static final Logger log =
       Logger.getLogger(DocumentStoreTestDataManipulator.class.getName());
+  private static final List<String> TERMINAL_STATUSES = List.of("SUCCEEDED", "FAILED", "CANCELED");
 
   @Inject private MongoDatabase mongoDb;
 
@@ -34,8 +38,18 @@ public class DocumentStoreTestDataManipulator implements TestDataManipulator {
         mongoDb
             .getCollection("scheduler_job")
             .updateOne(eq("_id", jobId), set("updated_at", Date.from(updatedAt)));
+    UpdateResult terminalResult =
+        mongoDb
+            .getCollection("scheduler_job")
+            .updateOne(
+                and(eq("_id", jobId), in("status", TERMINAL_STATUSES)),
+                set("terminated_at", Date.from(updatedAt)));
     if (!result.wasAcknowledged()) {
       throw new IllegalStateException("MongoDB did not acknowledge updated_at update for " + jobId);
+    }
+    if (!terminalResult.wasAcknowledged()) {
+      throw new IllegalStateException(
+          "MongoDB did not acknowledge terminated_at update for " + jobId);
     }
     if (result.getMatchedCount() == 0) {
       throw new IllegalStateException("No scheduler_job document found for " + jobId);


### PR DESCRIPTION
## Summary

This fixes the v5 store data-correctness cluster: PostgreSQL lease precision, resource-permit re-acquire idempotency, archive cutoff semantics, MySQL archive cursor pagination, and the PostgreSQL recurring-claim guard.

The PR also updates store contracts and TCK coverage around the affected paths. The goal is to make retry and cleanup behavior match the SPI contract instead of relying on provider-specific quirks.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- Store module and TCK compile checks
- PostgreSQL lock, resource permit, batch, and job claim contract tests
- MySQL resource permit, batch, and job query contract tests
- Mongo lock, resource permit, archive, and batch contract tests
- `mvn -pl ratchet-store-mongodb -Dtest=MongoArchiveStoreContractTest test`
- Spotless and `git diff --check HEAD`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

Mongo now writes `terminated_at` for terminal archive semantics. The fallback to `updated_at` is still there for legacy rows.
