### PR TITLE
Use scheduler clocks for residue events

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
@@ -6,7 +6,9 @@ import java.util.UUID;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
-/** Fired when a batch is about to complete (before callbacks). */
+/**
+ * Fired after all batch children are terminal and before the batch completion event is published.
+ */
 public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 2629383623872540166L;
@@ -19,8 +21,8 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
    * Creates a batch-completing event with an explicit timestamp.
    *
    * @param totalItems total number of child jobs in the batch
-   * @param completedItems number of successful child jobs observed before callbacks run
-   * @param failedItems number of failed child jobs observed before callbacks run
+   * @param completedItems number of successful child jobs in the completed batch
+   * @param failedItems number of failed child jobs in the completed batch
    */
   public BatchCompletingEvent(
       UUID jobId,
@@ -43,8 +45,8 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
    * Creates a batch-completing event using the current system clock instant.
    *
    * @param totalItems total number of child jobs in the batch
-   * @param completedItems number of successful child jobs observed before callbacks run
-   * @param failedItems number of failed child jobs observed before callbacks run
+   * @param completedItems number of successful child jobs in the completed batch
+   * @param failedItems number of failed child jobs in the completed batch
    */
   public BatchCompletingEvent(
       UUID jobId,
@@ -67,12 +69,12 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
     return totalItems;
   }
 
-  /** Returns the number of child jobs completed before callbacks run. */
+  /** Returns the number of successful child jobs in the completed batch. */
   public int getCompletedItems() {
     return completedItems;
   }
 
-  /** Returns the number of child jobs that failed before callbacks run. */
+  /** Returns the number of failed child jobs in the completed batch. */
   public int getFailedItems() {
     return failedItems;
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
@@ -18,7 +18,8 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
   /**
    * Creates an event with an explicit timestamp.
    *
-   * @param callbackAttempt 1-based callback attempt number
+   * @param callbackAttempt 1-based callback invocation attempt. Ratchet currently invokes each
+   *     lifecycle callback once, so RI producers pass {@code 1}.
    */
   public JobCallbackFailedEvent(
       UUID jobId,
@@ -41,7 +42,8 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
   /**
    * Creates an event using the current system clock instant.
    *
-   * @param callbackAttempt 1-based callback attempt number
+   * @param callbackAttempt 1-based callback invocation attempt. Ratchet currently invokes each
+   *     lifecycle callback once, so RI producers pass {@code 1}.
    */
   public JobCallbackFailedEvent(
       UUID jobId,
@@ -75,7 +77,7 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
     return causeClassName;
   }
 
-  /** Returns the 1-based callback attempt number. */
+  /** Returns the 1-based callback invocation attempt. */
   public int getCallbackAttempt() {
     return callbackAttempt;
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/PerformanceMetricsEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/PerformanceMetricsEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Legacy placeholder for dashboard-level aggregate metrics.
@@ -10,8 +11,9 @@ import java.util.Map;
  * <p>The RI does not publish this event. Use the {@code MetricsCollector} SPI for scheduler
  * telemetry instead. This type is retained only for source compatibility with early API drafts.
  *
- * <p>The {@code performanceData} map is defensively copied and is immutable after construction. All
- * keys and values must be non-null and serializable by the event transport used by the application.
+ * <p>The {@code performanceData} map must be non-null, is defensively copied, and is immutable
+ * after construction. All keys and values must be non-null and serializable by the event transport
+ * used by the application.
  *
  * @deprecated no scheduler producer exists; use {@code MetricsCollector} instead
  */
@@ -21,6 +23,6 @@ public record PerformanceMetricsEvent(Map<String, Object> performanceData) imple
   @Serial private static final long serialVersionUID = 1L;
 
   public PerformanceMetricsEvent {
-    performanceData = Map.copyOf(performanceData);
+    performanceData = Map.copyOf(Objects.requireNonNull(performanceData, "performanceData"));
   }
 }

--- a/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
@@ -371,6 +371,8 @@ class EventApiContractTest {
 
   @Test
   void performanceMetricsDefensivelyCopiesInputMap() {
+    assertThrows(NullPointerException.class, () -> new PerformanceMetricsEvent(null));
+
     Map<String, Object> data = new HashMap<>();
     data.put("queued", 1);
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -770,12 +770,12 @@ public class DefaultJobSchedulerService
       log.warn("deliverSignal called but no SignalStore is wired — returning 0");
       return 0;
     }
+    JobEntity job = jobCrudStore.findById(jobId).orElse(null);
     String principal =
         callerPrincipalProvider != null
             ? callerPrincipalProvider.currentPrincipal().orElse(null)
             : null;
     if (authorizationPolicy != null) {
-      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
       authorizationPolicy.checkDeliverSignal(jobId, ownerPrincipal, principal);
     }
@@ -795,8 +795,7 @@ public class DefaultJobSchedulerService
             now,
             deliveryId);
     if (unblocked > 0) {
-      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
-      publishSignaledEvent(jobId, job, deliveredBy, SignalDecision.Outcome.APPROVED, null);
+      publishSignaledEvent(jobId, job, deliveredBy, now, SignalDecision.Outcome.APPROVED, null);
       log.debugf("Signal delivered to job %s by %s", jobId, deliveredBy);
     }
     return unblocked;
@@ -807,12 +806,12 @@ public class DefaultJobSchedulerService
       log.warn("deliverSignal called but no SignalStore is wired — returning 0");
       return 0;
     }
+    JobEntity job = jobCrudStore.findById(jobId).orElse(null);
     String principal =
         callerPrincipalProvider != null
             ? callerPrincipalProvider.currentPrincipal().orElse(null)
             : null;
     if (authorizationPolicy != null) {
-      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
       authorizationPolicy.checkDeliverSignal(jobId, ownerPrincipal, principal);
     }
@@ -832,8 +831,8 @@ public class DefaultJobSchedulerService
             now,
             deliveryId);
     if (unblocked > 0) {
-      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
-      publishSignaledEvent(jobId, job, deliveredBy, decision.outcome(), decision.rejectionReason());
+      publishSignaledEvent(
+          jobId, job, deliveredBy, now, decision.outcome(), decision.rejectionReason());
       log.debugf("Signal decision delivered to job %s by %s", jobId, deliveredBy);
     }
     return unblocked;
@@ -868,7 +867,7 @@ public class DefaultJobSchedulerService
             deliveryId);
     if (unblocked > 0) {
       publishBulkSignaledEvent(
-          signalKey, unblocked, deliveredBy, SignalDecision.Outcome.APPROVED, null);
+          signalKey, unblocked, deliveredBy, now, SignalDecision.Outcome.APPROVED, null);
       log.debugf("Signal '%s' broadcast to %s job(s) by %s", signalKey, unblocked, deliveredBy);
     }
     return unblocked;
