### PR TITLE
wire batch and chain workflow events

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -175,7 +175,7 @@ public interface JobSchedulerService {
    *       ChainFailedEvent}, {@code WorkflowBranchTriggeredEvent}
    *   <li><b>Signals:</b> {@code JobSignalWaitingEvent}, {@code JobSignaledEvent}, {@code
    *       JobsBulkSignaledEvent}, {@code JobSignalTimedOutEvent}
-   *   <li><b>Observability:</b> {@code JobDlqEvent}, {@code PerformanceMetricsEvent}
+   *   <li><b>Observability:</b> {@code JobDlqEvent}
    * </ul>
    *
    * <p><b>Transaction attribute:</b> {@code NOT_SUPPORTED}. Listener registration is an in-memory

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
@@ -24,7 +24,7 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
    * Creates a failure event with an explicit timestamp.
    *
    * @param errorMessage sanitized failure message, or {@code null} when no message was recorded
-   * @param retryAttempt 1-based execution attempt count that failed
+   * @param retryAttempt recorded retry count when the job failed; zero means no retry was consumed
    */
   public JobFailedEvent(
       UUID jobId,
@@ -37,14 +37,14 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
     this.errorMessage = errorMessage;
-    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
+    this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }
 
   /**
    * Creates a failure event using the current system clock instant.
    *
    * @param errorMessage sanitized failure message, or {@code null} when no message was recorded
-   * @param retryAttempt 1-based execution attempt count that failed
+   * @param retryAttempt recorded retry count when the job failed; zero means no retry was consumed
    */
   public JobFailedEvent(
       UUID jobId,
@@ -56,7 +56,7 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId);
     this.errorMessage = errorMessage;
-    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
+    this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }
 
   /** Returns the sanitized failure message, or {@code null} when no message was recorded. */
@@ -64,7 +64,7 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
     return errorMessage;
   }
 
