### PR TITLE
define circuit-open resilience contract

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/exception/CircuitBreakerOpenException.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/exception/CircuitBreakerOpenException.java
@@ -1,0 +1,23 @@
+package run.ratchet.api.exception;
+
+import java.io.Serial;
+
+/**
+ * Thrown when a resilience strategy rejects a protected call because the circuit is open.
+ *
+ * <p>This exception identifies scheduler back-pressure caused by an unavailable protected service.
+ * It is distinct from task failure: callers that catch it should reschedule or delay the work
+ * without consuming a job retry attempt.
+ */
+public class CircuitBreakerOpenException extends RuntimeException {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  public CircuitBreakerOpenException(String message) {
+    super(message);
+  }
+
+  public CircuitBreakerOpenException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/ResilienceStrategy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ResilienceStrategy.java
@@ -3,6 +3,7 @@ package run.ratchet.spi;
 import java.time.Duration;
 import java.util.concurrent.Callable;
 import run.ratchet.api.Incubating;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 /**
  * Strategy for wrapping job execution with resilience patterns such as circuit breakers. The
@@ -17,22 +18,32 @@ public interface ResilienceStrategy {
    *
    * @param serviceName identifies the service being protected (must be from a bounded vocabulary)
    * @param <T> the return type
-   * @throws Exception if the task fails or the service is unavailable. Implementations that reject
-   *     a call because a circuit is open should throw a distinct runtime exception so callers can
-   *     tell circuit rejection from task failure.
+   * @throws CircuitBreakerOpenException if the call is rejected because the circuit is open. This
+   *     rejection is distinct from task failure; scheduler implementations should delay/reschedule
+   *     the work without consuming a retry attempt.
+   * @throws Exception if the task itself fails
    */
   <T> T execute(String serviceName, Callable<T> task) throws Exception;
 
   /**
    * Checks whether a service is currently available (circuit not open).
    *
+   * <p>This method is an advisory pre-check only. Availability can change immediately after it
+   * returns, so callers must still handle {@link CircuitBreakerOpenException} from {@link
+   * #execute(String, Callable)}.
+   *
    * @return true if calls are permitted, false if the circuit is open
    */
   boolean isServiceAvailable(String serviceName);
 
   /**
-   * Returns the recommended delay before retrying work that was rejected because the protected
-   * service is unavailable.
+   * Returns the recommended delay before retrying work that was rejected with {@link
+   * CircuitBreakerOpenException}.
+   *
+   * <p>Implementations must not return {@code null} or a negative duration. Return {@link
+   * Duration#ZERO} when an immediate retry is appropriate. For open circuits, implementations
+   * should return the remaining open-window duration when known, or a conservative retry delay when
+   * it is not known.
    *
    * <p>The default implementation preserves the existing RI behavior of 30 seconds so existing SPI
    * implementations remain source- and binary-compatible.

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractResilienceStrategyContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractResilienceStrategyContract.java
@@ -1,0 +1,56 @@
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
+import run.ratchet.spi.ResilienceStrategy;
+
+/**
+ * Base contract for {@link ResilienceStrategy} open-circuit semantics.
+ *
+ * <p>Implementations subclass this contract with a strategy instance and an implementation-specific
+ * way to force the named service into an open-circuit state before assertions run.
+ */
+public abstract class AbstractResilienceStrategyContract {
+
+  @Test
+  void openCircuitExecuteThrowsDistinctRuntimeExceptionWithoutCallingTask() throws Exception {
+    String serviceName = "tck-open-circuit";
+    forceOpenCircuit(serviceName);
+
+    AtomicBoolean taskCalled = new AtomicBoolean(false);
+
+    assertThrows(
+        CircuitBreakerOpenException.class,
+        () ->
+            resilienceStrategy()
+                .execute(
+                    serviceName,
+                    () -> {
+                      taskCalled.set(true);
+                      return "should not run";
+                    }));
+    assertFalse(taskCalled.get(), "Open-circuit rejection must not invoke the task body");
+  }
+
+  @Test
+  void openCircuitReportsUnavailableAndNonNegativeRetryDelay() throws Exception {
+    String serviceName = "tck-open-circuit-delay";
+    forceOpenCircuit(serviceName);
+
+    assertFalse(
+        resilienceStrategy().isServiceAvailable(serviceName),
+        "Forced-open circuit must report unavailable");
+
+    Duration retryDelay = resilienceStrategy().getRetryDelay(serviceName);
+    assertFalse(retryDelay.isNegative(), "getRetryDelay must not return a negative duration");
+  }
+
+  protected abstract ResilienceStrategy resilienceStrategy();
+
+  protected abstract void forceOpenCircuit(String serviceName) throws Exception;
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -24,7 +24,8 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractJobCancelContract",
                   "AbstractDelayedSchedulingContract",
                   "AbstractIdempotencyContract",
-                  "AbstractSimpleWorkflowContract")));
+                  "AbstractSimpleWorkflowContract",
+                  "AbstractResilienceStrategyContract")));
 
   @Override
   protected String tierTitle() {

--- a/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DocumentStoreTestCleanupStrategy.java
+++ b/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DocumentStoreTestCleanupStrategy.java
@@ -4,6 +4,7 @@ import com.mongodb.client.MongoDatabase;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 import org.bson.Document;
 
@@ -53,5 +54,12 @@ public class DocumentStoreTestCleanupStrategy implements TestCleanupStrategy {
         log.fine("Truncate skipped for " + collection + ": " + e.getMessage());
       }
     }
