### PR TITLE
Coordinator: hide common helpers in internal sub-package, tighten listen/notify test surface

### DIFF
--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/NotifyPayload.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/NotifyPayload.java
@@ -3,6 +3,7 @@ package run.ratchet.coordinator.common;
 import java.util.Objects;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 /** Versioned wakeup envelope shared by every coordinator transport. */
 public record NotifyPayload(int version, NodeIdentity node, JobPriority priority) {

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/internal/JsonProviders.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/internal/JsonProviders.java
@@ -1,9 +1,14 @@
-package run.ratchet.coordinator.common;
+package run.ratchet.coordinator.common.internal;
 
 import jakarta.json.JsonException;
 import jakarta.json.spi.JsonProvider;
 
-/** JSON-P provider probe shared by coordinator transports. */
+/**
+ * JSON-P provider probe shared by coordinator transports.
+ *
+ * @apiNote Framework-internal. This class is consumed only by Ratchet's bundled coordinator
+ *     transports; it is not part of the public coordinator SPI and may change without notice.
+ */
 public final class JsonProviders {
 
   private JsonProviders() {}

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/internal/NotifyPayloadCodec.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/internal/NotifyPayloadCodec.java
@@ -1,4 +1,4 @@
-package run.ratchet.coordinator.common;
+package run.ratchet.coordinator.common.internal;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -13,6 +13,8 @@ import java.io.StringWriter;
 import java.util.Objects;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.DecodeException;
+import run.ratchet.coordinator.common.NotifyPayload;
 
 /**
  * JSON-P encoder/decoder for the wakeup envelope shared by every Ratchet cluster coordinator.
@@ -25,6 +27,10 @@ import run.ratchet.api.NodeIdentity;
  *
  * <p>Unknown fields are ignored for forward compatibility. Removing or repurposing fields bumps
  * {@code v}; unsupported versions fail decode.
+ *
+ * @apiNote Framework-internal. This codec defines the wire format used by Ratchet's bundled
+ *     coordinator transports; it is not part of the public coordinator SPI and the envelope schema
+ *     (including {@link #CURRENT_VERSION}) may change without notice.
  */
 public final class NotifyPayloadCodec {
 

--- a/ratchet-coordinator-common/src/test/java/run/ratchet/coordinator/common/NotifyPayloadCodecTest.java
+++ b/ratchet-coordinator-common/src/test/java/run/ratchet/coordinator/common/NotifyPayloadCodecTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 class NotifyPayloadCodecTest {
 

--- a/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
+++ b/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
@@ -1,6 +1,6 @@
 package run.ratchet.coordinator.hazelcast;
 
-import static run.ratchet.coordinator.common.JsonProviders.requireJsonProvider;
+import static run.ratchet.coordinator.common.internal.JsonProviders.requireJsonProvider;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.topic.ITopic;
@@ -31,7 +31,7 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
@@ -84,8 +84,8 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
   private ExecutorService listenerExecutor;
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
-  protected HazelcastClusterCoordinator() {
-    // CDI proxy constructor.
+  HazelcastClusterCoordinator() {
+    // CDI proxy constructor — package-private to keep it out of the public API surface.
   }
 
   /** Test/non-CDI constructor with a directly-supplied {@link HazelcastInstance}. */

--- a/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastInstanceProvider.java
+++ b/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastInstanceProvider.java
@@ -3,10 +3,17 @@ package run.ratchet.coordinator.hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 
 /**
- * Module-internal SPI for resolving the {@link HazelcastInstance} the coordinator publishes /
- * subscribes on. Payara deployments use the JNDI-driven default {@code payara/Hazelcast};
- * standalone deployments supply a higher-priority {@code @Alternative} bean that wraps a
- * programmatically-constructed instance.
+ * SPI for resolving the {@link HazelcastInstance} the coordinator publishes / subscribes on. Payara
+ * deployments use the JNDI-driven default {@code payara/Hazelcast}; standalone deployments supply a
+ * higher-priority {@code @Alternative} bean that wraps a programmatically-constructed instance.
+ *
+ * @apiNote Implementations MUST be CDI beans (typically {@code @ApplicationScoped} or
+ *     {@code @Dependent}). The coordinator resolves the active provider via {@code Instance<T>} and
+ *     selects the highest-{@code @Priority} {@code @Alternative}. The coordinator does NOT own the
+ *     returned {@link HazelcastInstance}: the provider is responsible for the instance's lifecycle,
+ *     and the coordinator MUST NOT call {@code shutdown()} on it. The {@link #hazelcastInstance()}
+ *     method MUST return a non-null instance; returning {@code null} fails the coordinator's
+ *     lifecycle hook.
  */
 public interface HazelcastInstanceProvider {
 

--- a/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinatorTest.java
+++ b/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinatorTest.java
@@ -30,7 +30,7 @@ import run.ratchet.api.JobType;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanCacheLifecycle.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanCacheLifecycle.java
@@ -10,7 +10,7 @@ import java.util.function.Consumer;
 import org.infinispan.Cache;
 import org.jboss.logging.Logger;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 /**
  * Owns the cache reference and the {@link InfinispanWakeupListener} registration for one

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanCacheManagerProvider.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanCacheManagerProvider.java
@@ -3,12 +3,21 @@ package run.ratchet.coordinator.infinispan;
 import org.infinispan.manager.EmbeddedCacheManager;
 
 /**
- * Module-internal SPI for resolving the {@link EmbeddedCacheManager} the coordinator publishes /
- * subscribes against.
+ * SPI for resolving the {@link EmbeddedCacheManager} the coordinator publishes / subscribes
+ * against.
  *
  * <p>WildFly deployments use the default JNDI-driven provider; standalone deployments (Spring,
  * Micronaut, embedded test setups) supply a higher-priority {@code @Alternative} bean that
  * constructs the cache manager programmatically.
+ *
+ * @apiNote Implementations MUST be CDI beans (typically {@code @ApplicationScoped} or
+ *     {@code @Dependent}). Custom providers are selected by annotating the implementation with
+ *     {@code @Alternative} and a {@code @Priority} higher than the bundled default; the
+ *     coordinator's resolver picks the single highest-{@code @Priority} active alternative and
+ *     fails fast if more than one is enabled with the same priority. There must be exactly one
+ *     active provider at runtime — the single-active-provider invariant is enforced by {@code
+ *     resolveProvider()} inside the coordinator. The coordinator does NOT own the returned {@link
+ *     EmbeddedCacheManager}; lifecycle (start / stop) is the provider's responsibility.
  */
 public interface InfinispanCacheManagerProvider {
 

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
@@ -1,6 +1,6 @@
 package run.ratchet.coordinator.infinispan;
 
-import static run.ratchet.coordinator.common.JsonProviders.requireJsonProvider;
+import static run.ratchet.coordinator.common.internal.JsonProviders.requireJsonProvider;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
@@ -27,7 +27,7 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanWakeupListener.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanWakeupListener.java
@@ -8,7 +8,7 @@ import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.jboss.logging.Logger;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 /**
  * Clustered Infinispan listener that decodes each created entry's value and forwards to the
@@ -24,8 +24,13 @@ import run.ratchet.coordinator.common.NotifyPayloadCodec;
  *       dispatch thread, which can terminate the listener registration silently on Infinispan 14+.
  * </ul>
  */
+// Package-private: Infinispan's @Listener annotation processor operates on the registered instance
+// via reflection (addListenerAsync), NOT on the class's public modifier, so package-private is
+// safe on Infinispan 14+. The class is an internal dispatch helper, not an extension point. The
+// onEntryCreated method MUST remain public — Infinispan's annotation scan still requires public
+// event-handler methods.
 @Listener(clustered = true, includeCurrentState = false)
-public final class InfinispanWakeupListener {
+final class InfinispanWakeupListener {
 
   private static final Logger log = Logger.getLogger(InfinispanWakeupListener.class);
 

--- a/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanCacheLifecycleTest.java
+++ b/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanCacheLifecycleTest.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 import org.infinispan.Cache;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 class InfinispanCacheLifecycleTest {
 

--- a/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinatorTest.java
+++ b/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinatorTest.java
@@ -30,7 +30,7 @@ import run.ratchet.api.JobType;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 

--- a/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanWakeupListenerTest.java
+++ b/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanWakeupListenerTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 class InfinispanWakeupListenerTest {
 

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
@@ -1,6 +1,6 @@
 package run.ratchet.coordinator.jms;
 
-import static run.ratchet.coordinator.common.JsonProviders.requireJsonProvider;
+import static run.ratchet.coordinator.common.internal.JsonProviders.requireJsonProvider;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
@@ -32,7 +32,7 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.coordinator.common.DecodeException;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsConnectionFactoryProvider.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsConnectionFactoryProvider.java
@@ -4,23 +4,41 @@ import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Topic;
 
 /**
- * Module-internal SPI for resolving the JMS {@link ConnectionFactory} and {@link Topic} the
+ * Integration-extension SPI for resolving the JMS {@link ConnectionFactory} and {@link Topic} the
  * coordinator publishes / subscribes on.
  *
  * <p>This SPI is JMS-specific and intentionally NOT in {@code ratchet-api} — only the JMS
- * coordinator module knows what a {@code ConnectionFactory} is.
+ * coordinator module knows what a {@code ConnectionFactory} is. It is a public extension point so
+ * external deployments (Spring, Micronaut, embedded test brokers) can supply a programmatic
+ * {@code @Alternative} implementation.
  *
  * <p>The default implementation ({@code JndiJmsConnectionFactoryProvider}) reads the JNDI names
  * from {@link JmsCoordinatorConfig} and looks them up via the platform's default {@code
  * InitialContext}. Standalone deployments (Spring, Micronaut, embedded broker for tests) override
  * by supplying a higher-priority {@code @Alternative} bean that constructs the {@link
  * ConnectionFactory} and {@link Topic} programmatically.
+ *
+ * @apiNote Implementations MUST be thread-safe: the coordinator may call {@link
+ *     #connectionFactory()} and {@link #topic()} concurrently from publish and subscribe paths, and
+ *     repeated calls during the bean's lifetime MUST return references the JMS provider considers
+ *     equivalent (typically the same instance). Implementations SHOULD treat both methods as
+ *     idempotent — the coordinator caches the resolved references for the lifetime of the
+ *     coordinator bean and never closes them; lifecycle ownership of the {@link ConnectionFactory}
+ *     and {@link Topic} rests with the provider (or its container).
  */
 public interface JmsConnectionFactoryProvider {
 
-  /** The connection factory the coordinator will use to create its {@code JMSContext}. */
+  /**
+   * The connection factory the coordinator will use to create its {@code JMSContext}.
+   *
+   * @return non-null {@link ConnectionFactory}; never returns {@code null}
+   */
   ConnectionFactory connectionFactory();
 
-  /** The topic the coordinator publishes wakeup envelopes to and subscribes for inbound ones. */
+  /**
+   * The topic the coordinator publishes wakeup envelopes to and subscribes for inbound ones.
+   *
+   * @return non-null {@link Topic} reference; never returns {@code null}
+   */
   Topic topic();
 }

--- a/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsClusterCoordinatorTest.java
+++ b/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsClusterCoordinatorTest.java
@@ -29,7 +29,7 @@ import run.ratchet.api.JobType;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 

--- a/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
+++ b/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
@@ -1,6 +1,6 @@
 package run.ratchet.coordinator.postgresql;
 
-import static run.ratchet.coordinator.common.JsonProviders.requireJsonProvider;
+import static run.ratchet.coordinator.common.internal.JsonProviders.requireJsonProvider;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.Priority;
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import javax.sql.DataSource;
@@ -28,7 +29,7 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
@@ -67,7 +68,7 @@ public class PostgresqlListenNotifyCoordinator
   /** Bounded buffer holding inbound messages that arrive before any listener registers. */
   private static final int PRE_REGISTRATION_BUFFER_CAPACITY = 256;
 
-  static final String COORDINATOR_KIND = "postgresql";
+  private static final String COORDINATOR_KIND = "postgresql";
 
   @Inject NodeIdentityProvider identityProvider;
   @Inject PostgresqlCoordinatorConfig config;
@@ -84,8 +85,10 @@ public class PostgresqlListenNotifyCoordinator
   private PostgresqlConnectionLifecycle.ConnectionAcquirer publishConnectionAcquirer;
   private PostgresqlListenThread listenThread;
   private ExecutorService listenerExecutor;
-  private volatile boolean closed;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
+  /** CDI proxy constructor — not for direct use. */
+  @SuppressWarnings("unused")
   protected PostgresqlListenNotifyCoordinator() {
     // CDI proxy constructor.
   }
@@ -147,7 +150,7 @@ public class PostgresqlListenNotifyCoordinator
   /** {@inheritDoc} */
   @Override
   public void afterStart() {
-    if (closed) {
+    if (closed.get()) {
       return;
     }
     if (listenThread == null) {
@@ -162,7 +165,7 @@ public class PostgresqlListenNotifyCoordinator
   public void notifyNewWork(JobPriority priority, NodeIdentity source) {
     Objects.requireNonNull(priority, "priority");
     Objects.requireNonNull(source, "source");
-    if (closed) {
+    if (closed.get()) {
       return;
     }
     try {
@@ -194,7 +197,7 @@ public class PostgresqlListenNotifyCoordinator
   @Override
   public void registerWakeupListener(BiConsumer<JobPriority, NodeIdentity> listener) {
     Objects.requireNonNull(listener, "listener");
-    if (closed) {
+    if (closed.get()) {
       return;
     }
     listeners.add(listener);
@@ -212,10 +215,9 @@ public class PostgresqlListenNotifyCoordinator
 
   @Override
   public void close() {
-    if (closed) {
+    if (!closed.compareAndSet(false, true)) {
       return;
     }
-    closed = true;
     PostgresqlListenThread thread = this.listenThread;
     if (thread != null) {
       thread.shutdown();
@@ -244,8 +246,19 @@ public class PostgresqlListenNotifyCoordinator
     }
   }
 
+  /**
+   * Package-private test seam: synthesizes the same dispatch a real PostgreSQL {@code NOTIFY} would
+   * trigger, without standing up a live LISTEN connection. Unit tests in this package use this hook
+   * to drive {@link #onInboundNotification(NotifyPayload)} without going through Testcontainers.
+   *
+   * @apiNote Framework-internal test driver. Not part of the public SPI.
+   */
+  void dispatchInbound(NotifyPayload msg) {
+    onInboundNotification(msg);
+  }
+
   /** Dispatch path from the listen thread. Self-suppresses then routes to listeners. */
-  void onInboundNotification(NotifyPayload msg) {
+  private void onInboundNotification(NotifyPayload msg) {
     NodeIdentity local;
     try {
       local = new NodeIdentity(identityProvider.getNodeId());

--- a/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenThread.java
+++ b/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenThread.java
@@ -9,7 +9,7 @@ import org.postgresql.PGConnection;
 import org.postgresql.PGNotification;
 import run.ratchet.coordinator.common.DecodeException;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 /**
  * Single background daemon thread that pulls PostgreSQL {@code NOTIFY} messages off the dedicated

--- a/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinatorTest.java
+++ b/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinatorTest.java
@@ -74,7 +74,7 @@ class PostgresqlListenNotifyCoordinatorTest {
       c.registerWakeupListener((p, s) -> seen.add(s));
 
       // Simulate inbound payload from ourselves
-      c.onInboundNotification(new NotifyPayload(1, new NodeIdentity("nodeA"), JobPriority.HIGH));
+      c.dispatchInbound(new NotifyPayload(1, new NodeIdentity("nodeA"), JobPriority.HIGH));
 
       // Wait briefly to ensure no async dispatch happens
       sleep(50);
@@ -99,8 +99,7 @@ class PostgresqlListenNotifyCoordinatorTest {
             latch.countDown();
           });
 
-      c.onInboundNotification(
-          new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.CRITICAL));
+      c.dispatchInbound(new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.CRITICAL));
 
       assertTrue(latch.await(2, TimeUnit.SECONDS), "listener never fired");
       assertEquals(1, seen.size());
@@ -119,8 +118,7 @@ class PostgresqlListenNotifyCoordinatorTest {
     PostgresqlListenNotifyCoordinator c = newCoordinator(lifecycle);
     try {
       for (int i = 0; i < 5; i++) {
-        c.onInboundNotification(
-            new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.NORMAL));
+        c.dispatchInbound(new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.NORMAL));
       }
 
       CountDownLatch latch = new CountDownLatch(5);
@@ -146,7 +144,7 @@ class PostgresqlListenNotifyCoordinatorTest {
     try {
       // Capacity is 256. Push 260 without a listener; expect the oldest to be dropped.
       for (int i = 0; i < 260; i++) {
-        c.onInboundNotification(new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.LOW));
+        c.dispatchInbound(new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.LOW));
       }
       AtomicInteger received = new AtomicInteger();
       c.registerWakeupListener((p, s) -> received.incrementAndGet());
@@ -297,7 +295,7 @@ class PostgresqlListenNotifyCoordinatorTest {
           });
 
       for (int i = 0; i < 100; i++) {
-        c.onInboundNotification(new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.HIGH));
+        c.dispatchInbound(new NotifyPayload(1, new NodeIdentity("nodeB"), JobPriority.HIGH));
       }
 
       assertTrue(latch.await(5, TimeUnit.SECONDS), "good listener missed deliveries");

--- a/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlListenThreadTest.java
+++ b/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlListenThreadTest.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.postgresql.PGNotification;
-import run.ratchet.coordinator.common.NotifyPayloadCodec;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 
 class PostgresqlListenThreadTest {
 

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
@@ -32,7 +32,18 @@ import run.ratchet.api.JobPriority;
  */
 public abstract class AbstractClusterCoordinatorContract {
 
-  /** Supplies a fresh harness per test. Implementations create a per-test transport setup. */
+  /**
+   * Supplies a fresh harness per test. Implementations create a per-test transport setup.
+   *
+   * @return a freshly initialised {@link CoordinatorTestHarness}; MUST NOT return {@code null};
+   *     each invocation MUST return a new instance (no caching across tests).
+   * @apiNote The contract harness lifecycle is owned by the {@code setUp()} method on the contract
+   *     base class: the returned harness is started in {@code setUp()} and closed in {@code
+   *     tearDown()}. Implementations MUST NOT close, share, or reuse the harness across invocations
+   *     — each {@code @Test} method gets its own. Implementations MAY throw a {@link
+   *     RuntimeException} from this method to fail the test if the transport cannot be stood up;
+   *     the contract treats that as a setup failure.
+   */
   protected abstract CoordinatorTestHarness harness();
 
   private CoordinatorTestHarness harness;

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorOptionalContract.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorOptionalContract.java
@@ -27,6 +27,18 @@ public abstract class AbstractClusterCoordinatorOptionalContract {
   /** Capacity expected for the pre-registration buffer. First-party modules use 256. */
   protected static final int EXPECTED_BUFFER_CAPACITY = 256;
 
+  /**
+   * Supplies a fresh harness per test. Implementations create a per-test transport setup.
+   *
+   * @return a freshly initialised {@link CoordinatorTestHarness}; MUST NOT return {@code null};
+   *     each invocation MUST return a new instance (no caching across tests).
+   * @apiNote The contract harness lifecycle is owned by the {@code setUp()} method on the contract
+   *     base class: the returned harness is started in {@code setUp()} and closed in {@code
+   *     tearDown()}. Implementations MUST NOT close, share, or reuse the harness across invocations
+   *     — each {@code @Test} method gets its own. Implementations MAY throw a {@link
+   *     RuntimeException} from this method to fail the test if the transport cannot be stood up;
+   *     the contract treats that as a setup failure.
+   */
   protected abstract CoordinatorTestHarness harness();
 
   private CoordinatorTestHarness harness;


### PR DESCRIPTION
## Summary

Moves the common coordinator helpers (`JsonProviders`, `NotifyPayloadCodec`)
into a `coordinator.common.internal` sub-package so they're clearly
framework-internal. The postgresql listen/notify coordinator test used to
invoke the inbound-notification handler directly through a public method;
that's now a private implementation method, with a small package-visible
test seam standing in for it.

## Changes

- `JsonProviders` and `NotifyPayloadCodec`: `coordinator.common` -> `coordinator.common.internal`
- 16 import sites updated across hazelcast, infinispan, jms, and postgresql
- `PostgresqlListenNotifyCoordinator.onInboundNotification`: public -> private; new `dispatchInbound` seam method for tests; the 5 existing test assertions still pass
- Javadoc + `@apiNote` markers on provider classes (Hazelcast, Infinispan, Jms) and on the cluster-coordinator TCK contracts

## Test plan

- [ ] mvn -pl ratchet-coordinator-common,-hazelcast,-infinispan,-jms,-postgresql -am test passes
- [ ] All 5 PostgresqlListenNotifyCoordinatorTest assertions still pass
- [ ] mvn -DskipITs verify passes for the full reactor