### PR TITLE
Fix recurring replace and cascade events

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -123,6 +123,8 @@ public interface JobSchedulerService {
    *
    * <p><b>Transaction attribute:</b> {@code REQUIRED}. The existence check, the submission of the
    * replacement, and the cancellation of the old job MUST execute within a single transaction.
+   * Authorization is checked against the old job using the same per-job cancellation policy as
+   * {@link #cancelJob(UUID)} before the replacement is submitted.
    *
    * @param jobId UUIDv7 job id of the job to replace
    * @param delay delay before the replacement job becomes eligible to run

--- a/ratchet-api/src/main/java/run/ratchet/api/exception/JobAuthorizationException.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/exception/JobAuthorizationException.java
@@ -24,8 +24,8 @@ public class JobAuthorizationException extends RuntimeException {
    * Creates an authorization-denied exception.
    *
    * @param jobId job that was denied, or {@code null} when denial occurs before a job id exists
-   * @param operation denied operation name, such as {@code create}, {@code cancel}, or {@code
-   *     execute}
+   * @param operation denied operation name, such as {@code create}, {@code cancel}, {@code
+   *     replace}, or {@code execute}
    * @param principal caller principal, or {@code null} when no caller security context is active
    * @param message human-readable denial message
    */

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -436,7 +436,7 @@ public class DefaultJobSchedulerService
     }
     JobHandle newHandle = builder.submit();
 
-    JobStatus cancelledFrom = cancelForReplacement(jobId);
+    JobStatus cancelledFrom = cancelForReplacement(jobId, existing);
     if (cancelledFrom == JobStatus.WAITING && metricsCollector != null) {
       metricsCollector.signalCancelled(jobId, existing.getPublicJobType(), existing.getSignalKey());
     }
@@ -454,6 +454,9 @@ public class DefaultJobSchedulerService
                 () ->
                     new IllegalStateException(
                         "Job " + jobId + " vanished mid-replace (deleted between load and save)"));
+    if (cancelledFrom != null) {
+      fresh.setStatus(JobStatus.CANCELED);
+    }
     fresh.setSupersededBy(newHandle.id());
     jobCrudStore.save(fresh);
 
@@ -683,7 +686,11 @@ public class DefaultJobSchedulerService
     }
   }
 