-  /** Returns the 1-based execution attempt count that failed. */
+  /** Returns the recorded retry count when the job failed. */
   public int getRetryAttempt() {
     return retryAttempt;
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
@@ -6,7 +6,13 @@ import java.util.UUID;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
-/** Fired when a job fails. */
+/**
+ * Fired when a job reaches terminal FAILED state.
+ *
+ * <p>Retryable per-attempt failures are reported through the metrics SPI and {@link
+ * JobRetryingEvent}; they do not publish this event unless the failed attempt exhausts retry
+ * handling and terminalizes the job.
+ */
 public class JobFailedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -8745178784765705117L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/PerformanceMetricsEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/PerformanceMetricsEvent.java
@@ -5,15 +5,17 @@ import java.io.Serializable;
 import java.util.Map;
 
 /**
- * Fired when performance metrics are ready for broadcasting to dashboard clients.
+ * Legacy placeholder for dashboard-level aggregate metrics.
  *
- * <p>Published periodically and observed by the WebSocket layer to push real-time metrics. Does not
- * extend {@link AbstractJobSchedulerEvent} because it represents system-level aggregate metrics,
- * not a per-job lifecycle event.
+ * <p>The RI does not publish this event. Use the {@code MetricsCollector} SPI for scheduler
+ * telemetry instead. This type is retained only for source compatibility with early API drafts.
  *
  * <p>The {@code performanceData} map is defensively copied and is immutable after construction. All
  * keys and values must be non-null and serializable by the event transport used by the application.
+ *
+ * @deprecated no scheduler producer exists; use {@code MetricsCollector} instead
  */
+@Deprecated(since = "0.1.0", forRemoval = false)
 public record PerformanceMetricsEvent(Map<String, Object> performanceData) implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;

--- a/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
@@ -188,11 +188,21 @@ class EventApiContractTest {
         () ->
             new BatchCompletingEvent(
                 JOB_ID, "business-key", JobType.BATCH, JobPriority.NORMAL, "node-a", 3, 2, 2));
+    JobFailedEvent firstAttemptFailure =
+        new JobFailedEvent(
+            JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", "failed", 0);
+    assertEquals(0, firstAttemptFailure.getRetryAttempt());
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new JobFailedEvent(
-                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", "failed", 0));
+                JOB_ID,
+                "business-key",
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                "failed",
+                -1));
     assertThrows(
         IllegalArgumentException.class,
         () ->

--- a/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
@@ -18,12 +18,16 @@ import org.jboss.logging.Logger;
 import org.objectweb.asm.Type;
 import run.ratchet.api.BatchContext;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.BatchCompletedEvent;
 import run.ratchet.api.event.BatchCompletingEvent;
+import run.ratchet.api.event.JobCompletedEvent;
+import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.dto.BatchProgress;
 import run.ratchet.store.entity.BatchEntity;
+import run.ratchet.store.entity.BatchMetricsEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobPayload;
 import run.ratchet.store.spi.BatchMetricsStore;
@@ -303,15 +307,16 @@ public class BatchService {
 
     metricsStore.finalizeBatchMetrics(parentId);
 
-    metricsStore
-        .findBatchMetrics(parentId)
-        .filter(metrics -> metrics.getTotalDurationMs() != null)
-        .ifPresent(
-            metrics ->
-                metricsCollector.jobCompleted(
-                    parentId, parent.getPublicJobType(), metrics.getTotalDurationMs()));
+    Long totalDurationMs =
+        metricsStore
+            .findBatchMetrics(parentId)
+            .map(BatchMetricsEntity::getTotalDurationMs)
+            .orElse(null);
+    if (totalDurationMs != null) {
+      metricsCollector.jobCompleted(parentId, parent.getPublicJobType(), totalDurationMs);
+    }
 
-    publishBatchEvent(batch, parent);
+    publishBatchEvents(batch, parent, succeeded, totalDurationMs);
 
     log.infof(
         "Batch %s completed: %d total, %d succeeded, %d failed",
@@ -362,7 +367,8 @@ public class BatchService {
     throw failure;
   }
 
-  private void publishBatchEvent(BatchEntity batch, JobEntity parent) {
+  private void publishBatchEvents(
+      BatchEntity batch, JobEntity parent, boolean succeeded, Long totalDurationMs) {
     eventPublisher.publish(
         new BatchCompletingEvent(
             batch.getId(),
@@ -373,6 +379,36 @@ public class BatchService {
             batch.getTotalItems(),
             batch.getCompletedItems(),
             batch.getFailedItems()));
+    eventPublisher.publish(
+        new BatchCompletedEvent(
+            batch.getId(),
+            parent.getBusinessKey(),
+            parent.getPublicJobType(),
+            parent.getPriority(),
+            parent.getPickedBy(),
+            batch.getTotalItems(),
+            batch.getCompletedItems(),
+            batch.getFailedItems()));
+    if (succeeded) {
+      eventPublisher.publish(
+          new JobCompletedEvent(
+              parent.getId(),
+              parent.getBusinessKey(),
+              parent.getPublicJobType(),
+              parent.getPriority(),
+              parent.getPickedBy(),
+              totalDurationMs));
+      return;
+    }
+    eventPublisher.publish(
+        new JobFailedEvent(
+            parent.getId(),
+            parent.getBusinessKey(),
+            parent.getPublicJobType(),
+            parent.getPriority(),
+            parent.getPickedBy(),
+            "Batch completed with " + batch.getFailedItems() + " failed children",
+            parent.getAttempts()));
   }
 
   private void trigger(BatchEntity batch) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/ChainScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/ChainScheduler.java
@@ -6,11 +6,17 @@ import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.ChainCompletedEvent;
+import run.ratchet.api.event.ChainFailedEvent;
+import run.ratchet.api.event.ChainStartedEvent;
 import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobTerminalStore;
 
@@ -34,27 +40,39 @@ public class ChainScheduler {
 
   protected final JobCrudStore jobCrudStore;
   protected final JobTerminalStore jobTerminalStore;
+  protected final InternalEventPublisher eventPublisher;
   private final Clock clock;
 
   protected ChainScheduler() {
     this.jobCrudStore = null;
     this.jobTerminalStore = null;
+    this.eventPublisher = null;
     this.clock = null;
   }
 
   public ChainScheduler(JobCrudStore jobCrudStore, JobTerminalStore jobTerminalStore) {
-    this(jobCrudStore, jobTerminalStore, Clock.systemUTC());
+    this(jobCrudStore, jobTerminalStore, Clock.systemUTC(), null);
   }
 
   ChainScheduler(JobCrudStore jobCrudStore, JobTerminalStore jobTerminalStore, Clock clock) {
+    this(jobCrudStore, jobTerminalStore, clock, null);
+  }
+
+  ChainScheduler(
+      JobCrudStore jobCrudStore,
+      JobTerminalStore jobTerminalStore,
+      Clock clock,
+      InternalEventPublisher eventPublisher) {
     this.jobCrudStore = jobCrudStore;
     this.jobTerminalStore = jobTerminalStore;
     this.clock = clock != null ? clock : Clock.systemUTC();
+    this.eventPublisher = eventPublisher;
   }
 
   public void cancelChain(JobEntity failed) {
     Deque<UUID> stack = new ArrayDeque<>();
     stack.push(failed.getId());
+    boolean canceled = false;
 
     while (!stack.isEmpty()) {
       UUID parentId = stack.pop();
@@ -66,16 +84,23 @@ public class ChainScheduler {
           // DELETE bkres atomically. setStatus()+save() is rejected by the hot guard.
           if (jobTerminalStore.cancelJob(child.getId())) {
             log.warnf("Chain step %s canceled (ancestor failed %s)", child.getId(), failed.getId());
+            canceled = true;
           }
         }
         stack.push(child.getId());
       }
+    }
+    if (canceled || failed.getJobType() == JobExecutionType.CHAIN_STEP) {
+      publishChainFailed(failed);
     }
   }
 
   public boolean scheduleNext(JobEntity finished) {
     List<JobEntity> children = findAllDependants(finished.getId());
     if (children.isEmpty()) {
+      if (finished.getJobType() == JobExecutionType.CHAIN_STEP) {
+        publishChainCompleted(finished);
+      }
       return false;
     }
 
@@ -85,6 +110,7 @@ public class ChainScheduler {
         c.setScheduledTime(effective().instant());
         jobCrudStore.save(c);
         log.infof("Chain step %s unlocked (prev=%s)", c.getId(), finished.getId());
+        publishChainStartedIfFirstStep(finished, c);
         scheduled = true;
       } else if (c.getStatus() == JobStatus.WAITING
           && CHAIN_LOCK_TIME.equals(c.getScheduledTime())) {
@@ -95,6 +121,7 @@ public class ChainScheduler {
         log.infof(
             "Signal-waiting chain step %s unlocked (signal still pending, prev=%s)",
             c.getId(), finished.getId());
+        publishChainStartedIfFirstStep(finished, c);
         scheduled = true;
       }
     }
@@ -116,5 +143,65 @@ public class ChainScheduler {
       }
       offset += page.size();
     }
+  }
+
+  private void publishChainStartedIfFirstStep(JobEntity finished, JobEntity child) {
+    if (eventPublisher == null
+        || child.getJobType() != JobExecutionType.CHAIN_STEP
+        || finished.getJobType() == JobExecutionType.CHAIN_STEP) {
+      return;
+    }
+    eventPublisher.publish(
+        new ChainStartedEvent(
+            child.getId(),
+            child.getBusinessKey(),
+            child.getPublicJobType(),
+            child.getPriority(),
+            child.getPickedBy(),
+            findRootJobId(finished)));
+  }
+
+  private void publishChainCompleted(JobEntity finished) {
+    if (eventPublisher == null) {
+      return;
+    }
+    eventPublisher.publish(
+        new ChainCompletedEvent(
+            finished.getId(),
+            finished.getBusinessKey(),
+            finished.getPublicJobType(),
+            finished.getPriority(),
+            finished.getPickedBy(),
+            findRootJobId(finished)));
+  }
+
+  private void publishChainFailed(JobEntity failed) {
+    if (eventPublisher == null) {
+      return;
+    }
+    eventPublisher.publish(
+        new ChainFailedEvent(
+            failed.getId(),
+            failed.getBusinessKey(),
+            failed.getPublicJobType(),
+            failed.getPriority(),
+            failed.getPickedBy(),
+            findRootJobId(failed),
+            failed.getLastError()));
+  }
+
+  private UUID findRootJobId(JobEntity job) {
+    UUID rootId = job.getId();
+    UUID parentId = job.getDependsOn();
+    Set<UUID> seen = new HashSet<>();
+    while (parentId != null && seen.add(parentId)) {
+      JobEntity parent = jobCrudStore.findById(parentId).orElse(null);
+      if (parent == null) {
+        return parentId;
+      }
+      rootId = parent.getId();
+      parentId = parent.getDependsOn();
+    }
+    return rootId;
   }
 }

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
@@ -28,6 +28,7 @@ import run.ratchet.api.event.JobCallbackFailedEvent;
 import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.api.event.JobDlqEvent;
+import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.event.JobRetryingEvent;
 import run.ratchet.api.event.JobStartedEvent;
 import run.ratchet.api.exception.JobTimeoutException;
@@ -794,7 +795,7 @@ public class JobTask implements Callable<Void> {
         job.getId(), JobStatus.RUNNING, JobStatus.FAILED, errorSanitizer.sanitize(ex))) {
       job.setAttempts(attempt);
       job.setStatus(JobStatus.FAILED);
-      publishDlqEvent(ex, attempt);
+      publishTerminalFailureEvents(ex, attempt);
       lifecycleFacade.moveToDlq(job, ex);
       handleBatchOrWorkflowPermanentFailure();
       invokeCallback(job.getOnFailurePayload(), "onFailure");
@@ -803,7 +804,17 @@ public class JobTask implements Callable<Void> {
     return false;
   }
 
-  private void publishDlqEvent(Throwable ex, int attempt) {
+  private void publishTerminalFailureEvents(Throwable ex, int attempt) {
+    String sanitized = errorSanitizer.sanitize(ex);
+    observabilityFacade.publishEvent(
+        new JobFailedEvent(
+            job.getId(),
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            sanitized,
+            attempt));
     observabilityFacade.publishEvent(
         new JobDlqEvent(
             job.getId(),
@@ -811,7 +822,7 @@ public class JobTask implements Callable<Void> {
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
-            errorSanitizer.sanitize(ex),
+            sanitized,
             attempt));
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
@@ -14,6 +14,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.JobDlqEvent;
+import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.event.JobSignalTimedOutEvent;
 import run.ratchet.api.exception.SignalTimeoutException;
 import run.ratchet.spi.MetricsCollector;
@@ -195,6 +197,9 @@ public class JobTimeoutHandler {
       return;
     }
     log.infof("Job %s marked as FAILED due to hard timeout (retries exhausted)", jobId);
+    job.setAttempts(newAttempts);
+    job.setStatus(JobStatus.FAILED);
+    publishHardTimeoutFailureEvents(job, timeoutEx.getMessage(), newAttempts);
     lifecycleFacade.handlePermanentFailure(job, timeoutEx);
   }
 
@@ -278,6 +283,31 @@ public class JobTimeoutHandler {
             null,
             job.getSignalKey(),
             elapsed != null ? elapsed.abs() : null));
+  }
+
+  private void publishHardTimeoutFailureEvents(
+      JobEntity job, String errorMessage, int retryAttempt) {
+    if (eventPublisher == null) {
+      return;
+    }
+    eventPublisher.publish(
+        new JobFailedEvent(
+            job.getId(),
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            errorMessage,
+            retryAttempt));
+    eventPublisher.publish(
+        new JobDlqEvent(
+            job.getId(),
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            errorMessage,
+            retryAttempt));
   }
 
   private String formatDuration(Duration duration) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/WorkflowScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/WorkflowScheduler.java
@@ -13,6 +13,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.WorkflowBranchTriggeredEvent;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.WorkflowConditionEntity;
@@ -65,7 +66,6 @@ public class WorkflowScheduler extends ChainScheduler {
         Clock.systemUTC());
   }
 
-  @Inject
   public WorkflowScheduler(
       JobCrudStore jobCrudStore,
       JobBatchStatusStore jobBatchStatusStore,
@@ -73,7 +73,26 @@ public class WorkflowScheduler extends ChainScheduler {
       WorkflowConditionStore conditionStore,
       WorkflowConditionEvaluator conditionEvaluator,
       Clock clock) {
-    super(jobCrudStore, jobTerminalStore, clock);
+    this(
+        jobCrudStore,
+        jobBatchStatusStore,
+        jobTerminalStore,
+        conditionStore,
+        conditionEvaluator,
+        clock,
+        null);
+  }
+
+  @Inject
+  public WorkflowScheduler(
+      JobCrudStore jobCrudStore,
+      JobBatchStatusStore jobBatchStatusStore,
+      JobTerminalStore jobTerminalStore,
+      WorkflowConditionStore conditionStore,
+      WorkflowConditionEvaluator conditionEvaluator,
+      Clock clock,
+      InternalEventPublisher eventPublisher) {
+    super(jobCrudStore, jobTerminalStore, clock, eventPublisher);
     this.jobBatchStatusStore = jobBatchStatusStore;
     this.jobTerminalStore = jobTerminalStore;
     this.conditionStore = conditionStore;
@@ -173,6 +192,7 @@ public class WorkflowScheduler extends ChainScheduler {
     cancelUnscheduledBranches(conditions, scheduledCondition, childJobs);
 
     if (scheduledCondition != null) {
+      publishWorkflowBranchTriggered(parentJob, scheduledCondition);
       log.infof(
           "Scheduled workflow branch job %s for parent job %s",
           scheduledCondition.getChildJobId(), parentJob.getId());
@@ -284,6 +304,30 @@ public class WorkflowScheduler extends ChainScheduler {
     childJob.setJobType(JobExecutionType.WORKFLOW_BRANCH);
     jobCrudStore.save(childJob);
     return true;
+  }
+
+  private void publishWorkflowBranchTriggered(
+      JobEntity parentJob, WorkflowConditionEntity condition) {
+    if (eventPublisher == null) {
+      return;
+    }
+    eventPublisher.publish(
+        new WorkflowBranchTriggeredEvent(
+            parentJob.getId(),
+            parentJob.getBusinessKey(),
+            parentJob.getPublicJobType(),
+            parentJob.getPriority(),
+            parentJob.getPickedBy(),
+            describeCondition(condition),
+            condition.getChildJobId()));
+  }
+
+  private String describeCondition(WorkflowConditionEntity condition) {
+    if (condition.getConditionExpression() != null
+        && !condition.getConditionExpression().isBlank()) {
+      return condition.getConditionExpression();
+    }
+    return condition.getConditionType().name();
   }
 
   private Map<UUID, JobEntity> loadChildJobs(List<WorkflowConditionEntity> conditions) {

--- a/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/BatchServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,7 +29,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobType;
+import run.ratchet.api.event.BatchCompletedEvent;
 import run.ratchet.api.event.BatchCompletingEvent;
+import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.MetricsCollector;
@@ -130,8 +133,13 @@ class BatchServiceTest {
     batchService.markChildSucceeded(child);
 
     ArgumentCaptor<Object> event = ArgumentCaptor.forClass(Object.class);
-    verify(eventPublisher).publish(event.capture());
-    BatchCompletingEvent completingEvent = (BatchCompletingEvent) event.getValue();
+    verify(eventPublisher, times(3)).publish(event.capture());
+    BatchCompletingEvent completingEvent =
+        event.getAllValues().stream()
+            .filter(BatchCompletingEvent.class::isInstance)
+            .map(BatchCompletingEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
     assertEquals(parentId, completingEvent.getJobId());
     assertEquals("invoice-run", completingEvent.getBusinessKey());
     assertEquals(JobType.BATCH, completingEvent.getJobType());
@@ -140,6 +148,23 @@ class BatchServiceTest {
     assertEquals(3, completingEvent.getTotalItems());
     assertEquals(3, completingEvent.getCompletedItems());
     assertEquals(0, completingEvent.getFailedItems());
+    BatchCompletedEvent completedEvent =
+        event.getAllValues().stream()
+            .filter(BatchCompletedEvent.class::isInstance)
+            .map(BatchCompletedEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(parentId, completedEvent.getJobId());
+    assertEquals(3, completedEvent.getTotalItems());
+    assertEquals(3, completedEvent.getCompletedItems());
+    assertEquals(0, completedEvent.getFailedItems());
+    JobCompletedEvent jobCompletedEvent =
+        event.getAllValues().stream()
+            .filter(JobCompletedEvent.class::isInstance)
+            .map(JobCompletedEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(parentId, jobCompletedEvent.getJobId());
     verify(batchStore, never()).findBatchById(parentId);
     verify(jobTerminalStore).markJobSucceededMinimal(parentId, FIXED_NOW, FIXED_NOW, 0L, 0L);
   }

--- a/ratchet/src/test/java/run/ratchet/ri/core/ChainSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/ChainSchedulerTest.java
@@ -24,7 +24,11 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.ChainCompletedEvent;
+import run.ratchet.api.event.ChainFailedEvent;
+import run.ratchet.api.event.ChainStartedEvent;
 import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobTerminalStore;
 
@@ -36,6 +40,7 @@ class ChainSchedulerTest {
 
   @Mock private JobCrudStore jobCrudStore;
   @Mock private JobTerminalStore jobTerminalStore;
+  @Mock private InternalEventPublisher eventPublisher;
 
   private ChainScheduler scheduler;
 
@@ -71,6 +76,27 @@ class ChainSchedulerTest {
   }
 
   @Test
+  void scheduleNext_finalChainStepPublishesChainCompletedEvent() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    JobEntity root = pendingJob();
+    root.setJobType(JobExecutionType.SINGLE);
+    JobEntity finished = pendingJob();
+    finished.setJobType(JobExecutionType.CHAIN_STEP);
+    finished.setDependsOn(root.getId());
+
+    when(jobCrudStore.findDependants(finished.getId())).thenReturn(List.of());
+    when(jobCrudStore.findById(root.getId())).thenReturn(java.util.Optional.of(root));
+
+    assertFalse(scheduler.scheduleNext(finished));
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    ChainCompletedEvent event = (ChainCompletedEvent) eventCaptor.getValue();
+    assertEquals(finished.getId(), event.getJobId());
+    assertEquals(root.getId(), event.getParentJobId());
+  }
+
+  @Test
   void scheduleNext_pendingChildWithSentinel_setsScheduledTimeAndReturnsTrue() {
     JobEntity finished = pendingJob();
     JobEntity child = pendingJob();
@@ -83,6 +109,26 @@ class ChainSchedulerTest {
     ArgumentCaptor<JobEntity> saved = ArgumentCaptor.forClass(JobEntity.class);
     verify(jobCrudStore).save(saved.capture());
     assertEquals(FIXED_NOW, saved.getValue().getScheduledTime());
+  }
+
+  @Test
+  void scheduleNext_firstChainStepPublishesChainStartedEvent() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    JobEntity root = pendingJob();
+    root.setJobType(JobExecutionType.SINGLE);
+    JobEntity child = pendingJob();
+    child.setJobType(JobExecutionType.CHAIN_STEP);
+    child.setScheduledTime(ChainScheduler.CHAIN_LOCK_TIME);
+
+    when(jobCrudStore.findDependants(root.getId())).thenReturn(List.of(child));
+
+    assertTrue(scheduler.scheduleNext(root));
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    ChainStartedEvent event = (ChainStartedEvent) eventCaptor.getValue();
+    assertEquals(child.getId(), event.getJobId());
+    assertEquals(root.getId(), event.getParentJobId());
   }
 
   @Test
@@ -209,6 +255,28 @@ class ChainSchedulerTest {
     scheduler.cancelChain(failed);
 
     verify(jobTerminalStore).cancelJob(child.getId());
+  }
+
+  @Test
+  void cancelChain_publishesChainFailedEventWhenDependantsAreCanceled() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    JobEntity failed = pendingJob();
+    failed.setJobType(JobExecutionType.SINGLE);
+    failed.setLastError("boom");
+    JobEntity child = pendingJob();
+    child.setJobType(JobExecutionType.CHAIN_STEP);
+
+    when(jobCrudStore.findDependants(failed.getId())).thenReturn(List.of(child));
+    when(jobCrudStore.findDependants(child.getId())).thenReturn(List.of());
+
+    scheduler.cancelChain(failed);
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    ChainFailedEvent event = (ChainFailedEvent) eventCaptor.getValue();
+    assertEquals(failed.getId(), event.getJobId());
+    assertEquals(failed.getId(), event.getParentJobId());
+    assertEquals("boom", event.getErrorMessage());
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobTimeoutHandlerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobTimeoutHandlerTest.java
@@ -31,6 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.JobDlqEvent;
+import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.exception.SignalTimeoutException;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
@@ -52,6 +54,7 @@ class JobTimeoutHandlerTest {
   @Mock private PostExecutionHandler lifecycleFacade;
   @Mock private MetricsCollector metricsCollector;
   @Mock private SignalStore signalStore;
+  @Mock private InternalEventPublisher eventPublisher;
 
   private JobTimeoutHandler handler;
 
@@ -159,6 +162,46 @@ class JobTimeoutHandlerTest {
     verify(jobBatchStatusStore, times(1))
         .compareAndSwapStatus(eq(JOB_ID), eq(JobStatus.RUNNING), eq(JobStatus.FAILED), anyString());
     verify(lifecycleFacade, times(1)).handlePermanentFailure(eq(job), any());
+  }
+
+  @Test
+  void hardTimeoutTerminalFailurePublishesFailedAndDlqEvents() {
+    handler =
+        newHandler(
+            null,
+            null,
+            JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE,
+            Clock.systemUTC(),
+            eventPublisher);
+    JobEntity job = jobWithMaxRetries(0);
+    job.setBusinessKey("timeout-key");
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobRetryStore.incrementRetryAttempt(JOB_ID)).thenReturn(1);
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), eq(JobStatus.RUNNING), eq(JobStatus.FAILED), anyString()))
+        .thenReturn(true);
+
+    handler.processHardTimeout(JOB_ID, TIMEOUT_SEC);
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher, times(2)).publish(eventCaptor.capture());
+    JobFailedEvent failedEvent =
+        eventCaptor.getAllValues().stream()
+            .filter(JobFailedEvent.class::isInstance)
+            .map(JobFailedEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(JOB_ID, failedEvent.getJobId());
+    assertEquals("timeout-key", failedEvent.getBusinessKey());
+    assertEquals(1, failedEvent.getRetryAttempt());
+    JobDlqEvent dlqEvent =
+        eventCaptor.getAllValues().stream()
+            .filter(JobDlqEvent.class::isInstance)
+            .map(JobDlqEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(JOB_ID, dlqEvent.getJobId());
+    assertEquals(1, dlqEvent.getRetryAttempt());
   }
 
   @Test
@@ -338,6 +381,15 @@ class JobTimeoutHandlerTest {
       MetricsCollector metricsCollector,
       int signalTimeoutBatchSize,
       Clock clock) {
+    return newHandler(signalStore, metricsCollector, signalTimeoutBatchSize, clock, null);
+  }
+
+  private JobTimeoutHandler newHandler(
+      SignalStore signalStore,
+      MetricsCollector metricsCollector,
+      int signalTimeoutBatchSize,
+      Clock clock,
+      InternalEventPublisher eventPublisher) {
     return new JobTimeoutHandler(
         jobCrudStore,
         jobRetryStore,
@@ -346,7 +398,7 @@ class JobTimeoutHandlerTest {
         80,
         60L,
         clock,
-        null,
+        eventPublisher,
         null,
         signalStore,
         metricsCollector,

--- a/ratchet/src/test/java/run/ratchet/ri/core/WorkflowSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/WorkflowSchedulerTest.java
@@ -23,10 +23,12 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.WorkflowCondition;
+import run.ratchet.api.event.WorkflowBranchTriggeredEvent;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.WorkflowConditionEntity;
@@ -46,6 +48,7 @@ class WorkflowSchedulerTest {
   @Mock private JobTerminalStore jobTerminalStore;
   @Mock private WorkflowConditionStore conditionStore;
   @Mock private WorkflowConditionEvaluator conditionEvaluator;
+  @Mock private InternalEventPublisher eventPublisher;
 
   private WorkflowScheduler scheduler;
 
@@ -167,6 +170,35 @@ class WorkflowSchedulerTest {
     assertEquals(JobStatus.PENDING, child.getStatus());
     assertEquals(JobExecutionType.WORKFLOW_BRANCH, child.getJobType());
     assertEquals(FIXED_NOW, child.getScheduledTime());
+  }
+
+  @Test
+  void scheduleNext_matchedBranchPublishesWorkflowBranchTriggeredEvent() {
+    scheduler =
+        new WorkflowScheduler(
+            jobCrudStore,
+            jobBatchStatusStore,
+            jobTerminalStore,
+            conditionStore,
+            conditionEvaluator,
+            FIXED_CLOCK,
+            eventPublisher);
+    JobEntity parent = job(new UUID(0L, 18L), JobStatus.SUCCEEDED);
+    JobEntity child = job(new UUID(0L, 19L), JobStatus.PENDING);
+    WorkflowConditionEntity condition = condition(parent.getId(), child.getId(), 0);
+    condition.setConditionExpression("result.ok == true");
+    when(conditionStore.findConditionsByParentJobId(parent.getId())).thenReturn(List.of(condition));
+    when(conditionEvaluator.evaluate(condition, parent)).thenReturn(true);
+    when(jobCrudStore.findById(child.getId())).thenReturn(Optional.of(child));
+
+    assertTrue(scheduler.scheduleNext(parent));
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    WorkflowBranchTriggeredEvent event = (WorkflowBranchTriggeredEvent) eventCaptor.getValue();
+    assertEquals(parent.getId(), event.getJobId());
+    assertEquals("result.ok == true", event.getBranchCondition());
+    assertEquals(child.getId(), event.getNextJobId());
   }
 
   @Test


### PR DESCRIPTION
## Summary

This wires the missing batch, chain, workflow, and failure events from the v5 ghost-event workstream. Batch terminalization now publishes batch and parent job terminal events, DLQ terminal failures publish `JobFailedEvent`, and chain/workflow transitions emit the events the API already exposed.

`PerformanceMetricsEvent` is deprecated and removed from delivered-event docs rather than deleted outright, so source compatibility is preserved.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet,ratchet-api -Dtest=EventApiContractTest,BatchServiceTest,JobTimeoutHandlerTest,ChainSchedulerTest,WorkflowSchedulerTest -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl ratchet-api test`
- `mvn -pl ratchet,ratchet-api spotless:apply`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

These producers publish synchronously like the existing local event paths. When this lands near the signal transaction PR, the after-commit helper should be reconciled deliberately.
