### PR TITLE
Fix scheduler state transition events

### DIFF
--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -19,6 +19,7 @@ import run.ratchet.api.BatchBuilder;
 import run.ratchet.api.JobBuilder;
 import run.ratchet.api.JobHandle;
 import run.ratchet.api.JobOptions;
+import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.RecurringJobBuilder;
@@ -28,6 +29,7 @@ import run.ratchet.api.StreamingBatchBuilder;
 import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobPausedEvent;
 import run.ratchet.api.event.JobResumedEvent;
+import run.ratchet.api.event.JobRetryingEvent;
 import run.ratchet.api.event.JobSignaledEvent;
 import run.ratchet.api.event.JobsBulkCancelledEvent;
 import run.ratchet.api.event.JobsBulkSignaledEvent;
@@ -294,12 +296,12 @@ public class DefaultJobSchedulerService
       return true;
     }
 
-    // Try RUNNING → CANCELED. RUNNING cancellation events are executor-owned so JobTask can
-    // include execution duration. If the worker dies before observing the status flip, the
-    // durable state is still CANCELED but no per-job RUNNING cancellation event is emitted.
+    // Try RUNNING → CANCELED. The scheduler publishes the durable state-transition event here so
+    // observers do not lose cancellation if the worker dies before it notices the status flip.
     if (jobBatchStatusStore.compareAndSwapStatus(
         jobId, JobStatus.RUNNING, JobStatus.CANCELED, null)) {
       log.debugf("Canceled running job %s", jobId);
+      publishCancelledEvent(jobId, JobStatus.RUNNING, job);
       return true;
     }
 
@@ -440,7 +442,7 @@ public class DefaultJobSchedulerService
     if (cancelledFrom == JobStatus.WAITING && metricsCollector != null) {
       metricsCollector.signalCancelled(jobId, existing.getPublicJobType(), existing.getSignalKey());
     }
