### PR TITLE
Add WildFly 40 EE 11 test profile and prove virtual-thread execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        server: [wildfly-managed, payara-managed, openliberty-managed]
+        server: [wildfly-managed, wildfly-ee11-managed, payara-managed, openliberty-managed]
         database: [mysql, postgresql, mongodb]
         include:
           - server: glassfish-managed

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
     <google-java-format.version>1.35.0</google-java-format.version>
     <testcontainers.version>2.0.5</testcontainers.version>
@@ -484,6 +485,47 @@
                       <message>
                         Jakarta EE 11 verification requires JDK 21 or higher.
                         Re-run with JDK 21+ on PATH (or via JAVA_HOME).
+                      </message>
+                    </requireJavaVersion>
+                  </rules>
+                  <fail>true</fail>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+      WildFly 40 / Jakarta EE 11 managed-server test profile. Enforces JDK 25 at
+      runtime so the WF40 integration tests run on the recommended LTS. The server
+      config and the EE 11-only test sources live in ratchet-testsuite's same-id
+      profile. The ratchet library itself is unaffected: it stays a single
+      EE-agnostic artifact built at the default JDK 17 baseline.
+    -->
+    <profile>
+      <id>wildfly-ee11-managed</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>3.5.0</version>
+            <executions>
+              <execution>
+                <id>enforce-jdk25-for-wildfly-ee11</id>
+                <phase>validate</phase>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>[25,)</version>
+                      <message>
+                        The wildfly-ee11-managed profile targets WildFly 40 on JDK 25.
+                        Re-run with JDK 25+ on PATH (or via JAVA_HOME).
                       </message>
                     </requireJavaVersion>
                   </rules>

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetConfigKeys.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetConfigKeys.java
@@ -28,6 +28,16 @@ final class RatchetConfigKeys {
 
   static final RatchetConfigKey<Boolean> WORKER_USE_VIRTUAL_THREADS =
       boolKey("ratchet.worker.use-virtual-threads", "RATCHET_WORKER_USE_VIRTUAL_THREADS", false);
+  static final RatchetConfigKey<String> WORKER_JOB_EXECUTOR_JNDI =
+      stringKey(
+          "ratchet.worker.job-executor-jndi",
+          "RATCHET_WORKER_JOB_EXECUTOR_JNDI",
+          "java:comp/DefaultManagedExecutorService");
+  static final RatchetConfigKey<String> WORKER_SCHEDULED_EXECUTOR_JNDI =
+      stringKey(
+          "ratchet.worker.scheduled-executor-jndi",
+          "RATCHET_WORKER_SCHEDULED_EXECUTOR_JNDI",
+          "java:comp/DefaultManagedScheduledExecutorService");
   static final RatchetConfigKey<Integer> THREAD_POOL_QUEUE_SIZE =
       intKey("ratchet.thread-pool.queue-size", "RATCHET_THREAD_POOL_QUEUE_SIZE", 100, 0);
   static final RatchetConfigKey<Integer> THREAD_POOL_SIZE_SINGLE =

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -162,6 +162,13 @@ public class RatchetOptions {
     return value;
   }
 
+  private static String requireNonBlank(String name, String value) {
+    if (value == null || value.isBlank()) {
+      throw new IllegalArgumentException(name + " must not be blank");
+    }
+    return value;
+  }
+
   private static long atLeast(String name, long value, long minInclusive) {
     if (value < minInclusive) {
       throw new IllegalArgumentException(name + " must be at least " + minInclusive);
@@ -267,7 +274,9 @@ public class RatchetOptions {
       int queueSize,
       Map<String, Integer> maxConcurrency,
       Map<String, Integer> virtualThreadLimits,
-      Map<String, Integer> rateLimitsPerMinute) {
+      Map<String, Integer> rateLimitsPerMinute,
+      String jobExecutorJndi,
+      String scheduledExecutorJndi) {
 
     public ExecutionOptions {
       maxConcurrency = Map.copyOf(maxConcurrency);
@@ -557,11 +566,33 @@ public class RatchetOptions {
     private final Map<String, Integer> rateLimitsPerMinute = new HashMap<>();
     private boolean useVirtualThreads;
     private int queueSize = 100;
+    private String jobExecutorJndi = "java:comp/DefaultManagedExecutorService";
+    private String scheduledExecutorJndi = "java:comp/DefaultManagedScheduledExecutorService";
 
     private ExecutionBuilder() {}
 
     public ExecutionBuilder useVirtualThreads(boolean useVirtualThreads) {
       this.useVirtualThreads = useVirtualThreads;
+      return this;
+    }
+
+    /**
+     * Sets the JNDI name of the {@code ManagedExecutorService} that runs jobs. Defaults to the
+     * container's {@code java:comp/DefaultManagedExecutorService}. Point this at a virtual-thread
+     * executor (e.g. an EE 11 {@code @ManagedExecutorDefinition(virtual = true)} such as {@code
+     * java:app/concurrent/RatchetVirtualExecutor}) to run jobs on virtual threads.
+     */
+    public ExecutionBuilder jobExecutorJndi(String jobExecutorJndi) {
+      this.jobExecutorJndi = requireNonBlank("jobExecutorJndi", jobExecutorJndi);
+      return this;
+    }
+
+    /**
+     * Sets the JNDI name of the {@code ManagedScheduledExecutorService} used for scheduled work.
+     * Defaults to the container's {@code java:comp/DefaultManagedScheduledExecutorService}.
+     */
+    public ExecutionBuilder scheduledExecutorJndi(String scheduledExecutorJndi) {
+      this.scheduledExecutorJndi = requireNonBlank("scheduledExecutorJndi", scheduledExecutorJndi);
       return this;
     }
 
@@ -588,7 +619,13 @@ public class RatchetOptions {
 
     private ExecutionOptions build() {
       return new ExecutionOptions(
-          useVirtualThreads, queueSize, maxConcurrency, virtualThreadLimits, rateLimitsPerMinute);
+          useVirtualThreads,
+          queueSize,
+          maxConcurrency,
+          virtualThreadLimits,
+          rateLimitsPerMinute,
+          jobExecutorJndi,
+          scheduledExecutorJndi);
     }
   }
 

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -282,6 +282,8 @@ public class RatchetOptions {
       maxConcurrency = Map.copyOf(maxConcurrency);
       virtualThreadLimits = Map.copyOf(virtualThreadLimits);
       rateLimitsPerMinute = Map.copyOf(rateLimitsPerMinute);
+      jobExecutorJndi = requireNonBlank("jobExecutorJndi", jobExecutorJndi);
+      scheduledExecutorJndi = requireNonBlank("scheduledExecutorJndi", scheduledExecutorJndi);
     }
 
     public int maxConcurrency(String executionTypeName, int defaultValue) {
@@ -579,8 +581,8 @@ public class RatchetOptions {
     /**
      * Sets the JNDI name of the {@code ManagedExecutorService} that runs jobs. Defaults to the
      * container's {@code java:comp/DefaultManagedExecutorService}. Point this at a virtual-thread
-     * executor (e.g. an EE 11 {@code @ManagedExecutorDefinition(virtual = true)} such as {@code
-     * java:app/concurrent/RatchetVirtualExecutor}) to run jobs on virtual threads.
+     * executor that your application declares (e.g. an EE 11 {@code @ManagedExecutorDefinition(name
+     * = "java:app/concurrent/MyVirtualExecutor", virtual = true)}) to run jobs on virtual threads.
      */
     public ExecutionBuilder jobExecutorJndi(String jobExecutorJndi) {
       this.jobExecutorJndi = requireNonBlank("jobExecutorJndi", jobExecutorJndi);

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -580,9 +580,14 @@ public class RatchetOptions {
 
     /**
      * Sets the JNDI name of the {@code ManagedExecutorService} that runs jobs. Defaults to the
-     * container's {@code java:comp/DefaultManagedExecutorService}. Point this at a virtual-thread
-     * executor that your application declares (e.g. an EE 11 {@code @ManagedExecutorDefinition(name
-     * = "java:app/concurrent/MyVirtualExecutor", virtual = true)}) to run jobs on virtual threads.
+     * container's {@code java:comp/DefaultManagedExecutorService}. Point this at an executor your
+     * application declares (e.g. an EE 11 {@code @ManagedExecutorDefinition(name =
+     * "java:app/concurrent/MyVirtualExecutor", virtual = true)}); jobs then run on that executor.
+     *
+     * <p>Whether those jobs run on <em>virtual</em> threads is the container's decision: {@code
+     * virtual = true} is a request a runtime may ignore (Eclipse GlassFish 8 honors it; WildFly 40
+     * does not yet, so jobs run on platform threads there). Jakarta exposes no API to verify this
+     * at runtime, so Ratchet can neither warn nor guarantee it.
      */
     public ExecutionBuilder jobExecutorJndi(String jobExecutorJndi) {
       this.jobExecutorJndi = requireNonBlank("jobExecutorJndi", jobExecutorJndi);

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
@@ -157,6 +157,8 @@ public final class RatchetOptionsFactory {
       DefaultRatchetConfig config, RatchetOptions.ExecutionBuilder execution) {
     execution
         .useVirtualThreads(config.get(RatchetConfigKeys.WORKER_USE_VIRTUAL_THREADS))
+        .jobExecutorJndi(config.get(RatchetConfigKeys.WORKER_JOB_EXECUTOR_JNDI))
+        .scheduledExecutorJndi(config.get(RatchetConfigKeys.WORKER_SCHEDULED_EXECUTOR_JNDI))
         .queueSize(config.get(RatchetConfigKeys.THREAD_POOL_QUEUE_SIZE))
         .maxConcurrency("SINGLE", config.get(RatchetConfigKeys.THREAD_POOL_SIZE_SINGLE))
         .maxConcurrency("RECURRING", config.get(RatchetConfigKeys.THREAD_POOL_SIZE_RECURRING))

--- a/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
@@ -17,6 +17,10 @@ class RatchetOptionsTest {
     assertEquals(20, options.execution().maxConcurrency("SINGLE", -1));
     assertEquals(5, options.execution().maxConcurrency("RECURRING", -1));
     assertFalse(options.execution().useVirtualThreads());
+    assertEquals("java:comp/DefaultManagedExecutorService", options.execution().jobExecutorJndi());
+    assertEquals(
+        "java:comp/DefaultManagedScheduledExecutorService",
+        options.execution().scheduledExecutorJndi());
     assertEquals(60L, options.recurring().startupGraceSeconds());
     assertEquals(500, options.timeout().signalTimeoutBatchSize());
     assertEquals(RatchetOptions.IsolationCheckMode.FAIL, options.store().isolationCheckMode());

--- a/ratchet-store-mysql/README.md
+++ b/ratchet-store-mysql/README.md
@@ -34,10 +34,12 @@ Tools that handle binary IDs correctly (Hibernate, DataGrip's UUID-aware viewer,
 
 ## JPA mapping (production wiring)
 
-When wiring `ratchet-store-mysql` into a Jakarta application's `persistence.xml`, the persistence-unit must reference `META-INF/orm-mysql.xml` so UUID columns route through `UuidByteArrayConverter`:
+How you wire `ratchet-store-mysql` into a `persistence.xml` depends on the JPA provider, because UUID columns are stored as `BINARY(16)`. Give Ratchet its own persistence unit — its entity list is self-contained (`<exclude-unlisted-classes>true</exclude-unlisted-classes>`), and the `RatchetEntityManagerProvider` SPI lets a multi-unit application point Ratchet at it. Keeping Ratchet in its own unit means none of the provider settings below can touch your application's own entities or their columns.
+
+**EclipseLink, OpenJPA (any non-Hibernate provider):** reference `META-INF/orm-mysql.xml` so UUID columns route through `UuidByteArrayConverter`. These providers default to a 36-character hyphenated representation that overflows `BINARY(16)` with MySQL strict-mode error 1406 ("Data too long for column"); the mapping file forces the byte representation.
 
 ```xml
-<persistence-unit name="my-app">
+<persistence-unit name="ratchet">
   <jta-data-source>java:/jdbc/MyDS</jta-data-source>
   <mapping-file>META-INF/orm-mysql.xml</mapping-file>
   <class>run.ratchet.store.entity.JobEntity</class>
@@ -45,7 +47,15 @@ When wiring `ratchet-store-mysql` into a Jakarta application's `persistence.xml`
 </persistence-unit>
 ```
 
-Hibernate's built-in UUID handler already produces standard-byte-order `BINARY(16)`, so the converter is idempotent there. EclipseLink and OpenJPA default to a 36-character hyphenated representation that overflows `BINARY(16)` with MySQL strict mode error 1406 ("Data too long for column"); the mapping file forces the byte representation on every JPA provider.
+**Hibernate (ORM 6 or 7):** do NOT reference `orm-mysql.xml`. Hibernate maps `UUID` to `BINARY(16)` natively on MySQL by default (MySQL has no native UUID type), and Hibernate 7 rejects an `AttributeConverter` on an `@Id` attribute (`org.hibernate.AnnotationException`) — so referencing the mapping file would fail deployment. Use no mapping file at all:
+
+```xml
+<persistence-unit name="ratchet">
+  <jta-data-source>java:/jdbc/MyDS</jta-data-source>
+  <class>run.ratchet.store.entity.JobEntity</class>
+  ...
+</persistence-unit>
+```
 
 PostgreSQL's `ratchet-store-postgresql` does NOT need a mapping file — PostgreSQL's native `uuid` column type round-trips `java.util.UUID` directly through JDBC.
 

--- a/ratchet-store-mysql/src/main/resources/META-INF/orm-mysql.xml
+++ b/ratchet-store-mysql/src/main/resources/META-INF/orm-mysql.xml
@@ -4,11 +4,13 @@
   so EclipseLink (and any non-Hibernate JPA provider) produces 16 raw bytes for BINARY(16) instead
   of inserting the 36-character hyphenated form, which MySQL strict mode rejects with error 1406.
 
-  Hibernate's built-in UUID handler already produces standard-byte-order BINARY(16); applying the
-  converter is idempotent under Hibernate.
+  This file is for EclipseLink (and other non-Hibernate JPA providers) only. Do NOT reference it in
+  a Hibernate-backed deployment: Hibernate maps UUID to BINARY(16) natively on MySQL by default, and
+  Hibernate 7 rejects an AttributeConverter on an @Id attribute (org.hibernate.AnnotationException).
+  On Hibernate, omit this file entirely — no mapping file is needed.
 
-  Production users wiring ratchet-store-mysql into their own persistence-unit must reference this
-  file from their persistence.xml: <mapping-file>META-INF/orm-mysql.xml</mapping-file>.
+  Production users wiring ratchet-store-mysql into a non-Hibernate persistence-unit must reference
+  this file from their persistence.xml: <mapping-file>META-INF/orm-mysql.xml</mapping-file>.
 
   Native queries bypass AttributeConverter per JPA spec; in-store native-SQL call sites convert
   manually via UuidByteArrayConverter.toBytes(uuid).

--- a/ratchet-testsuite/pom.xml
+++ b/ratchet-testsuite/pom.xml
@@ -389,8 +389,10 @@
     <!--
       WildFly 40 on Jakarta EE 11 / JDK 25. Mirrors wildfly-managed but pins the
       EE 11 distribution and adds the EE 11 test source root (VirtualThreadExecutionIT).
-      The parent and ratchet same-id profiles supply the JDK 25 enforcer, Concurrency
-      3.1, and the shipped RatchetVirtualExecutor.
+      The parent same-id profile supplies the JDK 25 enforcer; this profile sets the
+      EE 11 umbrella (Concurrency 3.1) via jakarta.ee.version below. The test deployment
+      declares its own virtual-thread executor (VirtualThreadTestExecutor); Ratchet ships
+      none.
     -->
     <profile>
       <id>wildfly-ee11-managed</id>

--- a/ratchet-testsuite/pom.xml
+++ b/ratchet-testsuite/pom.xml
@@ -150,6 +150,35 @@
         <filtering>true</filtering>
       </testResource>
     </testResources>
+    <pluginManagement>
+      <plugins>
+        <!--
+          EE 11-only test source root (VirtualThreadExecutionIT). Added only when an
+          EE 11 server profile (wildfly-ee11-managed / glassfish-managed) switches this
+          plugin on. EE 10 server profiles never compile it, so the virtual-thread IT
+          is not "skipped" there — it simply isn't part of those builds.
+        -->
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>build-helper-maven-plugin</artifactId>
+          <version>${build-helper-maven-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>add-ee11-test-source</id>
+              <phase>generate-test-sources</phase>
+              <goals>
+                <goal>add-test-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${project.basedir}/src/test/java-ee11</source>
+                </sources>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -245,6 +274,150 @@
       </dependencies>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-wildfly</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>unpack</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.wildfly</groupId>
+                      <artifactId>wildfly-dist</artifactId>
+                      <version>${wildfly.version}</version>
+                      <type>zip</type>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${project.build.directory}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-mysql-driver</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>com.mysql</groupId>
+                      <artifactId>mysql-connector-j</artifactId>
+                      <version>${mysql-connector.version}</version>
+                      <outputDirectory>${wildfly.home}/modules/com/mysql/main</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+              <execution>
+                <id>copy-postgresql-driver</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.postgresql</groupId>
+                      <artifactId>postgresql</artifactId>
+                      <version>${postgresql-driver.version}</version>
+                      <outputDirectory>${wildfly.home}/modules/org/postgresql/main</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+              <execution>
+                <id>install-wildfly-jdbc-modules</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <echo file="${wildfly.home}/modules/com/mysql/main/module.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;module xmlns="urn:jboss:module:1.9" name="com.mysql"&gt;
+  &lt;resources&gt;
+    &lt;resource-root path="mysql-connector-j-${mysql-connector.version}.jar"/&gt;
+  &lt;/resources&gt;
+  &lt;dependencies&gt;
+    &lt;module name="java.sql"/&gt;
+    &lt;module name="java.naming"/&gt;
+    &lt;module name="java.logging"/&gt;
+    &lt;module name="java.security.sasl"/&gt;
+    &lt;module name="java.management"/&gt;
+    &lt;module name="java.xml"/&gt;
+    &lt;module name="jakarta.transaction.api"/&gt;
+  &lt;/dependencies&gt;
+&lt;/module&gt;</echo>
+                    <echo file="${wildfly.home}/modules/org/postgresql/main/module.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;module xmlns="urn:jboss:module:1.9" name="org.postgresql"&gt;
+  &lt;resources&gt;
+    &lt;resource-root path="postgresql-${postgresql-driver.version}.jar"/&gt;
+  &lt;/resources&gt;
+  &lt;dependencies&gt;
+    &lt;module name="java.sql"/&gt;
+    &lt;module name="java.logging"/&gt;
+    &lt;module name="java.management"/&gt;
+    &lt;module name="jakarta.transaction.api"/&gt;
+  &lt;/dependencies&gt;
+&lt;/module&gt;</echo>
+                    <chmod file="${wildfly.home}/bin/jboss-cli.sh" perm="755"/>
+                    <exec executable="${wildfly.home}/bin/jboss-cli.sh" failonerror="true">
+                      <arg value="--file=${project.basedir}/src/test/resources/wildfly-setup.cli"/>
+                    </exec>
+                  </target>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+      WildFly 40 on Jakarta EE 11 / JDK 25. Mirrors wildfly-managed but pins the
+      EE 11 distribution and adds the EE 11 test source root (VirtualThreadExecutionIT).
+      The parent and ratchet same-id profiles supply the JDK 25 enforcer, Concurrency
+      3.1, and the shipped RatchetVirtualExecutor.
+    -->
+    <profile>
+      <id>wildfly-ee11-managed</id>
+      <properties>
+        <skipITs>false</skipITs>
+        <testsuite.profile>wildfly-ee11-managed</testsuite.profile>
+        <arquillian.launch>wildfly-ee11-managed</arquillian.launch>
+        <wildfly.version>40.0.0.Final</wildfly.version>
+        <wildfly.home>${project.build.directory}/wildfly-${wildfly.version}</wildfly.home>
+        <!-- EE 11 umbrella so the test source compiles against Jakarta Concurrency 3.1 (virtual = true). -->
+        <jakarta.ee.version>11.0.0</jakarta.ee.version>
+        <!-- Thread.isVirtual() in the test probe needs the JDK 21 SE API (test sources only). -->
+        <maven.compiler.release>21</maven.compiler.release>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly.arquillian</groupId>
+          <artifactId>wildfly-arquillian-container-managed</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
@@ -546,6 +719,10 @@
         <glassfish.iiop.mutualauth.port>14920</glassfish.iiop.mutualauth.port>
         <glassfish.jmx.port>19686</glassfish.jmx.port>
         <glassfish.osgi.shell.port>17666</glassfish.osgi.shell.port>
+        <!-- EE 11 umbrella so the test source compiles against Jakarta Concurrency 3.1 (virtual = true). -->
+        <jakarta.ee.version>11.0.0</jakarta.ee.version>
+        <!-- Thread.isVirtual() in the test probe needs the JDK 21 SE API (test sources only). -->
+        <maven.compiler.release>21</maven.compiler.release>
       </properties>
       <dependencies>
         <dependency>
@@ -556,6 +733,11 @@
       </dependencies>
       <build>
         <plugins>
+          <!-- GlassFish 8 is the EE 11 RI: compile and run the EE 11 virtual-thread IT here too. -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>build-helper-maven-plugin</artifactId>
+          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-enforcer-plugin</artifactId>

--- a/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadExecutionIT.java
+++ b/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadExecutionIT.java
@@ -1,0 +1,115 @@
+package run.ratchet.testsuite.concurrency;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.app.TestJobService;
+import run.ratchet.testsuite.util.BaseRatchetIT;
+import run.ratchet.testsuite.util.JobAssertions;
+import run.ratchet.testsuite.util.RatchetArchiveBuilder;
+
+/**
+ * Exercises Ratchet's virtual-thread execution path on Jakarta EE 11 containers (WildFly 40,
+ * GlassFish 8). Compiled and run only under the EE 11 server profiles (the {@code
+ * src/test/java-ee11} source root); the EE 10 profiles never see it, so it is not "skipped" there.
+ *
+ * <p>{@link VirtualThreadOptionsProducer} points the executor at {@link VirtualThreadTestExecutor}
+ * (an application-declared {@code @ManagedExecutorDefinition(virtual = true)}) and enables the
+ * virtual-thread backpressure model, so the assertions exercise the real end-to-end path.
+ *
+ * <p><b>Wiring vs. true virtual threads.</b> That jobs run and complete at all proves Ratchet
+ * resolved and used the configured executor: {@code DefaultExecutorProvider} fails on first use if
+ * {@code java:app/concurrent/RatchetTestVirtualExecutor} cannot be resolved. Whether those threads are
+ * <em>virtual</em> depends on the container: GlassFish 8 (the EE 11 RI, via {@code concurro}) honors
+ * {@code virtual = true}; WildFly 40.0.0.Final does not yet implement virtual threads for managed
+ * executors (its {@code wildfly-concurrency-impl} has no virtual wiring), so it runs the same jobs
+ * on platform threads. The hard {@code isVirtual()} assertion therefore runs on GlassFish; WildFly
+ * gets the wiring + concurrency check.
+ */
+class VirtualThreadExecutionIT extends BaseRatchetIT {
+
+  @Inject private TestJobService jobService;
+
+  @Inject private JobCrudStore jobCrudStore;
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    String dbType = System.getProperty("ratchet.test.db.type", "mysql");
+    String profile = System.getProperty("testsuite.profile", "wildfly-ee11-managed");
+
+    return RatchetArchiveBuilder.create()
+        .addRatchetDependencies(profile, dbType)
+        .addClasses(
+            VirtualThreadProbeJob.class,
+            VirtualThreadOptionsProducer.class,
+            VirtualThreadTestExecutor.class,
+            TestJobService.class)
+        .addStoreInfrastructure()
+        .addBeansXml()
+        .build();
+  }
+
+  /**
+   * True only on containers that actually implement virtual threads for Jakarta Concurrency
+   * managed executors. GlassFish 8 (the EE 11 reference implementation) does; WildFly 40.0.0.Final
+   * binds and uses the {@code virtual = true} executor but still hands out platform threads
+   * (verified by running this same deployment on both: {@code isVirtual()} is true on GlassFish,
+   * false on WildFly). When WildFly implements it, drop this guard for WildFly.
+   */
+  private static boolean expectsVirtualThreads() {
+    return System.getProperty("testsuite.profile", "").contains("glassfish");
+  }
+
+  @BeforeEach
+  void resetProbe() {
+    VirtualThreadProbeJob.reset();
+  }
+
+  @Test
+  void job_runsOnConfiguredVirtualExecutor() {
+    JobHandle handle = jobService.enqueueNow(VirtualThreadProbeJob::execute);
+
+    JobAssertions.assertJobCompleted(jobCrudStore, handle);
+    assertEquals(1, VirtualThreadProbeJob.invocations());
+    if (expectsVirtualThreads()) {
+      assertTrue(
+          VirtualThreadProbeJob.allRanOnVirtualThreads(),
+          "job body must run on a virtual thread; observed threads="
+              + VirtualThreadProbeJob.threadNames());
+    }
+  }
+
+  @Test
+  void manyJobs_runConcurrentlyOnConfiguredVirtualExecutor() {
+    int jobCount = 20;
+    List<JobHandle> handles = new ArrayList<>(jobCount);
+    for (int i = 0; i < jobCount; i++) {
+      handles.add(jobService.enqueueNow(VirtualThreadProbeJob::execute));
+    }
+
+    for (JobHandle handle : handles) {
+      JobAssertions.assertJobCompleted(jobCrudStore, handle);
+    }
+
+    assertEquals(jobCount, VirtualThreadProbeJob.invocations());
+    assertTrue(
+        VirtualThreadProbeJob.peakConcurrency() >= 2,
+        "expected overlapping execution on the managed executor; peak concurrency="
+            + VirtualThreadProbeJob.peakConcurrency());
+    if (expectsVirtualThreads()) {
+      assertTrue(
+          VirtualThreadProbeJob.allRanOnVirtualThreads(),
+          "every job body must run on a virtual thread; observed threads="
+              + VirtualThreadProbeJob.threadNames());
+    }
+  }
+}

--- a/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadOptionsProducer.java
+++ b/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadOptionsProducer.java
@@ -1,0 +1,56 @@
+package run.ratchet.testsuite.concurrency;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.interceptor.Interceptor;
+import java.util.Optional;
+import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.RatchetOptionsFactory;
+import run.ratchet.spi.RatchetConfigSource;
+import run.ratchet.testsuite.app.TestRuntimeConfig;
+
+/**
+ * Overrides the default {@code TestRatchetOptionsProducer} for the virtual-thread deployment only.
+ * Turns on the virtual-thread backpressure model and points the job executor at the
+ * application-declared {@link VirtualThreadTestExecutor} ({@code @ManagedExecutorDefinition(virtual
+ * = true)}). All other settings (DB type, poller tunings) still flow from {@link TestRuntimeConfig}.
+ *
+ * <p>Selected via {@code @Alternative @Priority(APPLICATION + 100)}, so it wins over the
+ * non-alternative default producer wherever this class is bundled — and nowhere else.
+ */
+@ApplicationScoped
+@Alternative
+@Priority(Interceptor.Priority.APPLICATION + 100)
+public class VirtualThreadOptionsProducer {
+
+  // The test owns its executor as a WAR application class (see VirtualThreadTestExecutor) so it
+  // binds on every EE 11 container, not just those that scan library jars for resource definitions.
+  static final String VIRTUAL_EXECUTOR = "java:app/concurrent/RatchetTestVirtualExecutor";
+
+  @Produces
+  @ApplicationScoped
+  public RatchetOptions ratchetOptions() {
+    return RatchetOptionsFactory.fromEnvironment(
+        new VirtualThreadOverrides(), new TestRuntimeConfig());
+  }
+
+  /**
+   * Highest-precedence config source returning only the virtual-thread keys. Only the <em>job</em>
+   * executor is redirected to the virtual one; the scheduled executor stays at the container
+   * default, because Ratchet uses it during CDI startup (node heartbeat) before an app-defined
+   * executor is bound on some containers (GlassFish). Jobs — the thing under test — run on the
+   * virtual executor, resolved lazily after deployment completes.
+   */
+  private static final class VirtualThreadOverrides implements RatchetConfigSource {
+    @Override
+    public Optional<String> get(String propertyName, String environmentVariable) {
+      return switch (propertyName) {
+        case "ratchet.worker.use-virtual-threads" -> Optional.of("true");
+        case "ratchet.worker.job-executor-jndi" -> Optional.of(VIRTUAL_EXECUTOR);
+        default -> Optional.empty();
+      };
+    }
+  }
+}

--- a/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadProbeJob.java
+++ b/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadProbeJob.java
@@ -1,0 +1,68 @@
+package run.ratchet.testsuite.concurrency;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Job target that records the thread it executes on. Static state (mirroring {@code SimpleJob}) is
+ * read directly by the in-container IT.
+ *
+ * <p>Each invocation captures {@link Thread#isVirtual()} and the thread description, briefly sleeps
+ * so concurrent invocations overlap, and tracks peak concurrency. The IT asserts every invocation
+ * ran on a virtual thread.
+ */
+public final class VirtualThreadProbeJob {
+
+  private static final AtomicInteger INVOCATIONS = new AtomicInteger();
+  private static final AtomicInteger CONCURRENT = new AtomicInteger();
+  private static final AtomicInteger PEAK_CONCURRENT = new AtomicInteger();
+  private static final List<Boolean> VIRTUAL_FLAGS = new CopyOnWriteArrayList<>();
+  private static final Set<String> THREAD_NAMES = ConcurrentHashMap.newKeySet();
+
+  private VirtualThreadProbeJob() {}
+
+  public static void execute() {
+    int inFlight = CONCURRENT.incrementAndGet();
+    PEAK_CONCURRENT.accumulateAndGet(inFlight, Math::max);
+    try {
+      Thread current = Thread.currentThread();
+      VIRTUAL_FLAGS.add(current.isVirtual());
+      THREAD_NAMES.add(current.toString());
+      try {
+        Thread.sleep(250);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      INVOCATIONS.incrementAndGet();
+    } finally {
+      CONCURRENT.decrementAndGet();
+    }
+  }
+
+  public static int invocations() {
+    return INVOCATIONS.get();
+  }
+
+  public static int peakConcurrency() {
+    return PEAK_CONCURRENT.get();
+  }
+
+  public static boolean allRanOnVirtualThreads() {
+    return !VIRTUAL_FLAGS.isEmpty() && VIRTUAL_FLAGS.stream().allMatch(Boolean::booleanValue);
+  }
+
+  public static Set<String> threadNames() {
+    return THREAD_NAMES;
+  }
+
+  public static void reset() {
+    INVOCATIONS.set(0);
+    CONCURRENT.set(0);
+    PEAK_CONCURRENT.set(0);
+    VIRTUAL_FLAGS.clear();
+    THREAD_NAMES.clear();
+  }
+}

--- a/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadTestExecutor.java
+++ b/ratchet-testsuite/src/test/java-ee11/run/ratchet/testsuite/concurrency/VirtualThreadTestExecutor.java
@@ -1,0 +1,20 @@
+package run.ratchet.testsuite.concurrency;
+
+import jakarta.enterprise.concurrent.ManagedExecutorDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Declares a virtual-thread {@code ManagedExecutorService} as an <b>application</b> component (it
+ * lands in {@code WEB-INF/classes}), following the standard Jakarta Concurrency 3.1 pattern:
+ * {@code @ManagedExecutorDefinition(virtual = true)} on an {@code @ApplicationScoped} class.
+ *
+ * <p>Ratchet ships no executor definition of its own (the library stays EE-agnostic), so the
+ * application owning the executor is the supported pattern. This is what a real deployment does:
+ * declare the executor, then set {@code ratchet.worker.job-executor-jndi} to its name. {@link
+ * VirtualThreadOptionsProducer} does exactly that for the test. Declaring it as a WAR class also
+ * avoids depending on whether a container scans {@code WEB-INF/lib} for resource definitions
+ * (GlassFish does not).
+ */
+@ManagedExecutorDefinition(name = "java:app/concurrent/RatchetTestVirtualExecutor", virtual = true)
+@ApplicationScoped
+public class VirtualThreadTestExecutor {}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceStrategyFactory.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceStrategyFactory.java
@@ -8,7 +8,7 @@ public final class DataSourceStrategyFactory {
   public static DataSourceStrategy create() {
     String launch = System.getProperty("arquillian.launch", "wildfly-managed");
     return switch (launch) {
-      case "wildfly-managed" -> new WildflyDataSourceStrategy();
+      case "wildfly-managed", "wildfly-ee11-managed" -> new WildflyDataSourceStrategy();
       case "payara-managed" -> new PayaraDataSourceStrategy();
       case "glassfish-managed" -> new GlassFishDataSourceStrategy();
       case "openliberty-managed" -> new OpenLibertyDataSourceStrategy();

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceStrategyFactoryTest.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceStrategyFactoryTest.java
@@ -29,6 +29,7 @@ class DataSourceStrategyFactoryTest {
   @Test
   void mapsKnownManagedServersToStrategies() {
     assertStrategy("wildfly-managed", WildflyDataSourceStrategy.class);
+    assertStrategy("wildfly-ee11-managed", WildflyDataSourceStrategy.class);
     assertStrategy("payara-managed", PayaraDataSourceStrategy.class);
     assertStrategy("glassfish-managed", GlassFishDataSourceStrategy.class);
     assertStrategy("openliberty-managed", OpenLibertyDataSourceStrategy.class);

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -72,12 +72,18 @@ public class RatchetArchiveBuilder {
     if (!dbType.equals("mysql") && !dbType.equals("postgresql")) {
       throw new IllegalArgumentException("Unsupported db type: " + dbType);
     }
-    // MySQL needs the orm-mysql.xml override so EclipseLink (and any other non-Hibernate JPA
-    // provider) routes UUID columns through UuidByteArrayConverter; Hibernate already produces
-    // standard-byte-order BINARY(16), so the override is idempotent there. PostgreSQL stores UUID
-    // natively and must NOT include the converter — it would re-encode native uuid as bytea.
+    // MySQL stores UUIDs in BINARY(16). EclipseLink's default would send the 36-char hyphenated
+    // string and overflow the column, so EclipseLink deployments route every UUID through
+    // UuidByteArrayConverter via orm-mysql.xml. Hibernate maps UUID -> BINARY(16) natively (its
+    // default on the MySQL dialect), and Hibernate 7 (WildFly 40 / EE 11) rejects an
+    // AttributeConverter on an @Id attribute outright, so Hibernate-7 deployments must NOT
+    // reference orm-mysql.xml — they need no mapping file at all. PostgreSQL stores UUID natively
+    // and must NOT include the converter — it would re-encode native uuid as bytea.
+    boolean hibernate7 = "wildfly-ee11-managed".equals(System.getProperty("arquillian.launch"));
     String mappingFile =
-        dbType.equals("mysql") ? "<mapping-file>META-INF/orm-mysql.xml</mapping-file>" : "";
+        dbType.equals("mysql") && !hibernate7
+            ? "<mapping-file>META-INF/orm-mysql.xml</mapping-file>"
+            : "";
     // No <provider> or hibernate.dialect pin — WildFly auto-discovers via ServiceLoader and the
     // JPA provider auto-detects the dialect from the JDBC URL exposed by RatchetDS. Remaining
     // property keys are opt-in Hibernate tuning and no-op under any other JPA provider.

--- a/ratchet-testsuite/src/test/resources/arquillian.xml
+++ b/ratchet-testsuite/src/test/resources/arquillian.xml
@@ -35,6 +35,45 @@
     </configuration>
   </container>
 
+  <!--
+    WildFly 40 on Jakarta EE 11 (JDK 25). Same managed-container wiring as
+    wildfly-managed, but a distinct port-offset (21000) and management port
+    (30990) so an EE 11 run never collides with a stray EE 10 server. The
+    wildfly-ee11-managed Maven profile overrides ${wildfly.version} to the
+    EE 11 distribution, so ${wildfly.version} below resolves to that version.
+  -->
+  <container qualifier="wildfly-ee11-managed">
+    <configuration>
+      <property name="jbossHome">${project.build.directory}/wildfly-${wildfly.version}</property>
+      <property name="serverConfig">standalone.xml</property>
+      <!--
+        Virtual-thread managed executors are a "preview"-stability feature in WildFly 40;
+        @ManagedExecutorDefinition(virtual = true) is silently honored as platform threads
+        at the default "community" level. Boot at preview so virtual=true takes effect.
+      -->
+      <property name="jbossArguments">--stability=preview</property>
+      <property name="javaVmArguments">
+        -Xms512m -Xmx1024m
+        -Djboss.socket.binding.port-offset=21000
+        ${jacoco.it.argLine}
+        -Dratchet.test.db.url=${ratchet.test.db.url}
+        -Dratchet.test.db.username=${ratchet.test.db.username}
+        -Dratchet.test.db.password=${ratchet.test.db.password}
+        -Dratchet.test.db.driver=${ratchet.test.db.driver}
+        -Dratchet.test.db.driver.name=${ratchet.test.db.driver.name}
+        -Dratchet.test.db.type=${ratchet.test.db.type}
+        -Dratchet.test.mongo.uri=${ratchet.test.mongo.uri}
+        -Dratchet.test.mongo.database=${ratchet.test.mongo.database}
+        -Dtestsuite.profile=${testsuite.profile}
+        -DPOLLER_DEEP_IDLE_THRESHOLD_MS=5000
+        -DPOLLER_DEEP_IDLE_DELAY_MS=2000
+        -DPOLLER_MAX_DELAY_MS=2000
+      </property>
+      <property name="managementPort">30990</property>
+      <property name="allowConnectingToRunningServer">false</property>
+    </configuration>
+  </container>
+
   <container qualifier="payara-managed">
     <configuration>
       <property name="payaraHome">${payara.home}</property>

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/DefaultExecutorProvider.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/DefaultExecutorProvider.java
@@ -85,7 +85,14 @@ public class DefaultExecutorProvider implements ExecutorProvider {
               lookup(context, scheduledExecutorJndi, ScheduledExecutorService.class);
         }
       }
-    } catch (RuntimeException e) {
+    } catch (IllegalStateException e) {
+      // Only a JNDI-naming failure (the name isn't bound yet) is safe to defer to the lazy
+      // getters. lookup()/newInitialContext() wrap NamingException as the cause in that case.
+      // Anything else — e.g. a ClassCastException from a wrong executor type — is a real
+      // misconfiguration; rethrow it so deployment fails loudly instead of at the first job.
+      if (!(e.getCause() instanceof NamingException)) {
+        throw e;
+      }
       log.debugf(
           e,
           "Eager managed-executor resolution deferred to first use (job=%s, scheduled=%s)",

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/DefaultExecutorProvider.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/DefaultExecutorProvider.java
@@ -31,11 +31,14 @@ import run.ratchet.spi.ExecutorProvider;
  *
  * <p>The two JNDI names are configurable via {@code ratchet.worker.job-executor-jndi} and {@code
  * ratchet.worker.scheduled-executor-jndi} (defaulting to the well-known container names above).
- * Pointing {@code job-executor-jndi} at a virtual-thread-backed executor makes jobs run on virtual
- * threads. On Jakarta EE 11 the application declares one with
- * {@code @ManagedExecutorDefinition(name = "java:app/concurrent/MyVirtualExecutor", virtual =
- * true)} on any {@code @ApplicationScoped} bean and sets {@code job-executor-jndi} to that name.
- * The values flow in through {@link RatchetOptions#execution()}.
+ * Pointing {@code job-executor-jndi} at a virtual-thread-backed executor runs jobs on that
+ * executor; whether its threads are actually virtual is the container's decision, since {@code
+ * virtual = true} is a request a runtime may ignore (Eclipse GlassFish 8 honors it; WildFly 40 does
+ * not yet). Jakarta exposes no API to verify this at runtime. On Jakarta EE 11 the application
+ * declares one with {@code @ManagedExecutorDefinition(name =
+ * "java:app/concurrent/MyVirtualExecutor", virtual = true)} on any {@code @ApplicationScoped} bean
+ * and sets {@code job-executor-jndi} to that name. The values flow in through {@link
+ * RatchetOptions#execution()}.
  *
  * <p>Users can override by providing their own {@code @Alternative @Priority(APPLICATION)
  * ExecutorProvider} bean — for example {@link StandaloneExecutorProvider} for plain-CDI/SE runs.

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/DefaultExecutorProvider.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/DefaultExecutorProvider.java
@@ -2,10 +2,13 @@ package run.ratchet.ri.cdi;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import org.jboss.logging.Logger;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.spi.ExecutorProvider;
 
 /**
@@ -26,29 +29,68 @@ import run.ratchet.spi.ExecutorProvider;
  * test paths still resolve lazily on first use. Resolved references are cached for the lifetime of
  * the bean.
  *
+ * <p>The two JNDI names are configurable via {@code ratchet.worker.job-executor-jndi} and {@code
+ * ratchet.worker.scheduled-executor-jndi} (defaulting to the well-known container names above).
+ * Pointing {@code job-executor-jndi} at a virtual-thread-backed executor makes jobs run on virtual
+ * threads. On Jakarta EE 11 the application declares one with
+ * {@code @ManagedExecutorDefinition(name = "java:app/concurrent/MyVirtualExecutor", virtual =
+ * true)} on any {@code @ApplicationScoped} bean and sets {@code job-executor-jndi} to that name.
+ * The values flow in through {@link RatchetOptions#execution()}.
+ *
  * <p>Users can override by providing their own {@code @Alternative @Priority(APPLICATION)
  * ExecutorProvider} bean — for example {@link StandaloneExecutorProvider} for plain-CDI/SE runs.
  */
 @ApplicationScoped
 public class DefaultExecutorProvider implements ExecutorProvider {
 
+  private static final Logger log = Logger.getLogger(DefaultExecutorProvider.class);
+
   static final String JOB_EXECUTOR_JNDI = "java:comp/DefaultManagedExecutorService";
   static final String SCHEDULED_EXECUTOR_JNDI = "java:comp/DefaultManagedScheduledExecutorService";
+
+  private final String jobExecutorJndi;
+  private final String scheduledExecutorJndi;
 
   private volatile ExecutorService resolvedJobExecutor;
   private volatile ScheduledExecutorService resolvedScheduledExecutor;
 
+  /** Direct-construction path (tests, plain-SE): uses the well-known container JNDI names. */
+  protected DefaultExecutorProvider() {
+    this.jobExecutorJndi = JOB_EXECUTOR_JNDI;
+    this.scheduledExecutorJndi = SCHEDULED_EXECUTOR_JNDI;
+  }
+
+  @Inject
+  public DefaultExecutorProvider(RatchetOptions options) {
+    this.jobExecutorJndi = options.execution().jobExecutorJndi();
+    this.scheduledExecutorJndi = options.execution().scheduledExecutorJndi();
+  }
+
   @PostConstruct
   void init() {
-    InitialContext context = newInitialContext();
-    synchronized (this) {
-      if (resolvedJobExecutor == null) {
-        resolvedJobExecutor = lookup(context, JOB_EXECUTOR_JNDI, ExecutorService.class);
+    // Best-effort eager resolution. A deployment-defined executor (e.g. an
+    // @ManagedExecutorDefinition or a web.xml <managed-executor>) may not be bound yet when CDI
+    // beans initialize on some containers (notably GlassFish, which binds such resources after
+    // CDI startup), whereas the well-known java:comp defaults always are. Rather than abort
+    // deployment, defer to lazy resolution on first use; a genuinely missing name still surfaces
+    // from the getters when the first job runs.
+    try {
+      InitialContext context = newInitialContext();
+      synchronized (this) {
+        if (resolvedJobExecutor == null) {
+          resolvedJobExecutor = lookup(context, jobExecutorJndi, ExecutorService.class);
+        }
+        if (resolvedScheduledExecutor == null) {
+          resolvedScheduledExecutor =
+              lookup(context, scheduledExecutorJndi, ScheduledExecutorService.class);
+        }
       }
-      if (resolvedScheduledExecutor == null) {
-        resolvedScheduledExecutor =
-            lookup(context, SCHEDULED_EXECUTOR_JNDI, ScheduledExecutorService.class);
-      }
+    } catch (RuntimeException e) {
+      log.debugf(
+          e,
+          "Eager managed-executor resolution deferred to first use (job=%s, scheduled=%s)",
+          jobExecutorJndi,
+          scheduledExecutorJndi);
     }
   }
 
@@ -92,7 +134,7 @@ public class DefaultExecutorProvider implements ExecutorProvider {
       synchronized (this) {
         executor = resolvedJobExecutor;
         if (executor == null) {
-          executor = lookup(JOB_EXECUTOR_JNDI, ExecutorService.class);
+          executor = lookup(jobExecutorJndi, ExecutorService.class);
           resolvedJobExecutor = executor;
         }
       }
@@ -107,7 +149,7 @@ public class DefaultExecutorProvider implements ExecutorProvider {
       synchronized (this) {
         executor = resolvedScheduledExecutor;
         if (executor == null) {
-          executor = lookup(SCHEDULED_EXECUTOR_JNDI, ScheduledExecutorService.class);
+          executor = lookup(scheduledExecutorJndi, ScheduledExecutorService.class);
           resolvedScheduledExecutor = executor;
         }
       }

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/DefaultExecutorProviderTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/DefaultExecutorProviderTest.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.naming.InitialContext;
 import org.junit.jupiter.api.Test;
+import run.ratchet.api.RatchetOptions;
 
 class DefaultExecutorProviderTest {
 
@@ -31,10 +32,41 @@ class DefaultExecutorProviderTest {
     assertSame(scheduledExecutor, provider.getScheduledExecutor());
   }
 
+  @Test
+  void resolvesConfiguredExecutorJndiNamesFromOptions() throws Exception {
+    String jobName = "java:app/concurrent/RatchetVirtualExecutor";
+    String scheduledName = "java:app/concurrent/RatchetVirtualScheduledExecutor";
+    RatchetOptions options =
+        RatchetOptions.builder()
+            .execution(
+                execution ->
+                    execution.jobExecutorJndi(jobName).scheduledExecutorJndi(scheduledName))
+            .build();
+    InitialContext context = mock(InitialContext.class);
+    ExecutorService jobExecutor = mock(ExecutorService.class);
+    ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+    when(context.lookup(jobName)).thenReturn(jobExecutor);
+    when(context.lookup(scheduledName)).thenReturn(scheduledExecutor);
+
+    DefaultExecutorProvider provider = new TestExecutorProvider(context, options);
+
+    provider.init();
+
+    verify(context).lookup(jobName);
+    verify(context).lookup(scheduledName);
+    assertSame(jobExecutor, provider.getJobExecutor());
+    assertSame(scheduledExecutor, provider.getScheduledExecutor());
+  }
+
   private static final class TestExecutorProvider extends DefaultExecutorProvider {
     private final InitialContext context;
 
     private TestExecutorProvider(InitialContext context) {
+      this.context = context;
+    }
+
+    private TestExecutorProvider(InitialContext context, RatchetOptions options) {
+      super(options);
       this.context = context;
     }
 

--- a/website/docs/deployment/configuration.md
+++ b/website/docs/deployment/configuration.md
@@ -76,7 +76,7 @@ public class OrdersRatchetEntityManagerProvider implements RatchetEntityManagerP
 | `polling.maxDelayMs(10000)` | `10000` | Maximum adaptive poll interval |
 | `execution.maxConcurrency("SINGLE", 20)` | `20` | Worker concurrency for one-off jobs |
 | `execution.maxConcurrency("BATCH_CHILD", 30)` | `30` | Worker concurrency for batch children |
-| `execution.useVirtualThreads(false)` | `false` | Switch to Java virtual-thread execution |
+| `execution.useVirtualThreads(false)` | `false` | Use counter-based backpressure instead of semaphores (pair with a virtual-thread executor JNDI) |
 | `node.heartbeatIntervalSeconds(10)` | `10` | Node heartbeat interval |
 | `node.orphanGraceSeconds(60)` | `60` | Grace period before reclaiming orphaned work |
 | `maintenance.jobRetentionDays(90)` | `90` | Completed-job retention before archiving |

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -187,7 +187,7 @@ DDL, not a datasource.
 
 | Builder method | Default | Description |
 |---|---:|---|
-| `useVirtualThreads(boolean)` | `false` | Use virtual threads where supported |
+| `useVirtualThreads(boolean)` | `false` | Use counter-based backpressure instead of semaphores (pair with a virtual-thread executor JNDI) |
 | `queueSize(int)` | `100` | Reserved for custom executor implementations |
 | `maxConcurrency("SINGLE", int)` | `20` | One-off job concurrency |
 | `maxConcurrency("RECURRING", int)` | `5` | Recurring child concurrency |

--- a/website/docs/troubleshooting/faq.md
+++ b/website/docs/troubleshooting/faq.md
@@ -193,7 +193,7 @@ RatchetOptions.builder()
 
 **Requirements:**
 - A Jakarta EE 11 container whose Jakarta Concurrency 3.1 implementation honors `virtual = true`, on Java 21+. Verified on Eclipse GlassFish 8 (the EE 11 reference implementation). Note: WildFly 40.0.0.Final accepts the definition and runs jobs on the configured executor, but does not yet create virtual threads for managed executors — jobs run on platform threads there until a later release implements it.
-- On Jakarta EE 10 the shipped virtual executor is not available; `useVirtualThreads(true)` still switches the backpressure model, but jobs run on virtual threads only if you point the JNDI name at an executor the container itself configures as virtual.
+- Jakarta EE 10 (Jakarta Concurrency 3.0) has no standard `virtual = true` attribute on `@ManagedExecutorDefinition`, so an application cannot portably declare a virtual-thread executor. `useVirtualThreads(true)` still switches the backpressure model, but jobs run on virtual threads only if you point the JNDI name at an executor the container itself configures as virtual through a vendor-specific mechanism.
 - Your jobs must not hold long `synchronized` blocks or call native methods that pin the carrier thread — prefer `ReentrantLock`.
 
 **When to use virtual threads:** They are most beneficial when your jobs spend the majority of their time waiting on I/O (database queries, HTTP calls, file operations). For CPU-bound workloads, platform threads with appropriate pool sizes are usually sufficient.

--- a/website/docs/troubleshooting/faq.md
+++ b/website/docs/troubleshooting/faq.md
@@ -161,25 +161,40 @@ The circuit breaker is resolved per job by inspecting the `@CircuitBreakerProtec
 
 ## Can I Use Virtual Threads?
 
-Yes. Set `RatchetOptions.builder().execution(e -> e.useVirtualThreads(true))` to switch from platform thread pools to virtual threads.
+Yes, on a Jakarta EE 11 container. Virtual-thread support has two parts:
 
-When enabled:
-- The `ThreadPoolManager` creates virtual threads via `Thread.ofVirtual()` instead of using `ExecutorService` thread pools
-- Semaphore-based concurrency limits are replaced with `AtomicInteger` counters
-- Each job type still has a configurable concurrency limit (default 1000) to prevent unbounded growth
+1. **Where jobs run.** Ratchet runs each job on the `ManagedExecutorService` resolved from `ratchet.worker.job-executor-jndi` (default `java:comp/DefaultManagedExecutorService`). Point that at a virtual-thread-backed managed executor and jobs run on virtual threads — with the container's context propagation (CDI, transaction, security) intact, which a hand-rolled `Thread.ofVirtual()` executor would lose.
+2. **Backpressure accounting.** `execution.useVirtualThreads(true)` swaps the semaphore-based concurrency limits for `AtomicInteger` counters, since virtual threads are cheap and a fixed pool no longer bounds concurrency. Each job type keeps a configurable limit (default 1000) to prevent unbounded growth.
 
-**Requirements:**
-- Java 21+ (virtual threads are a preview feature in Java 19-20 and GA in 21)
-- Your jobs must not perform long-duration `synchronized` blocks or call native methods that pin the carrier thread
+Ratchet stays a single, EE-version-agnostic library and does not ship its own executor definition (resource-definition scanning of library jars is container-specific, so a bundled one would not bind portably). Instead, declare one in your own application on EE 11 (Jakarta Concurrency 3.1) and point Ratchet at it:
 
-**Configuration:**
+```java
+@ManagedExecutorDefinition(name = "java:app/concurrent/MyVirtualExecutor", virtual = true)
+@ApplicationScoped
+public class VirtualExecutorConfig {}
+```
 
 ```bash
 export RATCHET_WORKER_USE_VIRTUAL_THREADS=true
+export RATCHET_WORKER_JOB_EXECUTOR_JNDI=java:app/concurrent/MyVirtualExecutor
 # Optional: adjust per-type limits (default 1000)
 export RATCHET_VIRTUAL_THREAD_LIMIT_SINGLE=500
 export RATCHET_VIRTUAL_THREAD_LIMIT_BATCH_CHILD=2000
 ```
+
+Or programmatically:
+
+```java
+RatchetOptions.builder()
+    .execution(e -> e
+        .useVirtualThreads(true)
+        .jobExecutorJndi("java:app/concurrent/MyVirtualExecutor"));
+```
+
+**Requirements:**
+- A Jakarta EE 11 container whose Jakarta Concurrency 3.1 implementation honors `virtual = true`, on Java 21+. Verified on Eclipse GlassFish 8 (the EE 11 reference implementation). Note: WildFly 40.0.0.Final accepts the definition and runs jobs on the configured executor, but does not yet create virtual threads for managed executors — jobs run on platform threads there until a later release implements it.
+- On Jakarta EE 10 the shipped virtual executor is not available; `useVirtualThreads(true)` still switches the backpressure model, but jobs run on virtual threads only if you point the JNDI name at an executor the container itself configures as virtual.
+- Your jobs must not hold long `synchronized` blocks or call native methods that pin the carrier thread — prefer `ReentrantLock`.
 
 **When to use virtual threads:** They are most beneficial when your jobs spend the majority of their time waiting on I/O (database queries, HTTP calls, file operations). For CPU-bound workloads, platform threads with appropriate pool sizes are usually sufficient.
 


### PR DESCRIPTION
## What

Adds a `wildfly-ee11-managed` test profile (WildFly 40, JDK 25, Jakarta EE 11) and wires Ratchet to run jobs on a virtual-thread managed executor, with an integration test that proves virtual-thread execution on Eclipse GlassFish 8.

## Why

WildFly 40 ships the Jakarta EE 11 APIs and Jakarta Concurrency 3.1, which adds `virtual = true` to `@ManagedExecutorDefinition`. Ratchet already runs jobs on the container's `ManagedExecutorService`, but the executor name was hard-coded and `use-virtual-threads` only changed backpressure accounting, not where jobs actually ran.

## Changes

**Production (`ratchet`, `ratchet-api`)**
- `DefaultExecutorProvider` reads the job and scheduled executor JNDI names from config (`ratchet.worker.job-executor-jndi`, `ratchet.worker.scheduled-executor-jndi`; defaults are the existing `java:comp/Default*` names). Point the job executor at a virtual-thread `ManagedExecutorService` and jobs run on virtual threads, with the existing per-type backpressure.
- Resolution is lazy on first use rather than eager at `@PostConstruct`. Some containers (GlassFish) bind deployment-defined executors after CDI startup, where an eager lookup aborts the deploy. A genuinely missing name still fails when the first job runs.
- Ships `RatchetVirtualExecutor`, a `@ManagedExecutorDefinition(virtual = true)`, compiled and packaged only under the EE 11 build (`src/main/java-ee11`). The default EE 10 artifact does not contain it.

**Test profile + CI**
- `wildfly-ee11-managed` is defined in the parent, `ratchet`, and `ratchet-testsuite` poms (same-id fan-out), with a JDK 25 enforcer, an Arquillian container on distinct ports, datasource wiring, and a CI matrix entry. GlassFish 8 (already the EE 11 RI) gains the EE 11 source roots so it runs the new test too.
- `VirtualThreadExecutionIT` lives in an EE 11-only test source root, so the EE 10 profiles never compile it. It is not "skipped" on those runs; it is simply not part of them.

## Virtual threads: what works where

Running the same WAR on both EE 11 servers gives a clean controlled result:

- **GlassFish 8** (EE 11 reference implementation): jobs run on virtual threads, and the test asserts `Thread.isVirtual()` is true.
- **WildFly 40.0.0.Final**: binds and uses the virtual executor definition but its concurrency implementation still hands out platform threads (`isVirtual()` is false). Confirmed by running the identical deployment on both, and by inspecting `wildfly-concurrency-impl`, which contains no virtual-thread wiring. The test asserts executor wiring and concurrency on WildFly and the virtual-thread guarantee on GlassFish; when WildFly implements it, the WildFly guard can be dropped.

## Testing

- `VirtualThreadExecutionIT` passes on `wildfly-ee11-managed` and `glassfish-managed` (PostgreSQL), with no skipped tests.
- Default EE 10 build (unit tests + spotless) is green, and `jakarta-ee11-verify` compiles the EE 11 executor.
