### PR TITLE
authorize signals and defer events

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -248,6 +248,9 @@ public interface JobSchedulerService {
    * <p>The signal payload is serialized and stored on the job entity; it is accessible to the
    * executing task via {@link JobContext#signalPayload(Class)}.
    *
+   * <p>Subject to {@link run.ratchet.spi.JobAuthorizationPolicy#checkDeliverSignal(UUID, String,
+   * String)}.
+   *
    * <p><b>Transaction attribute:</b> {@code REQUIRED}.
    *
    * @param jobId UUIDv7 job id of the WAITING job
@@ -264,6 +267,9 @@ public interface JobSchedulerService {
    *
    * <p>Idempotent: if the job is already in a non-WAITING state (including terminal states), this
    * method returns {@code 0} without modifying the job.
+   *
+   * <p>Subject to {@link run.ratchet.spi.JobAuthorizationPolicy#checkDeliverSignal(UUID, String,
+   * String)}.
    *
    * <p><b>Transaction attribute:</b> {@code REQUIRED}.
    *
@@ -285,6 +291,10 @@ public interface JobSchedulerService {
    * <p>Idempotent: jobs already past WAITING are not affected and do not count toward the return
    * value.
    *
+   * <p>Subject to {@link run.ratchet.spi.JobAuthorizationPolicy#checkDeliverSignal(String,
+   * String)}. Because this is an atomic bulk operation, the policy receives the signal key rather
+   * than per-job owner principals.
+   *
    * <p><b>Transaction attribute:</b> {@code REQUIRED}.
    *
    * @param signalKey the named signal to broadcast
@@ -297,6 +307,10 @@ public interface JobSchedulerService {
   /**
    * Delivers a structured approval/rejection decision to all WAITING jobs whose {@code signalKey}
    * matches, transitioning each to PENDING.
+   *
+   * <p>Subject to {@link run.ratchet.spi.JobAuthorizationPolicy#checkDeliverSignal(String,
+   * String)}. Because this is an atomic bulk operation, the policy receives the signal key rather
+   * than per-job owner principals.
    *
    * <p><b>Transaction attribute:</b> {@code REQUIRED}.
    *

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
@@ -38,7 +38,10 @@ public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
     return signalKey;
   }
 
-  /** Returns the configured maximum wait duration that elapsed. */
+  /**
+   * Returns the configured maximum wait duration that elapsed, or {@code null} when the timeout was
+   * not available on the job snapshot.
+   */
   public Duration getSignalTimeout() {
     return signalTimeout;
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkSignaledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkSignaledEvent.java
@@ -37,7 +37,7 @@ public class JobsBulkSignaledEvent implements Serializable {
       Instant signaledAt) {
     this.signalKey = Objects.requireNonNull(signalKey, "signalKey");
     this.count = count;
-    this.signalDeliveredBy = signalDeliveredBy;
+    this.signalDeliveredBy = Objects.requireNonNull(signalDeliveredBy, "signalDeliveredBy");
     this.outcome = Objects.requireNonNull(outcome, "outcome");
     this.rejectionReason =
         rejectionReason == null || rejectionReason.isBlank() ? null : rejectionReason.trim();
@@ -54,10 +54,7 @@ public class JobsBulkSignaledEvent implements Serializable {
     return count;
   }
 
-  /**
-   * Returns the principal that delivered the signal, or {@code null} if no security context was
-   * active.
-   */
+  /** Returns the principal or system component that delivered the signal. */
   public String getSignalDeliveredBy() {
     return signalDeliveredBy;
   }

--- a/ratchet-api/src/main/java/run/ratchet/spi/JobAuthorizationPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/JobAuthorizationPolicy.java
@@ -130,6 +130,42 @@ public interface JobAuthorizationPolicy {
       throws JobAuthorizationException;
 
   /**
+   * Called before delivering a signal to a specific job, within the {@code REQUIRED} transaction.
+   *
+   * <p>Note: same TOCTOU caveat as {@link #checkCancel} — {@code ownerPrincipal} may be {@code
+   * null} if the job was deleted between the pre-load and the signal delivery CAS.
+   *
+   * <p>The default implementation is a no-op for compatibility. Override to enforce who may unblock
+   * a WAITING job.
+   *
+   * @param jobId the job to signal
+   * @param ownerPrincipal the principal who created the job; {@code null} for system jobs
+   * @param currentPrincipal the principal delivering the signal; {@code null} if no security
+   *     context is active
+   * @throws JobAuthorizationException if signal delivery is denied
+   */
+  default void checkDeliverSignal(UUID jobId, String ownerPrincipal, String currentPrincipal)
+      throws JobAuthorizationException {}
+
+  /**
+   * Called before bulk delivery of a named signal, within the {@code REQUIRED} transaction.
+   *
+   * <p>Key-based delivery is an atomic bulk operation, so this hook receives the signal key instead
+   * of per-job owner principals. Policies that need owner-scoped authorization should require
+   * callers to use the job-id overload.
+   *
+   * <p>The default implementation is a no-op for compatibility. Override to restrict who may
+   * broadcast signals by key.
+   *
+   * @param signalKey the named signal being delivered
+   * @param currentPrincipal the principal delivering the signal; {@code null} if no security
+   *     context is active
+   * @throws JobAuthorizationException if signal delivery is denied
+   */
+  default void checkDeliverSignal(String signalKey, String currentPrincipal)
+      throws JobAuthorizationException {}
+
+  /**
    * Called before returning a single job's detail to the caller via {@link
    * run.ratchet.api.JobQueryService#getJobDetail}.
    *

--- a/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
@@ -140,6 +140,11 @@ class EventApiContractTest {
         NullPointerException.class,
         () ->
             new JobsBulkSignaledEvent(
+                "signal-key", 2, null, SignalDecision.Outcome.APPROVED, null, TIMESTAMP));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new JobsBulkSignaledEvent(
                 "signal-key", 2, "operator", SignalDecision.Outcome.APPROVED, null, null));
 
     JobsBulkSignaledEvent event =

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
@@ -1,6 +1,7 @@
 package run.ratchet.ri.cdi;
 
 import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.Initialized;
@@ -88,6 +89,8 @@ public class RatchetProducer {
   private final CircuitBreakerConfigProvider circuitBreakerConfigProvider;
   private volatile Instance.Handle<PayloadSerializer> dependentPayloadSerializerHandle;
 
+  @Resource private TransactionSynchronizationRegistry txRegistry;
+
   protected RatchetProducer() {
     this.executorProvider = null;
     this.metricsCollector = null;
@@ -156,8 +159,7 @@ public class RatchetProducer {
       Clock clock,
       InternalEventPublisher eventPublisher,
       WorkflowScheduler workflowScheduler,
-      SignalStore signalStore,
-      TransactionSynchronizationRegistry txRegistry) {
+      SignalStore signalStore) {
     int softTimeoutPercent = options.timeout().softTimeoutPercent();
     long defaultTimeoutSeconds = options.timeout().defaultSlaSeconds();
     int signalTimeoutBatchSize = options.timeout().signalTimeoutBatchSize();

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.Produces;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import jakarta.inject.Inject;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Clock;
 import java.util.EnumMap;
 import java.util.Map;
@@ -155,7 +156,8 @@ public class RatchetProducer {
       Clock clock,
       InternalEventPublisher eventPublisher,
       WorkflowScheduler workflowScheduler,
-      SignalStore signalStore) {
+      SignalStore signalStore,
+      TransactionSynchronizationRegistry txRegistry) {
     int softTimeoutPercent = options.timeout().softTimeoutPercent();
     long defaultTimeoutSeconds = options.timeout().defaultSlaSeconds();
     int signalTimeoutBatchSize = options.timeout().signalTimeoutBatchSize();
@@ -172,7 +174,8 @@ public class RatchetProducer {
         workflowScheduler,
         signalStore,
         metricsCollector,
-        signalTimeoutBatchSize);
+        signalTimeoutBatchSize,
+        txRegistry);
   }
 
   @Produces

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
@@ -1,7 +1,6 @@
 package run.ratchet.ri.cdi;
 
 import jakarta.annotation.PreDestroy;
-import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.Initialized;
@@ -25,6 +24,7 @@ import run.ratchet.ri.core.ExecutionObserver;
 import run.ratchet.ri.core.InternalEventPublisher;
 import run.ratchet.ri.core.JobExecutionCoordinator;
 import run.ratchet.ri.core.JobTimeoutHandler;
+import run.ratchet.ri.core.JobWakeupService;
 import run.ratchet.ri.core.OrphanRecoveryTimer;
 import run.ratchet.ri.core.Poller;
 import run.ratchet.ri.core.PollerScheduler;
@@ -89,7 +89,7 @@ public class RatchetProducer {
   private final CircuitBreakerConfigProvider circuitBreakerConfigProvider;
   private volatile Instance.Handle<PayloadSerializer> dependentPayloadSerializerHandle;
 
-  @Resource private TransactionSynchronizationRegistry txRegistry;
+  private volatile TransactionSynchronizationRegistry txRegistry;
 
   protected RatchetProducer() {
     this.executorProvider = null;
@@ -177,7 +177,21 @@ public class RatchetProducer {
         signalStore,
         metricsCollector,
         signalTimeoutBatchSize,
-        txRegistry);
+        resolveTxRegistry());
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    TransactionSynchronizationRegistry reg = txRegistry;
+    if (reg == null) {
+      synchronized (this) {
+        reg = txRegistry;
+        if (reg == null) {
+          reg = JobWakeupService.lookupTxRegistry(log);
+          txRegistry = reg;
+        }
+      }
+    }
+    return reg;
   }
 
   @Produces

--- a/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
@@ -1,9 +1,11 @@
 package run.ratchet.ri.core;
 
 import jakarta.annotation.PreDestroy;
+import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import jakarta.transaction.Transactional;
 import java.lang.reflect.Method;
 import java.time.Clock;
@@ -56,6 +58,8 @@ public class BatchService {
   private final BeanResolver beanResolver;
   private final Clock clock;
   private final Instance<BatchService> self;
+
+  @Resource private TransactionSynchronizationRegistry txRegistry;
 
   protected BatchService() {
     this.batchStore = null;
@@ -363,7 +367,7 @@ public class BatchService {
   }
 
   private void publishBatchEvent(BatchEntity batch, JobEntity parent) {
-    eventPublisher.publish(
+    BatchCompletingEvent event =
         new BatchCompletingEvent(
             batch.getId(),
             parent.getBusinessKey(),
@@ -372,7 +376,22 @@ public class BatchService {
             parent.getPickedBy(),
             batch.getTotalItems(),
             batch.getCompletedItems(),
-            batch.getFailedItems()));
+            batch.getFailedItems());
+    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+      eventPublisher.publish(event);
+    }
+  }
+
+  private boolean registerAfterCommit(Runnable action) {
+    return JobWakeupService.registerAfterCommit(
+        txRegistry,
+        action,
+        log,
+        "After-commit batch completing event registration failed; publishing immediately: %s");
+  }
+
+  void setTxRegistryForTesting(TransactionSynchronizationRegistry txRegistry) {
+    this.txRegistry = txRegistry;
   }
 
   private void trigger(BatchEntity batch) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
@@ -1,7 +1,6 @@
 package run.ratchet.ri.core;
 
 import jakarta.annotation.PreDestroy;
-import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -59,7 +58,7 @@ public class BatchService {
   private final Clock clock;
   private final Instance<BatchService> self;
 
-  @Resource private TransactionSynchronizationRegistry txRegistry;
+  private volatile TransactionSynchronizationRegistry txRegistry;
 
   protected BatchService() {
     this.batchStore = null;
@@ -384,10 +383,24 @@ public class BatchService {
 
   private boolean registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
-        txRegistry,
+        resolveTxRegistry(),
         action,
         log,
         "After-commit batch completing event registration failed; publishing immediately: %s");
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    TransactionSynchronizationRegistry reg = txRegistry;
+    if (reg == null) {
+      synchronized (this) {
+        reg = txRegistry;
+        if (reg == null) {
+          reg = JobWakeupService.lookupTxRegistry(log);
+          txRegistry = reg;
+        }
+      }
+    }
+    return reg;
   }
 
   void setTxRegistryForTesting(TransactionSynchronizationRegistry txRegistry) {
@@ -460,9 +473,21 @@ public class BatchService {
     if (batchStore.markBatchCompleteIfReady(parentId)) {
       // markBatchCompleteIfReady can have more than one apparent winner under concurrent commits.
       // The parent pickup CAS in processBatchCompletion is the exactly-once gate.
-      return processBatchCompletion(parentId, batchFromProgress(progress));
+      return processBatchCompletion(parentId, completionSnapshot(parentId, progress));
     }
     return false;
+  }
+
+  private BatchEntity completionSnapshot(UUID parentId, BatchProgress progress) {
+    return batchStore
+        .findBatchById(parentId)
+        .orElseGet(
+            () -> {
+              log.warnf(
+                  "Batch %s not found after completion marker was set; using progress snapshot",
+                  parentId);
+              return batchFromProgress(progress);
+            });
   }
 
   private BatchEntity batchFromProgress(BatchProgress progress) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -2,7 +2,6 @@ package run.ratchet.ri.core;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.time.ExecutionTime;
-import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.TransactionSynchronizationRegistry;
@@ -77,7 +76,7 @@ public class DefaultJobCreationService
   private final MetricsCollector metricsCollector;
   private final Clock clock;
 
-  @Resource private TransactionSynchronizationRegistry txRegistry;
+  private volatile TransactionSynchronizationRegistry txRegistry;
 
   protected DefaultJobCreationService() {
     this.jobBatchStatusStore = null;
@@ -607,10 +606,24 @@ public class DefaultJobCreationService
 
   private boolean registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
-        txRegistry,
+        resolveTxRegistry(),
         action,
         log,
         "After-commit signal waiting event registration failed; publishing immediately: %s");
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    TransactionSynchronizationRegistry reg = txRegistry;
+    if (reg == null) {
+      synchronized (this) {
+        reg = txRegistry;
+        if (reg == null) {
+          reg = JobWakeupService.lookupTxRegistry(log);
+          txRegistry = reg;
+        }
+      }
+    }
+    return reg;
   }
 
   void setTxRegistryForTesting(TransactionSynchronizationRegistry txRegistry) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -2,8 +2,10 @@ package run.ratchet.ri.core;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.time.ExecutionTime;
+import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import jakarta.transaction.Transactional;
 import java.io.Serializable;
 import java.time.Clock;
@@ -74,6 +76,8 @@ public class DefaultJobCreationService
   private final InternalEventPublisher eventPublisher;
   private final MetricsCollector metricsCollector;
   private final Clock clock;
+
+  @Resource private TransactionSynchronizationRegistry txRegistry;
 
   protected DefaultJobCreationService() {
     this.jobBatchStatusStore = null;
@@ -230,15 +234,7 @@ public class DefaultJobCreationService
     UUID jobId = saved.getId();
 
     if (isSignalWaiting && eventPublisher != null) {
-      eventPublisher.publish(
-          new JobSignalWaitingEvent(
-              jobId,
-              saved.getBusinessKey(),
-              saved.getPublicJobType(),
-              saved.getPriority(),
-              null,
-              signalKey,
-              signalTimeout));
+      publishSignalWaitingEvent(saved, signalKey, signalTimeout);
     }
     if (isSignalWaiting && metricsCollector != null) {
       metricsCollector.signalWaiting(jobId, saved.getPublicJobType(), signalKey);
@@ -591,6 +587,34 @@ public class DefaultJobCreationService
       job.setId(UuidV7Factory.create());
     }
     authorizationPolicy.checkCreate(job.getId(), job.getCallerPrincipal());
+  }
+
+  private void publishSignalWaitingEvent(
+      JobEntity saved, String signalKey, Duration signalTimeout) {
+    JobSignalWaitingEvent event =
+        new JobSignalWaitingEvent(
+            saved.getId(),
+            saved.getBusinessKey(),
+            saved.getPublicJobType(),
+            saved.getPriority(),
+            null,
+            signalKey,
+            signalTimeout);
+    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+      eventPublisher.publish(event);
+    }
+  }
+
+  private boolean registerAfterCommit(Runnable action) {
+    return JobWakeupService.registerAfterCommit(
+        txRegistry,
+        action,
+        log,
+        "After-commit signal waiting event registration failed; publishing immediately: %s");
+  }
+
+  void setTxRegistryForTesting(TransactionSynchronizationRegistry txRegistry) {
+    this.txRegistry = txRegistry;
   }
 
   /**

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -717,6 +717,11 @@ public class DefaultJobSchedulerService
         callerPrincipalProvider != null
             ? callerPrincipalProvider.currentPrincipal().orElse(null)
             : null;
+    if (authorizationPolicy != null) {
+      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
+      String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
+      authorizationPolicy.checkDeliverSignal(jobId, ownerPrincipal, principal);
+    }
     String serializedPayload = serializeSignalPayload(payload);
     Instant now = effective().instant();
     String deliveryId = UUID.randomUUID().toString();
@@ -749,6 +754,11 @@ public class DefaultJobSchedulerService
         callerPrincipalProvider != null
             ? callerPrincipalProvider.currentPrincipal().orElse(null)
             : null;
+    if (authorizationPolicy != null) {
+      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
+      String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
+      authorizationPolicy.checkDeliverSignal(jobId, ownerPrincipal, principal);
+    }
     String serializedPayload = serializeSignalPayload(decision.payload());
     Instant now = effective().instant();
     String deliveryId = UUID.randomUUID().toString();
@@ -781,6 +791,10 @@ public class DefaultJobSchedulerService
         callerPrincipalProvider != null
             ? callerPrincipalProvider.currentPrincipal().orElse(null)
             : null;
+    if (authorizationPolicy != null) {
+      authorizationPolicy.checkDeliverSignal(signalKey, principal);
+    }
+    String deliveredBy = principal != null ? principal : DEFAULT_SIGNAL_DELIVERED_BY;
     String serializedPayload = serializeSignalPayload(payload);
     Instant now = effective().instant();
     String deliveryId = UUID.randomUUID().toString();
@@ -792,13 +806,13 @@ public class DefaultJobSchedulerService
             SIGNAL_PAYLOAD_TYPE_RAW,
             SignalDecision.Outcome.APPROVED.name(),
             null,
-            principal,
+            deliveredBy,
             now,
             deliveryId);
     if (unblocked > 0) {
       publishBulkSignaledEvent(
-          signalKey, unblocked, principal, SignalDecision.Outcome.APPROVED, null);
-      log.debugf("Signal '%s' broadcast to %s job(s) by %s", signalKey, unblocked, principal);
+          signalKey, unblocked, deliveredBy, SignalDecision.Outcome.APPROVED, null);
+      log.debugf("Signal '%s' broadcast to %s job(s) by %s", signalKey, unblocked, deliveredBy);
     }
     return unblocked;
   }
@@ -812,6 +826,10 @@ public class DefaultJobSchedulerService
         callerPrincipalProvider != null
             ? callerPrincipalProvider.currentPrincipal().orElse(null)
             : null;
+    if (authorizationPolicy != null) {
+      authorizationPolicy.checkDeliverSignal(signalKey, principal);
+    }
+    String deliveredBy = principal != null ? principal : DEFAULT_SIGNAL_DELIVERED_BY;
     String serializedPayload = serializeSignalPayload(decision.payload());
     Instant now = effective().instant();
     String deliveryId = UUID.randomUUID().toString();
@@ -823,14 +841,14 @@ public class DefaultJobSchedulerService
             SIGNAL_PAYLOAD_TYPE_DECISION,
             decision.outcome().name(),
             decision.rejectionReason(),
-            principal,
+            deliveredBy,
             now,
             deliveryId);
     if (unblocked > 0) {
       publishBulkSignaledEvent(
-          signalKey, unblocked, principal, decision.outcome(), decision.rejectionReason());
+          signalKey, unblocked, deliveredBy, decision.outcome(), decision.rejectionReason());
       log.debugf(
-          "Signal decision '%s' broadcast to %s job(s) by %s", signalKey, unblocked, principal);
+          "Signal decision '%s' broadcast to %s job(s) by %s", signalKey, unblocked, deliveredBy);
     }
     return unblocked;
   }

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
@@ -320,10 +320,14 @@ public class JobTimeoutHandler {
 
   private boolean registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
-        txRegistry,
+        resolveTxRegistry(),
         action,
         log,
         "After-commit signal timeout event registration failed; publishing immediately: %s");
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    return txRegistry != null ? txRegistry : JobWakeupService.lookupTxRegistry(log);
   }
 
   private String formatDuration(Duration duration) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
@@ -1,5 +1,6 @@
 package run.ratchet.ri.core;
 
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -43,6 +44,7 @@ public class JobTimeoutHandler {
   private final long defaultTimeoutSeconds;
   private final Clock clock;
   private final int signalTimeoutBatchSize;
+  private final TransactionSynchronizationRegistry txRegistry;
 
   protected JobTimeoutHandler() {
     this.jobCrudStore = null;
@@ -57,6 +59,7 @@ public class JobTimeoutHandler {
     this.defaultTimeoutSeconds = 0;
     this.clock = null;
     this.signalTimeoutBatchSize = 0;
+    this.txRegistry = null;
   }
 
   public JobTimeoutHandler(
@@ -72,6 +75,36 @@ public class JobTimeoutHandler {
       SignalStore signalStore,
       MetricsCollector metricsCollector,
       int signalTimeoutBatchSize) {
+    this(
+        jobCrudStore,
+        jobRetryStore,
+        jobBatchStatusStore,
+        lifecycleFacade,
+        softTimeoutPercent,
+        defaultTimeoutSeconds,
+        clock,
+        eventPublisher,
+        chainScheduler,
+        signalStore,
+        metricsCollector,
+        signalTimeoutBatchSize,
+        null);
+  }
+
+  public JobTimeoutHandler(
+      JobCrudStore jobCrudStore,
+      JobRetryStore jobRetryStore,
+      JobBatchStatusStore jobBatchStatusStore,
+      PostExecutionHandler lifecycleFacade,
+      int softTimeoutPercent,
+      long defaultTimeoutSeconds,
+      Clock clock,
+      InternalEventPublisher eventPublisher,
+      ChainScheduler chainScheduler,
+      SignalStore signalStore,
+      MetricsCollector metricsCollector,
+      int signalTimeoutBatchSize,
+      TransactionSynchronizationRegistry txRegistry) {
     this.jobCrudStore = jobCrudStore;
     this.jobRetryStore = jobRetryStore;
     this.jobBatchStatusStore = jobBatchStatusStore;
@@ -84,6 +117,7 @@ public class JobTimeoutHandler {
     this.signalStore = signalStore;
     this.metricsCollector = metricsCollector;
     this.signalTimeoutBatchSize = Math.max(1, signalTimeoutBatchSize);
+    this.txRegistry = txRegistry;
   }
 
   public TimeoutHandles scheduleTimeoutMonitoring(
@@ -218,7 +252,6 @@ public class JobTimeoutHandler {
       Instant retryTime = now.plusMillis(backoffMs);
       boolean rescheduled = jobRetryStore.scheduleJobRetry(jobId, message, retryTime, newAttempts);
       if (rescheduled) {
-        publishSignalTimedOutEvent(job, now);
         log.warnf(
             "Job %s signal timed out but has retries remaining (%s/%s) — rescheduled for %s",
             jobId, newAttempts, job.getMaxRetries(), retryTime);
@@ -239,7 +272,7 @@ public class JobTimeoutHandler {
     }
 
     log.infof("Job %s FAILED due to signal timeout (key=%s)", jobId, job.getSignalKey());
-    publishSignalTimedOutEvent(job, now);
+    publishSignalTimedOutEvent(job);
     lifecycleFacade.handlePermanentFailure(job, timeoutEx);
 
     if (chainScheduler != null) {
@@ -260,16 +293,18 @@ public class JobTimeoutHandler {
     return effective().instant().plusSeconds(timeoutSec).plusMillis(jitterMs);
   }
 
-  private void publishSignalTimedOutEvent(JobEntity job, Instant now) {
+  private void publishSignalTimedOutEvent(JobEntity job) {
     if (metricsCollector != null) {
       metricsCollector.signalTimedOut(job.getId(), job.getPublicJobType(), job.getSignalKey());
     }
     if (eventPublisher == null) {
       return;
     }
-    Duration elapsed =
-        job.getSignalTimeout() != null ? Duration.between(job.getSignalTimeout(), now) : null;
-    eventPublisher.publish(
+    Duration configuredTimeout =
+        job.getCreatedAt() != null && job.getSignalTimeout() != null
+            ? Duration.between(job.getCreatedAt(), job.getSignalTimeout())
+            : null;
+    JobSignalTimedOutEvent event =
         new JobSignalTimedOutEvent(
             job.getId(),
             job.getBusinessKey(),
@@ -277,7 +312,18 @@ public class JobTimeoutHandler {
             job.getPriority(),
             null,
             job.getSignalKey(),
-            elapsed != null ? elapsed.abs() : null));
+            configuredTimeout);
+    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+      eventPublisher.publish(event);
+    }
+  }
+
+  private boolean registerAfterCommit(Runnable action) {
+    return JobWakeupService.registerAfterCommit(
+        txRegistry,
+        action,
+        log,
+        "After-commit signal timeout event registration failed; publishing immediately: %s");
   }
 
   private String formatDuration(Duration duration) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobWakeupService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobWakeupService.java
@@ -1,6 +1,5 @@
 package run.ratchet.ri.core;
 
-import jakarta.annotation.Resource;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -8,6 +7,8 @@ import jakarta.transaction.Status;
 import jakarta.transaction.Synchronization;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Duration;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.spi.ClusterCoordinator;
@@ -29,7 +30,7 @@ public class JobWakeupService {
   private final Instance<PollerScheduler> pollerSchedulerInstance;
   private final MetricsCollector metricsCollector;
 
-  @Resource private TransactionSynchronizationRegistry txRegistry;
+  private volatile TransactionSynchronizationRegistry txRegistry;
 
   protected JobWakeupService() {
     this.clusterCoordinator = null;
@@ -93,7 +94,32 @@ public class JobWakeupService {
 
   private boolean registerAfterCommit(Runnable action) {
     return registerAfterCommit(
-        txRegistry, action, log, "After-commit wakeup registration error; firing now: %s");
+        resolveTxRegistry(), action, log, "After-commit wakeup registration error; firing now: %s");
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    TransactionSynchronizationRegistry reg = txRegistry;
+    if (reg == null) {
+      synchronized (this) {
+        reg = txRegistry;
+        if (reg == null) {
+          reg = lookupTxRegistry(log);
+          txRegistry = reg;
+        }
+      }
+    }
+    return reg;
+  }
+
+  public static TransactionSynchronizationRegistry lookupTxRegistry(Logger log) {
+    try {
+      return InitialContext.doLookup("java:comp/TransactionSynchronizationRegistry");
+    } catch (NamingException e) {
+      log.debugf(
+          "TransactionSynchronizationRegistry lookup unavailable; using immediate fallback: %s",
+          e.getMessage());
+      return null;
+    }
   }
 
   static boolean registerAfterCommit(

--- a/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import jakarta.transaction.Transactional;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -58,6 +61,7 @@ class BatchServiceTest {
   @Mock private WorkflowScheduler workflowScheduler;
   @Mock private ClassPolicy classPolicy;
   @Mock private BeanResolver beanResolver;
+  @Mock private TransactionSynchronizationRegistry txRegistry;
 
   private BatchService batchService;
 
@@ -142,6 +146,42 @@ class BatchServiceTest {
     assertEquals(0, completingEvent.getFailedItems());
     verify(batchStore, never()).findBatchById(parentId);
     verify(jobTerminalStore).markJobSucceededMinimal(parentId, FIXED_NOW, FIXED_NOW, 0L, 0L);
+  }
+
+  @Test
+  void completedBatchEventPublishesAfterCommit() {
+    batchService.setTxRegistryForTesting(txRegistry);
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    ArgumentCaptor<Synchronization> synchronizationCaptor =
+        ArgumentCaptor.forClass(Synchronization.class);
+    UUID parentId = UUID.randomUUID();
+    JobEntity child = new JobEntity();
+    child.setDependsOn(parentId);
+    BatchProgress progress = new BatchProgress(parentId, 1, 1, 0, null);
+    JobEntity parent = new JobEntity();
+    parent.setId(parentId);
+    parent.setStatus(JobStatus.PENDING);
+    parent.setJobType(JobExecutionType.BATCH_PARENT);
+    parent.setPriority(JobPriority.NORMAL);
+
+    when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(progress);
+    when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
+    when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
+        .thenReturn(true);
+    when(jobTerminalStore.markJobSucceededMinimal(parentId, FIXED_NOW, FIXED_NOW, 0L, 0L))
+        .thenReturn(true);
+    when(metricsStore.findBatchMetrics(parentId)).thenReturn(Optional.empty());
+    when(workflowScheduler.scheduleNext(any(JobEntity.class))).thenReturn(false);
+
+    batchService.markChildSucceeded(child);
+
+    verify(txRegistry).registerInterposedSynchronization(synchronizationCaptor.capture());
+    verify(eventPublisher, never()).publish(any());
+
+    synchronizationCaptor.getValue().afterCompletion(Status.STATUS_COMMITTED);
+
+    verify(eventPublisher).publish(any(BatchCompletingEvent.class));
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
@@ -144,7 +144,7 @@ class BatchServiceTest {
     assertEquals(3, completingEvent.getTotalItems());
     assertEquals(3, completingEvent.getCompletedItems());
     assertEquals(0, completingEvent.getFailedItems());
-    verify(batchStore, never()).findBatchById(parentId);
+    verify(batchStore).findBatchById(parentId);
     verify(jobTerminalStore).markJobSucceededMinimal(parentId, FIXED_NOW, FIXED_NOW, 0L, 0L);
   }
 
@@ -166,6 +166,7 @@ class BatchServiceTest {
 
     when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(progress);
     when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(batchStore.findBatchById(parentId)).thenReturn(Optional.of(batch(parentId, 1, 1, 0)));
     when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
     when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
         .thenReturn(true);
@@ -182,6 +183,36 @@ class BatchServiceTest {
     synchronizationCaptor.getValue().afterCompletion(Status.STATUS_COMMITTED);
 
     verify(eventPublisher).publish(any(BatchCompletingEvent.class));
+  }
+
+  @Test
+  void completedBatchUsesFreshBatchSnapshotAfterReadinessRace() {
+    UUID parentId = UUID.randomUUID();
+    JobEntity child = new JobEntity();
+    child.setDependsOn(parentId);
+
+    BatchProgress staleSuccessProgress = new BatchProgress(parentId, 3, 2, 0, null);
+    BatchEntity freshCompletedBatch = batch(parentId, 3, 2, 1);
+    JobEntity parent = parent(parentId);
+
+    when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(staleSuccessProgress);
+    when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(batchStore.findBatchById(parentId)).thenReturn(Optional.of(freshCompletedBatch));
+    when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
+    when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
+        .thenReturn(true);
+    when(jobTerminalStore.markJobFailedTerminal(
+            parentId, "Batch completed with 1 failed children", 0))
+        .thenReturn(true);
+    when(metricsStore.findBatchMetrics(parentId)).thenReturn(Optional.empty());
+    when(workflowScheduler.scheduleNext(any(JobEntity.class))).thenReturn(false);
+
+    batchService.markChildSucceeded(child);
+
+    assertEquals(JobStatus.FAILED, parent.getStatus());
+    verify(jobTerminalStore, never()).markJobSucceededMinimal(any(), any(), any(), any(), any());
+    verify(jobTerminalStore)
+        .markJobFailedTerminal(parentId, "Batch completed with 1 failed children", 0);
   }
 
   @Test
@@ -209,7 +240,7 @@ class BatchServiceTest {
     verify(metricsStore, never()).finalizeBatchMetrics(any());
     verify(eventPublisher, never()).publish(any());
     verify(workflowScheduler, never()).scheduleNext(any());
-    verify(batchStore, never()).findBatchById(parentId);
+    verify(batchStore).findBatchById(parentId);
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
@@ -13,6 +13,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -68,6 +71,7 @@ class DefaultJobCreationServiceAuthorizationTest {
   @Mock private JobAuthorizationPolicy authorizationPolicy;
   @Mock private InternalEventPublisher eventPublisher;
   @Mock private MetricsCollector metricsCollector;
+  @Mock private TransactionSynchronizationRegistry txRegistry;
 
   private DefaultJobCreationService service;
   private JobWakeupService wakeupService;
@@ -304,6 +308,31 @@ class DefaultJobCreationServiceAuthorizationTest {
     service.submit(builder);
 
     verify(metricsCollector).signalWaiting(saved.getId(), JobType.SINGLE, "approval");
+    verify(eventPublisher).publish(any(JobSignalWaitingEvent.class));
+  }
+
+  @Test
+  void signalWaitingEventPublishesAfterCommit() {
+    service.setTxRegistryForTesting(txRegistry);
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    ArgumentCaptor<Synchronization> synchronizationCaptor =
+        ArgumentCaptor.forClass(Synchronization.class);
+    JobEntity saved = savedEntity();
+    when(jobCrudStore.findByIdempotencyKey(anyString())).thenReturn(Optional.empty());
+    when(jobCrudStore.create(any(JobEntity.class))).thenReturn(saved);
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                    service, DefaultJobCreationServiceAuthorizationTest::noopTask, Duration.ZERO)
+                .awaitSignal("approval", Duration.ofSeconds(30));
+
+    service.submit(builder);
+
+    verify(txRegistry).registerInterposedSynchronization(synchronizationCaptor.capture());
+    verify(eventPublisher, never()).publish(any(JobSignalWaitingEvent.class));
+
+    synchronizationCaptor.getValue().afterCompletion(Status.STATUS_COMMITTED);
+
     verify(eventPublisher).publish(any(JobSignalWaitingEvent.class));
   }
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceSignalTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceSignalTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,7 +32,9 @@ import run.ratchet.api.SignalDecision;
 import run.ratchet.api.event.JobSignaledEvent;
 import run.ratchet.api.event.JobsBulkCancelledEvent;
 import run.ratchet.api.event.JobsBulkSignaledEvent;
+import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.PayloadSerializer;
 import run.ratchet.store.entity.JobEntity;
@@ -65,6 +68,7 @@ class DefaultJobSchedulerServiceSignalTest {
   @Mock private JobWakeupService wakeupService;
   @Mock private RecurringScheduler recurringScheduler;
   @Mock private DefaultJobCreationService jobCreationService;
+  @Mock private JobAuthorizationPolicy authorizationPolicy;
   @Mock private SignalStore signalStore;
   @Mock private PayloadSerializer payloadSerializer;
   @Mock private MetricsCollector metricsCollector;
@@ -229,6 +233,77 @@ class DefaultJobSchedulerServiceSignalTest {
   }
 
   @Test
+  void deliverSignalByIdChecksAuthorizationBeforeStoreUpdate() {
+    DefaultJobSchedulerService authorizedService =
+        newService(payloadSerializer, authorizationPolicy);
+    JobEntity job = job(JOB_ID, "approval-key");
+    job.setCallerPrincipal("alice");
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(signalStore.deliverSignalById(
+            eq(JOB_ID),
+            isNull(),
+            eq(DefaultJobSchedulerService.SIGNAL_PAYLOAD_TYPE_RAW),
+            eq("APPROVED"),
+            isNull(),
+            eq("bob"),
+            eq(FIXED_NOW),
+            anyString()))
+        .thenReturn(1);
+
+    assertEquals(1, authorizedService.deliverSignal(JOB_ID, (Serializable) null));
+
+    verify(authorizationPolicy).checkDeliverSignal(JOB_ID, "alice", "bob");
+    verify(signalStore)
+        .deliverSignalById(
+            eq(JOB_ID), isNull(), eq("RAW"), eq("APPROVED"), isNull(), eq("bob"), any(), any());
+  }
+
+  @Test
+  void deliverSignalByIdAuthorizationDenialSkipsStoreUpdate() {
+    DefaultJobSchedulerService authorizedService =
+        newService(payloadSerializer, authorizationPolicy);
+    JobEntity job = job(JOB_ID, "approval-key");
+    job.setCallerPrincipal("alice");
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    doThrow(new JobAuthorizationException(JOB_ID, "deliverSignal", "bob", "denied"))
+        .when(authorizationPolicy)
+        .checkDeliverSignal(JOB_ID, "alice", "bob");
+
+    assertThrows(
+        JobAuthorizationException.class,
+        () -> authorizedService.deliverSignal(JOB_ID, (Serializable) null));
+
+    verify(signalStore, never())
+        .deliverSignalById(eq(JOB_ID), any(), any(), any(), any(), any(), any(), any());
+    verify(eventPublisher, never()).publish(any());
+  }
+
+  @Test
+  void deliverSignalByKeyWithNullPrincipalPersistsAndPublishesSystemActor() {
+    DefaultJobSchedulerService systemService =
+        newService(payloadSerializer, metricsCollector, authorizationPolicy, Optional.empty());
+    when(signalStore.deliverSignalByKey(
+            eq("approval-key"),
+            isNull(),
+            eq(DefaultJobSchedulerService.SIGNAL_PAYLOAD_TYPE_RAW),
+            eq("APPROVED"),
+            isNull(),
+            eq("system"),
+            eq(FIXED_NOW),
+            anyString()))
+        .thenReturn(2);
+
+    assertEquals(2, systemService.deliverSignal("approval-key", (Serializable) null));
+
+    verify(authorizationPolicy).checkDeliverSignal("approval-key", null);
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    JobsBulkSignaledEvent event =
+        assertInstanceOf(JobsBulkSignaledEvent.class, eventCaptor.getValue());
+    assertEquals("system", event.getSignalDeliveredBy());
+  }
+
+  @Test
   void deliverSignalRawWithPayloadWithoutSerializerThrowsBeforeStoreUpdate() {
     DefaultJobSchedulerService noSerializer = newService(null);
 
@@ -251,7 +326,7 @@ class DefaultJobSchedulerServiceSignalTest {
 
   @Test
   void deliverSignalWithoutMetricsCollectorStillPublishesEvent() {
-    DefaultJobSchedulerService noMetrics = newService(payloadSerializer, null);
+    DefaultJobSchedulerService noMetrics = newService(payloadSerializer, (MetricsCollector) null);
     SignalDecision decision = SignalDecision.approved("approved-payload");
     JobEntity job = job(JOB_ID, "approval-key");
     when(payloadSerializer.serialize("approved-payload")).thenReturn("serialized-payload");
@@ -292,11 +367,24 @@ class DefaultJobSchedulerServiceSignalTest {
 
   private DefaultJobSchedulerService newService(
       PayloadSerializer serializer, MetricsCollector signalMetricsCollector) {
+    return newService(serializer, signalMetricsCollector, null, Optional.of("bob"));
+  }
+
+  private DefaultJobSchedulerService newService(
+      PayloadSerializer serializer, JobAuthorizationPolicy signalAuthorizationPolicy) {
+    return newService(serializer, metricsCollector, signalAuthorizationPolicy, Optional.of("bob"));
+  }
+
+  private DefaultJobSchedulerService newService(
+      PayloadSerializer serializer,
+      MetricsCollector signalMetricsCollector,
+      JobAuthorizationPolicy signalAuthorizationPolicy,
+      Optional<String> currentPrincipal) {
     CallerPrincipalProvider callerProvider =
         new CallerPrincipalProvider(null) {
           @Override
           public Optional<String> currentPrincipal() {
-            return Optional.of("bob");
+            return currentPrincipal;
           }
         };
 
@@ -315,7 +403,7 @@ class DefaultJobSchedulerServiceSignalTest {
         null,
         jobCreationService,
         callerProvider,
-        null,
+        signalAuthorizationPolicy,
         signalStore,
         serializer,
         signalMetricsCollector,

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobTimeoutHandlerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobTimeoutHandlerTest.java
@@ -13,9 +13,13 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -31,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.JobSignalTimedOutEvent;
 import run.ratchet.api.exception.SignalTimeoutException;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
@@ -52,6 +57,8 @@ class JobTimeoutHandlerTest {
   @Mock private PostExecutionHandler lifecycleFacade;
   @Mock private MetricsCollector metricsCollector;
   @Mock private SignalStore signalStore;
+  @Mock private InternalEventPublisher eventPublisher;
+  @Mock private TransactionSynchronizationRegistry txRegistry;
 
   private JobTimeoutHandler handler;
 
@@ -220,6 +227,27 @@ class JobTimeoutHandlerTest {
   }
 
   @Test
+  void signalTimeoutRetryRescheduleDoesNotPublishTimedOutEvent() {
+    JobTimeoutHandler eventHandler =
+        newHandler(
+            null,
+            metricsCollector,
+            JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE,
+            Clock.systemUTC(),
+            eventPublisher,
+            null);
+    JobEntity job = waitingJobWithMaxRetries(3);
+    when(jobRetryStore.incrementRetryAttempt(JOB_ID)).thenReturn(1);
+    when(jobRetryStore.scheduleJobRetry(eq(JOB_ID), anyString(), any(Instant.class), eq(1)))
+        .thenReturn(true);
+
+    eventHandler.processSignalTimeout(job, Instant.now());
+
+    verify(eventPublisher, never()).publish(any());
+    verify(metricsCollector, never()).signalTimedOut(any(), any(), anyString());
+  }
+
+  @Test
   void signalTimeoutRetriesExhaustedFailsAndEscalatesDlq() {
     JobEntity job = waitingJobWithMaxRetries(0);
     Instant now = Instant.now();
@@ -277,6 +305,42 @@ class JobTimeoutHandlerTest {
     metricsHandler.processSignalTimeout(job, Instant.now());
 
     verify(metricsCollector).signalTimedOut(JOB_ID, job.getPublicJobType(), "approval");
+  }
+
+  @Test
+  void signalTimeoutEventPublishesAfterCommitWithConfiguredTimeout() {
+    Instant createdAt = Instant.parse("2026-05-09T12:00:00Z");
+    JobTimeoutHandler txHandler =
+        newHandler(
+            null,
+            metricsCollector,
+            JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE,
+            Clock.fixed(createdAt.plusSeconds(31), ZoneOffset.UTC),
+            eventPublisher,
+            txRegistry);
+    JobEntity job = waitingJobWithMaxRetries(0);
+    job.setCreatedAt(createdAt);
+    job.setSignalTimeout(createdAt.plusSeconds(30));
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    ArgumentCaptor<Synchronization> synchronizationCaptor =
+        ArgumentCaptor.forClass(Synchronization.class);
+    when(jobRetryStore.incrementRetryAttempt(JOB_ID)).thenReturn(1);
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), eq(JobStatus.WAITING), eq(JobStatus.FAILED), anyString()))
+        .thenReturn(true);
+
+    txHandler.processSignalTimeout(job, createdAt.plusSeconds(31));
+
+    verify(txRegistry).registerInterposedSynchronization(synchronizationCaptor.capture());
+    verify(eventPublisher, never()).publish(any());
+
+    synchronizationCaptor.getValue().afterCompletion(Status.STATUS_COMMITTED);
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    JobSignalTimedOutEvent event =
+        assertInstanceOf(JobSignalTimedOutEvent.class, eventCaptor.getValue());
+    assertEquals(Duration.ofSeconds(30), event.getSignalTimeout());
   }
 
   @Test
@@ -338,6 +402,16 @@ class JobTimeoutHandlerTest {
       MetricsCollector metricsCollector,
       int signalTimeoutBatchSize,
       Clock clock) {
+    return newHandler(signalStore, metricsCollector, signalTimeoutBatchSize, clock, null, null);
+  }
+
+  private JobTimeoutHandler newHandler(
+      SignalStore signalStore,
+      MetricsCollector metricsCollector,
+      int signalTimeoutBatchSize,
+      Clock clock,
+      InternalEventPublisher eventPublisher,
+      TransactionSynchronizationRegistry txRegistry) {
     return new JobTimeoutHandler(
         jobCrudStore,
         jobRetryStore,
@@ -346,10 +420,11 @@ class JobTimeoutHandlerTest {
         80,
         60L,
         clock,
-        null,
+        eventPublisher,
         null,
         signalStore,
         metricsCollector,
-        signalTimeoutBatchSize);
+        signalTimeoutBatchSize,
+        txRegistry);
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/security/PermitAllJobAuthorizationPolicyTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/security/PermitAllJobAuthorizationPolicyTest.java
@@ -53,6 +53,16 @@ class PermitAllJobAuthorizationPolicyTest {
   }
 
   @Test
+  void checkDeliverSignalById_permitsAlways() {
+    assertDoesNotThrow(() -> policy.checkDeliverSignal(UUID.randomUUID(), "owner", "actor"));
+  }
+
+  @Test
+  void checkDeliverSignalByKey_permitsAlways() {
+    assertDoesNotThrow(() -> policy.checkDeliverSignal("approval", "actor"));
+  }
+
+  @Test
   void checkRead_permitsAlways() {
     assertDoesNotThrow(() -> policy.checkRead(UUID.randomUUID(), "actor"));
   }


### PR DESCRIPTION
## Summary

This handles the v5 signal security and transaction-timing findings. Signal delivery now goes through authorization hooks, unauthenticated/system delivery is audited consistently, and signal-related events are published after commit instead of inside the store transaction.

The timeout path also stops emitting failure-style signal events when a job is merely rescheduled for retry.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet-api -Dtest=EventApiContractTest test`
- `mvn -pl ratchet -am -Dtest=DefaultJobSchedulerServiceSignalTest,DefaultJobCreationServiceAuthorizationTest,JobTimeoutHandlerTest,BatchServiceTest,PermitAllJobAuthorizationPolicyTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl ratchet-api,ratchet spotless:check`
- `git diff --check`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [x] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

The authorization check is scoped to `signalKey` for bulk delivery. Per-job-owner authorization would need a different store shape, because the current bulk update stays atomic.
