### PR TITLE
Make recurring-claim concurrency test deterministic

### DIFF
--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRecurringJobStoreContractTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRecurringJobStoreContractTest.java
@@ -57,8 +57,8 @@ class MongoRecurringJobStoreContractTest extends AbstractRecurringJobStoreContra
    * claim_expires_at} lease, so two workers calling {@code claimDueRecurring} in parallel observe
    * each due master exactly once regardless of thread interleaving. This is the stateful-claim
    * flavor of the contract; the SQL flavor (which requires explicit transaction overlap to
-   * demonstrate {@code FOR UPDATE SKIP LOCKED}) lives in
-   * {@code AbstractJpaRecurringClaimConcurrencyContract}.
+   * demonstrate {@code FOR UPDATE SKIP LOCKED}) lives in {@code
+   * AbstractJpaRecurringClaimConcurrencyContract}.
    */
   @Test
   void claimDueRecurring_parallelClaimersDoNotDoubleObserve() throws Exception {
@@ -89,8 +89,7 @@ class MongoRecurringJobStoreContractTest extends AbstractRecurringJobStoreContra
       Set<UUID> overlap = new HashSet<>(idsA);
       overlap.retainAll(idsB);
       assertTrue(
-          overlap.isEmpty(),
-          () -> "two claimers must not share any master id; overlap=" + overlap);
+          overlap.isEmpty(), () -> "two claimers must not share any master id; overlap=" + overlap);
       assertEquals(
           masterCount,
           idsA.size() + idsB.size(),

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRecurringJobStoreContractTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRecurringJobStoreContractTest.java
@@ -1,8 +1,24 @@
 package run.ratchet.store.mongodb;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.BackoffPolicy;
 import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.id.UuidV7Factory;
+import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.TagStore;
 import run.ratchet.tck.store.AbstractRecurringJobStoreContract;
@@ -34,5 +50,78 @@ class MongoRecurringJobStoreContractTest extends AbstractRecurringJobStoreContra
   @Override
   protected void cleanupRecurringStore() {
     fixture.cleanupStore();
+  }
+
+  /**
+   * Mongo-only TCK: per-row {@code findOneAndUpdate} stamps a {@code claim_token} + {@code
+   * claim_expires_at} lease, so two workers calling {@code claimDueRecurring} in parallel observe
+   * each due master exactly once regardless of thread interleaving. This is the stateful-claim
+   * flavor of the contract; the SQL flavor (which requires explicit transaction overlap to
+   * demonstrate {@code FOR UPDATE SKIP LOCKED}) lives in
+   * {@code AbstractJpaRecurringClaimConcurrencyContract}.
+   */
+  @Test
+  void claimDueRecurring_parallelClaimersDoNotDoubleObserve() throws Exception {
+    int masterCount = 8;
+    Instant pastDue = Instant.now().minusSeconds(60);
+    for (int i = 0; i < masterCount; i++) {
+      recurringStore().createRecurring(definition(UuidV7Factory.create(), "0 * * * * ?", pastDue));
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      CompletableFuture<List<RecurringJobDefinition>> batchA =
+          CompletableFuture.supplyAsync(
+              () -> recurringStore().claimDueRecurring(masterCount, "node-a"), executor);
+      CompletableFuture<List<RecurringJobDefinition>> batchB =
+          CompletableFuture.supplyAsync(
+              () -> recurringStore().claimDueRecurring(masterCount, "node-b"), executor);
+
+      List<UUID> idsA;
+      List<UUID> idsB;
+      try {
+        idsA = batchA.get().stream().map(RecurringJobDefinition::id).toList();
+        idsB = batchB.get().stream().map(RecurringJobDefinition::id).toList();
+      } catch (ExecutionException e) {
+        throw new IllegalStateException("claim threw asynchronously", e.getCause());
+      }
+
+      Set<UUID> overlap = new HashSet<>(idsA);
+      overlap.retainAll(idsB);
+      assertTrue(
+          overlap.isEmpty(),
+          () -> "two claimers must not share any master id; overlap=" + overlap);
+      assertEquals(
+          masterCount,
+          idsA.size() + idsB.size(),
+          "every master should appear in exactly one of the two batches");
+    } finally {
+      executor.shutdown();
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private RecurringJobDefinition definition(UUID id, String cron, Instant nextFire) {
+    return new RecurringJobDefinition(
+        id,
+        cron,
+        "UTC",
+        nextFire,
+        false,
+        null,
+        2,
+        0,
+        BackoffPolicy.NONE,
+        0,
+        0,
+        noopPayload(),
+        null,
+        null,
+        null,
+        null,
+        Instant.now(),
+        null);
   }
 }

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlRecurringClaimConcurrencyContractTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlRecurringClaimConcurrencyContractTest.java
@@ -1,0 +1,33 @@
+package run.ratchet.store.mysql;
+
+import java.util.List;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.tck.store.AbstractJpaRecurringClaimConcurrencyContract;
+import run.ratchet.tck.store.JpaContainerFixture;
+
+class MysqlRecurringClaimConcurrencyContractTest
+    extends AbstractJpaRecurringClaimConcurrencyContract {
+
+  private final MysqlTestFixture fixture = new MysqlTestFixture();
+
+  @Override
+  protected JpaContainerFixture fixture() {
+    return fixture;
+  }
+
+  @Override
+  protected RecurringJobStore recurringStore() {
+    return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobPayload noopPayload() {
+    return new JobPayload("run.ratchet.tck.store.NoopTask", "run", "()V", true, List.of());
+  }
+
+  @Override
+  protected void cleanupRecurringStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlRecurringClaimConcurrencyContractTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlRecurringClaimConcurrencyContractTest.java
@@ -1,0 +1,33 @@
+package run.ratchet.store.postgresql;
+
+import java.util.List;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.tck.store.AbstractJpaRecurringClaimConcurrencyContract;
+import run.ratchet.tck.store.JpaContainerFixture;
+
+class PostgresqlRecurringClaimConcurrencyContractTest
+    extends AbstractJpaRecurringClaimConcurrencyContract {
+
+  private final PostgresqlTestFixture fixture = new PostgresqlTestFixture();
+
+  @Override
+  protected JpaContainerFixture fixture() {
+    return fixture;
+  }
+
+  @Override
+  protected RecurringJobStore recurringStore() {
+    return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobPayload noopPayload() {
+    return new JobPayload("run.ratchet.tck.store.NoopTask", "run", "()V", true, List.of());
+  }
+
+  @Override
+  protected void cleanupRecurringStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJpaRecurringClaimConcurrencyContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJpaRecurringClaimConcurrencyContract.java
@@ -1,0 +1,166 @@
+package run.ratchet.tck.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.id.UuidV7Factory;
+import run.ratchet.store.spi.RecurringJobDefinition;
+import run.ratchet.store.spi.RecurringJobStore;
+
+/**
+ * SQL-only concurrency contract for {@link RecurringJobStore#claimDueRecurring}.
+ *
+ * <p>The SQL claim path is a pure {@code SELECT ... FOR UPDATE SKIP LOCKED}: it returns rows but
+ * does not modify state. Mutex only holds for the lifetime of the transaction's row locks. The
+ * common {@link AbstractRecurringJobStoreContract} cannot exercise this guarantee on a JPA store —
+ * its proxy commits each store call, so a serial pair of calls would re-observe the same rows.
+ *
+ * <p>This contract uses {@link JpaContainerFixture#runInTransaction} to keep two transactions open
+ * simultaneously: each worker thread opens a tx, runs the claim SELECT (acquiring row locks), waits
+ * at a barrier, then commits. With both locks held in parallel, {@code SKIP LOCKED} forces each row
+ * into exactly one claimant.
+ *
+ * <p>Note: if a store impl ever drops {@code SKIP LOCKED} from its claim SQL, the second worker's
+ * SELECT will block on the first worker's row locks, the {@code bothInTx} latch will never reach
+ * zero, and this test will fail on latch timeout rather than on the overlap assertion. The failure
+ * is still a failure — just diagnosed via timeout rather than via the assertion message.
+ */
+public abstract class AbstractJpaRecurringClaimConcurrencyContract {
+
+  private static final long LATCH_TIMEOUT_SECONDS = 15;
+
+  /** Returns the JPA fixture so the test can open its own transactions across a barrier. */
+  protected abstract JpaContainerFixture fixture();
+
+  /** Returns the {@link RecurringJobStore} under test (typically {@code fixture().store()}). */
+  protected abstract RecurringJobStore recurringStore();
+
+  /** Builds a no-op {@link JobPayload} so the contract is store-impl agnostic. */
+  protected abstract JobPayload noopPayload();
+
+  /** Removes all rows from the recurring tables. */
+  protected abstract void cleanupRecurringStore();
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    cleanupRecurringStore();
+  }
+
+  /**
+   * Two workers calling {@code claimDueRecurring} with their transactions held open across a
+   * barrier must observe each due master exactly once. The barrier guarantees both lock-hold
+   * windows overlap — without that, a serial BEGIN+SELECT+COMMIT pair on either thread would
+   * re-observe every row.
+   */
+  @Test
+  void forUpdateSkipLocked_isolatesConcurrentClaimers() throws Exception {
+    int masterCount = 8;
+    Instant pastDue = Instant.now().minusSeconds(60);
+    for (int i = 0; i < masterCount; i++) {
+      recurringStore().createRecurring(definition(UuidV7Factory.create(), "0 * * * * ?", pastDue));
+    }
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CountDownLatch bothInTx = new CountDownLatch(2);
+    CountDownLatch okToCommit = new CountDownLatch(1);
+    try {
+      Future<List<UUID>> futureA =
+          executor.submit(() -> claimInsideTx("node-a", masterCount, bothInTx, okToCommit));
+      Future<List<UUID>> futureB =
+          executor.submit(() -> claimInsideTx("node-b", masterCount, bothInTx, okToCommit));
+
+      assertTrue(
+          bothInTx.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+          "both workers should be inside their tx with row locks held; if this times out, the"
+              + " store impl probably lost FOR UPDATE SKIP LOCKED and one worker is blocked on"
+              + " the other's row locks");
+      okToCommit.countDown();
+
+      List<UUID> idsA = futureA.get(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      List<UUID> idsB = futureB.get(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      Set<UUID> overlap = new HashSet<>(idsA);
+      overlap.retainAll(idsB);
+      assertTrue(
+          overlap.isEmpty(), () -> "two claimers must not share any master id; overlap=" + overlap);
+      assertEquals(
+          masterCount,
+          idsA.size() + idsB.size(),
+          "every master should appear in exactly one of the two batches");
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("worker threw asynchronously", e.getCause());
+    } catch (TimeoutException e) {
+      throw new IllegalStateException("worker did not finish before the test timeout", e);
+    } finally {
+      executor.shutdown();
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  private List<UUID> claimInsideTx(
+      String nodeId, int limit, CountDownLatch bothInTx, CountDownLatch okToCommit) {
+    List<UUID> ids = new ArrayList<>();
+    fixture()
+        .runInTransaction(
+            () -> {
+              List<RecurringJobDefinition> claimed =
+                  recurringStore().claimDueRecurring(limit, nodeId);
+              for (RecurringJobDefinition def : claimed) {
+                ids.add(def.id());
+              }
+              bothInTx.countDown();
+              try {
+                if (!okToCommit.await(LATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                  throw new IllegalStateException("okToCommit latch timed out inside worker tx");
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("worker interrupted while holding tx", e);
+              }
+            });
+    return ids;
+  }
+
+  private RecurringJobDefinition definition(UUID id, String cron, Instant nextFire) {
+    return new RecurringJobDefinition(
+        id,
+        cron,
+        "UTC",
+        nextFire,
+        false,
+        null,
+        2,
+        0,
+        BackoffPolicy.NONE,
+        0,
+        0,
+        noopPayload(),
+        null,
+        null,
+        null,
+        null,
+        Instant.now(),
+        null);
+  }
+}

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractRecurringJobStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractRecurringJobStoreContract.java
@@ -10,11 +10,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,53 +82,15 @@ public abstract class AbstractRecurringJobStoreContract {
     assertTrue(secondBatch.isEmpty(), "post-advance, the master must not re-claim");
   }
 
-  /**
-   * TCK 1b — real-thread concurrency: two workers calling {@code claimDueRecurring} in parallel
-   * before either calls {@code advanceNextFire} must observe each master at most once across the
-   * union of their batches. SQL stores rely on {@code FOR UPDATE SKIP LOCKED}; Mongo relies on
-   * per-row {@code findOneAndUpdate} bumping next_fire into a lease window.
-   */
-  @Test
-  void claimDueRecurring_parallelClaimersDoNotDoubleObserve() throws Exception {
-    int masterCount = 8;
-    Instant pastDue = Instant.now().minusSeconds(60);
-    for (int i = 0; i < masterCount; i++) {
-      recurringStore().createRecurring(definition(UuidV7Factory.create(), "0 * * * * ?", pastDue));
-    }
-
-    ExecutorService executor = Executors.newFixedThreadPool(2);
-    try {
-      CompletableFuture<List<RecurringJobDefinition>> batchA =
-          CompletableFuture.supplyAsync(
-              () -> recurringStore().claimDueRecurring(masterCount, "node-a"), executor);
-      CompletableFuture<List<RecurringJobDefinition>> batchB =
-          CompletableFuture.supplyAsync(
-              () -> recurringStore().claimDueRecurring(masterCount, "node-b"), executor);
-
-      List<UUID> idsA;
-      List<UUID> idsB;
-      try {
-        idsA = batchA.get().stream().map(RecurringJobDefinition::id).toList();
-        idsB = batchB.get().stream().map(RecurringJobDefinition::id).toList();
-      } catch (ExecutionException e) {
-        throw new IllegalStateException("claim threw asynchronously", e.getCause());
-      }
-
-      java.util.Set<UUID> overlap = new java.util.HashSet<>(idsA);
-      overlap.retainAll(idsB);
-      assertTrue(
-          overlap.isEmpty(), () -> "two claimers must not share any master id; overlap=" + overlap);
-      assertEquals(
-          masterCount,
-          idsA.size() + idsB.size(),
-          "every master should appear in exactly one of the two batches");
-    } finally {
-      executor.shutdown();
-      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
-        executor.shutdownNow();
-      }
-    }
-  }
+  // TCK 1b — real-thread concurrent-claim safety used to live here. It was deleted because the
+  // store impls' two strategies are too different to share one test: Mongo's claim path stamps
+  // a per-row claim_token + claim_expires_at lease (stateful, safe under serial OR parallel
+  // calls), while the SQL stores rely on FOR UPDATE SKIP LOCKED which only enforces mutex while
+  // the two transactions' lock-hold windows overlap. A common test with no synchronization
+  // could not prove either guarantee deterministically. The Mongo flavor lives at
+  // MongoRecurringJobStoreContractTest#claimDueRecurring_parallelClaimersDoNotDoubleObserve;
+  // the SQL flavor lives at AbstractJpaRecurringClaimConcurrencyContract, which uses
+  // JpaContainerFixture.runInTransaction + latches to force the lock-hold windows to overlap.
 
   /**
    * TCK 1c — releaseClaim returns the row to the eligible pool without changing next_fire. SQL

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
@@ -171,8 +171,13 @@ public abstract class JpaContainerFixture implements JobStoreContractFixture {
   /** Instantiate the concrete store with a plain EM and a no-op metrics collector. */
   protected abstract JobStore createStore(EntityManager em, MetricsCollector metrics);
 
-  /** Run a unit of work inside a JPA transaction on the calling thread's EM. */
-  protected final void runInTransaction(Runnable work) {
+  /**
+   * Run a unit of work inside a JPA transaction on the calling thread's EM. Public so that
+   * concurrency contracts living in concrete store-test modules (different package than this
+   * fixture) can hold a transaction open across a barrier — see {@link
+   * AbstractJpaRecurringClaimConcurrencyContract}.
+   */
+  public final void runInTransaction(Runnable work) {
     EntityManager em = threadEm.get();
     EntityTransaction tx = em.getTransaction();
     boolean owner = !tx.isActive();


### PR DESCRIPTION
## Summary

The TCK test `claimDueRecurring_parallelClaimersDoNotDoubleObserve` was flaking intermittently on the MySQL build. It fired two parallel `claimDueRecurring` calls and asserted disjoint batches without any synchronization between the threads. SQL stores back the claim with `SELECT ... FOR UPDATE SKIP LOCKED`, which enforces mutex only while two transactions' lock-hold windows overlap. The test fixture commits each store call automatically, so it was easy for the first transaction's BEGIN+SELECT+COMMIT to finish before the second began. When that happened, both claimers saw the full set of 8 due masters and the overlap assertion failed. Mongo's per-row `findOneAndUpdate` lease is stateful, so Mongo never flaked.

The fix splits the contract along the two strategies:

- The Mongo version moves to `MongoRecurringJobStoreContractTest` unchanged. Mongo's stateful claim handles serial and parallel calls the same way.
- The SQL version moves to a new `AbstractJpaRecurringClaimConcurrencyContract`. It uses `JpaContainerFixture.runInTransaction` and a pair of latches to hold two transactions open at the same time, then commits both. That forces the lock-hold windows to overlap so `SKIP LOCKED` has something to enforce against.
- MySQL and PostgreSQL each wire the new contract in through a sibling test class.
- `JpaContainerFixture.runInTransaction` is now public so tests in the concrete store modules can drive their own transaction boundaries.

## Testing

- [x] `mvn -pl ratchet-store-mysql -am test` (340 tests pass on MySQL)
- [x] `mvn -pl ratchet-store-mysql -am test -Dtest=MysqlRecurringClaimConcurrencyContractTest` ran 10 times in a row, all green
- [x] `mvn -pl ratchet-store-postgresql -am test -Dtest='*Recurring*'` (15 tests pass)
- [x] `mvn -pl ratchet-store-mongodb -am test -Dtest=MongoRecurringJobStoreContractTest` (15 tests pass)
- [x] `mvn spotless:check` clean

## Docs

- [x] No docs update needed

## Review Notes

- [x] Public API or SPI change. `JpaContainerFixture.runInTransaction` widened from `protected` to `public`. It is a test-only TCK helper, so no production impact.

## Additional Context

Reviewed the design with Codex peer reviewer before implementing. Codex flagged that a future store dropping `SKIP LOCKED` would surface as a latch timeout rather than the overlap assertion. That limitation is documented in the abstract contract's javadoc.