### PR TITLE
publish cancel, pause, and resume events

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobPausedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobPausedEvent.java
@@ -7,14 +7,7 @@ import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
-/**
- * Reserved for a future pause notification contract.
- *
- * <p>The current reference implementation does not publish this event. Treat it as an incubating
- * API type until pause event delivery is specified.
- *
- * @since 0.1
- */
+/** Fired when a job is paused. @since 0.1 */
 @Incubating
 public class JobPausedEvent extends AbstractJobSchedulerEvent {
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
@@ -441,7 +441,11 @@ public class BatchService {
     if (batchStore.markBatchCompleteIfReady(parentId)) {
       // markBatchCompleteIfReady can have more than one apparent winner under concurrent commits.
       // The parent pickup CAS in processBatchCompletion is the exactly-once gate.
-      return processBatchCompletion(parentId, batchFromProgress(progress));
+      // Reload counters after winning the gate: another child can update failed/completed counts
+      // between this child's increment snapshot and the live readiness check.
+      BatchEntity completedBatch =
+          batchStore.findBatchById(parentId).orElseGet(() -> batchFromProgress(progress));
+      return processBatchCompletion(parentId, completedBatch);
     }
     return false;
   }

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -26,6 +26,8 @@ import run.ratchet.api.SerializableCheckedRunnable;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.api.StreamingBatchBuilder;
 import run.ratchet.api.event.JobCancelledEvent;
+import run.ratchet.api.event.JobPausedEvent;
+import run.ratchet.api.event.JobResumedEvent;
 import run.ratchet.api.event.JobSignaledEvent;
 import run.ratchet.api.event.JobsBulkCancelledEvent;
 import run.ratchet.api.event.JobsBulkSignaledEvent;
@@ -292,9 +294,9 @@ public class DefaultJobSchedulerService
       return true;
     }
 
-    // Try RUNNING → CANCELED (the executor will publish JobCancelledEvent itself when the
-    // running task observes the status flip — see JobTask. We do NOT publish here for the
-    // RUNNING path to avoid duplicate events.)
+    // Try RUNNING → CANCELED. RUNNING cancellation events are executor-owned so JobTask can
+    // include execution duration. If the worker dies before observing the status flip, the
+    // durable state is still CANCELED but no per-job RUNNING cancellation event is emitted.
     if (jobBatchStatusStore.compareAndSwapStatus(
         jobId, JobStatus.RUNNING, JobStatus.CANCELED, null)) {
       log.debugf("Canceled running job %s", jobId);
@@ -434,16 +436,13 @@ public class DefaultJobSchedulerService
     }
     JobHandle newHandle = builder.submit();
 
-    // Cancel the old job using CAS to avoid conflicting with concurrent executors.
-    // Try each cancellable state in order; if all fail, the job is already terminal.
-    boolean canceled =
-        jobBatchStatusStore.compareAndSwapStatus(jobId, JobStatus.PENDING, JobStatus.CANCELED, null)
-            || jobBatchStatusStore.compareAndSwapStatus(
-                jobId, JobStatus.RUNNING, JobStatus.CANCELED, null)
-            || jobBatchStatusStore.compareAndSwapStatus(
-                jobId, JobStatus.PAUSED, JobStatus.CANCELED, null)
-            || jobBatchStatusStore.compareAndSwapStatus(
-                jobId, JobStatus.WAITING, JobStatus.CANCELED, null);
+    JobStatus cancelledFrom = cancelForReplacement(jobId);
+    if (cancelledFrom == JobStatus.WAITING && metricsCollector != null) {
+      metricsCollector.signalCancelled(jobId, existing.getPublicJobType(), existing.getSignalKey());
+    }
+    if (cancelledFrom != null && cancelledFrom != JobStatus.RUNNING) {
+      publishCancelledEvent(jobId, cancelledFrom, existing);
+    }
 
     // Reload after CAS: compareAndSwapStatus bumps the optimistic-lock version; writing the
     // pre-CAS entity would throw. The intent is to annotate a terminal CANCELED row with
@@ -458,7 +457,7 @@ public class DefaultJobSchedulerService
     fresh.setSupersededBy(newHandle.id());
     jobCrudStore.save(fresh);
 
