### PR TITLE
Add SpotBugs, PIT, and OWASP gates; fix a concurrency finding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,25 @@ jobs:
       - name: Format check
         run: mvn spotless:check -B
 
+  spotbugs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      # Single-pass reactor: test-compile builds every module so spotbugs:check
+      # resolves siblings from the workspace, then the concurrency/correctness
+      # gate runs once across all modules.
+      - name: SpotBugs concurrency/correctness gate
+        run: mvn -B -ntp -DskipTests clean test-compile spotbugs:check
+
   ee11-verify:
     runs-on: ubuntu-latest
     steps:
@@ -84,7 +103,9 @@ jobs:
           key: m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: m2-
       - name: Integration tests (${{ matrix.server }} / ${{ matrix.database }})
-        run: mvn verify -P ${{ matrix.server }},${{ matrix.database }} -B -pl ratchet-testsuite,ratchet-coverage -am
+        # spotbugs.skip: the SpotBugs gate is bound to verify but runs once in the
+        # dedicated spotbugs job — skip it here so it isn't re-analyzed per matrix cell.
+        run: mvn verify -P ${{ matrix.server }},${{ matrix.database }} -B -Dspotbugs.skip=true -pl ratchet-testsuite,ratchet-coverage -am
       - name: Upload coverage report
         if: matrix.server == 'wildfly-managed' && matrix.database == 'mysql'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,39 @@
+name: Mutation Testing (PIT)
+
+# On-demand only: mutation analysis reruns the test suite once per mutant, so it
+# is far too slow to gate every push. Trigger it manually from the Actions tab,
+# plus a weekly run for drift. It is non-gating — it produces a surviving-mutant
+# report you read; it never fails CI.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  pit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+      - uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      # Scoped to the RI core (run.ratchet.ri.core.*) via the pit profile. -am
+      # builds upstream modules so the targets resolve in a single reactor pass.
+      - name: Run PIT mutation analysis (run.ratchet.ri.core.*)
+        run: mvn -B -ntp -P pit -pl ratchet -am test-compile org.pitest:pitest-maven:mutationCoverage
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pit-mutation-report
+          path: ratchet/target/pit-reports/
+          if-no-files-found: warn

--- a/.github/workflows/owasp-depcheck.yml
+++ b/.github/workflows/owasp-depcheck.yml
@@ -3,6 +3,9 @@ name: OWASP Dependency Check
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:
@@ -36,7 +39,10 @@ jobs:
         run: mvn -B -DskipTests install
 
       - name: Run OWASP Dependency-Check
-        uses: dependency-check/Dependency-Check_Action@main
+        # Pinned to the main HEAD SHA: upstream only tags 1.0.0/1.1.0 (2021),
+        # which predate the SARIF support this workflow relies on. main is the
+        # maintained line. Bump the SHA + comment when upstream advances.
+        uses: dependency-check/Dependency-Check_Action@1e54355a8b4c8abaa8cc7d0b70aa655a3bb15a6c # main @ 2025-12-10
         env:
           JAVA_HOME: /opt/jdk
         with:
@@ -69,9 +75,12 @@ jobs:
             **/target/dependency-check-report.sarif
           if-no-files-found: ignore
 
-#      - name: Upload SARIF to GitHub code scanning
-#        if: always()
-#        uses: github/codeql-action/upload-sarif@v4
-#        with:
-#          sarif_file: target/dependency-check-report.sarif
-#        continue-on-error: true
+      - name: Upload SARIF to GitHub code scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: target/dependency-check-report.sarif
+          # Distinct category so these results don't overwrite CodeQL's in the
+          # Security tab — each SARIF category is a separate analysis stream.
+          category: owasp-dependency-check
+        continue-on-error: true

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,9 @@
     <license-maven-plugin.version>2.7.1</license-maven-plugin.version>
     <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
     <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
