### PR TITLE
README modules table + logging example fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,7 +320,13 @@ flowchart TD
 | `ratchet-store-mysql` | MySQL store implementation with optimized DDL | ratchet-store-core |
 | `ratchet-store-postgresql` | PostgreSQL store with partial indexes and JSONB | ratchet-store-core |
 | `ratchet-store-mongodb` | MongoDB document store implementation | ratchet-store-core |
+| `ratchet-coordinator-common` | Shared abstractions for pluggable `ClusterCoordinator` implementations | ratchet-api |
+| `ratchet-coordinator-postgresql` | PostgreSQL `LISTEN`/`NOTIFY`-backed cross-node wakeups for low-latency CRITICAL/immediate jobs | ratchet-coordinator-common, PostgreSQL JDBC driver |
+| `ratchet-coordinator-jms` | JMS-topic-backed cross-node wakeups for deployments that already run a JMS broker | ratchet-coordinator-common, Jakarta Messaging API (provided) |
+| `ratchet-coordinator-infinispan` | Infinispan-clustered-cache wakeup notifications for WildFly / Quarkus deployments | ratchet-coordinator-common, Infinispan API (provided) |
+| `ratchet-coordinator-hazelcast` | Hazelcast topic-backed wakeup notifications for Hazelcast clusters | ratchet-coordinator-common, Hazelcast client (provided) |
 | `ratchet-micrometer` | Micrometer metrics adapter | ratchet-api, Micrometer |
+| `ratchet-otel` | OpenTelemetry-based `TracingCollector` implementation (incubating; not yet in the BOM) | ratchet-api, OpenTelemetry API |
 | `ratchet-tck` | Aggregator (pom-packaging) for the four TCK submodules below | — |
 | `ratchet-tck-util` | JUnit-only helpers shared across TCK modules | JUnit 5 |
 | `ratchet-tck-store` | Store SPI conformance — CRUD, claiming, status transitions, archiving, batches, locks | ratchet-store-core, ratchet-tck-util, JUnit 5 |
@@ -347,7 +353,7 @@ Ratchet is designed to be extended. Provide a CDI `@Alternative @Priority(APPLIC
 | `JobLoggerFactory` | Per-job job-scoped logging | JBoss Logging-backed logger |
 | `CircuitBreakerConfigProvider` | Built-in breaker enablement and thresholds | Config-backed profile settings |
 | `SchedulerLifecycleHook` | Scheduler startup/shutdown hooks | No hooks |
-| `ClusterCoordinator` | Distributed wakeup notifications | `NoOpClusterCoordinator` |
+| `ClusterCoordinator` | Distributed wakeup notifications | `NoOpClusterCoordinator`; pluggable PostgreSQL / JMS / Infinispan / Hazelcast implementations ship in the BOM under `ratchet-coordinator-*` |
 | `StartupCoordinator` | Destructive startup work gated by store-backed leases | `StoreBackedStartupCoordinator` |
 | `MetricsCollector` | Metrics sink (counters, gauges, timers) | No-op |
 | `BeanResolver` | Bean instantiation strategy | CDI `Instance<T>` |

--- a/examples/logging/README.md
+++ b/examples/logging/README.md
@@ -75,7 +75,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-public class OrderJob implements SerializableRunnable {
+public class OrderJob implements SerializableCheckedRunnable {
 
   private static final Logger log = LoggerFactory.getLogger(OrderJob.class);
 
@@ -98,6 +98,23 @@ public class OrderJob implements SerializableRunnable {
     }
   }
 }
+```
+
+### Enqueuing the job
+
+Inject `JobSchedulerService` and submit the job through the fluent builder:
+
+```java
+@Inject JobSchedulerService scheduler;
+
+scheduler.enqueue(new OrderJob(12345, "req-7c3f")).submit();
+```
+
+The lambda form is equivalent when the work is a single method call on a CDI
+bean:
+
+```java
+scheduler.enqueue(() -> orderProcessor.process(12345, "req-7c3f")).submit();
 ```
 
 When this job runs, every log line emitted via `log.info(...)`


### PR DESCRIPTION
## Summary

Two small docs fixes. README was missing the cluster coordinator and otel
rows. The logging example referenced a functional interface that doesn't
exist on the public surface.

## Changes

- README: add ratchet-coordinator-common, -postgresql, -jms, -infinispan, -hazelcast, and ratchet-otel to the Module Overview table
- README: clarify in the SPI Extension Points that the four pluggable ClusterCoordinator impls ship in the BOM
- examples/logging: rename SerializableRunnable to SerializableCheckedRunnable (the actual public interface) and add an "Enqueuing the job" section with both class and lambda forms

## Test plan

- [ ] Markdown renders correctly on GitHub
- [ ] Example snippets match the actual public API signatures