-    if (canceled) {
+    if (cancelledFrom != null) {
       log.infof("Replaced job %s with new job %s", jobId, newHandle.id());
     } else {
       log.infof(
@@ -494,6 +493,7 @@ public class DefaultJobSchedulerService
     if (job.getJobType() == JobExecutionType.RECURRING) {
       if (jobPauseStore.pauseRecurring(jobId)) {
         log.debugf("Paused recurring master %s", jobId);
+        publishPausedEvent(jobId, job);
         return true;
       }
       log.debugf("Cannot pause recurring master %s — current rec_status %s", jobId, current);
@@ -503,6 +503,7 @@ public class DefaultJobSchedulerService
     // Executable jobs: try PENDING → PAUSED on hot.
     if (jobPauseStore.transitionToPaused(jobId, JobStatus.PENDING)) {
       log.debugf("Paused pending job %s", jobId);
+      publishPausedEvent(jobId, job);
       return true;
     }
 
@@ -534,6 +535,7 @@ public class DefaultJobSchedulerService
     if (job.getJobType() == JobExecutionType.RECURRING) {
       if (jobPauseStore.resumeRecurring(jobId)) {
         log.debugf("Resumed recurring master %s", jobId);
+        publishResumedEvent(jobId, job);
         recurringScheduler.kick();
         return true;
       }
@@ -548,6 +550,7 @@ public class DefaultJobSchedulerService
       return false;
     }
     log.debugf("Resumed job %s to %s", jobId, target);
+    publishResumedEvent(jobId, job);
     if (target == JobStatus.PENDING) {
       recurringScheduler.kick();
     }
@@ -657,21 +660,75 @@ public class DefaultJobSchedulerService
    * get for running-cancellations.
    */
   private void publishCancelledEvent(UUID jobId, JobStatus previousStatus, JobEntity job) {
+    Instant timestamp = effective().instant();
     JobCancelledEvent event =
         job == null
             // Race: job was deleted between CAS and our lookup. Fire a minimal event so observers
             // at least know the cancellation happened.
-            ? new JobCancelledEvent(jobId, null, null, null, null, previousStatus.name(), null)
+            ? new JobCancelledEvent(
+                jobId, null, null, null, null, timestamp, previousStatus.name(), null)
             : new JobCancelledEvent(
                 jobId,
                 job.getBusinessKey(),
                 job.getPublicJobType(),
                 job.getPriority(),
                 job.getPickedBy(),
+                timestamp,
                 previousStatus.name(),
                 null);
     // Defer publication until after the surrounding TX commits so a rollback does not produce a
     // spurious CANCELLED event. Falls back to immediate publication when no TX is active.
+    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+      eventPublisher.publish(event);
+    }
+  }
+
+  private JobStatus cancelForReplacement(UUID jobId) {
+    if (jobBatchStatusStore.compareAndSwapStatus(
+        jobId, JobStatus.PENDING, JobStatus.CANCELED, null)) {
+      return JobStatus.PENDING;
+    }
+    if (jobBatchStatusStore.compareAndSwapStatus(
+        jobId, JobStatus.RUNNING, JobStatus.CANCELED, null)) {
+      // RUNNING cancellation events are executor-owned. JobTask publishes the event with execution
+      // duration when it observes the status flip; publishing here would create a duplicate. This
+      // carries the same dropped-event risk as cancelJob if the worker dies before that check.
+      return JobStatus.RUNNING;
+    }
+    if (jobBatchStatusStore.compareAndSwapStatus(
+        jobId, JobStatus.PAUSED, JobStatus.CANCELED, null)) {
+      return JobStatus.PAUSED;
+    }
+    if (jobBatchStatusStore.compareAndSwapStatus(
+        jobId, JobStatus.WAITING, JobStatus.CANCELED, null)) {
+      return JobStatus.WAITING;
+    }
+    return null;
+  }
+
+  private void publishPausedEvent(UUID jobId, JobEntity job) {
+    JobPausedEvent event =
+        new JobPausedEvent(
+            jobId,
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            effective().instant());
+    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+      eventPublisher.publish(event);
+    }
+  }
+
+  private void publishResumedEvent(UUID jobId, JobEntity job) {
+    JobResumedEvent event =
+        new JobResumedEvent(
+            jobId,
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            effective().instant());
     if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
       eventPublisher.publish(event);
     }

--- a/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
@@ -119,6 +119,7 @@ class BatchServiceTest {
 
     when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(progress);
     when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(batchStore.findBatchById(parentId)).thenReturn(Optional.of(batch(parentId, 3, 3, 0)));
     when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
     when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
         .thenReturn(true);
@@ -140,8 +141,48 @@ class BatchServiceTest {
     assertEquals(3, completingEvent.getTotalItems());
     assertEquals(3, completingEvent.getCompletedItems());
     assertEquals(0, completingEvent.getFailedItems());
-    verify(batchStore, never()).findBatchById(parentId);
     verify(jobTerminalStore).markJobSucceededMinimal(parentId, FIXED_NOW, FIXED_NOW, 0L, 0L);
+  }
+
+  @Test
+  void completedBatchReloadsCountersBeforeFinalizingParent() {
+    UUID parentId = UUID.randomUUID();
+    JobEntity child = new JobEntity();
+    child.setDependsOn(parentId);
+
+    BatchProgress staleProgress = new BatchProgress(parentId, 3, 2, 0, null);
+    BatchEntity currentBatch = batch(parentId, 3, 2, 1);
+    JobEntity parent = new JobEntity();
+    parent.setId(parentId);
+    parent.setStatus(JobStatus.PENDING);
+    parent.setJobType(JobExecutionType.BATCH_PARENT);
+    parent.setPriority(JobPriority.NORMAL);
+
+    when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(staleProgress);
+    when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(batchStore.findBatchById(parentId)).thenReturn(Optional.of(currentBatch));
+    when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
+    when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
+        .thenReturn(true);
+    when(jobTerminalStore.markJobFailedTerminal(
+            parentId, "Batch completed with 1 failed children", 0))
+        .thenReturn(true);
+    when(metricsStore.findBatchMetrics(parentId)).thenReturn(Optional.empty());
+    when(workflowScheduler.scheduleNext(any(JobEntity.class))).thenReturn(false);
+
+    batchService.markChildSucceeded(child);
+
+    assertEquals(JobStatus.FAILED, parent.getStatus());
+    verify(jobTerminalStore, never()).markJobSucceededMinimal(any(), any(), any(), any(), any());
+    verify(jobTerminalStore)
+        .markJobFailedTerminal(parentId, "Batch completed with 1 failed children", 0);
+
+    ArgumentCaptor<Object> event = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(event.capture());
+    BatchCompletingEvent completingEvent = (BatchCompletingEvent) event.getValue();
+    assertEquals(3, completingEvent.getTotalItems());
+    assertEquals(2, completingEvent.getCompletedItems());
+    assertEquals(1, completingEvent.getFailedItems());
   }
 
   @Test
@@ -158,6 +199,7 @@ class BatchServiceTest {
 
     when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(progress);
     when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(batchStore.findBatchById(parentId)).thenReturn(Optional.of(batch(parentId, 1, 1, 0)));
     when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
     when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
         .thenReturn(false);
@@ -169,7 +211,6 @@ class BatchServiceTest {
     verify(metricsStore, never()).finalizeBatchMetrics(any());
     verify(eventPublisher, never()).publish(any());
     verify(workflowScheduler, never()).scheduleNext(any());
-    verify(batchStore, never()).findBatchById(parentId);
   }
 
   @Test
@@ -186,6 +227,7 @@ class BatchServiceTest {
 
     when(batchStore.incrementCompletedAtomic(parentId)).thenReturn(progress);
     when(batchStore.markBatchCompleteIfReady(parentId)).thenReturn(true);
+    when(batchStore.findBatchById(parentId)).thenReturn(Optional.of(batch(parentId, 1, 1, 0)));
     when(jobCrudStore.findById(parentId)).thenReturn(Optional.of(parent));
     when(jobBatchStatusStore.tryPickUpJob(parentId, DefaultBatchBuilder.BATCH_LIFECYCLE_NODE_ID))
         .thenReturn(true);

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceEventTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceEventTest.java
@@ -1,0 +1,263 @@
+package run.ratchet.ri.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.JobType;
+import run.ratchet.api.event.JobCancelledEvent;
+import run.ratchet.api.event.JobPausedEvent;
+import run.ratchet.api.event.JobResumedEvent;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobPauseStore;
+import run.ratchet.store.spi.JobRetryStore;
+import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.spi.SignalStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultJobSchedulerServiceEventTest {
+
+  private static final UUID JOB_ID = new UUID(0L, 90L);
+  private static final UUID REPLACEMENT_ID = new UUID(0L, 91L);
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-15T10:15:30Z");
+  private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+
+  @Mock private InternalEventPublisher eventPublisher;
+  @Mock private JobBatchStatusStore jobBatchStatusStore;
+  @Mock private JobPauseStore jobPauseStore;
+  @Mock private JobRetryStore jobRetryStore;
+  @Mock private JobTerminalStore jobTerminalStore;
+  @Mock private JobCrudStore jobCrudStore;
+  @Mock private BatchStore batchStore;
+  @Mock private TagStore tagStore;
+  @Mock private WorkflowConditionStore workflowConditionStore;
+  @Mock private JobWakeupService wakeupService;
+  @Mock private RecurringScheduler recurringScheduler;
+  @Mock private DefaultJobCreationService jobCreationService;
+  @Mock private SignalStore signalStore;
+  @Mock private MetricsCollector metricsCollector;
+
+  private DefaultJobSchedulerService service;
+
+  public static void noopTask() {}
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new DefaultJobSchedulerService(
+            eventPublisher,
+            jobBatchStatusStore,
+            jobPauseStore,
+            jobRetryStore,
+            jobTerminalStore,
+            jobCrudStore,
+            batchStore,
+            tagStore,
+            workflowConditionStore,
+            wakeupService,
+            recurringScheduler,
+            null,
+            jobCreationService,
+            null,
+            null,
+            signalStore,
+            null,
+            metricsCollector,
+            FIXED_CLOCK);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobStatus.class,
+      names = {"PENDING", "PAUSED", "WAITING"})
+  void replacePublishesCancelledEventForServiceOwnedCancellation(JobStatus previousStatus) {
+    JobEntity job = job(previousStatus, JobExecutionType.SINGLE);
+    job.setSignalKey("approval-" + previousStatus.name());
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobCreationService.submit(any(DefaultJobBuilder.class))).thenReturn(() -> REPLACEMENT_ID);
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), any(JobStatus.class), eq(JobStatus.CANCELED), isNull()))
+        .thenAnswer(inv -> inv.getArgument(1) == previousStatus);
+    when(jobCrudStore.save(any(JobEntity.class))).thenReturn(job);
+
+    assertEquals(
+        REPLACEMENT_ID,
+        service
+            .replace(JOB_ID, Duration.ZERO, DefaultJobSchedulerServiceEventTest::noopTask, null)
+            .id());
+
+    JobCancelledEvent event = published(JobCancelledEvent.class);
+    assertEquals(JOB_ID, event.getJobId());
+    assertEquals(previousStatus.name(), event.getPreviousStatus());
+    assertEquals(FIXED_NOW, event.getTimestamp());
+    assertEquals("business-90", event.getBusinessKey());
+    assertEquals(JobType.SINGLE, event.getJobType());
+    assertEquals(JobPriority.HIGH, event.getPriority());
+    assertEquals("node-a", event.getNodeId());
+    if (previousStatus == JobStatus.WAITING) {
+      verify(metricsCollector).signalCancelled(JOB_ID, job.getPublicJobType(), job.getSignalKey());
+    } else {
+      verify(metricsCollector, never()).signalCancelled(any(), any(), any());
+    }
+  }
+
+  @Test
+  void replaceRunningCancellationLeavesEventToExecutor() {
+    JobEntity job = job(JobStatus.RUNNING, JobExecutionType.SINGLE);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobCreationService.submit(any(DefaultJobBuilder.class))).thenReturn(() -> REPLACEMENT_ID);
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), any(JobStatus.class), eq(JobStatus.CANCELED), isNull()))
+        .thenAnswer(inv -> inv.getArgument(1) == JobStatus.RUNNING);
+    when(jobCrudStore.save(any(JobEntity.class))).thenReturn(job);
+
+    assertEquals(
+        REPLACEMENT_ID,
+        service
+            .replace(JOB_ID, Duration.ZERO, DefaultJobSchedulerServiceEventTest::noopTask, null)
+            .id());
+
+    verify(eventPublisher, never()).publish(any());
+    verify(metricsCollector, never()).signalCancelled(any(), any(), any());
+  }
+
+  @Test
+  void cancelJobRunningCancellationLeavesEventToExecutor() {
+    JobEntity job = job(JobStatus.RUNNING, JobExecutionType.SINGLE);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), any(JobStatus.class), eq(JobStatus.CANCELED), isNull()))
+        .thenAnswer(inv -> inv.getArgument(1) == JobStatus.RUNNING);
+
+    assertTrue(service.cancelJob(JOB_ID));
+
+    verify(eventPublisher, never()).publish(any());
+  }
+
+  @Test
+  void pauseJobPendingPublishesPausedEvent() {
+    JobEntity job = job(JobStatus.PENDING, JobExecutionType.SINGLE);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobPauseStore.transitionToPaused(JOB_ID, JobStatus.PENDING)).thenReturn(true);
+
+    assertTrue(service.pauseJob(JOB_ID));
+
+    JobPausedEvent event = published(JobPausedEvent.class);
+    assertCommonJobEvent(event, JobType.SINGLE);
+  }
+
+  @Test
+  void pauseJobRecurringPublishesPausedEvent() {
+    JobEntity job = job(JobStatus.PENDING, JobExecutionType.RECURRING);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobPauseStore.pauseRecurring(JOB_ID)).thenReturn(true);
+
+    assertTrue(service.pauseJob(JOB_ID));
+
+    JobPausedEvent event = published(JobPausedEvent.class);
+    assertCommonJobEvent(event, JobType.RECURRING);
+  }
+
+  @Test
+  void pauseJobAlreadyPausedDoesNotRepublishPausedEvent() {
+    JobEntity job = job(JobStatus.PAUSED, JobExecutionType.SINGLE);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+
+    assertTrue(service.pauseJob(JOB_ID));
+
+    verify(eventPublisher, never()).publish(any());
+  }
+
+  @Test
+  void resumeJobPausedPublishesResumedEvent() {
+    JobEntity job = job(JobStatus.PAUSED, JobExecutionType.SINGLE);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobPauseStore.transitionFromPausedAtomic(JOB_ID)).thenReturn(JobStatus.PENDING);
+
+    assertTrue(service.resumeJob(JOB_ID));
+
+    JobResumedEvent event = published(JobResumedEvent.class);
+    assertCommonJobEvent(event, JobType.SINGLE);
+    verify(recurringScheduler).kick();
+  }
+
+  @Test
+  void resumeJobRecurringPublishesResumedEvent() {
+    JobEntity job = job(JobStatus.PAUSED, JobExecutionType.RECURRING);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobPauseStore.resumeRecurring(JOB_ID)).thenReturn(true);
+
+    assertTrue(service.resumeJob(JOB_ID));
+
+    JobResumedEvent event = published(JobResumedEvent.class);
+    assertCommonJobEvent(event, JobType.RECURRING);
+    verify(recurringScheduler).kick();
+  }
+
+  @Test
+  void resumeJobNotPausedDoesNotPublishResumedEvent() {
+    JobEntity job = job(JobStatus.PENDING, JobExecutionType.SINGLE);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+
+    assertFalse(service.resumeJob(JOB_ID));
+
+    verify(eventPublisher, never()).publish(any());
+  }
+
+  private static JobEntity job(JobStatus status, JobExecutionType type) {
+    JobEntity job = new JobEntity();
+    job.setId(JOB_ID);
+    job.setStatus(status);
+    job.setJobType(type);
+    job.setBusinessKey("business-90");
+    job.setPriority(JobPriority.HIGH);
+    job.setPickedBy("node-a");
+    return job;
+  }
+
+  private <T> T published(Class<T> type) {
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    return assertInstanceOf(type, eventCaptor.getValue());
+  }
+
+  private static void assertCommonJobEvent(
+      run.ratchet.api.event.AbstractJobSchedulerEvent event, JobType jobType) {
+    assertEquals(JOB_ID, event.getJobId());
+    assertEquals("business-90", event.getBusinessKey());
+    assertEquals(jobType, event.getJobType());
+    assertEquals(JobPriority.HIGH, event.getPriority());
+    assertEquals("node-a", event.getNodeId());
+    assertEquals(FIXED_NOW, event.getTimestamp());
+  }
+}


### PR DESCRIPTION
## Summary

This wires the missing pause, resume, and replace-cancellation events from the v5 event findings. `replace()` now publishes cancellation events for the cancellable states it wins, and pause/resume operations publish their events instead of changing durable state silently.

The PR also tightens the affected event constructor behavior through the existing API tests.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet -Dtest=DefaultJobSchedulerServiceEventTest,DefaultJobSchedulerServiceSignalTest,DefaultJobSchedulerServiceAuthorizationTest test`
- `mvn -pl ratchet-api -Dtest=EventApiContractTest,JobCancellationEventTest,ApiIncubatingContractTest test`

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

RUNNING cancellation remains executor-owned to avoid duplicate events and keep duration fields correct. If a worker dies before it observes cancellation, durable state is still `CANCELED`, but the per-job RUNNING cancellation event can be missed.