-    if (cancelledFrom != null && cancelledFrom != JobStatus.RUNNING) {
+    if (cancelledFrom != null) {
       publishCancelledEvent(jobId, cancelledFrom, existing);
     }
 
@@ -563,10 +565,10 @@ public class DefaultJobSchedulerService
   @Override
   @Transactional
   public boolean retryJob(UUID jobId) {
+    JobEntity job = jobCrudStore.findById(jobId).orElse(null);
     if (authorizationPolicy != null) {
       // Pre-load to obtain ownerPrincipal. TOCTOU: if the job is deleted between this load
       // and the CAS below, ownerPrincipal will be null — the policy must tolerate null.
-      JobEntity job = jobCrudStore.findById(jobId).orElse(null);
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
       String currentPrincipal =
           callerPrincipalProvider != null
@@ -577,6 +579,7 @@ public class DefaultJobSchedulerService
 
     if (jobRetryStore.resetFailedToPending(jobId)) {
       log.debugf("Retried failed job %s — reset to PENDING", jobId);
+      publishRetryingEventAndWakeup(jobId, job);
       return true;
     }
 
@@ -655,12 +658,10 @@ public class DefaultJobSchedulerService
   }
 
   /**
-   * Publishes a {@link JobCancelledEvent} for a job that was cancelled outside the executor (i.e.,
-   * from PENDING or PAUSED state). The RUNNING path publishes its own event from within {@code
-   * JobTask} when the running task observes the status flip; we skip publication there to avoid
-   * duplicate events. Uses the pre-CAS entity snapshot to populate businessKey / jobType / priority
-   * / nodeId on the event so downstream observers (audit logs, monitoring) see the same shape they
-   * get for running-cancellations.
+   * Publishes a {@link JobCancelledEvent} for a successful cancellation CAS. Uses the pre-CAS
+   * entity snapshot to populate businessKey / jobType / priority / nodeId on the event so
+   * downstream observers (audit logs, monitoring) get the same shape for each cancellable source
+   * state.
    */
   private void publishCancelledEvent(UUID jobId, JobStatus previousStatus, JobEntity job) {
     Instant timestamp = effective().instant();
@@ -686,6 +687,37 @@ public class DefaultJobSchedulerService
     }
   }
 
+  private void publishRetryingEventAndWakeup(UUID jobId, JobEntity job) {
+    Instant retryAt = effective().instant();
+    if (eventPublisher != null) {
+      JobRetryingEvent event =
+          job == null
+              ? new JobRetryingEvent(jobId, null, null, null, null, retryAt, null, 1, retryAt)
+              : new JobRetryingEvent(
+                  jobId,
+                  job.getBusinessKey(),
+                  job.getPublicJobType(),
+                  job.getPriority(),
+                  job.getPickedBy(),
+                  retryAt,
+                  job.getLastError(),
+                  1,
+                  retryAt);
+      if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+        eventPublisher.publish(event);
+      }
+    }
+
+    if (wakeupService == null) {
+      return;
+    }
+    if (job == null) {
+      wakeupService.notify(JobPriority.NORMAL, true);
+    } else {
+      wakeupService.notifyIfNeeded(job.getJobType(), job.getPriority(), Duration.ZERO);
+    }
+  }
+
   private JobStatus cancelForReplacement(UUID jobId, JobEntity existing) {
     if (existing.getJobType() == JobExecutionType.RECURRING) {
       JobStatus previousStatus = existing.getStatus();
@@ -697,9 +729,6 @@ public class DefaultJobSchedulerService
     }
     if (jobBatchStatusStore.compareAndSwapStatus(
         jobId, JobStatus.RUNNING, JobStatus.CANCELED, null)) {
-      // RUNNING cancellation events are executor-owned. JobTask publishes the event with execution
-      // duration when it observes the status flip; publishing here would create a duplicate. This
-      // carries the same dropped-event risk as cancelJob if the worker dies before that check.
       return JobStatus.RUNNING;
     }
     if (jobBatchStatusStore.compareAndSwapStatus(

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTask.java
@@ -25,7 +25,6 @@ import run.ratchet.api.JobType;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.api.event.JobCallbackFailedEvent;
-import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.api.event.JobDlqEvent;
 import run.ratchet.api.event.JobFailedEvent;
@@ -391,8 +390,10 @@ public class JobTask implements Callable<Void> {
           safeError = t.getClass().getName();
         }
         try {
-          jobStore.compareAndSwapStatus(
-              job.getId(), JobStatus.RUNNING, JobStatus.FAILED, safeError);
+          if (jobStore.compareAndSwapStatus(
+              job.getId(), JobStatus.RUNNING, JobStatus.FAILED, safeError)) {
+            publishForcedTerminalFailure(t, safeError);
+          }
         } catch (Throwable lastResort) {
           log.errorf(
               lastResort,
@@ -572,17 +573,6 @@ public class JobTask implements Callable<Void> {
     }
 
     observabilityFacade.recordJobCancellation(job);
-
-    observabilityFacade.publishEvent(
-        new JobCancelledEvent(
-            job.getId(),
-            job.getBusinessKey(),
-            job.getPublicJobType(),
-            job.getPriority(),
-            job.getPickedBy(),
-            endTime,
-            JobStatus.RUNNING.name(),
-            executionMs));
 
     handleBatchOrWorkflowCancellation();
   }
@@ -842,6 +832,38 @@ public class JobTask implements Callable<Void> {
             timestamp,
             sanitized,
             attempt));
+  }
+
+  private void publishForcedTerminalFailure(Throwable ex, String safeError) {
+    job.setStatus(JobStatus.FAILED);
+    int attempt = Math.max(1, job.getAttempts());
+    try {
+      observabilityFacade.publishEvent(
+          new JobFailedEvent(
+              job.getId(),
+              job.getBusinessKey(),
+              job.getPublicJobType(),
+              job.getPriority(),
+              job.getPickedBy(),
+              safeError,
+              attempt));
+      observabilityFacade.publishEvent(
+          new JobDlqEvent(
+              job.getId(),
+              job.getBusinessKey(),
+              job.getPublicJobType(),
+              job.getPriority(),
+              job.getPickedBy(),
+              safeError,
+              attempt));
+    } catch (Throwable eventError) {
+      log.warnf(eventError, "Fallback failure event publish failed for job %s", job.getId());
+    }
+    try {
+      lifecycleFacade.moveToDlq(job, ex);
+    } catch (Throwable dlqError) {
+      log.warnf(dlqError, "Fallback DLQ handling failed for job %s", job.getId());
+    }
   }
 
   private void invokeCallback(JobPayload callbackPayload, String callbackName) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobTimeoutHandler.java
@@ -257,6 +257,10 @@ public class JobTimeoutHandler {
       Instant retryTime = now.plusMillis(backoffMs);
       boolean rescheduled = jobRetryStore.scheduleJobRetry(jobId, message, retryTime, newAttempts);
       if (rescheduled) {
+        job.setAttempts(newAttempts);
+        job.setLastError(message);
+        job.setScheduledTime(retryTime);
+        job.setStatus(JobStatus.PENDING);
         log.warnf(
             "Job %s signal timed out but has retries remaining (%s/%s) — rescheduled for %s",
             jobId, newAttempts, job.getMaxRetries(), retryTime);
@@ -277,6 +281,9 @@ public class JobTimeoutHandler {
     }
 
     log.infof("Job %s FAILED due to signal timeout (key=%s)", jobId, job.getSignalKey());
+    job.setAttempts(newAttempts);
+    job.setLastError(message);
+    job.setStatus(JobStatus.FAILED);
     publishSignalTimedOutEvent(job);
     lifecycleFacade.handlePermanentFailure(job, timeoutEx);
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceEventTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceEventTest.java
@@ -31,6 +31,7 @@ import run.ratchet.api.JobType;
 import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobPausedEvent;
 import run.ratchet.api.event.JobResumedEvent;
+import run.ratchet.api.event.JobRetryingEvent;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
@@ -132,7 +133,7 @@ class DefaultJobSchedulerServiceEventTest {
   }
 
   @Test
-  void replaceRunningCancellationLeavesEventToExecutor() {
+  void replaceRunningCancellationPublishesCancelledEventAfterStateChange() {
     JobEntity job = job(JobStatus.RUNNING, JobExecutionType.SINGLE);
     when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
     when(jobCreationService.submit(any(DefaultJobBuilder.class))).thenReturn(() -> REPLACEMENT_ID);
@@ -147,7 +148,9 @@ class DefaultJobSchedulerServiceEventTest {
             .replace(JOB_ID, Duration.ZERO, DefaultJobSchedulerServiceEventTest::noopTask, null)
             .id());
 
-    verify(eventPublisher, never()).publish(any());
+    JobCancelledEvent event = published(JobCancelledEvent.class);
+    assertEquals(JobStatus.RUNNING.name(), event.getPreviousStatus());
+    assertEquals(FIXED_NOW, event.getTimestamp());
     verify(metricsCollector, never()).signalCancelled(any(), any(), any());
   }
 
@@ -179,7 +182,7 @@ class DefaultJobSchedulerServiceEventTest {
   }
 
   @Test
-  void cancelJobRunningCancellationLeavesEventToExecutor() {
+  void cancelJobRunningCancellationPublishesCancelledEventAfterStateChange() {
     JobEntity job = job(JobStatus.RUNNING, JobExecutionType.SINGLE);
     when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
     when(jobBatchStatusStore.compareAndSwapStatus(
@@ -188,7 +191,32 @@ class DefaultJobSchedulerServiceEventTest {
 
     assertTrue(service.cancelJob(JOB_ID));
 
-    verify(eventPublisher, never()).publish(any());
+    JobCancelledEvent event = published(JobCancelledEvent.class);
+    assertEquals(JobStatus.RUNNING.name(), event.getPreviousStatus());
+    assertEquals(FIXED_NOW, event.getTimestamp());
+    assertEquals("business-90", event.getBusinessKey());
+  }
+
+  @Test
+  void retryJobPublishesRetryingEventAndWakesPoller() {
+    JobEntity job = job(JobStatus.FAILED, JobExecutionType.SINGLE);
+    job.setLastError("boom");
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobRetryStore.resetFailedToPending(JOB_ID)).thenReturn(true);
+
+    assertTrue(service.retryJob(JOB_ID));
+
+    JobRetryingEvent event = published(JobRetryingEvent.class);
+    assertEquals(JOB_ID, event.getJobId());
+    assertEquals("business-90", event.getBusinessKey());
+    assertEquals(JobType.SINGLE, event.getJobType());
+    assertEquals(JobPriority.HIGH, event.getPriority());
+    assertEquals("node-a", event.getNodeId());
+    assertEquals(FIXED_NOW, event.getTimestamp());
+    assertEquals("boom", event.getErrorMessage());
+    assertEquals(1, event.getRetryAttempt());
+    assertEquals(FIXED_NOW, event.getScheduledTime());
+    verify(wakeupService).notifyIfNeeded(JobExecutionType.SINGLE, JobPriority.HIGH, Duration.ZERO);
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobTaskTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,8 +33,9 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.api.event.JobCallbackFailedEvent;
-import run.ratchet.api.event.JobCancelledEvent;
 import run.ratchet.api.event.JobCompletedEvent;
+import run.ratchet.api.event.JobDlqEvent;
+import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.BeanResolver;
@@ -358,6 +360,33 @@ class JobTaskTest {
 
   @Test
   @SuppressWarnings("unchecked")
+  void handleFailureFallbackPublishesTerminalEventsWhenFailureHandlingThrows() throws Exception {
+    JobEntity job = createTestJob();
+    initJobTaskWithDefaultStubs(job);
+    when(jobStore.getJobStatus(JOB_UUID)).thenReturn(JobStatus.RUNNING);
+    when(resilienceStrategy.isServiceAvailable(anyString())).thenReturn(true);
+
+    RuntimeException error = new RuntimeException("original");
+    when(resilienceStrategy.execute(anyString(), any(Callable.class))).thenThrow(error);
+    when(validationFacade.shouldNotRetry(error)).thenReturn(false);
+    when(jobStore.incrementRetryAttempt(JOB_UUID)).thenReturn(1);
+    doThrow(new IllegalStateException("observer failed"))
+        .when(observabilityFacade)
+        .recordJobFailure(job, error, 1);
+    when(errorSanitizer.sanitize(error)).thenReturn("safe original");
+    when(jobStore.compareAndSwapStatus(
+            eq(JOB_UUID), eq(JobStatus.RUNNING), eq(JobStatus.FAILED), eq("safe original")))
+        .thenReturn(true);
+
+    jobTask.call();
+
+    verify(observabilityFacade).publishEvent(any(JobFailedEvent.class));
+    verify(observabilityFacade).publishEvent(any(JobDlqEvent.class));
+    verify(lifecycleFacade).moveToDlq(job, error);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
   void handleFailure_batchChild_marksBatchChildFailedInsteadOfSchedulingNext() throws Exception {
     JobEntity job = createTestJob();
     job.setJobType(JobExecutionType.BATCH_CHILD);
@@ -412,7 +441,6 @@ class JobTaskTest {
     verify(jobStore, never())
         .markJobSucceeded(any(UUID.class), any(), any(), any(), any(), anyLong(), anyLong());
     verify(observabilityFacade).recordJobCancellation(job);
-    verify(observabilityFacade).publishEvent(any(JobCancelledEvent.class));
     verify(observabilityFacade, never()).publishEvent(any(JobCompletedEvent.class));
     verify(observabilityFacade, never()).recordJobSuccess(any(), anyLong());
     verify(lifecycleFacade).cancelChain(job);

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobTimeoutHandlerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobTimeoutHandlerTest.java
@@ -264,6 +264,10 @@ class JobTimeoutHandlerTest {
     verify(jobRetryStore, times(1))
         .scheduleJobRetry(eq(JOB_ID), anyString(), retryTimeCaptor.capture(), eq(1));
     assertEquals(now.plusMillis(2_500), retryTimeCaptor.getValue());
+    assertEquals(JobStatus.PENDING, job.getStatus());
+    assertEquals(1, job.getAttempts());
+    assertEquals("Signal timeout exceeded for key: approval", job.getLastError());
+    assertEquals(now.plusMillis(2_500), job.getScheduledTime());
     verify(jobBatchStatusStore, never()).compareAndSwapStatus(any(UUID.class), any(), any(), any());
     verify(lifecycleFacade, never()).handlePermanentFailure(any(), any());
   }
@@ -303,6 +307,9 @@ class JobTimeoutHandlerTest {
     verify(jobRetryStore, never()).scheduleJobRetry(any(UUID.class), anyString(), any(), anyInt());
     verify(jobBatchStatusStore, times(1))
         .compareAndSwapStatus(eq(JOB_ID), eq(JobStatus.WAITING), eq(JobStatus.FAILED), anyString());
+    assertEquals(JobStatus.FAILED, job.getStatus());
+    assertEquals(1, job.getAttempts());
+    assertEquals("Signal timeout exceeded for key: approval", job.getLastError());
     verify(lifecycleFacade, times(1)).handlePermanentFailure(eq(job), any());
   }
 


### PR DESCRIPTION
## Summary

Fixes scheduler state-transition event gaps left in the v5 residue audit.

RUNNING cancellation now publishes from the scheduler service after the CANCELED CAS, so the event is not lost if a worker dies before seeing the status flip. `JobTask` still records cancellation metrics and execution data when it notices the cancellation, but it no longer emits a duplicate cancellation event.

Manual retry now emits `JobRetryingEvent` and wakes the poller after `FAILED -> PENDING` succeeds. Signal-timeout handling updates the in-memory job before retry or permanent-failure callbacks. The last-resort `JobTask` failure branch now emits failed/DLQ events after its fallback CAS.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet -Dtest=DefaultJobSchedulerServiceAuthorizationTest,DefaultJobSchedulerServiceEventTest,JobTaskTest,JobTimeoutHandlerTest test`
- [x] `mvn -pl ratchet spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

RUNNING cancellation events are now crash-safe, but they no longer carry execution duration. Preserving both would need a broader event/update design.

This PR overlaps scheduler event code touched by #29, so it should land after #29 or be rebased after #29 merges.