@@ -903,7 +902,7 @@ public class DefaultJobSchedulerService
             deliveryId);
     if (unblocked > 0) {
       publishBulkSignaledEvent(
-          signalKey, unblocked, deliveredBy, decision.outcome(), decision.rejectionReason());
+          signalKey, unblocked, deliveredBy, now, decision.outcome(), decision.rejectionReason());
       log.debugf(
           "Signal decision '%s' broadcast to %s job(s) by %s", signalKey, unblocked, deliveredBy);
     }
@@ -914,11 +913,11 @@ public class DefaultJobSchedulerService
       String signalKey,
       int count,
       String principal,
+      Instant timestamp,
       SignalDecision.Outcome outcome,
       String rejectionReason) {
     JobsBulkSignaledEvent event =
-        new JobsBulkSignaledEvent(
-            signalKey, count, principal, outcome, rejectionReason, effective().instant());
+        new JobsBulkSignaledEvent(signalKey, count, principal, outcome, rejectionReason, timestamp);
     if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
       eventPublisher.publish(event);
     }
@@ -928,6 +927,7 @@ public class DefaultJobSchedulerService
       UUID jobId,
       JobEntity job,
       String principal,
+      Instant timestamp,
       SignalDecision.Outcome outcome,
       String rejectionReason) {
     if (metricsCollector != null && job != null) {
@@ -940,6 +940,7 @@ public class DefaultJobSchedulerService
             job != null ? job.getPublicJobType() : null,
             job != null ? job.getPriority() : null,
             null,
+            timestamp,
             job != null ? job.getSignalKey() : null,
             principal,
             outcome,

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
@@ -312,13 +312,15 @@ public class JobTask implements Callable<Void> {
     currentExecution =
         observabilityFacade.startExecution(jobId, attemptNumber, nodeIdProvider.getNodeId());
 
+    Instant start = effective().instant();
     observabilityFacade.publishEvent(
         new JobStartedEvent(
             jobEntity.getId(),
             jobEntity.getBusinessKey(),
             jobEntity.getPublicJobType(),
             jobEntity.getPriority(),
-            jobEntity.getPickedBy()));
+            jobEntity.getPickedBy(),
+            start));
 
     if (log.isInfoEnabled()) {
       log.infov(
@@ -332,7 +334,6 @@ public class JobTask implements Callable<Void> {
           jobEntity.getPayload().method());
     }
 
-    Instant start = effective().instant();
     Object jobResult;
     permitAcquired = false;
     String resilienceServiceName = resolveResilienceServiceName(jobEntity.getPayload());
@@ -579,6 +580,7 @@ public class JobTask implements Callable<Void> {
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
+            endTime,
             JobStatus.RUNNING.name(),
             executionMs));
 
@@ -686,6 +688,7 @@ public class JobTask implements Callable<Void> {
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
+            endTime,
             executionMs));
 
     try {
@@ -818,6 +821,7 @@ public class JobTask implements Callable<Void> {
 
   private void publishTerminalFailureEvents(Throwable ex, int attempt) {
     String sanitized = errorSanitizer.sanitize(ex);
+    Instant timestamp = effective().instant();
     observabilityFacade.publishEvent(
         new JobFailedEvent(
             job.getId(),
@@ -825,6 +829,7 @@ public class JobTask implements Callable<Void> {
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
+            timestamp,
             sanitized,
             attempt));
     observabilityFacade.publishEvent(
@@ -834,6 +839,7 @@ public class JobTask implements Callable<Void> {
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
+            timestamp,
             sanitized,
             attempt));
   }
@@ -880,6 +886,7 @@ public class JobTask implements Callable<Void> {
                 job.getPublicJobType(),
                 job.getPriority(),
                 job.getPickedBy(),
+                effective().instant(),
                 type,
                 e.getMessage(),
                 e.getClass().getName(),
@@ -1059,7 +1066,8 @@ public class JobTask implements Callable<Void> {
             ? BackoffPolicyHandler.computeDelay(
                 job.getBackoffPolicy(), job.getBackoffParamMs(), attempt)
             : policyDelay.toMillis();
-    Instant newScheduledTime = effective().instant().plusMillis(backoff);
+    Instant timestamp = effective().instant();
+    Instant newScheduledTime = timestamp.plusMillis(backoff);
     String sanitizedError = errorSanitizer.sanitize(ex);
 
     if (jobStore.scheduleJobRetry(job.getId(), sanitizedError, newScheduledTime, attempt)) {
@@ -1075,6 +1083,7 @@ public class JobTask implements Callable<Void> {
               job.getPublicJobType(),
               job.getPriority(),
               job.getPickedBy(),
+              timestamp,
               sanitizedError,
               attempt,
               newScheduledTime));

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceSignalTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceSignalTest.java
@@ -124,6 +124,7 @@ class DefaultJobSchedulerServiceSignalTest {
     assertEquals("bob", event.getSignalDeliveredBy());
     assertEquals(SignalDecision.Outcome.APPROVED, event.getOutcome());
     assertNull(event.getRejectionReason());
+    assertEquals(FIXED_NOW, event.getTimestamp());
   }
 
   @Test
@@ -156,6 +157,37 @@ class DefaultJobSchedulerServiceSignalTest {
     assertEquals("bob", event.getSignalDeliveredBy());
     assertEquals(SignalDecision.Outcome.REJECTED, event.getOutcome());
     assertEquals("denied", event.getRejectionReason());
+    assertEquals(FIXED_NOW, event.getTimestamp());
+  }
+
+  @Test
+  void deliverSignalByIdPublishesFromPreCasSnapshotWhenPostCasReloadWouldMiss() {
+    DefaultJobSchedulerService authorizedService =
+        newService(payloadSerializer, authorizationPolicy);
+    SignalDecision decision = SignalDecision.approved("approved-payload");
+    JobEntity job = job(JOB_ID, "approval-key");
+    job.setCallerPrincipal("alice");
+    when(payloadSerializer.serialize("approved-payload")).thenReturn("serialized-payload");
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job), Optional.empty());
+    when(signalStore.deliverSignalById(
+            eq(JOB_ID),
+            eq("serialized-payload"),
+            eq(DefaultJobSchedulerService.SIGNAL_PAYLOAD_TYPE_DECISION),
+            eq("APPROVED"),
+            isNull(),
+            eq("bob"),
+            eq(FIXED_NOW),
+            anyString()))
+        .thenReturn(1);
+
+    assertEquals(1, authorizedService.deliverSignal(JOB_ID, decision));
+
+    verify(authorizationPolicy).checkDeliverSignal(JOB_ID, "alice", "bob");
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    JobSignaledEvent event = assertInstanceOf(JobSignaledEvent.class, eventCaptor.getValue());
+    assertEquals("approval-key", event.getSignalKey());
+    assertEquals(FIXED_NOW, event.getTimestamp());
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobTaskTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import run.ratchet.api.JobContext;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.SignalDecision;
+import run.ratchet.api.event.JobCallbackFailedEvent;
 import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.api.exception.CircuitBreakerOpenException;
@@ -56,6 +58,8 @@ import run.ratchet.store.spi.JobStore;
 class JobTaskTest {
 
   private static final UUID JOB_UUID = new UUID(0L, 42L);
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-05T12:00:00Z");
+  private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_NOW, java.time.ZoneOffset.UTC);
   private static final ThreadLocal<SignalDecision> OBSERVED_SIGNAL_DECISION = new ThreadLocal<>();
 
   private final ClassPolicy classPolicy = className -> true;
@@ -78,6 +82,10 @@ class JobTaskTest {
   public static String captureSignalDecision() {
     OBSERVED_SIGNAL_DECISION.set(JobContext.current().signalPayload(SignalDecision.class));
     return "done";
+  }
+
+  public static void failingCallback() {
+    throw new IllegalStateException("callback boom");
   }
 
   @Test
@@ -430,6 +438,45 @@ class JobTaskTest {
 
   @Test
   @SuppressWarnings("unchecked")
+  void handleSuccessPublishesCompletionAndCallbackFailureEventsWithInjectedClock()
+      throws Exception {
+    JobTask fixedClockTask = newJobTaskWithClock(FIXED_CLOCK);
+    JobEntity job = createTestJob();
+    job.setOnSuccessPayload(
+        new JobPayload(JobTaskTest.class.getName(), "failingCallback", "()V", true, List.of()));
+    initJobTaskWithDefaultStubs(fixedClockTask, job);
+    when(jobStore.getJobStatus(JOB_UUID)).thenReturn(JobStatus.RUNNING);
+    when(resilienceStrategy.isServiceAvailable(anyString())).thenReturn(true);
+    when(resilienceStrategy.execute(anyString(), any(Callable.class)))
+        .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(jobStore.markJobSucceeded(
+            any(UUID.class), any(), any(), any(), any(), anyLong(), anyLong()))
+        .thenReturn(true);
+
+    fixedClockTask.call();
+
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(observabilityFacade, atLeastOnce()).publishEvent(eventCaptor.capture());
+    JobCompletedEvent completedEvent =
+        eventCaptor.getAllValues().stream()
+            .filter(JobCompletedEvent.class::isInstance)
+            .map(JobCompletedEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    JobCallbackFailedEvent callbackEvent =
+        eventCaptor.getAllValues().stream()
+            .filter(JobCallbackFailedEvent.class::isInstance)
+            .map(JobCallbackFailedEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+
+    Assertions.assertEquals(FIXED_NOW, completedEvent.getTimestamp());
+    Assertions.assertEquals(FIXED_NOW, callbackEvent.getTimestamp());
+    Assertions.assertEquals(1, callbackEvent.getCallbackAttempt());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   void call_releasesResourcePermit_onSuccess() throws Exception {
     JobEntity job = createTestJob();
     job.setResourceName("api-gateway");
@@ -692,6 +739,28 @@ class JobTaskTest {
         .thenReturn(JobExecutionEntity.start(job.getId(), 1, "node-1"));
     when(observabilityFacade.startExecutionScope(any(JobEntity.class)))
         .thenReturn(TracingCollector.NoOpExecutionScope.INSTANCE);
+  }
+
+  private JobTask newJobTaskWithClock(Clock taskClock) {
+    ResultPersistenceStrategy resultPersistenceStrategy =
+        (jobId, result) -> SerializedJobResult.empty();
+    return new JobTask(
+        jobStore,
+        resourcePermitService,
+        lifecycleFacade,
+        nodeIdProvider,
+        observabilityFacade,
+        validationFacade,
+        beanResolver,
+        retryPolicy,
+        resilienceStrategy,
+        errorSanitizer,
+        classPolicy,
+        context -> noopLogger(),
+        resultPersistenceStrategy,
+        null,
+        null,
+        taskClock);
   }
 
   public static class AnnotatedJobTarget {


### PR DESCRIPTION
## Summary

Fixes the remaining event API residue from the v5 audit.

This PR makes RI event producers use the scheduler clock for job lifecycle, retry, callback failure, and signal events. It also builds per-job signal events from the pre-CAS job snapshot, so event metadata is still available if a row disappears between a successful signal update and event publication.

It also tightens the legacy `PerformanceMetricsEvent` null contract and cleans up stale callback and batch-completion event wording.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet-api -Dtest=EventApiContractTest test`
- [x] `mvn -pl ratchet -am -Dtest=DefaultJobSchedulerServiceSignalTest,JobTaskTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl ratchet-api,ratchet spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

This covers v5 residue around clock-aware timestamps and the signal event reload race. I did not run the full reactor.
