### PR TITLE
tighten store TCK edge cases

### DIFF
--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobPauseStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobPauseStoreContract.java
@@ -1,12 +1,18 @@
 package run.ratchet.tck.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Instant;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
 
 /** Base contract tests for {@code JobPauseStore}. */
 public abstract class AbstractJobPauseStoreContract implements JobStoreContractFixture {
@@ -36,5 +42,71 @@ public abstract class AbstractJobPauseStoreContract implements JobStoreContractF
 
     var resumedJob = store().findById(saved.getId()).orElseThrow();
     assertEquals(JobStatus.PENDING, resumedJob.getStatus());
+  }
+
+  @Test
+  void transitionFromPausedAtomic_restoresStoredStatusAndClearsPauseMetadata() {
+    var saved = persist(newPendingJob());
+
+    assertTrue(store().transitionToPaused(saved.getId(), JobStatus.PENDING));
+
+    JobStatus restored = store().transitionFromPausedAtomic(saved.getId());
+
+    assertEquals(JobStatus.PENDING, restored);
+    var resumed = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.PENDING, resumed.getStatus());
+    assertNull(resumed.getPausedFromStatus(), "resume must clear pausedFromStatus");
+  }
+
+  @Test
+  void transitionFromPausedAtomic_nonPausedJob_returnsNull() {
+    var saved = persist(newPendingJob());
+
+    JobStatus restored = store().transitionFromPausedAtomic(saved.getId());
+
+    assertNull(restored, "non-PAUSED rows should not be resumed atomically");
+    assertEquals(JobStatus.PENDING, store().getJobStatus(saved.getId()));
+  }
+
+  @Test
+  void transitionFromPausedAtomic_unknownJob_returnsNull() {
+    assertNull(store().transitionFromPausedAtomic(new UUID(0L, Long.MAX_VALUE)));
+  }
+
+  @Test
+  void pauseRecurring_andResumeRecurring_onlyOperateOnRecurringMasters() {
+    var recurring = persist(recurringJob());
+    var oneShot = persist(newPendingJob());
+
+    assertFalse(
+        store().pauseRecurring(oneShot.getId()), "one-shot jobs must not use recurring pause");
+    assertTrue(store().pauseRecurring(recurring.getId()), "recurring master should pause");
+    assertEquals(JobStatus.PAUSED, store().getJobStatus(recurring.getId()));
+
+    assertFalse(
+        store().resumeRecurring(oneShot.getId()), "one-shot jobs must not use recurring resume");
+    assertTrue(store().resumeRecurring(recurring.getId()), "paused recurring master should resume");
+    assertEquals(JobStatus.PENDING, store().getJobStatus(recurring.getId()));
+  }
+
+  @Test
+  void pauseRecurring_resumeRecurring_areIdempotentForWrongState() {
+    var recurring = persist(recurringJob());
+
+    assertTrue(store().pauseRecurring(recurring.getId()));
+    assertFalse(
+        store().pauseRecurring(recurring.getId()), "already-paused master should not pause");
+
+    assertTrue(store().resumeRecurring(recurring.getId()));
+    assertFalse(
+        store().resumeRecurring(recurring.getId()), "already-pending master should not resume");
+  }
+
+  private JobEntity recurringJob() {
+    JobEntity job = newPendingJob();
+    job.setJobType(JobExecutionType.RECURRING);
+    job.setCronExpr("0 * * * *");
+    job.setNextFire(Instant.now().plusSeconds(60));
+    return job;
   }
 }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobRetryStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobRetryStoreContract.java
@@ -1,9 +1,11 @@
 package run.ratchet.tck.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,5 +75,33 @@ public abstract class AbstractJobRetryStoreContract implements JobStoreContractF
     assertTrue(reset, "resetFailedToPending should succeed for a FAILED job");
     var reloaded = store().findById(saved.getId()).orElseThrow();
     assertEquals(JobStatus.PENDING, reloaded.getStatus());
+  }
+
+  @Test
+  void incrementRetryAttempt_unknownJob_returnsMinusOne() {
+    assertEquals(-1, store().incrementRetryAttempt(new UUID(0L, Long.MAX_VALUE)));
+  }
+
+  @Test
+  void scheduleJobRetry_rejectsNonRetryableOrMissingRows() {
+    var pending = persist(newPendingJob());
+    Instant retryTime = Instant.now().plusSeconds(300);
+
+    assertFalse(
+        store().scheduleJobRetry(pending.getId(), "not running", retryTime, 1),
+        "PENDING jobs should not be rescheduled through retry");
+    assertFalse(
+        store().scheduleJobRetry(new UUID(0L, Long.MAX_VALUE), "missing", retryTime, 1),
+        "missing jobs should not be rescheduled through retry");
+  }
+
+  @Test
+  void resetFailedToPending_rejectsNonFailedOrMissingRows() {
+    var pending = persist(newPendingJob());
+
+    assertFalse(
+        store().resetFailedToPending(pending.getId()),
+        "resetFailedToPending should only reset FAILED jobs");
+    assertFalse(store().resetFailedToPending(new UUID(0L, Long.MAX_VALUE)));
   }
 }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractTagStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractTagStoreContract.java
