### PR TITLE
Fix store contract edge cases

### DIFF
--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/ExecutionStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/ExecutionStore.java
@@ -31,7 +31,9 @@ public interface ExecutionStore {
   /**
    * Returns a page of execution records for a job, ordered by attempt ascending.
    *
-   * <p>Transaction attribute: {@code SUPPORTS}.
+   * @param limit maximum number of rows to return; {@code 0} returns an empty page
+   * @param offset number of matching rows to skip
+   *     <p>Transaction attribute: {@code SUPPORTS}.
    */
   List<JobExecutionEntity> findExecutionsByJobId(UUID jobId, int limit, int offset);
 

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobPauseStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobPauseStore.java
@@ -15,13 +15,16 @@ public interface JobPauseStore {
 
   /**
    * Atomically transitions to PAUSED, recording the original status for later resume in the same
-   * operation to avoid TOCTOU gaps. Transaction attribute: {@code REQUIRED}.
+   * operation to avoid TOCTOU gaps. Returns {@code false} when {@code expected} is WAITING or
+   * terminal. Throws {@link IllegalArgumentException} when {@code expected} is PAUSED. Transaction
+   * attribute: {@code REQUIRED}.
    */
   boolean transitionToPaused(UUID id, JobStatus expected);
 
   /**
    * Atomically transitions from PAUSED to the target status, clearing the stored paused-from
-   * status. Transaction attribute: {@code REQUIRED}.
+   * status. The target must be a non-PAUSED, non-WAITING live status. Transaction attribute: {@code
+   * REQUIRED}.
    */
   boolean transitionFromPaused(UUID id, JobStatus target);
 

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobRetryStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobRetryStore.java
@@ -16,7 +16,11 @@ public interface JobRetryStore {
    */
   int incrementRetryAttempt(UUID id);
 
-  /** Schedules the next retry attempt. Transaction attribute: {@code REQUIRED}. */
+  /**
+   * Schedules the next retry attempt for a RUNNING or WAITING job. Implementations return {@code
+   * false} for missing rows and for jobs in every other status, including FAILED terminal rows.
+   * Transaction attribute: {@code REQUIRED}.
+   */
   boolean scheduleJobRetry(UUID id, String error, Instant newScheduledTime, int attempts);
 
   /**

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/WorkflowConditionStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/WorkflowConditionStore.java
@@ -33,7 +33,8 @@ public interface WorkflowConditionStore {
 
   /**
    * Returns every condition pointing at the child job. This is intentionally not paged because the
-   * result represents the complete stored workflow graph for the child.
+   * result represents the complete stored workflow graph for the child. Results are ordered by
+   * condition priority ascending.
    *
    * <p>Transaction attribute: {@code SUPPORTS}.
    */
@@ -41,7 +42,8 @@ public interface WorkflowConditionStore {
 
   /**
    * Returns every condition of the requested type for the parent job. This is intentionally not
-   * paged because workflow routing evaluates the complete matching set.
+   * paged because workflow routing evaluates the complete matching set. Results are ordered by
+   * condition priority ascending.
    *
    * <p>Transaction attribute: {@code SUPPORTS}.
    */

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoAuxiliaryOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoAuxiliaryOperations.java
@@ -87,6 +87,9 @@ final class MongoAuxiliaryOperations {
   }
 
   List<JobExecutionEntity> findExecutionsByJobId(UUID jobId, int limit, int offset) {
+    if (limit == 0) {
+      return List.of();
+    }
     List<JobExecutionEntity> results = new ArrayList<>();
     for (Document doc :
         ctx.executions()
@@ -153,7 +156,10 @@ final class MongoAuxiliaryOperations {
 
   List<WorkflowConditionEntity> findConditionsByChildJobId(UUID childJobId) {
     List<WorkflowConditionEntity> results = new ArrayList<>();
-    for (Document doc : ctx.workflowConditions().find(eq(CHILD_JOB_ID, childJobId))) {
+    for (Document doc :
+        ctx.workflowConditions()
+            .find(eq(CHILD_JOB_ID, childJobId))
+            .sort(ascending(CONDITION_PRIORITY))) {
       results.add(DocumentMapper.toWorkflowConditionEntity(doc));
       warnIfLargeConditionResult("child job", childJobId, results.size());
     }
@@ -165,7 +171,8 @@ final class MongoAuxiliaryOperations {
     List<WorkflowConditionEntity> results = new ArrayList<>();
     for (Document doc :
         ctx.workflowConditions()
-            .find(and(eq(PARENT_JOB_ID, parentJobId), eq(CONDITION_TYPE, type.name())))) {
+            .find(and(eq(PARENT_JOB_ID, parentJobId), eq(CONDITION_TYPE, type.name())))
+            .sort(ascending(CONDITION_PRIORITY))) {
       results.add(DocumentMapper.toWorkflowConditionEntity(doc));
       warnIfLargeConditionResult("parent job/type", parentJobId, results.size());
     }

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
@@ -286,7 +286,7 @@ final class MongoJobLifecycleOperations
           UpdateResult result =
               ctx.jobs()
                   .updateOne(
-                      and(eq(ID, id), in(STATUS, List.of("RUNNING", "WAITING", "FAILED"))),
+                      and(eq(ID, id), in(STATUS, List.of("RUNNING", "WAITING"))),
                       combine(
                           set(STATUS, "PENDING"),
                           set(SCHEDULED_TIME, DocumentMapper.toDate(newScheduledTime)),
@@ -586,6 +586,13 @@ final class MongoJobLifecycleOperations
 
   @Override
   public boolean transitionToPaused(UUID id, JobStatus expected) {
+    if (expected == JobStatus.PAUSED) {
+      throw new IllegalArgumentException("transitionToPaused expects expected != PAUSED");
+    }
+    if (expected == JobStatus.WAITING
+        || MongoStoreContext.TERMINAL_STATUSES.contains(expected.name())) {
+      return false;
+    }
     return booleanMutation(
         "transition_to_paused",
         () -> {
@@ -604,6 +611,12 @@ final class MongoJobLifecycleOperations
 
   @Override
   public boolean transitionFromPaused(UUID id, JobStatus target) {
+    if (!MongoStoreContext.ACTIVE_STATUSES.contains(target.name())
+        || target == JobStatus.PAUSED
+        || target == JobStatus.WAITING) {
+      throw new IllegalArgumentException(
+          "transitionFromPaused expects a non-PAUSED live status; got " + target);
+    }
     return booleanMutation(
         "transition_from_paused",
         () -> {

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobCrudOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobCrudOperations.java
@@ -208,6 +208,11 @@ final class MysqlJobCrudOperations implements JobCrudStore, JobBulkStore {
   }
 
   @Override
+  public int resetOrphanJobsBefore(Instant cutoff) {
+    return deletes.resetOrphanJobsBefore(cutoff);
+  }
+
+  @Override
   public int resetOrphanJobsForNode(String nodeId) {
     return deletes.resetOrphanJobsForNode(nodeId);
   }

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobCrudOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobCrudOperations.java
@@ -208,6 +208,11 @@ final class PostgresqlJobCrudOperations implements JobCrudStore, JobBulkStore {
   }
 
   @Override
+  public int resetOrphanJobsBefore(Instant cutoff) {
+    return deletes.resetOrphanJobsBefore(cutoff);
+  }
+
+  @Override
   public int resetOrphanJobsForNode(String nodeId) {
     return deletes.resetOrphanJobsForNode(nodeId);
   }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractExecutionStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractExecutionStoreContract.java
@@ -76,6 +76,16 @@ public abstract class AbstractExecutionStoreContract implements JobStoreContract
   }
 
   @Test
+  void findExecutionsByJobId_zeroLimit_returnsEmptyPage() {
+    var job = persist(newPendingJob());
+    store().saveExecution(JobExecutionEntity.start(job.getId(), 1, "node-1"));
+
+    var executions = store().findExecutionsByJobId(job.getId(), 0, 0);
+
+    assertTrue(executions.isEmpty(), "limit=0 should return an empty execution page");
+  }
+
+  @Test
   void findExecutionsByJobId_unknownJob_returnsEmpty() {
     var executions = store().findExecutionsByJobId(new UUID(0L, Long.MAX_VALUE));
 

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBulkStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBulkStoreContract.java
@@ -77,6 +77,27 @@ public abstract class AbstractJobBulkStoreContract implements JobStoreContractFi
   }
 
   @Test
+  void resetOrphanJobsBefore_usesExactCutoff() {
+    var old = persist(newPendingJob());
+    old.setStatus(JobStatus.RUNNING);
+    old.setPickedBy("phantom-node-" + old.getId());
+    old.setPickedAt(Instant.now().minusSeconds(45));
+    store().save(old);
+
+    var recent = persist(newPendingJob());
+    recent.setStatus(JobStatus.RUNNING);
+    recent.setPickedBy("phantom-node-" + recent.getId());
+    recent.setPickedAt(Instant.now().minusSeconds(10));
+    store().save(recent);
+
+    int reset = store().resetOrphanJobsBefore(Instant.now().minusSeconds(30));
+
+    assertEquals(1, reset, "Only rows picked before the cutoff should be reset");
+    assertEquals(JobStatus.PENDING, store().findById(old.getId()).orElseThrow().getStatus());
+    assertEquals(JobStatus.RUNNING, store().findById(recent.getId()).orElseThrow().getStatus());
+  }
+
+  @Test
   void deleteJobsByIds_removesSpecifiedJobs() {
     var first = persist(newPendingJob());
     var second = persist(newPendingJob());

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobPauseStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobPauseStoreContract.java
@@ -3,6 +3,7 @@ package run.ratchet.tck.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -71,6 +72,47 @@ public abstract class AbstractJobPauseStoreContract implements JobStoreContractF
   @Test
   void transitionFromPausedAtomic_unknownJob_returnsNull() {
     assertNull(store().transitionFromPausedAtomic(new UUID(0L, Long.MAX_VALUE)));
+  }
+
+  @Test
+  void transitionToPaused_rejectsAlreadyPausedExpectedStatus() {
+    var saved = persist(newPendingJob());
+    assertTrue(store().transitionToPaused(saved.getId(), JobStatus.PENDING));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store().transitionToPaused(saved.getId(), JobStatus.PAUSED));
+  }
+
+  @Test
+  void transitionToPaused_returnsFalseForNonPausableExpectedStatuses() {
+    var waiting = newPendingJob();
+    waiting.setStatus(JobStatus.WAITING);
+    waiting = persist(waiting);
+
+    assertFalse(store().transitionToPaused(waiting.getId(), JobStatus.WAITING));
+
+    var terminal = persist(newPendingJob());
+    store().compareAndSwapStatus(terminal.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store().compareAndSwapStatus(terminal.getId(), JobStatus.RUNNING, JobStatus.FAILED, "boom");
+
+    assertFalse(store().transitionToPaused(terminal.getId(), JobStatus.FAILED));
+  }
+
+  @Test
+  void transitionFromPaused_rejectsPausedWaitingAndTerminalTargets() {
+    var saved = persist(newPendingJob());
+    assertTrue(store().transitionToPaused(saved.getId(), JobStatus.PENDING));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store().transitionFromPaused(saved.getId(), JobStatus.PAUSED));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store().transitionFromPaused(saved.getId(), JobStatus.WAITING));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store().transitionFromPaused(saved.getId(), JobStatus.FAILED));
   }
 
   @Test

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobRetryStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobRetryStoreContract.java
@@ -65,6 +65,20 @@ public abstract class AbstractJobRetryStoreContract implements JobStoreContractF
   }
 
   @Test
+  void scheduleJobRetry_rejectsFailedTerminalRows() {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store().compareAndSwapStatus(saved.getId(), JobStatus.RUNNING, JobStatus.FAILED, "boom");
+
+    boolean retried =
+        store()
+            .scheduleJobRetry(saved.getId(), "already terminal", Instant.now().plusSeconds(300), 1);
+
+    assertFalse(retried, "FAILED terminal jobs should not be rescheduled through retry");
+    assertEquals(JobStatus.FAILED, store().getJobStatus(saved.getId()));
+  }
+
+  @Test
   void resetFailedToPending_transitionsAndResetsMetadata() {
     var saved = persist(newPendingJob());
     store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractWorkflowConditionStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractWorkflowConditionStoreContract.java
@@ -128,6 +128,38 @@ public abstract class AbstractWorkflowConditionStoreContract implements JobStore
   }
 
   @Test
+  void findConditionsByChildJobId_ordersByConditionPriority() {
+    var highPriorityParent = persist(newPendingJob());
+    var lowPriorityParent = persist(newPendingJob());
+    var child = persist(newPendingJob());
+
+    store()
+        .saveCondition(
+            newCondition(
+                lowPriorityParent.getId(),
+                child.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                20));
+    store()
+        .saveCondition(
+            newCondition(
+                highPriorityParent.getId(),
+                child.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                5));
+
+    var orderedParentIds =
+        store().findConditionsByChildJobId(child.getId()).stream()
+            .map(WorkflowConditionEntity::getParentJobId)
+            .toList();
+
+    assertEquals(
+        List.of(highPriorityParent.getId(), lowPriorityParent.getId()),
+        orderedParentIds,
+        "child condition scans should evaluate lower priority numbers first");
+  }
+
+  @Test
   void findConditionsByType_filtersCorrectly() {
     var parent = persist(newPendingJob());
     var childA = persist(newPendingJob());
@@ -146,6 +178,40 @@ public abstract class AbstractWorkflowConditionStoreContract implements JobStore
 
     assertEquals(1, successConditions.size(), "Should return only SUCCESS conditions");
     assertEquals(childA.getId(), successConditions.get(0).getChildJobId());
+  }
+
+  @Test
+  void findConditionsByType_ordersByConditionPriority() {
+    var parent = persist(newPendingJob());
+    var lowPriorityChild = persist(newPendingJob());
+    var highPriorityChild = persist(newPendingJob());
+
+    store()
+        .saveCondition(
+            newCondition(
+                parent.getId(),
+                lowPriorityChild.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                20));
+    store()
+        .saveCondition(
+            newCondition(
+                parent.getId(),
+                highPriorityChild.getId(),
+                WorkflowCondition.ConditionType.SUCCESS,
+                5));
+
+    var orderedChildIds =
+        store()
+            .findConditionsByType(parent.getId(), WorkflowCondition.ConditionType.SUCCESS)
+            .stream()
+            .map(WorkflowConditionEntity::getChildJobId)
+            .toList();
+
+    assertEquals(
+        List.of(highPriorityChild.getId(), lowPriorityChild.getId()),
+        orderedChildIds,
+        "type condition scans should evaluate lower priority numbers first");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes store contract edge cases that still diverged after the v5 high-priority sweep.

Mongo now rejects illegal pause and retry transitions the same way as the SQL stores. Workflow-condition lookups by child or type now sort by condition priority. SQL CRUD adapters delegate `resetOrphanJobsBefore` to their native delete operations instead of using the duration-based default.

The store TCK now covers these cases, plus `limit=0` execution queries.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet-store-core,ratchet-tck/store test`
- [x] `mvn -pl ratchet-store-mongodb -am -Dtest=MongoJobRetryStoreContractTest,MongoJobPauseStoreContractTest,MongoWorkflowConditionStoreContractTest,MongoExecutionStoreContractTest,MongoJobBulkStoreContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl ratchet-store-mysql -am -Dtest=MysqlJobRetryStoreContractTest,MysqlJobPauseStoreContractTest,MysqlWorkflowConditionStoreContractTest,MysqlExecutionStoreContractTest,MysqlJobBulkStoreContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl ratchet-store-postgresql -am -Dtest=PostgresqlJobRetryStoreContractTest,PostgresqlJobPauseStoreContractTest,PostgresqlWorkflowConditionStoreContractTest,PostgresqlExecutionStoreContractTest,PostgresqlJobBulkStoreContractTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

The batch-store return-value finding was left for a later store PR because it lives outside this branch's write scope.