-  private JobStatus cancelForReplacement(UUID jobId) {
+  private JobStatus cancelForReplacement(UUID jobId, JobEntity existing) {
+    if (existing.getJobType() == JobExecutionType.RECURRING) {
+      JobStatus previousStatus = existing.getStatus();
+      return jobTerminalStore.cancelJob(jobId) ? previousStatus : null;
+    }
     if (jobBatchStatusStore.compareAndSwapStatus(
         jobId, JobStatus.PENDING, JobStatus.CANCELED, null)) {
       return JobStatus.PENDING;

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobCascadeService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobCascadeService.java
@@ -2,7 +2,10 @@ package run.ratchet.ri.core;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import jakarta.transaction.Transactional;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -10,7 +13,12 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import org.jboss.logging.Logger;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.event.JobPausedEvent;
+import run.ratchet.api.event.JobResumedEvent;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobPauseStore;
@@ -27,19 +35,36 @@ import run.ratchet.store.spi.JobPauseStore;
 public class JobCascadeService {
 
   private static final int DEPENDANT_PAGE_SIZE = JobCrudStore.DEFAULT_PAGE_LIMIT;
+  private static final Logger log = Logger.getLogger(JobCascadeService.class);
 
   private final JobCrudStore jobCrudStore;
   private final JobPauseStore jobPauseStore;
+  private final InternalEventPublisher eventPublisher;
+  private final Clock clock;
+
+  private volatile TransactionSynchronizationRegistry txRegistry;
 
   protected JobCascadeService() {
     this.jobCrudStore = null;
     this.jobPauseStore = null;
+    this.eventPublisher = null;
+    this.clock = null;
+  }
+
+  public JobCascadeService(JobCrudStore jobCrudStore, JobPauseStore jobPauseStore) {
+    this(jobCrudStore, jobPauseStore, null, null);
   }
 
   @Inject
-  public JobCascadeService(JobCrudStore jobCrudStore, JobPauseStore jobPauseStore) {
+  public JobCascadeService(
+      JobCrudStore jobCrudStore,
+      JobPauseStore jobPauseStore,
+      InternalEventPublisher eventPublisher,
+      Clock clock) {
     this.jobCrudStore = jobCrudStore;
     this.jobPauseStore = jobPauseStore;
+    this.eventPublisher = eventPublisher;
+    this.clock = clock;
   }
 
   /**
@@ -81,6 +106,7 @@ public class JobCascadeService {
           if (child.getStatus() == JobStatus.PENDING
               && jobPauseStore.transitionToPaused(child.getId(), JobStatus.PENDING)) {
             pausedCount++;
+            publishPausedEvent(child);
           } else {
             skippedCount++;
           }
@@ -129,6 +155,7 @@ public class JobCascadeService {
           if (child.getStatus() == JobStatus.PAUSED
               && jobPauseStore.transitionFromPaused(child.getId(), JobStatus.PENDING)) {
             resumedCount++;
+            publishResumedEvent(child);
           } else {
             skippedCount++;
           }
@@ -154,5 +181,70 @@ public class JobCascadeService {
       }
       offset += page.size();
     }
+  }
+
+  private void publishPausedEvent(JobEntity job) {
+    if (eventPublisher == null) {
+      return;
+    }
+    JobPausedEvent event =
+        new JobPausedEvent(
+            job.getId(),
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            now());
+    publishAfterCommit(event);
+  }
+
+  private void publishResumedEvent(JobEntity job) {
+    if (eventPublisher == null) {
+      return;
+    }
+    JobResumedEvent event =
+        new JobResumedEvent(
+            job.getId(),
+            job.getBusinessKey(),
+            job.getPublicJobType(),
+            job.getPriority(),
+            job.getPickedBy(),
+            now());
+    publishAfterCommit(event);
+  }
+
+  private Instant now() {
+    return clock != null ? clock.instant() : Instant.now();
+  }
+
+  private void publishAfterCommit(Object event) {
+    if (!JobWakeupService.registerAfterCommit(
+        resolveTxRegistry(),
+        () -> eventPublisher.publish(event),
+        log,
+        "After-commit cascade event registration failed; publishing immediately: %s")) {
+      eventPublisher.publish(event);
+    }
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    TransactionSynchronizationRegistry reg = txRegistry;
+    if (reg == null) {
+      synchronized (this) {
+        reg = txRegistry;
+        if (reg == null) {
+          try {
+            reg = InitialContext.doLookup("java:comp/TransactionSynchronizationRegistry");
+            txRegistry = reg;
+          } catch (NamingException e) {
+            log.debugf(
+                "TransactionSynchronizationRegistry lookup unavailable on this thread; using immediate"
+                    + " fallback cascade event publication: %s",
+                e.getMessage());
+          }
+        }
+      }
+    }
+    return reg;
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceAuthorizationTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -17,6 +18,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.JobPriority;
@@ -245,6 +247,11 @@ class DefaultJobSchedulerServiceAuthorizationTest {
     service.replace(
         JOB_ID, Duration.ZERO, DefaultJobSchedulerServiceAuthorizationTest::noopTask, null);
 
+    InOrder order = inOrder(jobCreationService, jobBatchStatusStore);
+    order.verify(jobCreationService).submit(any(DefaultJobBuilder.class));
+    order
+        .verify(jobBatchStatusStore)
+        .compareAndSwapStatus(eq(JOB_ID), eq(JobStatus.PENDING), eq(JobStatus.CANCELED), eq(null));
     verify(jobBatchStatusStore)
         .compareAndSwapStatus(eq(JOB_ID), eq(JobStatus.WAITING), eq(JobStatus.CANCELED), eq(null));
     verify(jobBatchStatusStore, times(4))

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceEventTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceEventTest.java
@@ -152,6 +152,33 @@ class DefaultJobSchedulerServiceEventTest {
   }
 
   @Test
+  void replaceRecurringMasterUsesTerminalCancelAndRecordsCanceledSupersession() {
+    JobEntity job = job(JobStatus.PENDING, JobExecutionType.RECURRING);
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));
+    when(jobCreationService.submit(any(DefaultJobBuilder.class))).thenReturn(() -> REPLACEMENT_ID);
+    when(jobTerminalStore.cancelJob(JOB_ID)).thenReturn(true);
+    when(jobCrudStore.save(any(JobEntity.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    assertEquals(
+        REPLACEMENT_ID,
+        service
+            .replace(JOB_ID, Duration.ZERO, DefaultJobSchedulerServiceEventTest::noopTask, null)
+            .id());
+
+    verify(jobTerminalStore).cancelJob(JOB_ID);
+    verify(jobBatchStatusStore, never()).compareAndSwapStatus(any(), any(), any(), any());
+
+    ArgumentCaptor<JobEntity> saved = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).save(saved.capture());
+    assertEquals(JobStatus.CANCELED, saved.getValue().getStatus());
+    assertEquals(REPLACEMENT_ID, saved.getValue().getSupersededBy());
+
+    JobCancelledEvent event = published(JobCancelledEvent.class);
+    assertEquals(JobStatus.PENDING.name(), event.getPreviousStatus());
+    assertCommonJobEvent(event, JobType.RECURRING);
+  }
+
+  @Test
   void cancelJobRunningCancellationLeavesEventToExecutor() {
     JobEntity job = job(JobStatus.RUNNING, JobExecutionType.SINGLE);
     when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job));

--- a/ratchet/src/test/java/run/ratchet/ri/core/JobCascadeServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/JobCascadeServiceTest.java
@@ -1,6 +1,8 @@
 package run.ratchet.ri.core;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -9,23 +11,37 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.JobType;
+import run.ratchet.api.event.AbstractJobSchedulerEvent;
+import run.ratchet.api.event.JobPausedEvent;
+import run.ratchet.api.event.JobResumedEvent;
 import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobPauseStore;
 
 @ExtendWith(MockitoExtension.class)
 class JobCascadeServiceTest {
 
+  private static final Instant FIXED_NOW = Instant.parse("2026-05-18T12:00:00Z");
+  private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+
   @Mock private JobCrudStore jobCrudStore;
   @Mock private JobPauseStore jobPauseStore;
+  @Mock private InternalEventPublisher eventPublisher;
 
   private JobCascadeService cascadeService;
 
@@ -39,12 +55,17 @@ class JobCascadeServiceTest {
     JobEntity job = new JobEntity();
     job.setId(UUID.randomUUID());
     job.setStatus(status);
+    job.setJobType(JobExecutionType.SINGLE);
+    job.setBusinessKey("cascade-key");
+    job.setPriority(JobPriority.HIGH);
+    job.setPickedBy("node-a");
     return job;
   }
 
   @BeforeEach
   void setUp() {
-    cascadeService = new JobCascadeService(jobCrudStore, jobPauseStore);
+    cascadeService =
+        new JobCascadeService(jobCrudStore, jobPauseStore, eventPublisher, FIXED_CLOCK);
     lenient()
         .when(jobCrudStore.findDependants(any(UUID.class), anyInt(), anyInt()))
         .thenAnswer(inv -> jobCrudStore.findDependants(inv.getArgument(0)));
@@ -68,6 +89,7 @@ class JobCascadeServiceTest {
     when(jobPauseStore.transitionToPaused(child.getId(), JobStatus.PENDING)).thenReturn(true);
 
     assertArrayEquals(new int[] {1, 0}, cascadeService.pauseChildrenIterative(rootId));
+    assertCommonEvent(published(JobPausedEvent.class), child.getId());
   }
 
   @Test
@@ -186,6 +208,7 @@ class JobCascadeServiceTest {
     when(jobPauseStore.transitionFromPaused(child.getId(), JobStatus.PENDING)).thenReturn(true);
 
     assertArrayEquals(new int[] {1, 0}, cascadeService.resumeChildrenIterative(rootId));
+    assertCommonEvent(published(JobResumedEvent.class), child.getId());
   }
 
   @Test
@@ -260,5 +283,20 @@ class JobCascadeServiceTest {
 
     assertArrayEquals(new int[] {3, 0}, result);
     verify(jobPauseStore).transitionFromPaused(eq(c.getId()), eq(JobStatus.PENDING));
+  }
+
+  private <T> T published(Class<T> type) {
+    ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    return assertInstanceOf(type, eventCaptor.getValue());
+  }
+
+  private static void assertCommonEvent(AbstractJobSchedulerEvent event, UUID jobId) {
+    assertEquals(jobId, event.getJobId());
+    assertEquals("cascade-key", event.getBusinessKey());
+    assertEquals(JobType.SINGLE, event.getJobType());
+    assertEquals(JobPriority.HIGH, event.getPriority());
+    assertEquals("node-a", event.getNodeId());
+    assertEquals(FIXED_NOW, event.getTimestamp());
   }
 }


### PR DESCRIPTION
## Summary

Fixes replace and cascade semantics from the v5 residue audit.

`replace()` now routes recurring masters through the terminal cancel path, so the recurring shim state is cleared instead of going through the executable CAS path. The supersession save keeps the old row marked `CANCELED`, which avoids writing a stale `PENDING` snapshot back over the terminal transition.

Cascade pause and resume now publish paused/resumed events for successful child transitions after commit. The API docs also state that replace uses the old job's cancel authorization check.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet -Dtest=DefaultJobSchedulerServiceAuthorizationTest,DefaultJobSchedulerServiceEventTest,JobCascadeServiceTest test`
- [x] `mvn -pl ratchet-api,ratchet -DskipTests compile`
- [x] `mvn -pl ratchet-api,ratchet spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

This does not change the public `replace()` API shape. Replacing a recurring master still creates the current one-shot replacement job; recurring-to-recurring replacement needs a separate API decision.

This PR overlaps scheduler service code touched by #29 and #30, so it may need a rebase depending on merge order.