+    <asm.version>9.8</asm.version>
+    <pitest-maven-plugin.version>1.19.1</pitest-maven-plugin.version>
+    <pitest-junit5-plugin.version>1.2.2</pitest-junit5-plugin.version>
     <argLine></argLine>
   </properties>
 
@@ -523,6 +526,68 @@
 
   <profiles>
     <!--
+      PIT mutation-testing profile. Opt-in and never bound to a default
+      lifecycle phase: mutation analysis reruns the test suite once per
+      mutant, so it is far too slow for `mvn verify`. It is a diagnostic you
+      invoke explicitly to find weakly-asserted code that line coverage hides.
+
+      Scoped by default to the RI core (run.ratchet.ri.core.*), the
+      correctness-critical claim/lease/retry engine where mutation signal is
+      most valuable. No mutationThreshold is set, so it never fails a build —
+      it produces a surviving-mutant report you read.
+
+      Usage (single module, recommended):
+        mvn -P pit -pl ratchet -am test-compile org.pitest:pitest-maven:mutationCoverage
+      Report lands at ratchet/target/pit-reports/ (HTML + XML).
+    -->
+    <profile>
+      <id>pit</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <version>${pitest-maven-plugin.version}</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.pitest</groupId>
+                <artifactId>pitest-junit5-plugin</artifactId>
+                <version>${pitest-junit5-plugin.version}</version>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <targetClasses>
+                <param>run.ratchet.ri.core.*</param>
+              </targetClasses>
+              <targetTests>
+                <param>run.ratchet.*</param>
+              </targetTests>
+              <!--
+                Modules outside the target package (every module but ratchet)
+                contribute no matching classes; without this they would fail
+                the goal with "no mutations found".
+              -->
+              <failWhenNoMutations>false</failWhenNoMutations>
+              <outputFormats>
+                <param>HTML</param>
+                <param>XML</param>
+              </outputFormats>
+              <timestampedReports>false</timestampedReports>
+              <!--
+                Timing-sensitive tests (sleep/await-based) can hang or time
+                out under a mutant that perturbs scheduling, producing noise
+                rather than signal. Add such tests here after the first run
+                if they prove flaky under mutation, e.g.:
+                  <param>run.ratchet.ri.resilience.CircuitBreakerTest</param>
+              -->
+              <excludedTestClasses/>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
       Jakarta EE 11 API verification profile. Retargets every individual
       Jakarta API version property to its EE 11 release (CDI 4.1,
       persistence 3.2, security 4.0, annotation 3.0, interceptor 2.2, etc.)
@@ -855,15 +920,61 @@
           <version>${maven-enforcer-plugin.version}</version>
         </plugin>
         <!--
