### PR TITLE
tighten event and SPI contracts

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobCancellationEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobCancellationEvent.java
@@ -24,8 +24,8 @@ public abstract class AbstractJobCancellationEvent extends AbstractJobSchedulerE
       String previousStatus,
       Long executionTimeMs) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.previousStatus = previousStatus;
-    this.executionTimeMs = executionTimeMs;
+    this.previousStatus = EventContract.requireNonBlank(previousStatus, "previousStatus");
+    this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
 
   /**
@@ -43,8 +43,8 @@ public abstract class AbstractJobCancellationEvent extends AbstractJobSchedulerE
       String previousStatus,
       Long executionTimeMs) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.previousStatus = previousStatus;
-    this.executionTimeMs = executionTimeMs;
+    this.previousStatus = EventContract.requireNonBlank(previousStatus, "previousStatus");
+    this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
 
   /**

--- a/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobSchedulerEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobSchedulerEvent.java
@@ -32,12 +32,12 @@ public abstract class AbstractJobSchedulerEvent implements Serializable {
       JobPriority priority,
       String nodeId,
       Instant timestamp) {
-    this.jobId = jobId;
+    this.jobId = EventContract.requireNonNull(jobId, "jobId");
     this.businessKey = businessKey;
     this.jobType = jobType;
     this.priority = priority;
     this.nodeId = nodeId;
-    this.timestamp = timestamp;
+    this.timestamp = EventContract.requireNonNull(timestamp, "timestamp");
   }
 
   /**

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletedEvent.java
@@ -32,6 +32,7 @@ public class BatchCompletedEvent extends AbstractJobSchedulerEvent {
       int completedItems,
       int failedItems) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;
     this.failedItems = failedItems;
@@ -47,6 +48,7 @@ public class BatchCompletedEvent extends AbstractJobSchedulerEvent {
       int completedItems,
       int failedItems) {
     super(jobId, businessKey, jobType, priority, nodeId);
+    EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;
     this.failedItems = failedItems;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
@@ -33,6 +33,7 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
       int completedItems,
       int failedItems) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;
     this.failedItems = failedItems;
@@ -55,6 +56,7 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
       int completedItems,
       int failedItems) {
     super(jobId, businessKey, jobType, priority, nodeId);
+    EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;
     this.failedItems = failedItems;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainCompletedEvent.java
@@ -27,7 +27,7 @@ public class ChainCompletedEvent extends AbstractJobSchedulerEvent {
       Instant timestamp,
       UUID parentJobId) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.parentJobId = parentJobId;
+    this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 
   public ChainCompletedEvent(
@@ -38,7 +38,7 @@ public class ChainCompletedEvent extends AbstractJobSchedulerEvent {
       String nodeId,
       UUID parentJobId) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.parentJobId = parentJobId;
+    this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 
   /** Returns the root job that initiated the completed chain. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainFailedEvent.java
@@ -30,8 +30,8 @@ public class ChainFailedEvent extends AbstractJobSchedulerEvent {
       UUID parentJobId,
       String errorMessage) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.parentJobId = parentJobId;
-    this.errorMessage = errorMessage;
+    this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
+    this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
   }
 
   /**
@@ -49,8 +49,8 @@ public class ChainFailedEvent extends AbstractJobSchedulerEvent {
       UUID parentJobId,
       String errorMessage) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.parentJobId = parentJobId;
-    this.errorMessage = errorMessage;
+    this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
+    this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
   }
 
   /** Returns the root or parent job whose chain failed. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainStartedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainStartedEvent.java
@@ -27,7 +27,7 @@ public class ChainStartedEvent extends AbstractJobSchedulerEvent {
       Instant timestamp,
       UUID parentJobId) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.parentJobId = parentJobId;
+    this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 
   public ChainStartedEvent(
@@ -38,7 +38,7 @@ public class ChainStartedEvent extends AbstractJobSchedulerEvent {
       String nodeId,
       UUID parentJobId) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.parentJobId = parentJobId;
+    this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 
   /** Returns the root job that triggered the chain. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/EventContract.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/EventContract.java
@@ -1,0 +1,50 @@
+package run.ratchet.api.event;
+
+import java.util.Objects;
+
+final class EventContract {
+
+  private EventContract() {}
+
+  static <T> T requireNonNull(T value, String name) {
+    return Objects.requireNonNull(value, name);
+  }
+
+  static String requireNonBlank(String value, String name) {
+    Objects.requireNonNull(value, name);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value;
+  }
+
+  static int requirePositive(int value, String name) {
+    if (value <= 0) {
+      throw new IllegalArgumentException(name + " must be positive");
+    }
+    return value;
+  }
+
+  static int requireNonNegative(int value, String name) {
+    if (value < 0) {
+      throw new IllegalArgumentException(name + " must not be negative");
+    }
+    return value;
+  }
+
+  static Long requireNonNegative(Long value, String name) {
+    if (value != null && value < 0) {
+      throw new IllegalArgumentException(name + " must not be negative");
+    }
+    return value;
+  }
+
+  static void requireBatchCounts(int totalItems, int completedItems, int failedItems) {
+    requirePositive(totalItems, "totalItems");
+    requireNonNegative(completedItems, "completedItems");
+    requireNonNegative(failedItems, "failedItems");
+    if ((long) completedItems + failedItems > totalItems) {
+      throw new IllegalArgumentException("completedItems + failedItems must not exceed totalItems");
+    }
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
@@ -32,10 +32,10 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
       String causeClassName,
       int callbackAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.callbackType = callbackType;
+    this.callbackType = EventContract.requireNonNull(callbackType, "callbackType");
     this.errorMessage = errorMessage;
-    this.causeClassName = causeClassName;
-    this.callbackAttempt = callbackAttempt;
+    this.causeClassName = EventContract.requireNonBlank(causeClassName, "causeClassName");
+    this.callbackAttempt = EventContract.requirePositive(callbackAttempt, "callbackAttempt");
   }
 
   /**
@@ -54,10 +54,10 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
       String causeClassName,
       int callbackAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.callbackType = callbackType;
+    this.callbackType = EventContract.requireNonNull(callbackType, "callbackType");
     this.errorMessage = errorMessage;
-    this.causeClassName = causeClassName;
-    this.callbackAttempt = callbackAttempt;
+    this.causeClassName = EventContract.requireNonBlank(causeClassName, "causeClassName");
+    this.callbackAttempt = EventContract.requirePositive(callbackAttempt, "callbackAttempt");
   }
 
   /** Returns which lifecycle callback failed. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCompletedEvent.java
@@ -28,7 +28,7 @@ public class JobCompletedEvent extends AbstractJobSchedulerEvent {
       Instant timestamp,
       Long executionTimeMs) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.executionTimeMs = executionTimeMs;
+    this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
 
   /**
@@ -48,7 +48,7 @@ public class JobCompletedEvent extends AbstractJobSchedulerEvent {
       String nodeId,
       Long executionTimeMs) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.executionTimeMs = executionTimeMs;
+    this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
 
   /** Returns the wall-clock execution duration in milliseconds, or {@code null} if not recorded. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
@@ -18,7 +18,7 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
    * Creates an event with an explicit timestamp.
    *
    * @param errorMessage sanitized final failure message
-   * @param retryAttempt final 1-based execution attempt count before DLQ
+   * @param retryAttempt final recorded retry attempt count before DLQ
    */
   public JobDlqEvent(
       UUID jobId,
@@ -30,8 +30,8 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
-    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
+    this.errorMessage = errorMessage;
+    this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }
 
   /**
@@ -41,7 +41,7 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
    * {@link Instant}.
    *
    * @param errorMessage sanitized final failure message
-   * @param retryAttempt final 1-based execution attempt count before DLQ
+   * @param retryAttempt final recorded retry attempt count before DLQ
    */
   public JobDlqEvent(
       UUID jobId,
@@ -52,8 +52,8 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
-    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
+    this.errorMessage = errorMessage;
+    this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }
 
   /** Returns the sanitized final failure message. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
@@ -30,8 +30,8 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.errorMessage = errorMessage;
-    this.retryAttempt = retryAttempt;
+    this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
+    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
   }
 
   /**
@@ -52,8 +52,8 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.errorMessage = errorMessage;
-    this.retryAttempt = retryAttempt;
+    this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
+    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
   }
 
   /** Returns the sanitized final failure message. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
@@ -31,7 +31,7 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
     this.errorMessage = errorMessage;
-    this.retryAttempt = retryAttempt;
+    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
   }
 
   /**
@@ -50,7 +50,7 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
       int retryAttempt) {
     super(jobId, businessKey, jobType, priority, nodeId);
     this.errorMessage = errorMessage;
-    this.retryAttempt = retryAttempt;
+    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
   }
 
   /** Returns the sanitized failure message, or {@code null} when no message was recorded. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobRetryingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobRetryingEvent.java
@@ -35,8 +35,8 @@ public class JobRetryingEvent extends AbstractJobSchedulerEvent {
       Instant scheduledTime) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
     this.errorMessage = errorMessage;
-    this.retryAttempt = retryAttempt;
-    this.scheduledTime = scheduledTime;
+    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
+    this.scheduledTime = EventContract.requireNonNull(scheduledTime, "scheduledTime");
   }
 
   /**
@@ -61,8 +61,8 @@ public class JobRetryingEvent extends AbstractJobSchedulerEvent {
       Instant scheduledTime) {
     super(jobId, businessKey, jobType, priority, nodeId);
     this.errorMessage = errorMessage;
-    this.retryAttempt = retryAttempt;
-    this.scheduledTime = scheduledTime;
+    this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
+    this.scheduledTime = EventContract.requireNonNull(scheduledTime, "scheduledTime");
   }
 
   /** Returns the sanitized failure message that caused the retry, or {@code null} if absent. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
@@ -2,6 +2,7 @@ package run.ratchet.api.event;
 
 import java.io.Serial;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
@@ -26,11 +27,29 @@ public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
       JobType jobType,
       JobPriority priority,
       String nodeId,
+      Instant timestamp,
       String signalKey,
       Duration signalTimeout) {
-    super(jobId, businessKey, jobType, priority, nodeId);
-    this.signalKey = signalKey;
-    this.signalTimeout = signalTimeout;
+    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
+    this.signalTimeout = EventContract.requireNonNull(signalTimeout, "signalTimeout");
+  }
+
+  /**
+   * Creates a signal-timeout event using the current system clock instant.
+   *
+   * @param signalKey signal key the job was waiting on
+   * @param signalTimeout configured maximum wait duration that elapsed
+   */
+  public JobSignalTimedOutEvent(
+      UUID jobId,
+      String businessKey,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId,
+      String signalKey,
+      Duration signalTimeout) {
+    this(jobId, businessKey, jobType, priority, nodeId, Instant.now(), signalKey, signalTimeout);
   }
 
   /** Returns the signal key the job was waiting on. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalWaitingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalWaitingEvent.java
@@ -2,6 +2,7 @@ package run.ratchet.api.event;
 
 import java.io.Serial;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.UUID;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
@@ -25,11 +26,23 @@ public class JobSignalWaitingEvent extends AbstractJobSchedulerEvent {
       JobType jobType,
       JobPriority priority,
       String nodeId,
+      Instant timestamp,
       String signalKey,
       Duration signalTimeout) {
-    super(jobId, businessKey, jobType, priority, nodeId);
-    this.signalKey = signalKey;
+    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
     this.signalTimeout = signalTimeout;
+  }
+
+  public JobSignalWaitingEvent(
+      UUID jobId,
+      String businessKey,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId,
+      String signalKey,
+      Duration signalTimeout) {
+    this(jobId, businessKey, jobType, priority, nodeId, Instant.now(), signalKey, signalTimeout);
   }
 
   /** Returns the signal key the job is waiting on. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignaledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignaledEvent.java
@@ -1,7 +1,7 @@
 package run.ratchet.api.event;
 
 import java.io.Serial;
-import java.util.Objects;
+import java.time.Instant;
 import java.util.UUID;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
@@ -45,6 +45,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
         jobType,
         priority,
         nodeId,
+        Instant.now(),
         signalKey,
         signalDeliveredBy,
         SignalDecision.Outcome.APPROVED,
@@ -65,19 +66,51 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
       JobType jobType,
       JobPriority priority,
       String nodeId,
+      Instant timestamp,
       String signalKey,
       String signalDeliveredBy,
       SignalDecision.Outcome outcome,
       String rejectionReason) {
-    super(jobId, businessKey, jobType, priority, nodeId);
-    this.signalKey = Objects.requireNonNull(signalKey, "signalKey");
-    this.signalDeliveredBy = Objects.requireNonNull(signalDeliveredBy, "signalDeliveredBy");
-    this.outcome = Objects.requireNonNull(outcome, "outcome");
+    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
+    this.signalDeliveredBy = EventContract.requireNonBlank(signalDeliveredBy, "signalDeliveredBy");
+    this.outcome = EventContract.requireNonNull(outcome, "outcome");
     this.rejectionReason =
         rejectionReason == null || rejectionReason.isBlank() ? null : rejectionReason.trim();
     if (this.outcome == SignalDecision.Outcome.APPROVED && this.rejectionReason != null) {
       throw new IllegalArgumentException("approved events cannot carry a rejection reason");
     }
+  }
+
+  /**
+   * Creates a signal-delivered event using the current system clock instant.
+   *
+   * @param signalKey signal key delivered to the waiting job
+   * @param signalDeliveredBy principal or system component that delivered the signal
+   * @param outcome approval/rejection outcome; must not be {@code null}
+   * @param rejectionReason optional rejection reason; blank values are normalized to {@code null}
+   */
+  public JobSignaledEvent(
+      UUID jobId,
+      String businessKey,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId,
+      String signalKey,
+      String signalDeliveredBy,
+      SignalDecision.Outcome outcome,
+      String rejectionReason) {
+    this(
+        jobId,
+        businessKey,
+        jobType,
+        priority,
+        nodeId,
+        Instant.now(),
+        signalKey,
+        signalDeliveredBy,
+        outcome,
+        rejectionReason);
   }
 
   /** Returns the signal key delivered to the waiting job. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkCancelledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkCancelledEvent.java
@@ -32,9 +32,9 @@ public class JobsBulkCancelledEvent implements Serializable {
    * @param cancelledAt instant when the bulk operation completed
    */
   public JobsBulkCancelledEvent(String tag, int count, Instant cancelledAt) {
-    this.tag = tag;
-    this.count = count;
-    this.cancelledAt = cancelledAt;
+    this.tag = EventContract.requireNonBlank(tag, "tag");
+    this.count = EventContract.requirePositive(count, "count");
+    this.cancelledAt = EventContract.requireNonNull(cancelledAt, "cancelledAt");
   }
 
   /** Returns the tag used to select jobs for cancellation. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkSignaledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkSignaledEvent.java
@@ -3,7 +3,6 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
-import java.util.Objects;
 import run.ratchet.api.SignalDecision;
 
 /**
@@ -35,13 +34,16 @@ public class JobsBulkSignaledEvent implements Serializable {
       SignalDecision.Outcome outcome,
       String rejectionReason,
       Instant signaledAt) {
-    this.signalKey = Objects.requireNonNull(signalKey, "signalKey");
-    this.count = count;
+    this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
+    this.count = EventContract.requirePositive(count, "count");
     this.signalDeliveredBy = signalDeliveredBy;
-    this.outcome = Objects.requireNonNull(outcome, "outcome");
+    this.outcome = EventContract.requireNonNull(outcome, "outcome");
     this.rejectionReason =
         rejectionReason == null || rejectionReason.isBlank() ? null : rejectionReason.trim();
-    this.signaledAt = Objects.requireNonNull(signaledAt, "signaledAt");
+    if (this.outcome == SignalDecision.Outcome.APPROVED && this.rejectionReason != null) {
+      throw new IllegalArgumentException("approved events cannot carry a rejection reason");
+    }
+    this.signaledAt = EventContract.requireNonNull(signaledAt, "signaledAt");
   }
 
   /** Returns the signal key that was delivered. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/WorkflowBranchTriggeredEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/WorkflowBranchTriggeredEvent.java
@@ -35,8 +35,8 @@ public class WorkflowBranchTriggeredEvent extends AbstractJobSchedulerEvent {
       String branchCondition,
       UUID nextJobId) {
     super(jobId, businessKey, jobType, priority, nodeId, timestamp);
-    this.branchCondition = branchCondition;
-    this.nextJobId = nextJobId;
+    this.branchCondition = EventContract.requireNonBlank(branchCondition, "branchCondition");
+    this.nextJobId = EventContract.requireNonNull(nextJobId, "nextJobId");
   }
 
   /**
@@ -54,8 +54,8 @@ public class WorkflowBranchTriggeredEvent extends AbstractJobSchedulerEvent {
       String branchCondition,
       UUID nextJobId) {
     super(jobId, businessKey, jobType, priority, nodeId);
-    this.branchCondition = branchCondition;
-    this.nextJobId = nextJobId;
+    this.branchCondition = EventContract.requireNonBlank(branchCondition, "branchCondition");
+    this.nextJobId = EventContract.requireNonNull(nextJobId, "nextJobId");
   }
 
   /** Returns the persisted condition description or expression that matched. */

