### PR TITLE
Fix VitePress CI paths and suppress prometheus CVE false positive

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,10 +48,10 @@ jobs:
       - name: Generate aggregate Javadoc
         run: mvn clean package -P javadoc-aggregate -DskipTests -B
 
-      - name: Copy Javadoc into Docusaurus static assets
+      - name: Copy Javadoc into VitePress public assets
         run: |
-          mkdir -p website/static/javadoc
-          cp -r target/reports/apidocs/* website/static/javadoc/
+          mkdir -p website/docs/public/javadoc
+          cp -r target/reports/apidocs/* website/docs/public/javadoc/
 
       # --- Conformance reports (downloaded from CI artifacts, workflow_run only) ---
       - name: Download TCK store conformance reports
@@ -149,7 +149,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v5
         with:
-          path: website/build
+          path: website/docs/.vitepress/dist
 
   deploy:
     needs: build

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -35,4 +35,26 @@
         <cve>CVE-2026-0994</cve>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+        False positive: this package is the Micrometer Prometheus registry
+        (Java client library that emits metrics), not the Prometheus server
+        binary. Dependency-Check attaches the Prometheus server CPE because
+        the artifact name contains "prometheus".
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus@.*$</packageUrl>
+        <cpe>cpe:/a:prometheus:prometheus</cpe>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
+        False positive: this package is the Prometheus Java client library
+        (metrics emission), not the Prometheus server binary. Dependency-Check
+        attaches the Prometheus server CPE because the artifact name contains
+        "prometheus".
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.prometheus/prometheus-metrics-core@.*$</packageUrl>
+        <cpe>cpe:/a:prometheus:prometheus</cpe>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
## Summary

Three small fixes for failures that surfaced after the Docusaurus → VitePress port merged in #34.

### 1. Documentation workflow path mismatch

`Documentation` workflow was failing at `Upload Pages artifact`:

```
tar: website/build: Cannot open: No such file or directory
```

Root cause: `.github/workflows/docs.yml` still pointed at the Docusaurus output directory and static-assets directory. VitePress uses:
- `docs/.vitepress/dist` for the built site (`vitepress build`'s default `outDir`)
- `docs/public/` for files served at the site root (Docusaurus equivalent: `static/`)

The two paths in the workflow are now updated.

The conformance-report heredocs (lines 79-128) still emit Docusaurus-style frontmatter (`id`, `sidebar_label`). VitePress ignores those keys, so the workflow continues to work — leaving them as-is for a follow-up cleanup PR.

### 2. OWASP Dependency-Check false positive

`OWASP Dependency Check` failed on `CVE-2026-42154` (CVSS 7.5) against:
- `micrometer-registry-prometheus-1.14.4`
- `prometheus-metrics-core-1.3.5`

The CVE is for the **Prometheus server's** `/api/v1/read` endpoint (CPE `cpe:2.3:a:prometheus:prometheus`, patched in Prometheus server 3.5.3 / 3.11.3). The two Java client libraries don't ship the server-side endpoint; Dependency-Check matches them only because their artifact names contain `prometheus`. Same false-positive pattern as the existing PostgreSQL JDBC entry in `owasp-suppressions.xml`.

Added two scoped suppression entries (per-artifact `packageUrl`, not a catch-all regex) so future genuine prometheus-package CVEs would still surface.

### 3. Dependabot vite/esbuild alerts — dismissed

Two new alerts on `website/package-lock.json`:
- vite 5.4.21 → [GHSA-4w7w-66w2-5vf9](https://github.com/advisories/GHSA-4w7w-66w2-5vf9) / CVE-2026-39365 ("Path Traversal in Optimized Deps `.map` Handling")
- esbuild 0.21.5 → [GHSA-67mh-4wv8-2f99](https://github.com/advisories/GHSA-67mh-4wv8-2f99) ("dev server CORS")

Both are dev-server-only. The vite advisory explicitly scopes impact to apps that "explicitly expose the Vite dev server to the network." This repo builds static HTML via `vitepress build` in CI and deploys to GitHub Pages — no dev server in production.

VitePress 1.x hard-pins vite `^5`; no vite 5.x patch exists (lowest patch line is 6.4.2). VitePress 2.x is still alpha. Forcing vite 6+ via `npm overrides` would put VitePress on an unsupported dep graph.

Both alerts dismissed as `tolerable_risk` with documenting comments.

## Test plan

- [ ] Documentation workflow completes through `Upload Pages artifact` and `Deploy to GitHub Pages`
- [ ] OWASP Dependency-Check job passes
- [ ] Live docs site renders correctly and `/javadoc/index.html` is reachable