-          SpotBugs static-analysis plugin. Declared in pluginManagement only
-          (no <executions> binding) so it is resolvable for ad-hoc invocation
-          via `mvn spotbugs:check` / `mvn spotbugs:gui` / `mvn spotbugs:spotbugs`
-          without forcing analysis into the normal verify cycle.
+          SpotBugs static-analysis plugin, adopted for its multithreaded-
+          correctness detectors (the MT_CORRECTNESS family) on this scheduler's
+          concurrency-heavy code — a class of bug CodeQL and Qodana underweight.
+
+          Effort is Max for the deepest dataflow analysis. The include filter
+          (spotbugs-include.xml) narrows reporting to the high-signal categories
+          (concurrency + definite correctness) so the gate stays low-noise. That
+          scoping IS the baseline — there is no instance-suppression file because
+          the findings present at adoption were fixed, not suppressed, so the gate
+          runs clean and any NEW concurrency/correctness finding fails the build.
         -->
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>${spotbugs-maven-plugin.version}</version>
+          <!--
+            SpotBugs 4.9.3 pins ASM 9.7.1, whose ClassReader rejects Java 25
+            bytecode (class file major version 69). The analyzer parses the
+            *running* JDK's runtime classes, so on a JDK 25 toolchain it fails
+            with "Unsupported class file major version 69" before analyzing a
+            single project class. Override the full ASM family to a build that
+            understands Java 25. ASM is unshaded here, so this override takes.
+          -->
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-analysis</artifactId>
+              <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-commons</artifactId>
+              <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-tree</artifactId>
+              <version>${asm.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm-util</artifactId>
+              <version>${asm.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <effort>Max</effort>
+            <threshold>Low</threshold>
+            <includeFilterFile>${maven.multiModuleProjectDirectory}/spotbugs-include.xml</includeFilterFile>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -937,6 +1048,26 @@
               <goal>check</goal>
             </goals>
             <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <!--
+        SpotBugs concurrency/correctness gate, bound to verify so `mvn verify`
+        fails on any new MT_CORRECTNESS or CORRECTNESS finding. Analysis config,
+        the include filter, and the Java-25 ASM override are inherited from
+        pluginManagement. CI runs this once in a dedicated job; the integration
+        matrix passes -Dspotbugs.skip=true to avoid re-analyzing 15× per build.
+      -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>spotbugs-check</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/ratchet-tck/jakarta/src/main/java/run/ratchet/tck/jakarta/CdiEventCollector.java
+++ b/ratchet-tck/jakarta/src/main/java/run/ratchet/tck/jakarta/CdiEventCollector.java
@@ -65,12 +65,16 @@ public class CdiEventCollector {
 
   private boolean awaitObserved(Set<UUID> observedIds, UUID jobId, Duration timeout) {
     long deadlineNanos = System.nanoTime() + timeout.toNanos();
-    while (!observedIds.contains(jobId)) {
-      long remainingNanos = deadlineNanos - System.nanoTime();
-      if (remainingNanos <= 0) {
-        return false;
-      }
-      synchronized (lock) {
+    // Guarded wait: the condition is re-checked while holding the monitor before
+    // each wait(), so a notifyAll() landing between the check and the wait cannot
+    // be lost. Re-checking outside the lock (the previous form) let a notify slip
+    // through that window and forced a full-timeout sleep on every such race.
+    synchronized (lock) {
+      while (!observedIds.contains(jobId)) {
+        long remainingNanos = deadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          return false;
+        }
         try {
           lock.wait(Math.max(1L, TimeUnit.NANOSECONDS.toMillis(remainingNanos)));
         } catch (InterruptedException ie) {
@@ -78,7 +82,7 @@ public class CdiEventCollector {
           return false;
         }
       }
+      return true;
     }
-    return true;
   }
 }

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -97,7 +97,12 @@ public class JobTask implements Callable<Void> {
   private JobExecutionEntity currentExecution;
   private TracingCollector.ExecutionScope currentScope =
       TracingCollector.NoOpExecutionScope.INSTANCE;
-  private boolean permitAcquired;
+  // volatile: this instance is single-use today (allocated fresh per submission
+  // in DefaultJobExecutorService.createTask()), but the field outlives no thread
+  // hop only by that invariant. Marking it volatile makes the flag correct under
+  // any future task reuse and clears SpotBugs AT_STALE_THREAD_WRITE_OF_PRIMITIVE
+  // at zero behavioral cost.
+  private volatile boolean permitAcquired;
 
   protected JobTask() {
     this.jobStore = null;

--- a/spotbugs-include.xml
+++ b/spotbugs-include.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs report scope for the Ratchet build gate.
+
+  SpotBugs at effort=Max/threshold=Low reports ~366 findings across the reactor,
+  the overwhelming majority being low-value BAD_PRACTICE / MALICIOUS_CODE noise
+  (documenting RuntimeException in throws clauses, \n vs %n, "returns mutable
+  reference"). Gating on all of that would red-wall every build.
+
+  Instead the gate reports only the two categories worth blocking a build over:
+
+    MT_CORRECTNESS — multithreaded-correctness defects (the reason SpotBugs was
+                     adopted: visibility, lost-wakeup, atomicity bugs in this
+                     scheduler's concurrency-heavy code that CodeQL/Qodana miss).
+    CORRECTNESS    — definite bugs (null-deref on all paths, impossible casts,
+                     format-string arg mismatches, etc.).
+
+  SECURITY is intentionally NOT gated here: its current findings are dynamic SQL
+  in PostgreSQL LISTEN/UNLISTEN (channel names quoted via quoteIdentifier()) and
+  DDL migration statements, and CodeQL's taint analysis covers injection more
+  thoroughly. Keeping it out avoids a third overlapping suppression surface.
+
+  This category scoping IS the baseline: there is no instance-suppression file
+  because the two real findings were fixed rather than suppressed. To accept a
+  future finding without fixing it, generate a SpotBugs result XML and reference
+  it via <excludeBugsFile> (hash-based, so it never masks a NEW bug in the same
+  method) — do not add broad method/class Match excludes here.
+-->
+<FindBugsFilter>
+  <Match>
+    <Bug category="MT_CORRECTNESS"/>
+  </Match>
+  <Match>
+    <Bug category="CORRECTNESS"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
## Summary

Formalizes three analysis tools into the build and CI, and fixes the findings the first one surfaced.

**SpotBugs** runs at `verify` and in a dedicated CI job. It reports only the multithreaded-correctness and definite-correctness categories (`spotbugs-include.xml`), which keeps the other ~364 lower-value findings out of the build and makes the category scoping the baseline — there is no suppression file. Its bundled ASM is overridden to 9.8 because the 9.7.1 SpotBugs ships cannot parse Java 25 bytecode (`Unsupported class file major version 69`), and the build runs on a JDK 25 toolchain. The 15-cell integration matrix passes `-Dspotbugs.skip=true` so analysis runs once rather than per cell.

**PIT** mutation testing is an opt-in `pit` profile plus a manual/weekly workflow, scoped to the RI core (`run.ratchet.ri.core.*`). It never binds to a lifecycle phase. First baseline: 2345 mutations, 49% killed, 75% test strength, 823 mutations with no test coverage at all.

**OWASP** dependency-check now runs on pull requests and the merge queue instead of only after merge, so `--failOnCVSS 7` becomes a pre-merge gate. The action is pinned to a commit SHA (it was on a mutable `@main` ref while holding `NVD_API_KEY`), and CVE results upload to code scanning under their own category.

SpotBugs surfaced two findings, both addressed here:
- `CdiEventCollector.awaitObserved()` (TCK) checked its wait condition outside the lock and then waited, so a notification landing in that window cost a full timeout. It now checks under the lock before waiting.
- `JobTask.permitAcquired` is a single-use field flagged for cross-thread visibility (a false positive — tasks are allocated fresh per submission). Marking it `volatile` clears the finding and keeps it correct if the task is ever reused.

## Testing

- [x] `mvn clean test -B`
- [x] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am` — not run locally; the integration matrix and the new SpotBugs job run it in CI
- [ ] `cd website && npm ci && npm run build` — no website changes

Also ran the full-reactor gate command (`mvn -DskipTests clean test-compile spotbugs:check`) green across all 21 modules, and a scoped PIT run end to end.

## Docs

- [x] No docs update needed
- [ ] Docs updated where behavior, configuration, logs, or examples changed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [x] Security-sensitive change
- [x] Follow-up work remains

Security-sensitive: the change edits the OWASP workflow (permissions, pinned action, SARIF upload). Follow-up: GitHub withholds secrets from fork PRs, so `NVD_API_KEY` is absent on external-fork `pull_request` runs and the OWASP step degrades there. `merge_group` is the secret-bearing pre-merge gate; if forks get noisy, drop `pull_request` from that one workflow.

## Additional Context

The SpotBugs ASM override will need bumping again on any future JDK or SpotBugs upgrade where the bundled ASM lags the build JVM — the symptom is always `Unsupported class file major version N` while scanning `java.lang.*`. CodeQL and Qodana still cover the security/general-static lane; SECURITY findings are intentionally left out of the SpotBugs gate (the SQL findings are quoted `LISTEN`/`UNLISTEN` channel names and DDL migrations).
