### PR TITLE
Pin MySQL test connection to UTC and document the datasource timezone requirement

### DIFF
--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/infra/JdbcContainerExtension.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/infra/JdbcContainerExtension.java
@@ -96,6 +96,21 @@ public class JdbcContainerExtension
           jdbcUrl = jdbcUrl.substring(0, queryStart);
         }
         jdbcUrl += "?stringtype=unspecified";
+      } else if ("mysql".equals(dbType)) {
+        // Force the driver to treat the zone-less DATETIME columns as UTC, matching the database
+        // container (whose server zone is UTC). Without this, mysql-connector-j interprets stored
+        // timestamps in the JVM-local zone, shifting round-tripped Instants by the JVM's offset
+        // from UTC and skewing the NOW(3)-based claim predicates on EclipseLink servers (Payara,
+        // GlassFish, OpenLiberty). This URL flows through config.url() into every server's
+        // datasource, so a single source keeps them consistent. See MysqlTestFixture for the
+        // unit-test analogue. One query param is used deliberately: the URL is interpolated into
+        // arquillian.xml attributes, where a literal `&` would be parsed as an XML entity and
+        // break deployment.
+        int queryStart = jdbcUrl.indexOf('?');
+        if (queryStart >= 0) {
+          jdbcUrl = jdbcUrl.substring(0, queryStart);
+        }
+        jdbcUrl += "?connectionTimeZone=UTC";
       }
 
       config =

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -146,6 +146,29 @@ public class OrdersRatchetEntityManagerProvider implements RatchetEntityManagerP
 }
 ```
 
+### Database timezone
+
+For SQL stores, configure the JDBC connection so it agrees with the database server on UTC.
+Ratchet stores `scheduled_time`, `next_fire`, and similar instants in zone-less `DATETIME` /
+`TIMESTAMP` columns, and selects due work by comparing them against the database's server-side
+clock (`NOW(3)` / `CURRENT_TIMESTAMP`). If the JDBC connection writes those columns in a different
+zone than the server evaluates the comparison in, due jobs are claimed late (or early) by the
+offset between the two zones.
+
+Most providers avoid this automatically — Hibernate, for example, negotiates `connectionTimeZone=UTC`
+with MySQL Connector/J. Others (notably EclipseLink) bind `java.sql.Timestamp` values in the JVM's
+default zone, so a non-UTC application JVM against a UTC database silently skews claim timing. To
+stay correct on any provider:
+
+- **MySQL / MariaDB:** add `connectionTimeZone=UTC` to the JDBC URL (or set it as a datasource
+  property).
+- **PostgreSQL:** run the application JVM in UTC, or pin the connection's session time zone to UTC.
+- **Any database:** running the application JVM in UTC (for example `-Duser.timezone=UTC`) also
+  resolves the mismatch.
+
+This requirement applies to the application's own datasource configuration; Ratchet ships only the
+DDL, not a datasource.
+
 ## Option Reference
 
 ### Polling


### PR DESCRIPTION
## Summary
- Addresses a timezone portability issue: on JPA providers that bind `java.sql.Timestamp` in the JVM's default zone (EclipseLink — Payara, GlassFish, OpenLiberty), a non-UTC application JVM against a UTC database writes the zone-less `DATETIME`/`TIMESTAMP` columns shifted from the database's server-side `NOW(3)`. The time-based claim predicates then miss due work, so chain continuations and recurring re-fires stall. Hibernate (WildFly) is unaffected because it negotiates `connectionTimeZone=UTC` with the driver.
- **Tests:** add `connectionTimeZone=UTC` to the MySQL test JDBC URL in `JdbcContainerExtension`. It flows through `config.url()` into every server's datasource (WildFly, Payara, GlassFish, OpenLiberty), matching the existing `MysqlTestFixture` precedent. A single query param is used because the URL is interpolated into `arquillian.xml` attributes, where a literal `&` would break deployment.
- **Docs:** document the UTC requirement for SQL stores in the configuration guide. Ratchet ships the DDL but not a datasource, so this is a deployment prerequisite for the application's own datasource (`connectionTimeZone=UTC` for MySQL/MariaDB; a UTC session or UTC JVM for PostgreSQL).

## Test plan
- [x] `mvn verify -P payara-managed,mysql -pl ratchet-testsuite -am` on a JVM in a non-UTC (EDT) zone — 176 tests pass with no `TZ` override, confirming the JDBC-layer fix resolves the skew on its own.
- [x] `mvn spotless:apply` clean (no formatting changes).

## Notes
This is complementary to the testsuite-wide `TZ=UTC` pin in #38: this PR fixes MySQL at the JDBC layer and documents the deployment requirement (covering PostgreSQL too); #38 provides a uniform UTC pin across all databases for local runs. CI already runs in UTC, so both are no-ops there.