@@ -82,10 +82,39 @@ public abstract class AbstractTagStoreContract implements JobStoreContractFixtur
 
     assertDoesNotThrow(
         () -> {
-          store().insertTags(saved.getId(), List.of("dup-tag"));
+          store().insertTags(saved.getId(), List.of("dup-tag", "dup-tag"));
           store().insertTags(saved.getId(), List.of("dup-tag"));
         },
         "Inserting the same tag twice should not throw");
+
+    assertEquals(
+        List.of(saved.getId()),
+        store().findJobIdsByTag("dup-tag", 10, 0),
+        "Duplicate tag insertion must leave a single association");
+  }
+
+  @Test
+  void findJobIdsByTag_returnsDeterministicIdOrder() {
+    var third = newPendingJob();
+    third.setId(new UUID(0L, 3L));
+    store().create(third);
+
+    var first = newPendingJob();
+    first.setId(new UUID(0L, 1L));
+    store().create(first);
+
+    var second = newPendingJob();
+    second.setId(new UUID(0L, 2L));
+    store().create(second);
+
+    store().insertTags(third.getId(), List.of("ordered-tag"));
+    store().insertTags(first.getId(), List.of("ordered-tag"));
+    store().insertTags(second.getId(), List.of("ordered-tag"));
+
+    assertEquals(
+        List.of(first.getId(), second.getId(), third.getId()),
+        store().findJobIdsByTag("ordered-tag", 10, 0),
+        "tag scans should return deterministic ascending job IDs");
   }
 
   @Test

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractWorkflowConditionStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractWorkflowConditionStoreContract.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +55,46 @@ public abstract class AbstractWorkflowConditionStoreContract implements JobStore
 
     var conditions = store().findConditionsByParentJobId(parent.getId());
     assertEquals(2, conditions.size(), "findConditionsByParentJobId should return both conditions");
+  }
+
+  @Test
+  void findConditionsByParentJobId_ordersByConditionPriority() {
+    var parent = persist(newPendingJob());
+    var lowPriorityChild = persist(newPendingJob());
+    var highPriorityChild = persist(newPendingJob());
+    var middlePriorityChild = persist(newPendingJob());
+
+    store()
+        .saveCondition(
+            newCondition(
+                parent.getId(),
+                lowPriorityChild.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                20));
+    store()
+        .saveCondition(
+            newCondition(
+                parent.getId(),
+                highPriorityChild.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                5));
+    store()
+        .saveCondition(
+            newCondition(
+                parent.getId(),
+                middlePriorityChild.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                10));
+
+    var orderedChildIds =
+        store().findConditionsByParentJobId(parent.getId()).stream()
+            .map(WorkflowConditionEntity::getChildJobId)
+            .toList();
+
+    assertEquals(
+        List.of(highPriorityChild.getId(), middlePriorityChild.getId(), lowPriorityChild.getId()),
+        orderedChildIds,
+        "parent condition scans should evaluate lower priority numbers first");
   }
 
   @Test

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/core/JobRetryIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/core/JobRetryIT.java
@@ -25,13 +25,10 @@ import run.ratchet.testsuite.util.RatchetArchiveBuilder;
 /** Validates retry behavior: failure → retry with backoff, configurable retry count. */
 class JobRetryIT extends BaseRatchetIT {
 
-  // The gap assertion measures scheduledTime − event.timestamp. Emission-lag between scheduling
-  // the retry and publishing the event eats into the gap, so the backoff must be large enough
-  // that a slow CI runner (GC pause, DB write latency) can't push the gap below the floor. 100ms
-  // was too tight — observed −42ms gap on a CI runner, i.e. ~142ms of emission lag. 500ms with a
-  // 150ms tolerance gives ~350ms of headroom while still catching real backoff regressions.
-  private static final Duration FIXED_BACKOFF = Duration.ofMillis(500);
-  private static final Duration BACKOFF_TOLERANCE = Duration.ofMillis(150);
+  // The gap assertion measures scheduledTime - event.timestamp. Event-publish lag on slow
+  // CI runners eats into that gap, so keep the backoff large enough to test a real delay.
+  private static final Duration FIXED_BACKOFF = Duration.ofMillis(1000);
+  private static final Duration BACKOFF_TOLERANCE = Duration.ofMillis(350);
 
   @Inject private TestJobService jobService;
 


### PR DESCRIPTION
## Summary

This is a focused TCK PR for v5 store-contract gaps. It adds edge-case coverage for pause, retry, tag, and workflow-condition stores without changing runtime behavior.

The point is to lock down provider behavior before the larger data-correctness fixes start moving through review.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet-tck/store test`
- `mvn -pl ratchet-tck/store -DskipTests install`
- Mongo pause, retry, tag, and workflow-condition contract tests
- MySQL pause, retry, tag, and workflow-condition contract tests
- PostgreSQL pause, retry, tag, and workflow-condition contract tests

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

This intentionally does not cover the public API/SPI contracts, JobCrud analytics helpers, NodeStore delete-by-ids, or SignalStore timeout bounds. Those stay in the v5 residue list.