+  }
+
+  @Override
+  public void deleteSchedulerLock(String name) {
+    mongoDb
+        .getCollection("scheduler_lock")
+        .deleteOne(new Document("_id", Objects.requireNonNull(name, "name")));
   }
 }

--- a/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestCleanupStrategy.java
+++ b/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestCleanupStrategy.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
 
@@ -80,6 +81,14 @@ public class JpaTestCleanupStrategy implements TestCleanupStrategy {
         }
       }
     }
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public void deleteSchedulerLock(String name) {
+    em().createNativeQuery("DELETE FROM scheduler_lock WHERE lock_name = ?")
+        .setParameter(1, Objects.requireNonNull(name, "name"))
+        .executeUpdate();
   }
 
   private EntityManager em() {

--- a/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestCleanupStrategy.java
+++ b/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestCleanupStrategy.java
@@ -5,4 +5,7 @@ public interface TestCleanupStrategy {
 
   /** Removes all scheduler data to ensure test isolation. */
   void truncateAll();
+
+  /** Removes one scheduler lease without touching registered jobs. */
+  void deleteSchedulerLock(String name);
 }

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/recurring/RecurringAnnotationIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/recurring/RecurringAnnotationIT.java
@@ -16,6 +16,7 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.ri.core.RecurringScheduler;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.app.TestCleanupStrategy;
 import run.ratchet.testsuite.app.TestJobService;
 import run.ratchet.testsuite.app.TestRecurringJobs;
 import run.ratchet.testsuite.util.BaseRatchetIT;
@@ -27,9 +28,13 @@ import run.ratchet.testsuite.util.RatchetArchiveBuilder;
  */
 class RecurringAnnotationIT extends BaseRatchetIT {
 
+  private static final String RECURRING_SCHEDULER_LEASE = "recurringScheduler";
+
   @Inject private JobCrudStore jobCrudStore;
 
   @Inject private RecurringScheduler recurringScheduler;
+
+  @Inject private TestCleanupStrategy cleanupStrategy;
 
   @Deployment
   public static WebArchive createDeployment() {
@@ -79,8 +84,8 @@ class RecurringAnnotationIT extends BaseRatchetIT {
   @Override
   @BeforeEach
   protected void truncateAll() {
-    // Skip table truncation — the @Recurring job registered during CDI startup is the
-    // subject under test. Truncating scheduler_job would destroy the recurring master
-    // that RecurringJobProcessor registered at deployment time.
+    // The @Recurring master is registered during CDI startup, so keep scheduler_job intact.
+    // Clear only this singleton lease so residue from a previous deployment cannot block polling.
+    cleanupStrategy.deleteSchedulerLock(RECURRING_SCHEDULER_LEASE);
   }
 }

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/resilience/CircuitBreakerIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/resilience/CircuitBreakerIT.java
@@ -24,11 +24,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import run.ratchet.api.CircuitBreakerProfile;
 import run.ratchet.api.CircuitBreakerProtected;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.ri.cdi.CircuitBreakerInterceptor;
 import run.ratchet.ri.resilience.CircuitBreaker;
 import run.ratchet.ri.resilience.CircuitBreakerConfiguration;
 import run.ratchet.ri.resilience.CircuitBreakerRegistry;
-import run.ratchet.ri.resilience.ServiceUnavailableException;
 import run.ratchet.spi.CircuitBreakerConfig;
 import run.ratchet.spi.CircuitBreakerConfigProvider;
 import run.ratchet.testsuite.app.CircuitBreakerTestService;
@@ -75,7 +75,7 @@ public class CircuitBreakerIT {
             CircuitBreaker.class,
             CircuitBreakerConfiguration.class,
             CircuitBreakerRegistry.class,
-            ServiceUnavailableException.class)
+            CircuitBreakerOpenException.class)
         .addAsLibraries(
             Maven.configureResolver()
                 .loadPomFromFile("pom.xml")
@@ -105,8 +105,8 @@ public class CircuitBreakerIT {
       assertThrows(RuntimeException.class, () -> service.callService());
     }
 
-    // Circuit should now be OPEN — next call should throw ServiceUnavailableException
-    assertThrows(ServiceUnavailableException.class, () -> service.callService());
+    // Circuit should now be OPEN — next call should throw CircuitBreakerOpenException
+    assertThrows(CircuitBreakerOpenException.class, () -> service.callService());
     assertEquals(
         3,
         CircuitBreakerTestService.getCallCount(),
@@ -114,7 +114,7 @@ public class CircuitBreakerIT {
 
     // Verify the breaker state
     CircuitBreaker breaker = registry.getBreaker(TEST_SERVICE, CircuitBreakerProfile.FAST);
-    // After ServiceUnavailableException, state is either OPEN or transitioning
+    // After CircuitBreakerOpenException, state is either OPEN or transitioning
     assertEquals(
         CircuitBreaker.State.OPEN,
         breaker.getState(),
@@ -188,8 +188,8 @@ public class CircuitBreakerIT {
       Future<String> second = executor.submit(() -> service.callService());
       assertTrue(started.await(1, TimeUnit.SECONDS), "Expected both trial calls to start");
 
-      ServiceUnavailableException thrown =
-          assertThrows(ServiceUnavailableException.class, () -> service.callService());
+      CircuitBreakerOpenException thrown =
+          assertThrows(CircuitBreakerOpenException.class, () -> service.callService());
       assertTrue(thrown.getMessage().contains("HALF_OPEN"));
 
       release.countDown();

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiResilienceStrategyIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiResilienceStrategyIT.java
@@ -1,0 +1,33 @@
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.ri.resilience.CircuitBreakerRegistry;
+import run.ratchet.spi.ResilienceStrategy;
+import run.ratchet.tck.api.AbstractResilienceStrategyContract;
+
+/** RI subclass of {@link AbstractResilienceStrategyContract}. */
+@ExtendWith(ArquillianExtension.class)
+class RiResilienceStrategyIT extends AbstractResilienceStrategyContract {
+
+  @Inject private ResilienceStrategy resilienceStrategy;
+  @Inject private CircuitBreakerRegistry circuitBreakerRegistry;
+
+  @Override
+  protected ResilienceStrategy resilienceStrategy() {
+    return resilienceStrategy;
+  }
+
+  @Override
+  protected void forceOpenCircuit(String serviceName) {
+    circuitBreakerRegistry.openBreaker(serviceName);
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.create();
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/CircuitBreakerInterceptor.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/CircuitBreakerInterceptor.java
@@ -18,7 +18,7 @@ import run.ratchet.spi.CircuitBreakerConfigProvider;
  *
  * <p>The interceptor resolves the circuit breaker instance from the {@link CircuitBreakerRegistry}
  * using the service name and profile from the annotation. If the circuit is OPEN, the invocation
- * fails immediately with a {@link run.ratchet.ri.resilience.ServiceUnavailableException}.
+ * fails immediately with a {@link run.ratchet.api.exception.CircuitBreakerOpenException}.
  *
  * <p>Service name defaults to {@code ClassName.methodName} if not specified in the annotation.
  */
@@ -26,7 +26,7 @@ import run.ratchet.spi.CircuitBreakerConfigProvider;
 @CircuitBreakerProtected
 // Run before @Transactional (Jakarta Transactions interceptor priority =
 // PLATFORM_BEFORE + 200 = 200). PLATFORM_BEFORE + 100 = 100 fires first, so an OPEN
-// circuit short-circuits with ServiceUnavailableException before a transaction is opened
+// circuit short-circuits with CircuitBreakerOpenException before a transaction is opened
 // and a connection is borrowed.
 @Priority(Interceptor.Priority.PLATFORM_BEFORE + 100)
 public class CircuitBreakerInterceptor {

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
@@ -30,10 +30,10 @@ import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.api.event.JobDlqEvent;
 import run.ratchet.api.event.JobRetryingEvent;
 import run.ratchet.api.event.JobStartedEvent;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.api.exception.JobTimeoutException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.ri.cdi.JsonbPayloadSerializer;
-import run.ratchet.ri.resilience.ServiceUnavailableException;
 import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.ErrorSanitizer;
@@ -369,6 +369,11 @@ public class JobTask implements Callable<Void> {
       } else {
         handleSuccess(start, jobResult);
       }
+    } catch (CircuitBreakerOpenException e) {
+      log.infof(
+          "Job %s rescheduled - circuit breaker OPEN for service: %s",
+          jobId, resilienceServiceName);
+      rescheduleForCircuitBreaker(jobEntity, resilienceServiceName, e);
     } catch (Throwable t) {
       try {
         handleFailure(t);
@@ -517,12 +522,19 @@ public class JobTask implements Callable<Void> {
    * delay matching the circuit breaker's typical OPEN-to-HALF_OPEN transition window.
    */
   private void rescheduleForCircuitBreaker(JobEntity jobEntity, String serviceName) {
+    rescheduleForCircuitBreaker(
+        jobEntity,
+        serviceName,
+        new CircuitBreakerOpenException("Circuit breaker OPEN for service: " + serviceName));
+  }
+
+  private void rescheduleForCircuitBreaker(
+      JobEntity jobEntity, String serviceName, CircuitBreakerOpenException rejection) {
     long delayMs = resilienceStrategy.getRetryDelay(serviceName).toMillis();
     Instant newScheduledTime = effective().instant().plusMillis(delayMs);
 
     if (currentExecution != null) {
-      currentExecution.markFailed(
-          new ServiceUnavailableException("Circuit breaker OPEN for service: " + serviceName));
+      currentExecution.markFailed(rejection);
       observabilityFacade.saveExecution(currentExecution);
     }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/Poller.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/Poller.java
@@ -8,10 +8,10 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.CircuitBreakerProfile;
 import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.ri.resilience.CircuitBreaker;
 import run.ratchet.ri.resilience.CircuitBreakerRegistry;
-import run.ratchet.ri.resilience.ServiceUnavailableException;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.NodeTagAffinityProvider;
@@ -243,7 +243,7 @@ public class Poller {
     } catch (RatchetTransientStoreException e) {
       publishClaimBreakerState();
       return handleTransientClaimFailure(pollStartTime, e);
-    } catch (ServiceUnavailableException e) {
+    } catch (CircuitBreakerOpenException e) {
       publishClaimBreakerState();
       return handleOpenCircuit(pollStartTime, e);
     }
@@ -318,8 +318,8 @@ public class Poller {
       if (e instanceof RatchetTransientStoreException transientStoreException) {
         throw transientStoreException;
       }
-      if (e instanceof ServiceUnavailableException serviceUnavailableException) {
-        throw serviceUnavailableException;
+      if (e instanceof CircuitBreakerOpenException circuitBreakerOpenException) {
+        throw circuitBreakerOpenException;
       }
       if (e instanceof RuntimeException runtimeException) {
         throw runtimeException;
@@ -335,7 +335,7 @@ public class Poller {
     return Math.min(options.polling().maxDelayMs(), Math.max(baseDelay, 1L) * 2L);
   }
 
-  private long handleOpenCircuit(long pollStartTime, ServiceUnavailableException e) {
+  private long handleOpenCircuit(long pollStartTime, CircuitBreakerOpenException e) {
     updateSystemLoadFactor();
     log.warnf("Claim path circuit breaker open: %s", e.getMessage());
     long baseDelay = strategy.recordPollResult(0, pollStartTime);

--- a/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreaker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreaker.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 /**
  * Lightweight circuit breaker state machine.
@@ -18,7 +19,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *   → When failure rate >= threshold AND calls >= minimumCalls → OPEN
  *
  * OPEN
- *   → All calls throw ServiceUnavailableException immediately
+ *   → All calls throw CircuitBreakerOpenException immediately
  *   → After waitDuration expires → HALF_OPEN
  *
  * HALF_OPEN
@@ -88,14 +89,14 @@ public class CircuitBreaker {
   /**
    * Executes the task with circuit breaker protection.
    *
-   * @throws ServiceUnavailableException if the circuit is OPEN
+   * @throws run.ratchet.api.exception.CircuitBreakerOpenException if the circuit is OPEN
    * @throws Exception if the task throws
    */
   public <T> T execute(Callable<T> task) throws Exception {
     State current = getState();
 
     if (current == State.OPEN) {
-      throw new ServiceUnavailableException(
+      throw new CircuitBreakerOpenException(
           "Circuit breaker '" + name + "' is OPEN — service unavailable");
     }
 
@@ -167,7 +168,7 @@ public class CircuitBreaker {
     try {
       int attempt = ++halfOpenAttempts;
       if (attempt > config.permittedCallsInHalfOpen()) {
-        throw new ServiceUnavailableException(
+        throw new CircuitBreakerOpenException(
             "Circuit breaker '" + name + "' is HALF_OPEN — trial calls exhausted");
       }
     } finally {

--- a/ratchet/src/main/java/run/ratchet/ri/resilience/DefaultResilienceStrategy.java
+++ b/ratchet/src/main/java/run/ratchet/ri/resilience/DefaultResilienceStrategy.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.concurrent.Callable;
 import org.jboss.logging.Logger;
 import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.spi.CircuitBreakerConfigProvider;
 import run.ratchet.spi.ResilienceStrategy;
 
@@ -36,7 +37,7 @@ public class DefaultResilienceStrategy implements ResilienceStrategy {
     CircuitBreaker breaker = registry.getBreaker(serviceName);
     try {
       return breaker.execute(task);
-    } catch (ServiceUnavailableException e) {
+    } catch (CircuitBreakerOpenException e) {
       log.warnv("Circuit breaker OPEN for service: {0}", serviceName);
       throw e;
     }

--- a/ratchet/src/main/java/run/ratchet/ri/resilience/ServiceUnavailableException.java
+++ b/ratchet/src/main/java/run/ratchet/ri/resilience/ServiceUnavailableException.java
@@ -1,9 +1,15 @@
 package run.ratchet.ri.resilience;
 
 import java.io.Serial;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
-/** Thrown when a circuit breaker is OPEN and calls are not permitted. */
-public class ServiceUnavailableException extends RuntimeException {
+/**
+ * RI compatibility alias for open-circuit rejections.
+ *
+ * @deprecated use {@link CircuitBreakerOpenException}
+ */
+@Deprecated(since = "1.0", forRemoval = false)
+public class ServiceUnavailableException extends CircuitBreakerOpenException {
 
   @Serial private static final long serialVersionUID = -2077185964269635004L;
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobTaskTest.java
@@ -32,6 +32,7 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobCompletedEvent;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
@@ -244,6 +245,33 @@ class JobTaskTest {
 
     verify(resilienceStrategy, never()).execute(anyString(), any(Callable.class));
     verify(jobStore).scheduleJobRetry(eq(JOB_UUID), anyString(), any(), anyInt());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void call_executeOpenCircuitException_reschedulesWithoutCountingTaskFailure() throws Exception {
+    JobEntity job = createTestJob();
+    job.setAttempts(2);
+    initJobTaskWithDefaultStubs(job);
+    String serviceName = JobTaskTest.class.getSimpleName() + ".testJobMethod";
+    CircuitBreakerOpenException rejection =
+        new CircuitBreakerOpenException("Circuit breaker OPEN for service: " + serviceName);
+    when(jobStore.getJobStatus(JOB_UUID)).thenReturn(JobStatus.RUNNING);
+    when(resilienceStrategy.isServiceAvailable(serviceName)).thenReturn(true);
+    when(resilienceStrategy.execute(eq(serviceName), any(Callable.class))).thenThrow(rejection);
+    when(resilienceStrategy.getRetryDelay(serviceName)).thenReturn(Duration.ofMillis(250));
+
+    jobTask.call();
+
+    verify(resilienceStrategy).getRetryDelay(serviceName);
+    verify(jobStore)
+        .scheduleJobRetry(
+            eq(JOB_UUID), eq("Circuit breaker OPEN for service: " + serviceName), any(), eq(2));
+    verify(observabilityFacade).saveExecution(any(JobExecutionEntity.class));
+    verify(jobStore, never()).incrementRetryAttempt(any(UUID.class));
+    verify(retryPolicy, never()).shouldRetry(anyInt(), any());
+    verify(lifecycleFacade, never()).moveToDlq(any(), any());
+    verify(observabilityFacade, never()).recordJobFailure(any(), any(), anyInt());
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 class CircuitBreakerTest {
 
@@ -83,7 +84,7 @@ class CircuitBreakerTest {
     breaker.transitionToOpen();
     assertEquals(CircuitBreaker.State.OPEN, breaker.getState());
 
-    assertThrows(ServiceUnavailableException.class, () -> breaker.execute(() -> "should not run"));
+    assertThrows(CircuitBreakerOpenException.class, () -> breaker.execute(() -> "should not run"));
   }
 
   @Test
@@ -122,8 +123,8 @@ class CircuitBreakerTest {
       Future<String> second = executor.submit(() -> blockingHalfOpenCall(started, release));
       assertTrue(started.await(1, java.util.concurrent.TimeUnit.SECONDS));
 
-      ServiceUnavailableException thrown =
-          assertThrows(ServiceUnavailableException.class, () -> breaker.execute(() -> "extra"));
+      CircuitBreakerOpenException thrown =
+          assertThrows(CircuitBreakerOpenException.class, () -> breaker.execute(() -> "extra"));
       assertTrue(thrown.getMessage().contains("HALF_OPEN"));
 
       release.countDown();

--- a/ratchet/src/test/java/run/ratchet/ri/resilience/DefaultResilienceStrategyTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/resilience/DefaultResilienceStrategyTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.CircuitBreakerProfile;
 import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.spi.CircuitBreakerConfig;
 import run.ratchet.spi.CircuitBreakerConfigProvider;
 
@@ -49,7 +50,7 @@ class DefaultResilienceStrategyTest {
     }
 
     assertThrows(
-        ServiceUnavailableException.class,
+        CircuitBreakerOpenException.class,
         () -> strategy.execute("failing-service", () -> "should not run"));
     assertFalse(strategy.isServiceAvailable("failing-service"));
   }

--- a/website/docs/advanced/circuit-breakers.md
+++ b/website/docs/advanced/circuit-breakers.md
@@ -32,7 +32,7 @@ CLOSED                    OPEN
 
 **CLOSED** -- The circuit is healthy. All calls pass through normally. Success and failure outcomes are tracked in a sliding window (ring buffer of the last N calls). When the failure rate exceeds the configured threshold and the minimum call count has been reached, the circuit transitions to OPEN.
 
-**OPEN** -- The circuit has tripped. All calls are rejected immediately with a `ServiceUnavailableException`, avoiding wasted work against a failing service. After the configured wait duration, the circuit transitions to HALF_OPEN.
+**OPEN** -- The circuit has tripped. All calls are rejected immediately with a `CircuitBreakerOpenException`, avoiding wasted work against a failing service. After the configured wait duration, the circuit transitions to HALF_OPEN.
 
 **HALF_OPEN** -- The circuit is testing recovery. A limited number of trial calls are permitted. If all trial calls succeed, the circuit resets to CLOSED. If any trial call fails, the circuit returns to OPEN.
 
@@ -205,6 +205,7 @@ For cases where annotation-based protection is insufficient, inject the `Circuit
 import run.ratchet.ri.resilience.CircuitBreakerRegistry;
 import run.ratchet.ri.resilience.CircuitBreaker;
 import run.ratchet.api.CircuitBreakerProfile;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 @ApplicationScoped
 public class AdaptiveJobService {
@@ -220,7 +221,7 @@ public class AdaptiveJobService {
                 work.run();
                 return null;
             });
-        } catch (ServiceUnavailableException e) {
+        } catch (CircuitBreakerOpenException e) {
             // Circuit is OPEN -- queue for later or use fallback
             log.warning("Service " + serviceName + " unavailable, queuing for retry");
         }
@@ -323,16 +324,16 @@ public class Resilience4jStrategy implements ResilienceStrategy {
 }
 ```
 
-## Handling ServiceUnavailableException
+## Handling CircuitBreakerOpenException
 
-When a circuit breaker is OPEN, calls throw `ServiceUnavailableException`. The Ratchet job engine handles this automatically by deferring the job and respecting the `getRetryDelay()` value from the `ResilienceStrategy`. For direct programmatic use, you should catch and handle this exception:
+When a circuit breaker is OPEN, calls throw `CircuitBreakerOpenException`. The Ratchet job engine handles this automatically by deferring the job and respecting the `getRetryDelay()` value from the `ResilienceStrategy`. For direct programmatic use, you should catch and handle this exception:
 
 ```java
-import run.ratchet.ri.resilience.ServiceUnavailableException;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 try {
     breaker.execute(() -> externalApi.call());
-} catch (ServiceUnavailableException e) {
+} catch (CircuitBreakerOpenException e) {
     // Service is down -- use a fallback or queue for later
     return cachedResult;
 }

--- a/website/docs/advanced/custom-retry-policies.md
+++ b/website/docs/advanced/custom-retry-policies.md
@@ -224,7 +224,7 @@ Combine retry policy with circuit breaker awareness to stop retrying when the do
 ```java
 import run.ratchet.spi.RetryPolicy;
 import run.ratchet.spi.ResilienceStrategy;
-import run.ratchet.ri.resilience.ServiceUnavailableException;
+import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -244,7 +244,7 @@ public class CircuitBreakerAwareRetryPolicy implements RetryPolicy {
     @Override
     public boolean shouldRetry(int attempt, Throwable cause) {
         // Don't retry if the circuit breaker rejected the call
-        if (cause instanceof ServiceUnavailableException) {
+        if (cause instanceof CircuitBreakerOpenException) {
             return false;
         }
         // Allow up to 5 retries for other failures

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -119,7 +119,7 @@ Executes the task with resilience protection.
 
 **Returns:** the result of the task.
 
-**Throws:** `Exception` if the task fails or the service is unavailable.
+**Throws:** `CircuitBreakerOpenException` if a circuit-open rejection prevents the task from running; `Exception` if the task itself fails.
 
 ### isServiceAvailable
 
@@ -127,7 +127,7 @@ Executes the task with resilience protection.
 boolean isServiceAvailable(String serviceName)
 ```
 
-Checks whether calls to the named service are currently permitted (circuit not open).
+Checks whether calls to the named service are currently permitted (circuit not open). This is an advisory pre-check; callers still need to handle `CircuitBreakerOpenException` from `execute()`.
 
 ### getRetryDelay
 
@@ -135,7 +135,7 @@ Checks whether calls to the named service are currently permitted (circuit not o
 default Duration getRetryDelay(String serviceName)
 ```
 
-Returns the recommended delay before retrying work rejected because the service is unavailable. Default implementation returns 30 seconds.
+Returns the recommended delay before retrying work rejected because the circuit is open. Implementations must not return `null` or a negative duration. Default implementation returns 30 seconds.
 
 ### Example
 


### PR DESCRIPTION
## Summary

v5 called out a real SPI leak: third-party `ResilienceStrategy` implementations had no API-level way to signal that the circuit is open. The only practical exception lived in the RI module.

This adds `CircuitBreakerOpenException` to the public API, keeps `ServiceUnavailableException` as a deprecated compatibility alias, and teaches `JobTask` to reschedule circuit-open rejections without counting them as job attempts. It also adds a resilience-strategy TCK contract.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet -am -DskipITs -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false -Dtest=JobTaskTest,DefaultResilienceStrategyTest,CircuitBreakerTest test`
- `mvn -pl ratchet-tck/api -am test`
- `mvn -pl ratchet-testsuite -am -DskipTests test-compile`
- Spotless check
- `git diff --check`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

Implementations that want to run the new TCK contract need a test hook that can force the circuit-open path.
