### PR TITLE
Tighten SPI validation contracts

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/spi/BeanResolver.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/BeanResolver.java
@@ -4,8 +4,7 @@ import run.ratchet.api.Incubating;
 
 /**
  * Resolves bean instances by type, abstracting the dependency injection mechanism. The CDI
- * implementation delegates to CDI.current().select(type).get(), while the default RI implementation
- * uses reflection.
+ * implementation delegates to CDI.current().select(type).get().
  */
 @Incubating
 @FunctionalInterface
@@ -16,8 +15,8 @@ public interface BeanResolver {
    * @param type concrete or assignable bean type to resolve; must not be {@code null}
    * @return resolved bean instance; never {@code null}
    * @throws NullPointerException if {@code type} is {@code null}
-   * @throws IllegalStateException if no instance can be resolved or if more than one bean is
-   *     eligible
+   * @throws IllegalStateException if no instance can be resolved, if more than one bean is
+   *     eligible, or if the implementation cannot safely manage the resolved bean lifecycle
    */
   <T> T resolve(Class<T> type);
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/ClassPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ClassPolicy.java
@@ -14,7 +14,7 @@ public interface ClassPolicy {
   /**
    * Returns whether a class name may be used during payload restoration or invocation.
    *
-   * @param className fully qualified binary class name; never {@code null} or blank
+   * @param className fully qualified binary class name; {@code null} or blank input must be denied
    * @return {@code true} to allow the class, {@code false} to deny it
    */
   boolean isAllowed(String className);

--- a/ratchet-api/src/main/java/run/ratchet/spi/ClusterCoordinator.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ClusterCoordinator.java
@@ -18,6 +18,9 @@ public interface ClusterCoordinator {
   /**
    * Signals that new work is available somewhere in the cluster.
    *
+   * <p>Wakeups are best-effort hints. Implementations should tolerate transport failures without
+   * throwing to the caller; the local poll loop remains the source of truth.
+   *
    * @param priority priority of the newly available work; never {@code null}
    */
   void notifyNewWork(JobPriority priority);
@@ -27,7 +30,9 @@ public interface ClusterCoordinator {
    *
    * <p>Implementations may invoke listeners from coordinator-owned threads, transport callback
    * threads, or scheduler threads. The listener must be fast, non-blocking, and thread-safe.
-   * Registering the same listener more than once may produce duplicate callbacks.
+   * Implementations must isolate listener failures so one throwing listener does not prevent other
+   * listeners or future wakeups. Registering the same listener more than once may produce duplicate
+   * callbacks.
    *
    * <p>The SPI has no unregister method. Callers that need shutdown behavior should register a
    * wrapper that checks local lifecycle state before dispatching.

--- a/ratchet-api/src/main/java/run/ratchet/spi/ErrorSanitizer.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ErrorSanitizer.java
@@ -19,7 +19,13 @@ public interface ErrorSanitizer {
   /**
    * Converts a throwable into text safe for persistence and event publication.
    *
-   * @param ex throwable to sanitize; never {@code null}
+   * <p>Implementations must inspect the throwable cause chain, must tolerate cyclic cause graphs,
+   * must return bounded text, and should not throw. If sanitization itself fails, returning the
+   * throwable class name or another conservative fallback is preferable to surfacing the sanitizer
+   * failure to the job execution path.
+   *
+   * @param ex throwable to sanitize; {@code null} input returns a bounded representation of {@code
+   *     "null"}
    * @return sanitized, bounded error text; never {@code null}
    */
   String sanitize(Throwable ex);

--- a/ratchet-api/src/main/java/run/ratchet/spi/ExecutorProvider.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ExecutorProvider.java
@@ -4,7 +4,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import run.ratchet.api.Incubating;
 
-/** Supplies the thread pools used for job execution and scheduling. */
+/**
+ * Supplies the thread pools used for job execution and scheduling.
+ *
+ * <p>Each accessor must return a stable executor instance for the provider lifecycle. Consumers may
+ * retain returned references for cancellation, delayed scheduling, and lifecycle coordination.
+ *
+ * <p>Executor ownership is implementation-specific. Managed-runtime providers must not shut down
+ * container-owned executors, and callers must not invoke shutdown methods on executors they did not
+ * create. Standalone providers that create their own pools are responsible for disposing them
+ * during application shutdown.
+ */
 @Incubating
 public interface ExecutorProvider {
 

--- a/ratchet-api/src/main/java/run/ratchet/spi/JobInvocationResolver.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/JobInvocationResolver.java
@@ -11,8 +11,13 @@ public interface JobInvocationResolver {
   /**
    * Resolves a serializable callback into a persisted invocation.
    *
+   * <p>Implementations must reject invocations that target non-public methods and must not bypass
+   * the scheduler's configured class policy. Returning an invocation is a claim that the target is
+   * eligible for persistence and later execution.
+   *
    * @param callback serializable user callback; never {@code null}
    * @return invocation descriptor suitable for persistence; never {@code null}
+   * @throws IllegalArgumentException if the callback cannot be resolved into a valid invocation
    */
   JobInvocation resolve(Serializable callback);
 
@@ -24,6 +29,7 @@ public interface JobInvocationResolver {
    *     there are no runtime arguments. Implementations must treat this list as read-only and must
    *     not retain it unless they make their own copy.
    * @return invocation descriptor suitable for persistence; never {@code null}
+   * @throws IllegalArgumentException if the callback cannot be resolved into a valid invocation
    */
   JobInvocation resolve(Serializable callback, List<Object> runtimeArguments);
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/JobLoggerFactory.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/JobLoggerFactory.java
@@ -10,5 +10,15 @@ import run.ratchet.api.Incubating;
 @Incubating
 public interface JobLoggerFactory {
 
+  /**
+   * Creates the logger bound to one job execution.
+   *
+   * <p>The RI calls this once per execution attempt before binding {@code JobContext}. Returning
+   * {@code null} violates the SPI contract. Implementations may throw a runtime exception when a
+   * required logging backend is unavailable; callers treat that as an execution setup failure.
+   *
+   * @param context immutable execution logging context; never {@code null}
+   * @return logger for this execution attempt; never {@code null}
+   */
   JobLogger create(JobLoggerContext context);
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/LambdaAnalyzer.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/LambdaAnalyzer.java
@@ -14,7 +14,9 @@ public interface LambdaAnalyzer {
   /**
    * Analyzes a serializable lambda and returns its target-method metadata.
    *
-   * @throws IllegalArgumentException if the lambda is null or cannot be analyzed
+   * @throws NullPointerException if {@code lambda} is {@code null}
+   * @throws IllegalStateException if the lambda cannot be serialized or its bytecode cannot be
+   *     analyzed
    */
   LambdaDescriptor analyze(Serializable lambda);
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/NodeIdentityProvider.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/NodeIdentityProvider.java
@@ -11,6 +11,6 @@ import run.ratchet.api.Incubating;
 @Incubating
 public interface NodeIdentityProvider {
 
-  /** Returns the non-null node identifier. Must be immutable for the node's lifecycle. */
+  /** Returns the non-null node identifier. Must be immutable for the provider lifecycle. */
   String getNodeId();
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/PollingConfig.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/PollingConfig.java
@@ -24,4 +24,36 @@ public record PollingConfig(
     long deepIdleDelayMs,
     long deepIdleThresholdMs,
     int idleThreshold,
-    int batchSize) {}
+    int batchSize) {
+
+  public PollingConfig {
+    if (burstDelayMs < 0) {
+      throw new IllegalArgumentException("burstDelayMs must be non-negative");
+    }
+    if (minDelayMs < 0) {
+      throw new IllegalArgumentException("minDelayMs must be non-negative");
+    }
+    if (maxDelayMs < 0) {
+      throw new IllegalArgumentException("maxDelayMs must be non-negative");
+    }
+    if (deepIdleDelayMs < 0) {
+      throw new IllegalArgumentException("deepIdleDelayMs must be non-negative");
+    }
+    if (deepIdleThresholdMs < 0) {
+      throw new IllegalArgumentException("deepIdleThresholdMs must be non-negative");
+    }
+    if (minDelayMs > maxDelayMs) {
+      throw new IllegalArgumentException("minDelayMs must be less than or equal to maxDelayMs");
+    }
+    if (maxDelayMs > deepIdleDelayMs) {
+      throw new IllegalArgumentException(
+          "maxDelayMs must be less than or equal to deepIdleDelayMs");
+    }
+    if (idleThreshold < 0) {
+      throw new IllegalArgumentException("idleThreshold must be non-negative");
+    }
+    if (batchSize <= 0) {
+      throw new IllegalArgumentException("batchSize must be positive");
+    }
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/RatchetConfigSource.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/RatchetConfigSource.java
@@ -10,10 +10,13 @@ public interface RatchetConfigSource {
   /**
    * Returns a raw configuration value for a property/env pair.
    *
-   * @param propertyName dotted property name, for example {@code ratchet.poller.batch-size}; never
-   *     {@code null}
+   * <p>When both names are supplied and both exist, lookup precedence is implementation-defined.
+   * Callers must order their configured sources rather than depending on intra-source precedence.
+   *
+   * @param propertyName dotted property name, for example {@code ratchet.poller.batch-size}; {@code
+   *     null} or blank values are treated as absent
    * @param environmentVariable environment variable fallback, for example {@code
-   *     RATCHET_POLLER_BATCH_SIZE}; never {@code null}
+   *     RATCHET_POLLER_BATCH_SIZE}; {@code null} or blank values are treated as absent
    * @return raw value when present, otherwise {@link Optional#empty()}
    * @throws RuntimeException if the source cannot be read; callers may continue to the next source
    */

--- a/ratchet-api/src/main/java/run/ratchet/spi/ResilienceStrategy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ResilienceStrategy.java
@@ -16,7 +16,8 @@ public interface ResilienceStrategy {
   /**
    * Executes the given task with resilience protection.
    *
-   * @param serviceName identifies the service being protected (must be from a bounded vocabulary)
+   * @param serviceName identifies the service being protected. Implementations should bound or
+   *     normalize service-name cardinality before using it as a circuit-breaker key or metrics tag.
    * @param <T> the return type
    * @throws CircuitBreakerOpenException if the call is rejected because the circuit is open. This
    *     rejection is distinct from task failure; scheduler implementations should delay/reschedule

--- a/ratchet-api/src/main/java/run/ratchet/spi/SchedulerLifecycleHook.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/SchedulerLifecycleHook.java
@@ -16,10 +16,11 @@ import run.ratchet.api.Incubating;
  *
  * <p>Exceptions thrown from {@link #beforeStart()}, {@link #afterStart()}, {@link #beforeStop()},
  * or {@link #afterStop()} are logged at {@code WARN} and swallowed by the lifecycle observer so a
- * single misbehaving hook does not block deployment. The one exception is {@code
- * run.ratchet.store.migration.SchemaInitializationException} thrown from {@link #beforeStart()},
- * which propagates and aborts startup; an unmigrated or incompatible schema must not silently
- * become a runtime failure on the first store call.
+ * single misbehaving hook does not block deployment. Store-provided schema initialization hooks may
+ * throw a store-specific startup-abort exception from {@link #beforeStart()}, which propagates and
+ * aborts startup; an unmigrated or incompatible schema must not silently become a runtime failure
+ * on the first store call. API-only hook implementations should treat other exceptions as
+ * best-effort warnings.
  */
 @Incubating
 public interface SchedulerLifecycleHook {
@@ -27,8 +28,8 @@ public interface SchedulerLifecycleHook {
   /**
    * Runs before Ratchet starts pollers, recurring registration, or maintenance work.
    *
-   * <p>Throw {@code SchemaInitializationException} here to abort startup for an incompatible
-   * schema.
+   * <p>Store modules may throw their startup-abort exception here to stop deployment for an
+   * incompatible schema.
    */
   default void beforeStart() {}
 

--- a/ratchet-api/src/main/java/run/ratchet/spi/StartupCoordinator.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/StartupCoordinator.java
@@ -8,6 +8,9 @@ import run.ratchet.api.Incubating;
  *
  * <p>The reference implementation uses the store's distributed lock/lease mechanism so startup work
  * can be safely gated without relying on an external leader-election system.
+ *
+ * <p>Failed acquisitions are retryable. {@link #release(String)} must be safe when the caller does
+ * not currently hold the lease, including when the lease has expired and another node acquired it.
  */
 @Incubating
 public interface StartupCoordinator {
@@ -23,6 +26,8 @@ public interface StartupCoordinator {
 
   /**
    * Releases a startup lease previously acquired by this node.
+   *
+   * <p>Implementations must make this a no-op when the current node does not hold the named lease.
    *
    * @param actionName non-blank logical name of the startup action
    */

--- a/ratchet-api/src/main/java/run/ratchet/spi/TracingCollector.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/TracingCollector.java
@@ -25,13 +25,14 @@ import run.ratchet.api.JobType;
  *
  * <h2>MDC integration</h2>
  *
- * <p>When a scope is active, implementations <em>must</em> inject {@code traceId} and {@code
- * spanId} into the logging MDC so that log lines emitted during job execution carry trace
- * coordinates alongside the four stable Ratchet MDC keys ({@code jobId}, {@code node}, {@code
- * jobCreator}, {@code jobType}). These keys must be removed when the scope is closed — use targeted
- * {@code MDC.remove(key)} calls, never {@code MDC.clear()}, to avoid wiping application MDC keys
- * set by Servlet filters or JAX-RS interceptors. Removal of the four Ratchet-owned keys remains the
- * responsibility of the RI job MDC context.
+ * <p>When the deployment's tracing/logging bridge supports MDC integration, implementations should
+ * expose {@code traceId} and {@code spanId} while a scope is active so that log lines emitted
+ * during job execution carry trace coordinates alongside the four stable Ratchet MDC keys ({@code
+ * jobId}, {@code node}, {@code jobCreator}, {@code jobType}). Implementations that write MDC keys
+ * directly must remove those keys when the scope is closed using targeted remove calls, never a
+ * blanket clear operation, to avoid wiping application MDC keys set by Servlet filters or JAX-RS
+ * interceptors. Removal of the four Ratchet-owned keys remains the responsibility of the RI job MDC
+ * context.
  *
  * <h2>Default implementation</h2>
  *

--- a/ratchet-api/src/test/java/run/ratchet/spi/PollingConfigTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/spi/PollingConfigTest.java
@@ -1,0 +1,50 @@
+package run.ratchet.spi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class PollingConfigTest {
+
+  @Test
+  void acceptsValidValues() {
+    PollingConfig config = new PollingConfig(50, 100, 1_000, 5_000, 10_000, 3, 25);
+
+    assertEquals(50, config.burstDelayMs());
+    assertEquals(100, config.minDelayMs());
+    assertEquals(1_000, config.maxDelayMs());
+    assertEquals(5_000, config.deepIdleDelayMs());
+    assertEquals(10_000, config.deepIdleThresholdMs());
+    assertEquals(3, config.idleThreshold());
+    assertEquals(25, config.batchSize());
+  }
+
+  @Test
+  void rejectsInvalidValues() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PollingConfig(-1, 100, 1_000, 5_000, 10_000, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PollingConfig(50, -1, 1_000, 5_000, 10_000, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PollingConfig(50, 100, -1, 5_000, 10_000, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PollingConfig(50, 100, 1_000, -1, 10_000, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PollingConfig(50, 100, 1_000, 5_000, -1, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PollingConfig(50, 1_001, 1_000, 5_000, 10_000, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PollingConfig(50, 100, 5_001, 5_000, 10_000, 3, 25));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PollingConfig(50, 100, 1_000, 5_000, 10_000, -1, 25));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new PollingConfig(50, 100, 1_000, 5_000, 10_000, 3, 0));
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -206,7 +206,7 @@ public class RatchetArchiveBuilder {
     putIfPresent(properties, "ratchet.test.mongo.database");
 
     put(properties, "ratchet.poller.deep-idle-threshold-ms", "5000");
-    put(properties, "ratchet.poller.deep-idle-delay-ms", "1000");
+    put(properties, "ratchet.poller.deep-idle-delay-ms", "2000");
     put(properties, "ratchet.poller.max-delay-ms", "2000");
     // Arquillian redeploys test archives rapidly; a long heartbeat cadence keeps the initial
     // liveness row without leaving periodic managed-executor work racing application undeploy.

--- a/ratchet-testsuite/src/test/resources/arquillian.xml
+++ b/ratchet-testsuite/src/test/resources/arquillian.xml
@@ -27,7 +27,7 @@
         -Dratchet.test.mongo.uri=${ratchet.test.mongo.uri}
         -Dratchet.test.mongo.database=${ratchet.test.mongo.database}
         -DPOLLER_DEEP_IDLE_THRESHOLD_MS=5000
-        -DPOLLER_DEEP_IDLE_DELAY_MS=1000
+        -DPOLLER_DEEP_IDLE_DELAY_MS=2000
         -DPOLLER_MAX_DELAY_MS=2000
       </property>
       <property name="managementPort">29990</property>
@@ -104,7 +104,7 @@
         -Dratchet.test.mongo.uri=${ratchet.test.mongo.uri}
         -Dratchet.test.mongo.database=${ratchet.test.mongo.database}
         -DPOLLER_DEEP_IDLE_THRESHOLD_MS=5000
-        -DPOLLER_DEEP_IDLE_DELAY_MS=1000
+        -DPOLLER_DEEP_IDLE_DELAY_MS=2000
         -DPOLLER_MAX_DELAY_MS=2000
       </property>
       <property name="allowConnectingToRunningServer">false</property>

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultNodeIdentityProvider.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultNodeIdentityProvider.java
@@ -198,7 +198,16 @@ public class DefaultNodeIdentityProvider implements NodeIdentityProvider {
 
   @Override
   public String getNodeId() {
-    return nodeId;
+    String current = nodeId;
+    if (current != null) {
+      return current;
+    }
+    synchronized (this) {
+      if (nodeId == null) {
+        nodeId = resolveNodeId();
+      }
+      return nodeId;
+    }
   }
 
   /** Resolves the node ID, sends an initial heartbeat, and schedules periodic heartbeats. */
@@ -208,19 +217,20 @@ public class DefaultNodeIdentityProvider implements NodeIdentityProvider {
       return;
     }
 
-    nodeId = resolveNodeId();
-    log.infof("Scheduler nodeId=%s", nodeId);
+    String resolvedNodeId = getNodeId();
+    log.infof("Scheduler nodeId=%s", resolvedNodeId);
 
     checkClockSkew();
 
-    nodeStore.upsertHeartbeat(nodeId, effective().instant());
+    nodeStore.upsertHeartbeat(resolvedNodeId, effective().instant());
 
     // Startup self-recovery: unconditionally reclaim RUNNING jobs owned by THIS nodeId. A node
     // that crashes and restarts inside the steady-state grace window would otherwise leave its
     // own prior RUNNING rows in place until the heartbeat aged out.
-    int ownReset = jobBulkStore.resetOrphanJobsForNode(nodeId);
+    int ownReset = jobBulkStore.resetOrphanJobsForNode(resolvedNodeId);
     if (ownReset > 0) {
-      log.infof("Reset %s RUNNING job(s) owned by this node (%s) at startup", ownReset, nodeId);
+      log.infof(
+          "Reset %s RUNNING job(s) owned by this node (%s) at startup", ownReset, resolvedNodeId);
     }
 
     // Also run the normal grace-based sweep to pick up any other nodes' rows that have aged out.

--- a/ratchet/src/main/java/run/ratchet/ri/core/StoreBackedStartupCoordinator.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/StoreBackedStartupCoordinator.java
@@ -37,9 +37,18 @@ public class StoreBackedStartupCoordinator implements StartupCoordinator {
     return LOCK_PREFIX + normalized;
   }
 
+  private static Duration positiveLeaseTtl(Duration leaseTtl) {
+    Duration ttl = Objects.requireNonNull(leaseTtl, "leaseTtl must not be null");
+    if (ttl.isZero() || ttl.isNegative()) {
+      throw new IllegalArgumentException("leaseTtl must be positive");
+    }
+    return ttl;
+  }
+
   @Override
   public boolean tryAcquire(String actionName, Duration leaseTtl) {
-    return lockStore.tryLock(lockName(actionName), leaseTtl, nodeIdentityProvider.getNodeId());
+    return lockStore.tryLock(
+        lockName(actionName), positiveLeaseTtl(leaseTtl), nodeIdentityProvider.getNodeId());
   }
 
   @Override

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/DefaultRetryPolicyTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/DefaultRetryPolicyTest.java
@@ -12,7 +12,7 @@ class DefaultRetryPolicyTest {
   void defaultPolicyIsOnlyAPassthrough() {
     DefaultRetryPolicy policy = new DefaultRetryPolicy();
 
-    assertTrue(policy.shouldRetry(0, new IllegalStateException("failed")));
+    assertTrue(policy.shouldRetry(1, new IllegalStateException("failed")));
     assertTrue(policy.shouldRetry(Integer.MAX_VALUE, new RuntimeException("still failed")));
     assertEquals(Duration.ZERO, policy.getDelay(Integer.MAX_VALUE));
   }

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultNodeIdentityProviderTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultNodeIdentityProviderTest.java
@@ -105,6 +105,18 @@ class DefaultNodeIdentityProviderTest {
   }
 
   @Test
+  void getNodeId_returnsStableValueBeforeInitAndInitReusesIt() {
+    assertEquals("test-node", provider.getNodeId());
+    assertEquals("test-node", provider.getNodeId());
+
+    provider.init();
+
+    verify(nodeStore).upsertHeartbeat("test-node", clock.instant());
+    verify(jobBulkStore).resetOrphanJobsForNode("test-node");
+    verify(scheduledExecutor).schedule(any(Runnable.class), eq(5L), eq(TimeUnit.SECONDS));
+  }
+
+  @Test
   void shutdown_preventsScheduledHeartbeatFromTouchingStore() {
     provider.init();
     Runnable scheduledHeartbeat = runnableCaptor.getValue();

--- a/ratchet/src/test/java/run/ratchet/ri/core/StoreBackedStartupCoordinatorTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/StoreBackedStartupCoordinatorTest.java
@@ -67,4 +67,21 @@ class StoreBackedStartupCoordinatorTest {
     assertThrows(
         IllegalArgumentException.class, () -> coordinator.tryAcquire("   ", Duration.ofMinutes(5)));
   }
+
+  @Test
+  void tryAcquire_rejectsNonPositiveLeaseTtl() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> coordinator.tryAcquire("recurring-annotation-orphan-cleanup", Duration.ZERO));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> coordinator.tryAcquire("recurring-annotation-orphan-cleanup", Duration.ofNanos(-1)));
+  }
+
+  @Test
+  void tryAcquire_rejectsNullLeaseTtl() {
+    assertThrows(
+        NullPointerException.class,
+        () -> coordinator.tryAcquire("recurring-annotation-orphan-cleanup", null));
+  }
 }


### PR DESCRIPTION
## Summary

Tightens SPI validation and clears contract drift found in the v5 residue audit.

`PollingConfig` now rejects invalid scheduler settings at construction time. `StoreBackedStartupCoordinator` validates positive lease TTLs before calling the lock store. `DefaultNodeIdentityProvider.getNodeId()` now resolves a stable non-null node id before `init()`.

The rest of the change updates SPI Javadocs where the RI behavior had moved away from the comments, including bean resolution, error sanitization, executor ownership, config lookup, lifecycle hooks, tracing MDC, and related extension points.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet-api -Dtest=PollingConfigTest,CircuitBreakerConfigTest,ExceptionFamilyTest test`
- [x] `mvn -pl ratchet -am -Dtest=DefaultNodeIdentityProviderTest,StoreBackedStartupCoordinatorTest,DefaultRetryPolicyTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl ratchet-api,ratchet spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

This is intentionally scoped to validation and contract cleanup. The broader API/SPI TCK work from v5 remains separate.
