### PR TITLE
Translate transient store helper failures

### DIFF
--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoTagOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoTagOperations.java
@@ -39,72 +39,97 @@ final class MongoTagOperations implements TagStore {
     if (tags == null || tags.isEmpty()) {
       return;
     }
-    ctx.jobs()
-        .updateOne(
-            eq(ID, jobId),
-            new Document("$addToSet", new Document(TAGS, new Document("$each", tags))));
+    try {
+      ctx.jobs()
+          .updateOne(
+              eq(ID, jobId),
+              new Document("$addToSet", new Document(TAGS, new Document("$each", tags))));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("insert job tags", e);
+    }
   }
 
   @Override
   public int deleteTagsByJobId(UUID jobId) {
-    Document before =
-        ctx.jobs()
-            .findOneAndUpdate(
-                eq(ID, jobId),
-                set(TAGS, List.of()),
-                new FindOneAndUpdateOptions().returnDocument(ReturnDocument.BEFORE));
-    if (before == null) {
-      return 0;
+    try {
+      Document before =
+          ctx.jobs()
+              .findOneAndUpdate(
+                  eq(ID, jobId),
+                  set(TAGS, List.of()),
+                  new FindOneAndUpdateOptions().returnDocument(ReturnDocument.BEFORE));
+      if (before == null) {
+        return 0;
+      }
+      List<String> oldTags = before.getList(TAGS, String.class);
+      return oldTags == null ? 0 : oldTags.size();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete job tags", e);
     }
-    List<String> oldTags = before.getList(TAGS, String.class);
-    return oldTags == null ? 0 : oldTags.size();
   }
 
   @Override
   public List<UUID> findJobIdsByTag(String tag, int limit, int offset) {
-    List<UUID> ids = new ArrayList<>();
-    for (Document doc :
-        ctx.jobs()
-            .find(eq(TAGS, tag))
-            .projection(new Document(ID, 1))
-            .sort(ascending(ID))
-            .skip(offset)
-            .limit(limit)) {
-      ids.add(doc.get(ID, UUID.class));
+    try {
+      List<UUID> ids = new ArrayList<>();
+      for (Document doc :
+          ctx.jobs()
+              .find(eq(TAGS, tag))
+              .projection(new Document(ID, 1))
+              .sort(ascending(ID))
+              .skip(offset)
+              .limit(limit)) {
+        ids.add(doc.get(ID, UUID.class));
+      }
+      return ids;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find job ids by tag", e);
     }
-    return ids;
   }
 
   @Override
   public Map<JobStatus, Long> countJobsByStatusForTag(String tag) {
-    Map<JobStatus, Long> counts = new EnumMap<>(JobStatus.class);
-    for (Document doc :
-        ctx.jobs()
-            .aggregate(
-                List.of(
-                    new Document("$match", new Document(TAGS, tag)),
-                    new Document(
-                        "$group",
-                        new Document(ID, "$" + STATUS).append("count", new Document("$sum", 1L))),
-                    new Document("$limit", JobStatus.values().length),
-                    new Document("$sort", new Document(ID, 1))))) {
-      String status = doc.getString(ID);
-      if (status != null) {
-        counts.put(JobStatus.valueOf(status), ((Number) doc.get("count")).longValue());
+    try {
+      Map<JobStatus, Long> counts = new EnumMap<>(JobStatus.class);
+      for (Document doc :
+          ctx.jobs()
+              .aggregate(
+                  List.of(
+                      new Document("$match", new Document(TAGS, tag)),
+                      new Document(
+                          "$group",
+                          new Document(ID, "$" + STATUS).append("count", new Document("$sum", 1L))),
+                      new Document("$limit", JobStatus.values().length),
+                      new Document("$sort", new Document(ID, 1))))) {
+        String status = doc.getString(ID);
+        if (status != null) {
+          counts.put(JobStatus.valueOf(status), ((Number) doc.get("count")).longValue());
+        }
       }
+      return counts;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by status for tag", e);
     }
-    return counts;
   }
 
   @Override
   public Map<String, Long> countJobsByParamForTag(String tag, String paramKey) {
-    return aggregateStringCountsByTag(
-        tag, new Document("$getField", new Document("field", paramKey).append("input", "$params")));
+    try {
+      return aggregateStringCountsByTag(
+          tag,
+          new Document("$getField", new Document("field", paramKey).append("input", "$params")));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by param for tag", e);
+    }
   }
 
   @Override
   public Map<String, Long> countJobsByExecutionNodeForTag(String tag) {
-    return aggregateStringCountsByTag(tag, "$" + PICKED_BY);
+    try {
+      return aggregateStringCountsByTag(tag, "$" + PICKED_BY);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by execution node for tag", e);
+    }
   }
 
   private Map<String, Long> aggregateStringCountsByTag(String tag, Object groupExpression) {

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoExceptionTranslationTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoExceptionTranslationTest.java
@@ -232,6 +232,27 @@ class MongoExceptionTranslationTest {
   }
 
   @Test
+  void tagOperationsTranslateTransientMongoFailure() {
+    MongoSocketException failure = transientFailure();
+    MongoCollection<Document> jobs =
+        mongoCollection(
+            (proxy, method, args) -> {
+              if ("updateOne".equals(method.getName())) {
+                throw failure;
+              }
+              return defaultValue(method);
+            });
+    MongoTagOperations tags = new MongoTagOperations(contextWithJobs(jobs));
+
+    RatchetTransientStoreException thrown =
+        assertThrows(
+            RatchetTransientStoreException.class,
+            () -> tags.insertTags(UUID.randomUUID(), List.of("urgent")));
+
+    assertSame(failure, thrown.getCause());
+  }
+
+  @Test
   void translateStoreExceptionWrapsNonTransientMongoFailures() {
     MongoException failure = new MongoException("plain command failure");
     MongoStoreContext ctx = contextWithJobs(null);

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlAuxiliaryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlAuxiliaryOperations.java
@@ -286,59 +286,73 @@ final class MysqlAuxiliaryOperations
 
   @Override
   public void releasePermit(String resource, UUID jobId) {
-    // language=MySQL
-    String sql = "DELETE FROM scheduler_resource_permit WHERE resource_name = ? AND job_id = ?";
-    ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, resource)
-        .setParameter(2, UuidByteArrayConverter.toBytes(jobId))
-        .executeUpdate();
+    try {
+      // language=MySQL
+      String sql = "DELETE FROM scheduler_resource_permit WHERE resource_name = ? AND job_id = ?";
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, resource)
+          .setParameter(2, UuidByteArrayConverter.toBytes(jobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("release resource permit", e);
+    }
   }
 
   @Override
   public void releaseAllPermits(UUID jobId) {
-    // language=MySQL
-    String sql = "DELETE FROM scheduler_resource_permit WHERE job_id = ?";
-    ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
-        .executeUpdate();
+    try {
+      // language=MySQL
+      String sql = "DELETE FROM scheduler_resource_permit WHERE job_id = ?";
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("release all permits", e);
+    }
   }
 
   @Override
   public int getPermitRetryDelay(String resource) {
-    // language=MySQL
-    String sql = "SELECT retry_delay_ms FROM scheduler_resource_limit WHERE resource_name = ?";
     try {
+      // language=MySQL
+      String sql = "SELECT retry_delay_ms FROM scheduler_resource_limit WHERE resource_name = ?";
       return ((Number) ctx.em().createNativeQuery(sql).setParameter(1, resource).getSingleResult())
           .intValue();
     } catch (NoResultException e) {
       return ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get permit retry delay", e);
     }
   }
 
   @Override
   public void configureResource(
       String name, int maxConcurrent, int retryDelayMs, String description) {
-    // language=MySQL
-    String sql =
-        """
-        INSERT INTO scheduler_resource_limit
-          (resource_name, max_concurrent, retry_delay_ms, description, created_at, updated_at)
-        VALUES (?, ?, ?, ?, NOW(3), NOW(3))
-        ON DUPLICATE KEY UPDATE
-          max_concurrent = VALUES(max_concurrent),
-          retry_delay_ms = VALUES(retry_delay_ms),
-          description = VALUES(description),
-          updated_at = NOW(3)
-        """;
-    ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, name)
-        .setParameter(2, maxConcurrent)
-        .setParameter(3, retryDelayMs)
-        .setParameter(4, description)
-        .executeUpdate();
+    try {
+      // language=MySQL
+      String sql =
+          """
+          INSERT INTO scheduler_resource_limit
+            (resource_name, max_concurrent, retry_delay_ms, description, created_at, updated_at)
+          VALUES (?, ?, ?, ?, NOW(3), NOW(3))
+          ON DUPLICATE KEY UPDATE
+            max_concurrent = VALUES(max_concurrent),
+            retry_delay_ms = VALUES(retry_delay_ms),
+            description = VALUES(description),
+            updated_at = NOW(3)
+          """;
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, name)
+          .setParameter(2, maxConcurrent)
+          .setParameter(3, retryDelayMs)
+          .setParameter(4, description)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("configure resource", e);
+    }
   }
 
   @Override
@@ -346,14 +360,18 @@ final class MysqlAuxiliaryOperations
     if (staleNodeIds.isEmpty()) {
       return 0;
     }
-    int deleted = 0;
-    for (int start = 0; start < staleNodeIds.size(); start += PERMIT_CLEANUP_CHUNK_SIZE) {
-      deleted +=
-          cleanupOrphanedPermitsChunk(
-              staleNodeIds.subList(
-                  start, Math.min(start + PERMIT_CLEANUP_CHUNK_SIZE, staleNodeIds.size())));
+    try {
+      int deleted = 0;
+      for (int start = 0; start < staleNodeIds.size(); start += PERMIT_CLEANUP_CHUNK_SIZE) {
+        deleted +=
+            cleanupOrphanedPermitsChunk(
+                staleNodeIds.subList(
+                    start, Math.min(start + PERMIT_CLEANUP_CHUNK_SIZE, staleNodeIds.size())));
+      }
+      return deleted;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("cleanup orphaned permits", e);
     }
-    return deleted;
   }
 
   private int cleanupOrphanedPermitsChunk(List<String> staleNodeIds) {

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlTagOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlTagOperations.java
@@ -45,174 +45,206 @@ final class MysqlTagOperations implements TagStore {
     if (tags == null || tags.isEmpty()) {
       return;
     }
-    // Build a single INSERT IGNORE with one VALUES row per tag to avoid N round-trips.
-    // language=MySQL
-    String placeholders = String.join(",", Collections.nCopies(tags.size(), "(?,?)"));
-    String sql = "INSERT IGNORE INTO scheduler_job_tag (job_id, tag) VALUES " + placeholders;
-    byte[] jobIdBytes = UuidByteArrayConverter.toBytes(jobId);
-    Query query = ctx.em().createNativeQuery(sql);
-    int param = 1;
-    for (String tag : tags) {
-      query.setParameter(param++, jobIdBytes);
-      query.setParameter(param++, tag);
+    try {
+      // Build a single INSERT IGNORE with one VALUES row per tag to avoid N round-trips.
+      // language=MySQL
+      String placeholders = String.join(",", Collections.nCopies(tags.size(), "(?,?)"));
+      String sql = "INSERT IGNORE INTO scheduler_job_tag (job_id, tag) VALUES " + placeholders;
+      byte[] jobIdBytes = UuidByteArrayConverter.toBytes(jobId);
+      Query query = ctx.em().createNativeQuery(sql);
+      int param = 1;
+      for (String tag : tags) {
+        query.setParameter(param++, jobIdBytes);
+        query.setParameter(param++, tag);
+      }
+      query.executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("insert job tags", e);
     }
-    query.executeUpdate();
   }
 
   @Override
   public int deleteTagsByJobId(UUID jobId) {
-    // language=MySQL
-    String sql = "DELETE FROM scheduler_job_tag WHERE job_id = ?";
-    return ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
-        .executeUpdate();
+    try {
+      // language=MySQL
+      String sql = "DELETE FROM scheduler_job_tag WHERE job_id = ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete job tags", e);
+    }
   }
 
   @Override
   public List<UUID> findJobIdsByTag(String tag, int limit, int offset) {
-    // language=MySQL
-    String sql = "SELECT job_id FROM scheduler_job_tag WHERE tag = ? LIMIT ? OFFSET ?";
-    List<?> rows =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, tag)
-            .setParameter(2, limit)
-            .setParameter(3, offset)
-            .getResultList();
-    return rows.stream().map(MysqlJobRowMapper::uuidOrNull).collect(Collectors.toList());
+    try {
+      // language=MySQL
+      String sql = "SELECT job_id FROM scheduler_job_tag WHERE tag = ? LIMIT ? OFFSET ?";
+      List<?> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, tag)
+              .setParameter(2, limit)
+              .setParameter(3, offset)
+              .getResultList();
+      return rows.stream().map(MysqlJobRowMapper::uuidOrNull).collect(Collectors.toList());
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find job ids by tag", e);
+    }
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public Map<JobStatus, Long> countJobsByStatusForTag(String tag) {
-    // language=MySQL
-    String sql =
-        """
-        SELECT s, SUM(c) FROM (
-          SELECT q.status AS s, COUNT(*) AS c FROM scheduler_job_queue q
-            JOIN scheduler_job_tag t ON t.job_id = q.job_id
-            WHERE t.tag = ? GROUP BY q.status
-          UNION ALL
-          SELECT c.terminal_status AS s, COUNT(*) AS c FROM scheduler_job c
-            JOIN scheduler_job_tag t ON t.job_id = c.job_id
-            WHERE t.tag = ? AND c.terminal_status IS NOT NULL
-            GROUP BY c.terminal_status
-        ) u GROUP BY s
-        """;
-    List<Object[]> rows =
-        ctx.em().createNativeQuery(sql).setParameter(1, tag).setParameter(2, tag).getResultList();
-    Map<JobStatus, Long> counts = new EnumMap<>(JobStatus.class);
-    for (Object[] row : rows) {
-      counts.put(JobStatus.valueOf((String) row[0]), ((Number) row[1]).longValue());
+    try {
+      // language=MySQL
+      String sql =
+          """
+          SELECT s, SUM(c) FROM (
+            SELECT q.status AS s, COUNT(*) AS c FROM scheduler_job_queue q
+              JOIN scheduler_job_tag t ON t.job_id = q.job_id
+              WHERE t.tag = ? GROUP BY q.status
+            UNION ALL
+            SELECT c.terminal_status AS s, COUNT(*) AS c FROM scheduler_job c
+              JOIN scheduler_job_tag t ON t.job_id = c.job_id
+              WHERE t.tag = ? AND c.terminal_status IS NOT NULL
+              GROUP BY c.terminal_status
+          ) u GROUP BY s
+          """;
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, tag).setParameter(2, tag).getResultList();
+      Map<JobStatus, Long> counts = new EnumMap<>(JobStatus.class);
+      for (Object[] row : rows) {
+        counts.put(JobStatus.valueOf((String) row[0]), ((Number) row[1]).longValue());
+      }
+      return counts;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by status for tag", e);
     }
-    return counts;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public Map<String, Long> countJobsByParamForTag(String tag, String paramKey) {
-    String jsonPath = toJsonFieldPath(paramKey);
-    // language=MySQL
-    String sql =
-        """
-        SELECT JSON_UNQUOTE(JSON_EXTRACT(j.params, ?)) AS param_value, COUNT(*)
-        FROM scheduler_job j
-        JOIN scheduler_job_tag t ON j.job_id = t.job_id
-        WHERE t.tag = ?
-          AND JSON_EXTRACT(j.params, ?) IS NOT NULL
-        GROUP BY param_value
-        ORDER BY param_value
-        """;
-    List<Object[]> rows =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, jsonPath)
-            .setParameter(2, tag)
-            .setParameter(3, jsonPath)
-            .getResultList();
-    return toStringCountMap(rows);
+    try {
+      String jsonPath = toJsonFieldPath(paramKey);
+      // language=MySQL
+      String sql =
+          """
+          SELECT JSON_UNQUOTE(JSON_EXTRACT(j.params, ?)) AS param_value, COUNT(*)
+          FROM scheduler_job j
+          JOIN scheduler_job_tag t ON j.job_id = t.job_id
+          WHERE t.tag = ?
+            AND JSON_EXTRACT(j.params, ?) IS NOT NULL
+          GROUP BY param_value
+          ORDER BY param_value
+          """;
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, jsonPath)
+              .setParameter(2, tag)
+              .setParameter(3, jsonPath)
+              .getResultList();
+      return toStringCountMap(rows);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by param for tag", e);
+    }
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public Map<String, Long> countJobsByExecutionNodeForTag(String tag) {
-    // language=MySQL
-    String sql =
-        """
-        SELECT node, SUM(c) FROM (
-          SELECT q.picked_by AS node, COUNT(*) AS c
-            FROM scheduler_job_queue q
-            JOIN scheduler_job_tag t ON t.job_id = q.job_id
-            WHERE t.tag = ? AND q.picked_by IS NOT NULL AND q.picked_by <> ''
-            GROUP BY q.picked_by
-          UNION ALL
-          SELECT e.node_id AS node, COUNT(*) AS c
-            FROM scheduler_job c2
-            JOIN scheduler_job_tag t ON t.job_id = c2.job_id
-            JOIN scheduler_job_execution e ON e.job_id = c2.job_id
-            WHERE t.tag = ? AND c2.terminal_status IS NOT NULL
-              AND e.id = (SELECT MAX(e2.id) FROM scheduler_job_execution e2
-                          WHERE e2.job_id = c2.job_id)
-              AND e.node_id IS NOT NULL AND e.node_id <> ''
-            GROUP BY e.node_id
-        ) u GROUP BY node ORDER BY node
-        """;
-    List<Object[]> rows =
-        ctx.em().createNativeQuery(sql).setParameter(1, tag).setParameter(2, tag).getResultList();
-    return toStringCountMap(rows);
+    try {
+      // language=MySQL
+      String sql =
+          """
+          SELECT node, SUM(c) FROM (
+            SELECT q.picked_by AS node, COUNT(*) AS c
+              FROM scheduler_job_queue q
+              JOIN scheduler_job_tag t ON t.job_id = q.job_id
+              WHERE t.tag = ? AND q.picked_by IS NOT NULL AND q.picked_by <> ''
+              GROUP BY q.picked_by
+            UNION ALL
+            SELECT e.node_id AS node, COUNT(*) AS c
+              FROM scheduler_job c2
+              JOIN scheduler_job_tag t ON t.job_id = c2.job_id
+              JOIN scheduler_job_execution e ON e.job_id = c2.job_id
+              WHERE t.tag = ? AND c2.terminal_status IS NOT NULL
+                AND e.id = (SELECT MAX(e2.id) FROM scheduler_job_execution e2
+                            WHERE e2.job_id = c2.job_id)
+                AND e.node_id IS NOT NULL AND e.node_id <> ''
+              GROUP BY e.node_id
+          ) u GROUP BY node ORDER BY node
+          """;
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, tag).setParameter(2, tag).getResultList();
+      return toStringCountMap(rows);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by execution node for tag", e);
+    }
   }
 
   @SuppressWarnings("unchecked")
   void hydrateTagsSingle(JobEntity job) {
     if (job == null || job.getId() == null) return;
-    // language=MySQL
-    String sql = "SELECT tag FROM scheduler_job_tag WHERE job_id = ?";
-    List<String> tags =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, UuidByteArrayConverter.toBytes(job.getId()))
-            .getResultList();
-    if (!tags.isEmpty()) {
-      job.setTags(tags);
+    try {
+      // language=MySQL
+      String sql = "SELECT tag FROM scheduler_job_tag WHERE job_id = ?";
+      List<String> tags =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(job.getId()))
+              .getResultList();
+      if (!tags.isEmpty()) {
+        job.setTags(tags);
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("hydrate job tags", e);
     }
   }
 
   void hydrateTagsBatch(List<JobEntity> jobs) {
     if (jobs.isEmpty()) return;
-    List<UUID> ids = new ArrayList<>(jobs.size());
-    Map<UUID, JobEntity> byId = new HashMap<>();
-    for (JobEntity j : jobs) {
-      if (j.getId() != null) {
-        ids.add(j.getId());
-        byId.put(j.getId(), j);
+    try {
+      List<UUID> ids = new ArrayList<>(jobs.size());
+      Map<UUID, JobEntity> byId = new HashMap<>();
+      for (JobEntity j : jobs) {
+        if (j.getId() != null) {
+          ids.add(j.getId());
+          byId.put(j.getId(), j);
+        }
       }
-    }
-    if (ids.isEmpty()) return;
-    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
-    // language=MySQL
-    String sql =
-        "SELECT job_id, tag FROM scheduler_job_tag WHERE job_id IN ("
-            + placeholders
-            + ") ORDER BY job_id";
-    Query tagQuery = ctx.em().createNativeQuery(sql);
-    int parameter = 1;
-    for (UUID id : ids) {
-      tagQuery.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
-    }
-    @SuppressWarnings("unchecked")
-    List<Object[]> rows = tagQuery.getResultList();
-    for (Object[] row : rows) {
-      UUID jid = MysqlJobRowMapper.uuidOrNull(row[0]);
-      String tag = (String) row[1];
-      JobEntity j = byId.get(jid);
-      if (j == null) continue;
-      List<String> tags = j.getTags();
-      if (tags == null) {
-        tags = new ArrayList<>();
-        j.setTags(tags);
+      if (ids.isEmpty()) return;
+      String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+      // language=MySQL
+      String sql =
+          "SELECT job_id, tag FROM scheduler_job_tag WHERE job_id IN ("
+              + placeholders
+              + ") ORDER BY job_id";
+      Query tagQuery = ctx.em().createNativeQuery(sql);
+      int parameter = 1;
+      for (UUID id : ids) {
+        tagQuery.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
       }
-      tags.add(tag);
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows = tagQuery.getResultList();
+      for (Object[] row : rows) {
+        UUID jid = MysqlJobRowMapper.uuidOrNull(row[0]);
+        String tag = (String) row[1];
+        JobEntity j = byId.get(jid);
+        if (j == null) continue;
+        List<String> tags = j.getTags();
+        if (tags == null) {
+          tags = new ArrayList<>();
+          j.setTags(tags);
+        }
+        tags.add(tag);
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("hydrate job tags batch", e);
     }
   }
 }

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTransientExceptionTranslationTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTransientExceptionTranslationTest.java
@@ -105,6 +105,22 @@ class MysqlTransientExceptionTranslationTest {
                 "signal", "{}", "json", "ACCEPTED", null, "node-1", Instant.EPOCH, "delivery"));
   }
 
+  @Test
+  void tagOperationsTranslateTransientWriteFailure() {
+    MysqlTagOperations tags = new MysqlTagOperations(throwingContext("executeUpdate"));
+
+    assertThrows(RatchetTransientStoreException.class, () -> tags.deleteTagsByJobId(JOB_ID));
+  }
+
+  @Test
+  void resourcePermitReleaseTranslatesTransientWriteFailure() {
+    MysqlAuxiliaryOperations auxiliary =
+        new MysqlAuxiliaryOperations(throwingContext("executeUpdate"));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> auxiliary.releasePermit("api", JOB_ID));
+  }
+
   private static MysqlStoreContext throwingContext(String throwingQueryMethod) {
     EntityManager em =
         (EntityManager)

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
@@ -219,116 +219,136 @@ final class PostgresqlAuxiliaryOperations
 
   @Override
   public boolean tryAcquirePermit(String resource, UUID jobId, String nodeId) {
-    // language=PostgreSQL
-    String lockSql =
-        """
-        SELECT resource_name FROM scheduler_resource_limit
-        WHERE resource_name = ?
-        FOR UPDATE
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object> lockedLimits =
-        ctx.em().createNativeQuery(lockSql).setParameter(1, resource).getResultList();
-    if (lockedLimits.isEmpty()) {
-      throw new IllegalArgumentException("Resource is not configured: " + resource);
-    }
+    try {
+      // language=PostgreSQL
+      String lockSql =
+          """
+          SELECT resource_name FROM scheduler_resource_limit
+          WHERE resource_name = ?
+          FOR UPDATE
+          """;
+      @SuppressWarnings("unchecked")
+      List<Object> lockedLimits =
+          ctx.em().createNativeQuery(lockSql).setParameter(1, resource).getResultList();
+      if (lockedLimits.isEmpty()) {
+        throw new IllegalArgumentException("Resource is not configured: " + resource);
+      }
 
-    // language=PostgreSQL
-    String existingSql =
-        """
-        SELECT COUNT(*) FROM scheduler_resource_permit
-        WHERE resource_name = ? AND job_id = ?
-        """;
-    Object existing =
-        ctx.em()
-            .createNativeQuery(existingSql)
-            .setParameter(1, resource)
-            .setParameter(2, jobId)
-            .getSingleResult();
-    if (((Number) existing).intValue() > 0) {
-      return true;
-    }
+      // language=PostgreSQL
+      String existingSql =
+          """
+          SELECT COUNT(*) FROM scheduler_resource_permit
+          WHERE resource_name = ? AND job_id = ?
+          """;
+      Object existing =
+          ctx.em()
+              .createNativeQuery(existingSql)
+              .setParameter(1, resource)
+              .setParameter(2, jobId)
+              .getSingleResult();
+      if (((Number) existing).intValue() > 0) {
+        return true;
+      }
 
-    // PostgreSQL uses one statement snapshot even after waiting on FOR UPDATE. Keep the lock
-    // acquisition as its own statement, then count and insert together with a fresh snapshot.
-    // language=PostgreSQL
-    String insertSql =
-        """
-        INSERT INTO scheduler_resource_permit
-          (id, resource_name, job_id, node_id, acquired_at)
-        SELECT ?, resource_name, ?, ?, ?
-        FROM scheduler_resource_limit
-        WHERE resource_name = ?
-          AND (
-            SELECT COUNT(*) FROM scheduler_resource_permit
-            WHERE resource_name = ?
-          ) < max_concurrent
-        """;
-    int inserted =
-        ctx.em()
-            .createNativeQuery(insertSql)
-            .setParameter(1, UuidV7Factory.create())
-            .setParameter(2, jobId)
-            .setParameter(3, nodeId)
-            .setParameter(4, Timestamp.from(Instant.now()))
-            .setParameter(5, resource)
-            .setParameter(6, resource)
-            .executeUpdate();
-    return inserted > 0;
+      // PostgreSQL uses one statement snapshot even after waiting on FOR UPDATE. Keep the lock
+      // acquisition as its own statement, then count and insert together with a fresh snapshot.
+      // language=PostgreSQL
+      String insertSql =
+          """
+          INSERT INTO scheduler_resource_permit
+            (id, resource_name, job_id, node_id, acquired_at)
+          SELECT ?, resource_name, ?, ?, ?
+          FROM scheduler_resource_limit
+          WHERE resource_name = ?
+            AND (
+              SELECT COUNT(*) FROM scheduler_resource_permit
+              WHERE resource_name = ?
+            ) < max_concurrent
+          """;
+      int inserted =
+          ctx.em()
+              .createNativeQuery(insertSql)
+              .setParameter(1, UuidV7Factory.create())
+              .setParameter(2, jobId)
+              .setParameter(3, nodeId)
+              .setParameter(4, Timestamp.from(Instant.now()))
+              .setParameter(5, resource)
+              .setParameter(6, resource)
+              .executeUpdate();
+      return inserted > 0;
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("try acquire permit", e);
+    }
   }
 
   @Override
   public void releasePermit(String resource, UUID jobId) {
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_resource_permit WHERE resource_name = ? AND job_id = ?";
-    ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, resource)
-        .setParameter(2, jobId)
-        .executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_resource_permit WHERE resource_name = ? AND job_id = ?";
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, resource)
+          .setParameter(2, jobId)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("release resource permit", e);
+    }
   }
 
   @Override
   public void releaseAllPermits(UUID jobId) {
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_resource_permit WHERE job_id = ?";
-    ctx.em().createNativeQuery(sql).setParameter(1, jobId).executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_resource_permit WHERE job_id = ?";
+      ctx.em().createNativeQuery(sql).setParameter(1, jobId).executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("release all permits", e);
+    }
   }
 
   @Override
   public int getPermitRetryDelay(String resource) {
-    // language=PostgreSQL
-    String sql = "SELECT retry_delay_ms FROM scheduler_resource_limit WHERE resource_name = ?";
     try {
+      // language=PostgreSQL
+      String sql = "SELECT retry_delay_ms FROM scheduler_resource_limit WHERE resource_name = ?";
       Object result = ctx.em().createNativeQuery(sql).setParameter(1, resource).getSingleResult();
       return ((Number) result).intValue();
     } catch (NoResultException e) {
       return ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get permit retry delay", e);
     }
   }
 
   @Override
   public void configureResource(
       String name, int maxConcurrent, int retryDelayMs, String description) {
-    // language=PostgreSQL
-    String sql =
-        """
-        INSERT INTO scheduler_resource_limit
-          (resource_name, max_concurrent, retry_delay_ms, description, created_at, updated_at)
-        VALUES (?, ?, ?, ?, statement_timestamp(), statement_timestamp())
-        ON CONFLICT (resource_name) DO UPDATE SET
-          max_concurrent = EXCLUDED.max_concurrent,
-          retry_delay_ms = EXCLUDED.retry_delay_ms,
-          description = EXCLUDED.description,
-          updated_at = statement_timestamp()
-        """;
-    ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, name)
-        .setParameter(2, maxConcurrent)
-        .setParameter(3, retryDelayMs)
-        .setParameter(4, description)
-        .executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql =
+          """
+          INSERT INTO scheduler_resource_limit
+            (resource_name, max_concurrent, retry_delay_ms, description, created_at, updated_at)
+          VALUES (?, ?, ?, ?, statement_timestamp(), statement_timestamp())
+          ON CONFLICT (resource_name) DO UPDATE SET
+            max_concurrent = EXCLUDED.max_concurrent,
+            retry_delay_ms = EXCLUDED.retry_delay_ms,
+            description = EXCLUDED.description,
+            updated_at = statement_timestamp()
+          """;
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, name)
+          .setParameter(2, maxConcurrent)
+          .setParameter(3, retryDelayMs)
+          .setParameter(4, description)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("configure resource", e);
+    }
   }
 
   @Override
@@ -336,15 +356,19 @@ final class PostgresqlAuxiliaryOperations
     if (staleNodeIds.isEmpty()) {
       return 0;
     }
-    String placeholders = String.join(",", Collections.nCopies(staleNodeIds.size(), "?"));
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_resource_permit WHERE node_id IN (" + placeholders + ")";
-    Query query = ctx.em().createNativeQuery(sql);
-    int parameter = 1;
-    for (String nodeId : staleNodeIds) {
-      query.setParameter(parameter++, nodeId);
+    try {
+      String placeholders = String.join(",", Collections.nCopies(staleNodeIds.size(), "?"));
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_resource_permit WHERE node_id IN (" + placeholders + ")";
+      Query query = ctx.em().createNativeQuery(sql);
+      int parameter = 1;
+      for (String nodeId : staleNodeIds) {
+        query.setParameter(parameter++, nodeId);
+      }
+      return query.executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("cleanup orphaned permits", e);
     }
-    return query.executeUpdate();
   }
 
   private void prepareCondition(WorkflowConditionEntity condition) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlNodeLockOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlNodeLockOperations.java
@@ -27,39 +27,47 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     requireLockName(name);
     requirePositiveDuration(ttl, "ttl");
     Objects.requireNonNull(nodeId, "nodeId");
-    long ttlMicros = durationMicros(ttl);
-    // language=PostgreSQL
-    String sql =
-        """
-        INSERT INTO scheduler_lock (lock_name, owner_node, locked_at, expires_at)
-        VALUES (?, ?, statement_timestamp(),
-                statement_timestamp() + ? * interval '1 microsecond')
-        ON CONFLICT (lock_name) DO UPDATE SET
-          owner_node = EXCLUDED.owner_node,
-          locked_at = statement_timestamp(),
-          expires_at = statement_timestamp() + ? * interval '1 microsecond'
-        WHERE scheduler_lock.expires_at < statement_timestamp()
-           OR scheduler_lock.owner_node = ?
-        """;
-    int updated =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, name)
-            .setParameter(2, nodeId)
-            .setParameter(3, ttlMicros)
-            .setParameter(4, ttlMicros)
-            .setParameter(5, nodeId)
-            .executeUpdate();
-    return updated > 0;
+    try {
+      long ttlMicros = durationMicros(ttl);
+      // language=PostgreSQL
+      String sql =
+          """
+          INSERT INTO scheduler_lock (lock_name, owner_node, locked_at, expires_at)
+          VALUES (?, ?, statement_timestamp(),
+                  statement_timestamp() + ? * interval '1 microsecond')
+          ON CONFLICT (lock_name) DO UPDATE SET
+            owner_node = EXCLUDED.owner_node,
+            locked_at = statement_timestamp(),
+            expires_at = statement_timestamp() + ? * interval '1 microsecond'
+          WHERE scheduler_lock.expires_at < statement_timestamp()
+             OR scheduler_lock.owner_node = ?
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, name)
+              .setParameter(2, nodeId)
+              .setParameter(3, ttlMicros)
+              .setParameter(4, ttlMicros)
+              .setParameter(5, nodeId)
+              .executeUpdate();
+      return updated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("try lock", e);
+    }
   }
 
   @Override
   public void unlock(String name, String nodeId) {
     requireLockName(name);
     Objects.requireNonNull(nodeId, "nodeId");
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_lock WHERE lock_name = ? AND owner_node = ?";
-    ctx.em().createNativeQuery(sql).setParameter(1, name).setParameter(2, nodeId).executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_lock WHERE lock_name = ? AND owner_node = ?";
+      ctx.em().createNativeQuery(sql).setParameter(1, name).setParameter(2, nodeId).executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("unlock", e);
+    }
   }
 
   @Override
@@ -67,22 +75,26 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     requireLockName(name);
     requirePositiveDuration(extension, "extension");
     Objects.requireNonNull(nodeId, "nodeId");
-    long extensionMicros = durationMicros(extension);
-    // language=PostgreSQL
-    String sql =
-        """
-        UPDATE scheduler_lock
-        SET expires_at = statement_timestamp() + ? * interval '1 microsecond'
-        WHERE lock_name = ? AND owner_node = ?
-        """;
-    int updated =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, extensionMicros)
-            .setParameter(2, name)
-            .setParameter(3, nodeId)
-            .executeUpdate();
-    return updated > 0;
+    try {
+      long extensionMicros = durationMicros(extension);
+      // language=PostgreSQL
+      String sql =
+          """
+          UPDATE scheduler_lock
+          SET expires_at = statement_timestamp() + ? * interval '1 microsecond'
+          WHERE lock_name = ? AND owner_node = ?
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, extensionMicros)
+              .setParameter(2, name)
+              .setParameter(3, nodeId)
+              .executeUpdate();
+      return updated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("renew lock", e);
+    }
   }
 
   private static void requireLockName(String name) {
@@ -112,43 +124,62 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
   public void upsertHeartbeat(String nodeId, Instant ts) {
     Objects.requireNonNull(nodeId, "nodeId");
     Objects.requireNonNull(ts, "ts");
-    // language=PostgreSQL
-    String sql =
-        """
-        INSERT INTO scheduler_node (node_id, heartbeat_ts, started_at)
-        VALUES (?, ?, ?)
-        ON CONFLICT (node_id) DO UPDATE SET heartbeat_ts = EXCLUDED.heartbeat_ts
-        """;
-    ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, nodeId)
-        .setParameter(2, Timestamp.from(ts))
-        .setParameter(3, Timestamp.from(ts))
-        .executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql =
+          """
+          INSERT INTO scheduler_node (node_id, heartbeat_ts, started_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT (node_id) DO UPDATE SET heartbeat_ts = EXCLUDED.heartbeat_ts
+          """;
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, nodeId)
+          .setParameter(2, Timestamp.from(ts))
+          .setParameter(3, Timestamp.from(ts))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("upsert heartbeat", e);
+    }
   }
 
   @Override
   public Optional<NodeEntity> findNodeById(String nodeId) {
-    return Optional.ofNullable(ctx.em().find(NodeEntity.class, nodeId));
+    try {
+      return Optional.ofNullable(ctx.em().find(NodeEntity.class, nodeId));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find node by id", e);
+    }
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public List<NodeEntity> findInactiveNodesSince(Instant cutoff) {
-    // language=PostgreSQL
-    String sql = "SELECT * FROM scheduler_node WHERE heartbeat_ts < ? LIMIT ?";
-    return ctx.em()
-        .createNativeQuery(sql, NodeEntity.class)
-        .setParameter(1, Timestamp.from(cutoff))
-        .setParameter(2, MAX_INACTIVE_NODES)
-        .getResultList();
+    try {
+      // language=PostgreSQL
+      String sql = "SELECT * FROM scheduler_node WHERE heartbeat_ts < ? LIMIT ?";
+      return ctx.em()
+          .createNativeQuery(sql, NodeEntity.class)
+          .setParameter(1, Timestamp.from(cutoff))
+          .setParameter(2, MAX_INACTIVE_NODES)
+          .getResultList();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find inactive nodes", e);
+    }
   }
 
   @Override
   public int deleteInactiveNodesSince(Instant cutoff) {
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_node WHERE heartbeat_ts < ?";
-    return ctx.em().createNativeQuery(sql).setParameter(1, Timestamp.from(cutoff)).executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_node WHERE heartbeat_ts < ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, Timestamp.from(cutoff))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete inactive nodes", e);
+    }
   }
 
   @Override
@@ -156,27 +187,35 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     if (nodeIds.isEmpty()) {
       return 0;
     }
-    String placeholders = String.join(",", Collections.nCopies(nodeIds.size(), "?"));
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_node WHERE node_id IN (" + placeholders + ")";
-    var query = ctx.em().createNativeQuery(sql);
-    int parameter = 1;
-    for (String nodeId : nodeIds) {
-      query.setParameter(parameter++, nodeId);
+    try {
+      String placeholders = String.join(",", Collections.nCopies(nodeIds.size(), "?"));
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_node WHERE node_id IN (" + placeholders + ")";
+      var query = ctx.em().createNativeQuery(sql);
+      int parameter = 1;
+      for (String nodeId : nodeIds) {
+        query.setParameter(parameter++, nodeId);
+      }
+      return query.executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete inactive nodes by id", e);
     }
-    return query.executeUpdate();
   }
 
   @Override
   public Instant getDatabaseTime() {
-    // language=PostgreSQL
-    String sql = "SELECT (EXTRACT(EPOCH FROM statement_timestamp()) * 1000)::bigint";
-    Object epochMillis = ctx.em().createNativeQuery(sql).getSingleResult();
-    if (epochMillis instanceof Number n) {
-      return Instant.ofEpochMilli(n.longValue());
+    try {
+      // language=PostgreSQL
+      String sql = "SELECT (EXTRACT(EPOCH FROM statement_timestamp()) * 1000)::bigint";
+      Object epochMillis = ctx.em().createNativeQuery(sql).getSingleResult();
+      if (epochMillis instanceof Number n) {
+        return Instant.ofEpochMilli(n.longValue());
+      }
+      throw new IllegalStateException(
+          "Unexpected database epoch millis result type: "
+              + (epochMillis == null ? "null" : epochMillis.getClass().getName()));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get database time", e);
     }
-    throw new IllegalStateException(
-        "Unexpected database epoch millis result type: "
-            + (epochMillis == null ? "null" : epochMillis.getClass().getName()));
   }
 }

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSignalOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSignalOperations.java
@@ -46,57 +46,61 @@ final class PostgresqlSignalOperations implements SignalStore {
   @Override
   @SuppressWarnings("unchecked")
   public List<JobEntity> findTimedOutSignalJobs(Instant now, int limit) {
-    int safeLimit = Math.max(1, limit);
-    // language=PostgreSQL
-    String sql =
-        """
-        SELECT q.job_id, q.signal_key, q.signal_timeout, q.status,
-               c.job_type, c.priority, c.max_retries, c.business_key,
-               c.backoff_policy, c.backoff_param_ms,
-               q.signal_payload, q.signal_payload_type, q.signal_outcome,
-               q.signal_rejection_reason, q.signal_delivered_at,
-               q.signal_delivered_by, q.signal_delivery_id
-        FROM scheduler_job_queue q
-        JOIN scheduler_job c ON c.job_id = q.job_id
-        WHERE q.status = 'WAITING'
-          AND q.signal_timeout IS NOT NULL
-          AND q.signal_timeout <= ?
-        ORDER BY q.signal_timeout ASC, q.job_id ASC
-        """;
-    List<Object[]> rows =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, Timestamp.from(now))
-            .setMaxResults(safeLimit)
-            .getResultList();
+    try {
+      int safeLimit = Math.max(1, limit);
+      // language=PostgreSQL
+      String sql =
+          """
+          SELECT q.job_id, q.signal_key, q.signal_timeout, q.status,
+                 c.job_type, c.priority, c.max_retries, c.business_key,
+                 c.backoff_policy, c.backoff_param_ms,
+                 q.signal_payload, q.signal_payload_type, q.signal_outcome,
+                 q.signal_rejection_reason, q.signal_delivered_at,
+                 q.signal_delivered_by, q.signal_delivery_id
+          FROM scheduler_job_queue q
+          JOIN scheduler_job c ON c.job_id = q.job_id
+          WHERE q.status = 'WAITING'
+            AND q.signal_timeout IS NOT NULL
+            AND q.signal_timeout <= ?
+          ORDER BY q.signal_timeout ASC, q.job_id ASC
+          """;
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, Timestamp.from(now))
+              .setMaxResults(safeLimit)
+              .getResultList();
 
-    List<JobEntity> result = new ArrayList<>(rows.size());
-    for (Object[] row : rows) {
-      JobEntity job = new JobEntity();
-      job.setId(toUuid(row[0]));
-      job.setSignalKey((String) row[1]);
-      job.setSignalTimeout(toInstant(row[2]));
-      job.setStatus(JobStatus.WAITING);
-      job.setJobType(row[4] != null ? JobExecutionType.valueOf((String) row[4]) : null);
-      job.setPriority(
-          row[5] != null
-              ? PostgresqlJobRowMapper.safeJobPriority(((Number) row[5]).intValue())
-              : JobPriority.NORMAL);
-      job.setMaxRetries(row[6] != null ? ((Number) row[6]).intValue() : 0);
-      job.setBusinessKey((String) row[7]);
-      job.setBackoffPolicy(
-          row[8] != null ? BackoffPolicy.valueOf((String) row[8]) : BackoffPolicy.NONE);
-      job.setBackoffParamMs(row[9] != null ? ((Number) row[9]).intValue() : 0);
-      job.setSignalPayload((String) row[10]);
-      job.setSignalPayloadType((String) row[11]);
-      job.setSignalOutcome((String) row[12]);
-      job.setSignalRejectionReason((String) row[13]);
-      job.setSignalDeliveredAt(toInstant(row[14]));
-      job.setSignalDeliveredBy((String) row[15]);
-      job.setSignalDeliveryId((String) row[16]);
-      result.add(job);
+      List<JobEntity> result = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        JobEntity job = new JobEntity();
+        job.setId(toUuid(row[0]));
+        job.setSignalKey((String) row[1]);
+        job.setSignalTimeout(toInstant(row[2]));
+        job.setStatus(JobStatus.WAITING);
+        job.setJobType(row[4] != null ? JobExecutionType.valueOf((String) row[4]) : null);
+        job.setPriority(
+            row[5] != null
+                ? PostgresqlJobRowMapper.safeJobPriority(((Number) row[5]).intValue())
+                : JobPriority.NORMAL);
+        job.setMaxRetries(row[6] != null ? ((Number) row[6]).intValue() : 0);
+        job.setBusinessKey((String) row[7]);
+        job.setBackoffPolicy(
+            row[8] != null ? BackoffPolicy.valueOf((String) row[8]) : BackoffPolicy.NONE);
+        job.setBackoffParamMs(row[9] != null ? ((Number) row[9]).intValue() : 0);
+        job.setSignalPayload((String) row[10]);
+        job.setSignalPayloadType((String) row[11]);
+        job.setSignalOutcome((String) row[12]);
+        job.setSignalRejectionReason((String) row[13]);
+        job.setSignalDeliveredAt(toInstant(row[14]));
+        job.setSignalDeliveredBy((String) row[15]);
+        job.setSignalDeliveryId((String) row[16]);
+        result.add(job);
+      }
+      return result;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find timed out signal jobs", e);
     }
-    return result;
   }
 
   @Override
@@ -109,35 +113,39 @@ final class PostgresqlSignalOperations implements SignalStore {
       String deliveredBy,
       Instant deliveredAt,
       String deliveryId) {
-    // language=PostgreSQL
-    String sql =
-        """
-        UPDATE scheduler_job_queue
-        SET status = 'PENDING',
-            signal_payload = ?,
-            signal_payload_type = ?,
-            signal_outcome = ?,
-            signal_rejection_reason = ?,
-            signal_delivered_at = ?,
-            signal_delivered_by = ?,
-            signal_delivery_id = ?,
-            updated_at = NOW()
-        WHERE job_id = ? AND status = 'WAITING'
-        """;
-    int updated =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, payload)
-            .setParameter(2, payloadType)
-            .setParameter(3, outcome)
-            .setParameter(4, rejectionReason)
-            .setParameter(5, deliveredAt != null ? Timestamp.from(deliveredAt) : null)
-            .setParameter(6, deliveredBy)
-            .setParameter(7, deliveryId)
-            .setParameter(8, jobId)
-            .executeUpdate();
-    log.debugf("deliverSignalById(%s): %s row(s) updated", jobId, updated);
-    return updated;
+    try {
+      // language=PostgreSQL
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              signal_payload = ?,
+              signal_payload_type = ?,
+              signal_outcome = ?,
+              signal_rejection_reason = ?,
+              signal_delivered_at = ?,
+              signal_delivered_by = ?,
+              signal_delivery_id = ?,
+              updated_at = NOW()
+          WHERE job_id = ? AND status = 'WAITING'
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, payload)
+              .setParameter(2, payloadType)
+              .setParameter(3, outcome)
+              .setParameter(4, rejectionReason)
+              .setParameter(5, deliveredAt != null ? Timestamp.from(deliveredAt) : null)
+              .setParameter(6, deliveredBy)
+              .setParameter(7, deliveryId)
+              .setParameter(8, jobId)
+              .executeUpdate();
+      log.debugf("deliverSignalById(%s): %s row(s) updated", jobId, updated);
+      return updated;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("deliver signal by id", e);
+    }
   }
 
   @Override
@@ -150,50 +158,58 @@ final class PostgresqlSignalOperations implements SignalStore {
       String deliveredBy,
       Instant deliveredAt,
       String deliveryId) {
-    // language=PostgreSQL
-    String sql =
-        """
-        UPDATE scheduler_job_queue
-        SET status = 'PENDING',
-            signal_payload = ?,
-            signal_payload_type = ?,
-            signal_outcome = ?,
-            signal_rejection_reason = ?,
-            signal_delivered_at = ?,
-            signal_delivered_by = ?,
-            signal_delivery_id = ?,
-            updated_at = NOW()
-        WHERE signal_key = ? AND status = 'WAITING'
-        """;
-    int updated =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, payload)
-            .setParameter(2, payloadType)
-            .setParameter(3, outcome)
-            .setParameter(4, rejectionReason)
-            .setParameter(5, deliveredAt != null ? Timestamp.from(deliveredAt) : null)
-            .setParameter(6, deliveredBy)
-            .setParameter(7, deliveryId)
-            .setParameter(8, signalKey)
-            .executeUpdate();
-    log.debugf("deliverSignalByKey('%s'): %s row(s) updated", signalKey, updated);
-    return updated;
+    try {
+      // language=PostgreSQL
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              signal_payload = ?,
+              signal_payload_type = ?,
+              signal_outcome = ?,
+              signal_rejection_reason = ?,
+              signal_delivered_at = ?,
+              signal_delivered_by = ?,
+              signal_delivery_id = ?,
+              updated_at = NOW()
+          WHERE signal_key = ? AND status = 'WAITING'
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, payload)
+              .setParameter(2, payloadType)
+              .setParameter(3, outcome)
+              .setParameter(4, rejectionReason)
+              .setParameter(5, deliveredAt != null ? Timestamp.from(deliveredAt) : null)
+              .setParameter(6, deliveredBy)
+              .setParameter(7, deliveryId)
+              .setParameter(8, signalKey)
+              .executeUpdate();
+      log.debugf("deliverSignalByKey('%s'): %s row(s) updated", signalKey, updated);
+      return updated;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("deliver signal by key", e);
+    }
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public List<JobEntity> findJobsBySignalDeliveryId(String deliveryId) {
-    if (deliveryId == null || deliveryId.isBlank()) {
-      return List.of();
+    try {
+      if (deliveryId == null || deliveryId.isBlank()) {
+        return List.of();
+      }
+      String sql =
+          "SELECT "
+              + PostgresqlJobRowMapper.hydrationSelect()
+              + " FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id"
+              + " WHERE q.signal_delivery_id = ?";
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, deliveryId).getResultList();
+      return PostgresqlJobRowMapper.hydrateRows(rows);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find jobs by signal delivery id", e);
     }
-    String sql =
-        "SELECT "
-            + PostgresqlJobRowMapper.hydrationSelect()
-            + " FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id"
-            + " WHERE q.signal_delivery_id = ?";
-    List<Object[]> rows =
-        ctx.em().createNativeQuery(sql).setParameter(1, deliveryId).getResultList();
-    return PostgresqlJobRowMapper.hydrateRows(rows);
   }
 }

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlExceptionTranslationTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlExceptionTranslationTest.java
@@ -7,6 +7,7 @@ import jakarta.persistence.PersistenceException;
 import jakarta.persistence.Query;
 import java.lang.reflect.Proxy;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -121,6 +122,40 @@ class PostgresqlExceptionTranslationTest {
             new PostgresqlStoreContext(entityManager(queryThrowingOnExecute())));
 
     assertThrows(RatchetTransientStoreException.class, () -> tags.deleteTagsByJobId(JOB_ID));
+  }
+
+  @Test
+  void nodeLockOperationsTranslateDeadlock() {
+    var locks =
+        new PostgresqlNodeLockOperations(
+            new PostgresqlStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> locks.tryLock("scheduler", Duration.ofSeconds(30), "node-1"));
+  }
+
+  @Test
+  void signalOperationsTranslateDeadlock() {
+    var signals =
+        new PostgresqlSignalOperations(
+            new PostgresqlStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () ->
+            signals.deliverSignalByKey(
+                "approval", "{}", "json", "APPROVED", null, "node-1", Instant.EPOCH, "delivery-1"));
+  }
+
+  @Test
+  void resourcePermitReleaseTranslatesDeadlock() {
+    var auxiliary =
+        new PostgresqlAuxiliaryOperations(
+            new PostgresqlStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> auxiliary.releasePermit("api", JOB_ID));
   }
 
   private static EntityManager entityManager(Query... queries) {


### PR DESCRIPTION
## Summary

Fixes transient exception translation gaps in store helper paths.

PostgreSQL lock and signal operations now route runtime store failures through the existing translator. Resource permit release, cleanup, and configuration paths in the SQL stores follow the same pattern. MySQL and Mongo tag operations now match PostgreSQL's retryable failure behavior.

The tests use focused proxy coverage for the helper paths that used to raw-throw provider failures.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet-store-postgresql,ratchet-store-mysql,ratchet-store-mongodb -Dtest=PostgresqlExceptionTranslationTest,PostgresqlNodeLockOperationsTest,MysqlTransientExceptionTranslationTest,MongoExceptionTranslationTest test`
- [x] `mvn -pl ratchet-store-postgresql,ratchet-store-mysql,ratchet-store-mongodb spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

This addresses v5 IDs 3, 133, 136, and 142 for the scoped store helper paths. Full container-backed store suites were not run in this pass.
