### PR TITLE
Pin testsuite JVMs to UTC to stabilize EclipseLink time-based claims

### DIFF
--- a/ratchet-testsuite/pom.xml
+++ b/ratchet-testsuite/pom.xml
@@ -197,6 +197,15 @@
           <environmentVariables>
             <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
             <TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>${env.TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE}</TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE>
+            <!--
+              Pin the test JVM and the Arquillian-spawned app-server JVMs (which inherit this
+              process environment) to UTC. The store's zone-less DATETIME/TIMESTAMP columns are
+              written via JDBC Timestamps and claimed against the database's server-side NOW(3);
+              when the JVM zone differs from the (UTC) database container, EclipseLink-based
+              servers (Payara/GlassFish) skew next_fire/scheduled_time and stall claims. CI already
+              runs in UTC, so this only aligns developer machines whose JVM zone is non-UTC.
+            -->
+            <TZ>UTC</TZ>
           </environmentVariables>
           <systemPropertyVariables>
             <ratchet.test.db.type>${ratchet.test.db.type}</ratchet.test.db.type>


### PR DESCRIPTION
## Summary
- Integration tests on EclipseLink-based servers (Payara, GlassFish, OpenLiberty) fail on developer machines whose JVM timezone is not UTC. The store writes `next_fire`/`scheduled_time` via JDBC `Timestamp` into zone-less `DATETIME`/`TIMESTAMP` columns, but claims due work against the database's server-side `NOW(3)`. A JVM↔database zone mismatch shifts the stored values, so chain continuations and recurring re-fires never satisfy the claim predicate and stall (jobs sit `PENDING`; `next_fire` reads as past).
- WildFly (Hibernate) is unaffected because it negotiates `connectionTimeZone=UTC` with the driver.
- Pin `TZ=UTC` on the failsafe `<environmentVariables>`. The forked failsafe JVM and the Arquillian-spawned app-server JVMs (which inherit its environment) then run in UTC, matching CI. This is a no-op on CI (already UTC) and only aligns developer machines whose JVM zone is non-UTC.

## Test plan
- [x] `mvn verify -P <server>,<db> -pl ratchet-testsuite` for all 12 combinations (WildFly / Payara / GlassFish / OpenLiberty × MySQL / PostgreSQL / MongoDB) — all green (176 tests each) on a JVM in a non-UTC (EDT) zone.
- [x] No behavioral change on CI, which already runs in UTC.