--- a/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.lang.reflect.Constructor;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +54,182 @@ class EventApiContractTest {
     assertEquals(TIMESTAMP, event.getTimestamp());
     assertEquals("failed", event.getErrorMessage());
     assertEquals(3, event.getRetryAttempt());
+  }
+
+  @Test
+  void perJobEventsRequireJobIdAndTimestamp() {
+    assertThrows(
+        NullPointerException.class,
+        () -> new JobStartedEvent(null, "business-key", JobType.SINGLE, JobPriority.NORMAL, null));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new JobStartedEvent(
+                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, null, null));
+
+    JobStartedEvent event = new JobStartedEvent(JOB_ID, null, null, null, null, TIMESTAMP);
+
+    assertEquals(JOB_ID, event.getJobId());
+    assertEquals(TIMESTAMP, event.getTimestamp());
+  }
+
+  @Test
+  void signalEventsPreserveExplicitTimestamps() {
+    JobSignalWaitingEvent waiting =
+        new JobSignalWaitingEvent(
+            JOB_ID,
+            "business-key",
+            JobType.SINGLE,
+            JobPriority.NORMAL,
+            "node-a",
+            TIMESTAMP,
+            "signal-key",
+            Duration.ofMinutes(5));
+    JobSignalTimedOutEvent timedOut =
+        new JobSignalTimedOutEvent(
+            JOB_ID,
+            "business-key",
+            JobType.SINGLE,
+            JobPriority.NORMAL,
+            "node-a",
+            TIMESTAMP,
+            "signal-key",
+            Duration.ofMinutes(5));
+    JobSignaledEvent signaled =
+        new JobSignaledEvent(
+            JOB_ID,
+            "business-key",
+            JobType.SINGLE,
+            JobPriority.NORMAL,
+            "node-a",
+            TIMESTAMP,
+            "signal-key",
+            "operator",
+            SignalDecision.Outcome.APPROVED,
+            null);
+
+    assertEquals(TIMESTAMP, waiting.getTimestamp());
+    assertEquals(TIMESTAMP, timedOut.getTimestamp());
+    assertEquals(TIMESTAMP, signaled.getTimestamp());
+  }
+
+  @Test
+  void eventSpecificRequiredFieldsAreValidated() {
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new ChainStartedEvent(
+                JOB_ID, "business-key", JobType.CHAIN, JobPriority.NORMAL, "node-a", null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new ChainFailedEvent(
+                JOB_ID,
+                "business-key",
+                JobType.CHAIN,
+                JobPriority.NORMAL,
+                "node-a",
+                NEXT_JOB_ID,
+                " "));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new WorkflowBranchTriggeredEvent(
+                JOB_ID,
+                "business-key",
+                JobType.WORKFLOW,
+                JobPriority.NORMAL,
+                "node-a",
+                " ",
+                NEXT_JOB_ID));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new WorkflowBranchTriggeredEvent(
+                JOB_ID,
+                "business-key",
+                JobType.WORKFLOW,
+                JobPriority.NORMAL,
+                "node-a",
+                "result == true",
+                null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobSignalWaitingEvent(
+                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", " ", null));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new JobSignalTimedOutEvent(
+                JOB_ID,
+                "business-key",
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                "signal-key",
+                null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobCancelledEvent(
+                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", " ", null));
+  }
+
+  @Test
+  void countsAttemptsAndDurationsRejectInvalidRanges() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BatchCompletedEvent(
+                JOB_ID, "business-key", JobType.BATCH, JobPriority.NORMAL, "node-a", 0, 0, 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new BatchCompletingEvent(
+                JOB_ID, "business-key", JobType.BATCH, JobPriority.NORMAL, "node-a", 3, 2, 2));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobFailedEvent(
+                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", "failed", 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobCallbackFailedEvent(
+                JOB_ID,
+                "business-key",
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                JobCallbackFailedEvent.CallbackType.ON_FAILURE,
+                "failed",
+                "java.lang.IllegalStateException",
+                0));
+    assertThrows(
+        NullPointerException.class,
+        () ->
+            new JobRetryingEvent(
+                JOB_ID,
+                "business-key",
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                "failed",
+                1,
+                null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobCompletedEvent(
+                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", -1L));
+    assertThrows(
+        IllegalArgumentException.class, () -> new JobsBulkCancelledEvent("tag-a", 0, TIMESTAMP));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobsBulkSignaledEvent(
+                "signal-key", 0, "operator", SignalDecision.Outcome.APPROVED, null, TIMESTAMP));
   }
 
   @Test
@@ -109,6 +286,19 @@ class EventApiContractTest {
                 "operator",
                 SignalDecision.Outcome.APPROVED,
                 "not allowed"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobSignaledEvent(
+                JOB_ID,
+                "business-key",
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                " ",
+                "operator",
+                SignalDecision.Outcome.APPROVED,
+                null));
 
     JobSignaledEvent event =
         new JobSignaledEvent(
@@ -141,6 +331,16 @@ class EventApiContractTest {
         () ->
             new JobsBulkSignaledEvent(
                 "signal-key", 2, "operator", SignalDecision.Outcome.APPROVED, null, null));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new JobsBulkSignaledEvent(
+                "signal-key",
+                2,
+                "operator",
+                SignalDecision.Outcome.APPROVED,
+                "not allowed",
+                TIMESTAMP));
 
     JobsBulkSignaledEvent event =
         new JobsBulkSignaledEvent(

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/ArchiveStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/ArchiveStore.java
@@ -10,10 +10,20 @@ import run.ratchet.store.entity.JobEntity;
 @Incubating
 public interface ArchiveStore {
 
-  /** Archives one terminal job. Transaction attribute: {@code REQUIRED}. */
+  /**
+   * Archives one terminal job in the caller's store transaction.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}. Implementations must insert the archive row in the
+   * same transaction as any caller-managed active-job cleanup.
+   */
   ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy);
 
-  /** Archives terminal jobs as one batch. Transaction attribute: {@code REQUIRED}. */
+  /**
+   * Archives terminal jobs as one batch in the caller's store transaction.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}. Implementations must insert all archive rows in the
+   * same transaction as any caller-managed active-job cleanup.
+   */
   int archiveJobsBatch(List<JobEntity> jobs, String reason, String archivedBy);
 
   /** Finds active terminal jobs old enough to archive. Transaction attribute: {@code SUPPORTS}. */

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobCrudStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobCrudStore.java
@@ -18,12 +18,21 @@ public interface JobCrudStore {
 
   int DEFAULT_PAGE_LIMIT = 100;
 
-  /** Inserts a new job row and returns the persisted entity view. */
+  /**
+   * Inserts a new job row and returns the persisted entity view.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}.
+   */
   JobEntity create(JobEntity job);
 
-  /** Updates an existing job row and returns the persisted entity view. */
+  /**
+   * Updates an existing job row and returns the persisted entity view.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}.
+   */
   JobEntity save(JobEntity job);
 
+  /** Finds a job by primary key. Transaction attribute: {@code SUPPORTS}. */
   Optional<JobEntity> findById(UUID id);
 
   /**
@@ -31,30 +40,46 @@ public interface JobCrudStore {
    * — backends rely on optimistic version checks at the actual mutation site ({@code
    * findOneAndUpdate} on Mongo, {@code WHERE version = ?} on SQL). Callers MUST use a
    * version-checked update path; this method is read-only.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
    */
   Optional<JobEntity> findByIdLatest(UUID id);
 
+  /** Deletes a job row by primary key. Transaction attribute: {@code REQUIRED}. */
   void delete(UUID id);
 
   /**
    * Returns the current persisted status for a job.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
    *
    * @param id job id to inspect
    * @return current status, or {@code null} when no job exists for {@code id}
    */
   JobStatus getJobStatus(UUID id);
 
-  /** Batch-loads jobs by primary key for hot-path recovery and draining flows. */
+  /**
+   * Batch-loads jobs by primary key for hot-path recovery and draining flows.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   List<JobEntity> findByIds(List<UUID> ids);
 
-  /** Finds the active job currently associated with a business key, if any. */
+  /**
+   * Finds the active job currently associated with a business key, if any.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   Optional<JobEntity> findActiveByBusinessKey(String businessKey);
 
+  /** Finds a job by idempotency key. Transaction attribute: {@code SUPPORTS}. */
   Optional<JobEntity> findByIdempotencyKey(String idempotencyKey);
 
   /**
    * Returns the first page of direct dependant jobs whose {@code dependsOn} points at the supplied
    * parent.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
    *
    * @deprecated use {@link #findDependants(UUID, int, int)} when callers need to walk more than the
    *     default page.
@@ -66,14 +91,22 @@ public interface JobCrudStore {
 
   /**
    * Returns a page of direct dependant jobs whose {@code dependsOn} points at the supplied parent.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
    */
   List<JobEntity> findDependants(UUID parentJobId, int limit, int offset);
 
-  /** Returns the next fire time of the earliest pending recurring master job. */
+  /**
+   * Returns the next fire time of the earliest pending recurring master job.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   Optional<Instant> findEarliestRecurringNextFire();
 
+  /** Counts pending jobs. Transaction attribute: {@code SUPPORTS}. */
   long countPendingJobs();
 
+  /** Counts jobs at the supplied status. Transaction attribute: {@code SUPPORTS}. */
   long countJobsByStatus(JobStatus status);
 
   /**
@@ -98,24 +131,36 @@ public interface JobCrudStore {
     return counts;
   }
 
-  /** Counts active jobs of the supplied type. */
+  /** Counts active jobs of the supplied type. Transaction attribute: {@code SUPPORTS}. */
   long countActiveJobs(JobExecutionType jobType);
 
-  /** Counts currently registered scheduler nodes. */
+  /** Counts currently registered scheduler nodes. Transaction attribute: {@code SUPPORTS}. */
   long countActiveNodes();
 
-  /** Counts jobs ready to execute at or before the supplied instant. */
+  /**
+   * Counts jobs ready to execute at or before the supplied instant. Transaction attribute: {@code
+   * SUPPORTS}.
+   */
   long countReadyJobs(Instant now);
 
-  /** Counts running jobs whose pickup timestamp is older than the supplied threshold. */
+  /**
+   * Counts running jobs whose pickup timestamp is older than the supplied threshold.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   long countStuckJobs(Instant stuckThreshold);
 
-  /** Counts running jobs whose execution start time is older than the supplied threshold. */
+  /**
+   * Counts running jobs whose execution start time is older than the supplied threshold.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   long countLongRunningJobs(Instant threshold);
 
+  /** Counts pending batch-child jobs. Transaction attribute: {@code SUPPORTS}. */
   long countPendingBatchChildren();
 
-  /** Counts pending jobs at the supplied priority. */
+  /** Counts pending jobs at the supplied priority. Transaction attribute: {@code SUPPORTS}. */
   long countPendingJobsByPriority(JobPriority priority);
 
   /**
@@ -139,7 +184,7 @@ public interface JobCrudStore {
     return counts;
   }
 
-  /** Counts pending jobs of the supplied type. */
+  /** Counts pending jobs of the supplied type. Transaction attribute: {@code SUPPORTS}. */
   long countPendingJobsByType(JobExecutionType jobType);
 
   /**
@@ -163,26 +208,49 @@ public interface JobCrudStore {
     return counts;
   }
 
-  /** Counts jobs in a status whose last update was at or after the supplied instant. */
+  /**
+   * Counts jobs in a status whose last update was at or after the supplied instant.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   long countJobsByStatusSince(JobStatus status, Instant since);
 
-  /** Counts jobs that have recorded at least one retry attempt. */
+  /**
+   * Counts jobs that have recorded at least one retry attempt. Transaction attribute: {@code
+   * SUPPORTS}.
+   */
   long countJobsWithRetries();
 
-  /** Returns the fraction of recently updated jobs that have retried at least once. */
+  /**
+   * Returns the fraction of recently updated jobs that have retried at least once.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   double getRetryRateStats(Instant since);
 
-  /** Returns average execution duration for jobs included in the store's metric definition. */
+  /**
+   * Returns average execution duration for jobs included in the store's metric definition.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   double getAverageProcessingTime(Instant since);
 
-  /** Returns the average number of child items for batches updated since the cutoff. */
+  /**
+   * Returns the average number of child items for batches updated since the cutoff.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   */
   double getAverageBatchSize(Instant since);
 
-  /** Returns the scheduled time of the oldest pending job. */
+  /**
+   * Returns the scheduled time of the oldest pending job. Transaction attribute: {@code SUPPORTS}.
+   */
   Optional<Instant> getOldestPendingJobTime();
 
   /**
    * Returns the queue wait time at the given percentile for succeeded jobs.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
    *
    * @param percentile a fraction in the range [0.0, 1.0], e.g. 0.95 for p95
    * @return queue wait time in milliseconds at the requested percentile, or 0 if no data


### PR DESCRIPTION
## Summary

This tightens the v5 API/SPI contract findings that were safe to batch: event constructors now reject missing required fields, `EventContract` captures the shared rules, and the API tests cover the stricter behavior.

It also fills in transaction Javadocs for `JobCrudStore` and `ArchiveStore`, which were the first pass of the SPI transaction-attribute audit.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [x] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

Ran:

- `mvn -pl ratchet-api -Dtest=EventApiContractTest,JobCancellationEventTest test`
- `mvn -pl ratchet-api test`
- `mvn -pl ratchet-api,ratchet-store-core -am -DskipTests compile`
- `mvn spotless:apply`
- `mvn spotless:check`
- `git diff --check`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

`mvn -pl ratchet-api,ratchet-store-core -am -DskipTests compile javadoc:javadoc` still fails on existing unknown `@apiNote` tags in API docs. I left that separate from this v5 PR.
