### PR TITLE
Clear coordinator-module dependency vulnerabilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,11 @@ updates:
       - /ratchet-store-mysql
       - /ratchet-store-postgresql
       - /ratchet-store-mongodb
+      - /ratchet-coordinator-common
+      - /ratchet-coordinator-postgresql
+      - /ratchet-coordinator-jms
+      - /ratchet-coordinator-infinispan
+      - /ratchet-coordinator-hazelcast
       - /ratchet-tck
       - /ratchet-tck/util
       - /ratchet-tck/store
@@ -37,6 +42,7 @@ updates:
       - /ratchet-testsuite-jpms
       - /ratchet-loadtest
       - /ratchet-micrometer
+      - /ratchet-otel
       - /ratchet-bom
       - /ratchet-coverage
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,10 @@
     <protobuf-java.version>3.25.9</protobuf-java.version>
     <postgresql-driver.version>42.7.11</postgresql-driver.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
-    <artemis.version>2.44.0</artemis.version>
+    <artemis.version>2.54.0</artemis.version>
+    <netty.version>4.1.133.Final</netty.version>
+    <commons-configuration2.version>2.15.0</commons-configuration2.version>
+    <jackson-core.version>2.18.6</jackson-core.version>
     <infinispan.version>15.1.7.Final</infinispan.version>
     <hazelcast.version>5.5.0</hazelcast.version>
     <mongodb-driver.version>5.7.0</mongodb-driver.version>
@@ -225,12 +228,12 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.activemq</groupId>
+        <groupId>org.apache.artemis</groupId>
         <artifactId>artemis-jakarta-server</artifactId>
         <version>${artemis.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.activemq</groupId>
+        <groupId>org.apache.artemis</groupId>
         <artifactId>artemis-jakarta-client</artifactId>
         <version>${artemis.version}</version>
       </dependency>
@@ -243,6 +246,32 @@
         <groupId>com.hazelcast</groupId>
         <artifactId>hazelcast</artifactId>
         <version>${hazelcast.version}</version>
+      </dependency>
+
+      <!--
+        Security pins for vulnerable dependencies pulled in transitively by the
+        coordinator modules. These coordinates are not declared directly by any
+        module, so they are overridden here to keep the resolved graph patched:
+          * io.netty:*               (test scope, via the embedded Artemis broker)
+          * commons-configuration2   (test scope, via the embedded Artemis broker)
+          * jackson-core             (compile scope, via infinispan-core)
+      -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>${commons-configuration2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson-core.version}</version>
       </dependency>
       <dependency>
         <groupId>jakarta.security.enterprise</groupId>

--- a/ratchet-coordinator-jms/pom.xml
+++ b/ratchet-coordinator-jms/pom.xml
@@ -93,12 +93,12 @@
         </dependency>
         <!-- Embedded Artemis broker for ITs (in-JVM, no Docker required) -->
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-server</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
## Summary

The JMS and Infinispan coordinator modules had 13 open Dependabot security
advisories, all from transitive dependencies. This clears every one of them.

| Count | Package | Scope | Move |
|------:|---------|-------|------|
| 10 | `io.netty:*` | test (embedded broker) | 4.1.128 → **4.1.133.Final** (via `netty-bom`) |
| 1 | `commons-configuration2` | test (embedded broker) | 2.11.0 → **2.15.0** |
| 1 | `jackson-core` (medium) | **compile — ships** (via `infinispan-core`) | 2.18.1 → **2.18.6** |
| 1 | `artemis-server` (**critical**) | test (embedded broker) | 2.44.0 → **2.54.0** |

The critical advisory (GHSA-fw88-pf9m-p947, missing authentication) is bounded
at `<= 2.44.0` for the old `org.apache.activemq` coordinate and fixed at
`2.52.0` for the relocated `org.apache.artemis` coordinate. Artemis 2.54.0
sits outside both, so the bump plus the official groupId relocation clears it.
2.54.0 only brings Netty 4.1.132 and commons-configuration2 2.14.0, so those
are pinned explicitly in the parent to reach the patched versions. All four
overrides live in the parent `dependencyManagement` because the vulnerable
coordinates are transitive — no module declares them directly.

Also closes a gap in `.github/dependabot.yml`: the five `ratchet-coordinator-*`
modules and `ratchet-otel` were never on the Maven watch list, so they got
security alerts but no routine update PRs. Every reactor module is now watched.

## Testing

Scoped to the two affected modules (the change only alters their resolved
dependency graph):

- `mvn -pl ratchet-coordinator-jms,ratchet-coordinator-infinispan -am verify` — **pass**
  - JMS: 42 unit tests + 19 integration tests against the embedded **Artemis 2.54.0** broker (incl. the 15-test TCK contract)
  - Infinispan: unit tests + 17 integration tests on jackson-core 2.18.6
- `dependency:tree` confirms every coordinate resolves to its patched version with no relocation warnings

- [ ] `mvn clean test -B`
- [x] `mvn spotless:check -B` (ran as part of `verify`; all files clean)
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [x] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

The 12 JMS-module advisories are all test-scope (the in-JVM Artemis broker used
by integration tests, never in the published artifact). Only `jackson-core`
ships. The Artemis bump is a 10-minor-version jump validated against the real
embedded-broker integration tests above.

Dependabot will auto-close the alerts after re-scanning this branch's resolved
graph on merge.
