### PR TITLE
Harden payload masking, coordinator portability, and query correctness

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,14 +34,13 @@ Please include:
 
 Ratchet currently enforces these runtime boundaries:
 
-- Job payload deserialization is guarded by `ClassPolicy` and an
-  `ObjectInputFilter`; the default package allowlist is empty and the RI
-  fails fast until the application provides a real policy.
+- Job target and result-type class names are guarded by `ClassPolicy`: a
+  hardcoded denylist of RCE-gadget classes is rejected first, then the name
+  must match a configured package allowlist. The default allowlist is empty
+  and the RI fails fast until the application provides a real policy.
 - Payload validation defers class initialization while resolving job target
   classes, so policy checks happen before user-controlled static initializers
   can run.
-- Archive writes route through `PayloadMasker` to reduce accidental exposure
-  of secrets in operational audit data.
 - Job creation captures the Jakarta Security caller principal when one is
   available and stores it with the job for audit. Authorization enforcement is
   not part of the current surface; a future `JobAuthorizationPolicy` SPI is

--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.UUID;
 import java.util.function.Consumer;
+import run.ratchet.api.exception.JobAuthorizationException;
 
 /**
  * Primary entry point for scheduling background jobs.
@@ -126,12 +127,19 @@ public interface JobSchedulerService {
    * Authorization is checked against the old job using the same per-job cancellation policy as
    * {@link #cancelJob(UUID)} before the replacement is submitted.
    *
+   * <p>Unlike {@link #cancelJob(UUID)}, which returns {@code false} for a missing or terminal job,
+   * this method fails loud: replacing a job that does not exist throws rather than returning a
+   * no-op handle.
+   *
    * @param jobId UUIDv7 job id of the job to replace
    * @param delay delay before the replacement job becomes eligible to run
    * @param newTask task to execute for the replacement job
    * @param opts optional job options to apply to the replacement; {@code null} uses implementation
    *     defaults
    * @return handle for the newly submitted replacement job
+   * @throws IllegalArgumentException if no job exists for {@code jobId}
+   * @throws JobAuthorizationException if the caller is not permitted to cancel the job being
+   *     replaced under the per-job cancellation policy
    */
   JobHandle replace(
       UUID jobId, Duration delay, SerializableCheckedRunnable newTask, JobOptions opts);

--- a/ratchet-api/src/main/java/run/ratchet/api/JobSubmitter.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSubmitter.java
@@ -4,7 +4,7 @@ package run.ratchet.api;
  * Functional interface for submitting a configured job for execution.
  *
  * <p>This decouples {@link JobBuilder} from the concrete scheduler service. The reference
- * implementation passes {@code this::persistJob} as the submitter.
+ * implementation implements {@code JobSubmitter} on its job-creation service.
  */
 @FunctionalInterface
 public interface JobSubmitter {

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
  * bean. Instances are still immutable — all fields are {@code final} and set only through {@link
  * Builder}. Use {@link #builder()} or {@link #defaults()} to construct.
  */
+@Incubating
 @SuppressWarnings("ClassCanBeRecord")
 public class RatchetOptions {
 
@@ -89,10 +90,20 @@ public class RatchetOptions {
     this.circuitBreaker = Objects.requireNonNull(circuitBreaker, "circuitBreaker must not be null");
   }
 
+  /**
+   * Returns an options instance with every section set to its built-in default.
+   *
+   * @return a fully-defaulted options instance
+   */
   public static RatchetOptions defaults() {
     return builder().build();
   }
 
+  /**
+   * Returns a new builder seeded with the built-in defaults for every section.
+   *
+   * @return a new builder
+   */
   public static Builder builder() {
     return new Builder();
   }
@@ -257,6 +268,7 @@ public class RatchetOptions {
     return circuitBreaker;
   }
 
+  @Incubating
   public enum IsolationCheckMode {
     WARN,
     FAIL,
@@ -300,6 +312,7 @@ public class RatchetOptions {
    * @param claimHeadroomFactor headroom multiplier applied to free-slot calculations; {@code 0}
    *     disables the headroom adjustment
    */
+  @Incubating
   public record PollingOptions(
       int batchSize,
       long burstDelayMs,
@@ -314,8 +327,9 @@ public class RatchetOptions {
    * Execution-pool wiring: target executor JNDI names, queue size, and per-execution-type
    * concurrency / virtual-thread / rate caps.
    *
-   * @param useVirtualThreads {@code true} to request virtual-thread execution where supported by
-   *     the chosen executor (the container ultimately decides)
+   * @param defaultThreadingMode pool a job runs on when it specifies no target of its own; defaults
+   *     to {@link ThreadingMode#PLATFORM}, and {@link ThreadingMode#VIRTUAL} falls back to platform
+   *     when no virtual executor is configured
    * @param queueSize bounded queue length used by the in-process fallback executor
    * @param maxConcurrency map of execution-type name to maximum concurrent executions; missing keys
    *     fall back to the per-type defaults
@@ -326,7 +340,13 @@ public class RatchetOptions {
    * @param jobExecutorJndi JNDI name of the {@code ManagedExecutorService} that runs jobs
    * @param scheduledExecutorJndi JNDI name of the {@code ManagedScheduledExecutorService} used for
    *     scheduled work
+   * @param virtualExecutorJndi JNDI name of an additional {@code ManagedExecutorService} backing the
+   *     virtual pool; absent (null or blank) means virtual-targeted jobs fall back to platform
+   * @param virtualCounterAccounting {@code true} to use lock-free counter accounting for the virtual
+   *     pool instead of the default semaphore bound; only safe when the executor is genuinely
+   *     virtual-thread backed
    */
+  @Incubating
   public record ExecutionOptions(
       ThreadingMode defaultThreadingMode,
       int queueSize,
@@ -357,14 +377,40 @@ public class RatchetOptions {
       return virtualExecutorJndi != null;
     }
 
+    /**
+     * Returns the configured max-concurrency for an execution type.
+     *
+     * @param executionTypeName execution-type name (normalized to upper case with {@code -}
+     *     replaced by {@code _})
+     * @param defaultValue value returned when no entry is configured for the type
+     * @return the configured limit, or {@code defaultValue} if none is set
+     * @throws IllegalArgumentException if {@code executionTypeName} is blank
+     */
     public int maxConcurrency(String executionTypeName, int defaultValue) {
       return maxConcurrency.getOrDefault(normalizeKey(executionTypeName), defaultValue);
     }
 
+    /**
+     * Returns the configured virtual-thread limit for an execution type.
+     *
+     * @param executionTypeName execution-type name (normalized to upper case with {@code -}
+     *     replaced by {@code _})
+     * @param defaultValue value returned when no entry is configured for the type
+     * @return the configured limit, or {@code defaultValue} if none is set
+     * @throws IllegalArgumentException if {@code executionTypeName} is blank
+     */
     public int virtualThreadLimit(String executionTypeName, int defaultValue) {
       return virtualThreadLimits.getOrDefault(normalizeKey(executionTypeName), defaultValue);
     }
 
+    /**
+     * Returns the configured per-minute rate limit for an execution type.
+     *
+     * @param executionTypeName execution-type name (normalized to upper case with {@code -}
+     *     replaced by {@code _})
+     * @return the configured limit, or {@code 0} (no limit) if none is set
+     * @throws IllegalArgumentException if {@code executionTypeName} is blank
+     */
     public int rateLimitPerMinute(String executionTypeName) {
       return rateLimitsPerMinute.getOrDefault(normalizeKey(executionTypeName), 0);
     }
@@ -384,6 +430,7 @@ public class RatchetOptions {
    *     empty list disables the require-list constraint
    * @param excludeTags job tags that, when present on a job, exclude that job from this node
    */
+  @Incubating
   public record NodeOptions(
       String nodeId,
       long heartbeatIntervalSeconds,
@@ -398,10 +445,21 @@ public class RatchetOptions {
       excludeTags = List.copyOf(excludeTags == null ? List.of() : excludeTags);
     }
 
+    /**
+     * Returns the explicit node id when one was configured.
+     *
+     * @return the explicit node id, or an empty optional when none was set (an id is generated at
+     *     startup)
+     */
     public Optional<String> explicitNodeId() {
       return nodeId == null || nodeId.isBlank() ? Optional.empty() : Optional.of(nodeId);
     }
 
+    /**
+     * Returns the tag filter built from the require/exclude tag lists.
+     *
+     * @return a node tag filter for this configuration
+     */
     public NodeTagFilter tagFilter() {
       return new NodeTagFilter(requireTags, excludeTags);
     }
@@ -419,6 +477,7 @@ public class RatchetOptions {
    * @param convergenceWindowSeconds rolling window in seconds during which competing recurring
    *     registrations are reconciled; {@code 0} disables convergence reconciliation
    */
+  @Incubating
   public record RecurringOptions(
       int batchLimit,
       long pollMs,
@@ -431,6 +490,7 @@ public class RatchetOptions {
    *
    * @param drainIntervalMs interval in milliseconds between buffer drains to the store
    */
+  @Incubating
   public record RetryBufferOptions(long drainIntervalMs) {}
 
   /**
@@ -442,6 +502,7 @@ public class RatchetOptions {
    *     their own
    * @param signalTimeoutBatchSize maximum number of WAITING jobs scanned per signal-timeout tick
    */
+  @Incubating
   public record TimeoutOptions(
       int softTimeoutPercent, long defaultSlaSeconds, int signalTimeoutBatchSize) {}
 
@@ -459,6 +520,7 @@ public class RatchetOptions {
    * @param logPurgeCron cron expression controlling the log-purge cadence
    * @param logRetentionDays age in days at which execution-log rows become eligible for purge
    */
+  @Incubating
   public record MaintenanceOptions(
       boolean dlqPurgeEnabled,
       String dlqPurgeCron,
@@ -479,6 +541,7 @@ public class RatchetOptions {
    * @param dlqAlertChannel channel identifier for DLQ alerts
    * @param timeoutAlertChannel channel identifier for timeout alerts
    */
+  @Incubating
   public record NotificationOptions(
       boolean enabled, String dlqAlertChannel, String timeoutAlertChannel) {}
 
@@ -492,6 +555,7 @@ public class RatchetOptions {
    * @param migrationPrefix classpath prefix under which dialect-specific migration scripts are
    *     resolved
    */
+  @Incubating
   public record SchemaOptions(
       boolean autoMigrate, String migrationDialect, String migrationPrefix) {}
 
@@ -501,6 +565,7 @@ public class RatchetOptions {
    * @param maxPayloadKb maximum job payload size in kilobytes
    * @param maxResultBytes maximum persisted job-result size in bytes
    */
+  @Incubating
   public record PayloadOptions(int maxPayloadKb, long maxResultBytes) {}
 
   /**
@@ -509,6 +574,7 @@ public class RatchetOptions {
    * @param clustering clustering-strategy identifier passed to the metrics collector (for example
    *     {@code none}); values are lowercased
    */
+  @Incubating
   public record MetricsOptions(String clustering) {}
 
   /**
@@ -518,6 +584,7 @@ public class RatchetOptions {
    *     ClassPolicy}; {@code false} (default) fails fast at startup when no policy is bound
    * @param redactEmails {@code true} to redact email-shaped strings from observability output
    */
+  @Incubating
   public record SecurityOptions(boolean allowEmptyClassPolicy, boolean redactEmails) {}
 
   /**
@@ -528,6 +595,7 @@ public class RatchetOptions {
    * @param priorityBoostIntervalMinutes interval in minutes at which long-waiting pending jobs are
    *     promoted to a higher effective priority; {@code 0} disables the boost
    */
+  @Incubating
   public record StoreOptions(
       IsolationCheckMode isolationCheckMode, int priorityBoostIntervalMinutes) {}
 
@@ -578,6 +646,11 @@ public class RatchetOptions {
       int permittedCallsInHalfOpen,
       int minimumCalls) {}
 
+  /**
+   * Mutable builder for {@link RatchetOptions}; each section is customized through a nested
+   * builder.
+   */
+  @Incubating
   public static final class Builder {
     private final PollingBuilder polling = new PollingBuilder();
     private final ExecutionBuilder execution = new ExecutionBuilder();
@@ -596,77 +669,166 @@ public class RatchetOptions {
 
     private Builder() {}
 
+    /**
+     * Customizes the polling section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder polling(Consumer<PollingBuilder> customizer) {
       customizer.accept(polling);
       return this;
     }
 
+    /**
+     * Customizes the execution section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder execution(Consumer<ExecutionBuilder> customizer) {
       customizer.accept(execution);
       return this;
     }
 
+    /**
+     * Customizes the node section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder node(Consumer<NodeBuilder> customizer) {
       customizer.accept(node);
       return this;
     }
 
+    /**
+     * Customizes the recurring-job section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder recurring(Consumer<RecurringBuilder> customizer) {
       customizer.accept(recurring);
       return this;
     }
 
+    /**
+     * Customizes the retry-buffer section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder retryBuffer(Consumer<RetryBufferBuilder> customizer) {
       customizer.accept(retryBuffer);
       return this;
     }
 
+    /**
+     * Customizes the timeout section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder timeout(Consumer<TimeoutBuilder> customizer) {
       customizer.accept(timeout);
       return this;
     }
 
+    /**
+     * Customizes the maintenance section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder maintenance(Consumer<MaintenanceBuilder> customizer) {
       customizer.accept(maintenance);
       return this;
     }
 
+    /**
+     * Customizes the notification section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder notifications(Consumer<NotificationBuilder> customizer) {
       customizer.accept(notifications);
       return this;
     }
 
+    /**
+     * Customizes the schema-migration section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder schema(Consumer<SchemaBuilder> customizer) {
       customizer.accept(schema);
       return this;
     }
 
+    /**
+     * Customizes the payload section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder payload(Consumer<PayloadBuilder> customizer) {
       customizer.accept(payload);
       return this;
     }
 
+    /**
+     * Customizes the metrics section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder metrics(Consumer<MetricsBuilder> customizer) {
       customizer.accept(metrics);
       return this;
     }
 
+    /**
+     * Customizes the security section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder security(Consumer<SecurityBuilder> customizer) {
       customizer.accept(security);
       return this;
     }
 
+    /**
+     * Customizes the store section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     public Builder store(Consumer<StoreBuilder> customizer) {
       customizer.accept(store);
       return this;
     }
 
+    /**
+     * Customizes the circuit-breaker section.
+     *
+     * @param customizer receives the section builder
+     * @return this builder
+     */
     @Incubating
     public Builder circuitBreaker(Consumer<CircuitBreakerBuilder> customizer) {
       customizer.accept(circuitBreaker);
       return this;
     }
 
+    /**
+     * Builds the immutable options instance from the current section state.
+     *
+     * @return the built options
+     */
     public RatchetOptions build() {
       return new RatchetOptions(
           polling.build(),
@@ -686,6 +848,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link PollingOptions}. */
+  @Incubating
   public static final class PollingBuilder {
     private int batchSize = 50;
     private long burstDelayMs = 500L;
@@ -698,41 +862,87 @@ public class RatchetOptions {
 
     private PollingBuilder() {}
 
+    /**
+     * @param batchSize maximum jobs claimed per tick; must be {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code batchSize < 1}
+     */
     public PollingBuilder batchSize(int batchSize) {
       this.batchSize = atLeast("batchSize", batchSize, 1);
       return this;
     }
 
+    /**
+     * @param burstDelayMs delay in milliseconds between consecutive busy ticks; must be
+     *     {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code burstDelayMs < 0}
+     */
     public PollingBuilder burstDelayMs(long burstDelayMs) {
       this.burstDelayMs = atLeast("burstDelayMs", burstDelayMs, 0L);
       return this;
     }
 
+    /**
+     * @param minDelayMs minimum idle backoff delay in milliseconds; must be {@code >= 0} and
+     *     {@code <= maxDelayMs} (enforced when the section is built)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code minDelayMs < 0}
+     */
     public PollingBuilder minDelayMs(long minDelayMs) {
       this.minDelayMs = atLeast("minDelayMs", minDelayMs, 0L);
       return this;
     }
 
+    /**
+     * @param maxDelayMs maximum idle backoff delay in milliseconds; must be {@code >= 1} and
+     *     {@code >= minDelayMs} (enforced when the section is built)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code maxDelayMs < 1}
+     */
     public PollingBuilder maxDelayMs(long maxDelayMs) {
       this.maxDelayMs = atLeast("maxDelayMs", maxDelayMs, 1L);
       return this;
     }
 
+    /**
+     * @param deepIdleDelayMs delay in milliseconds applied once deep idle is reached; must be
+     *     {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code deepIdleDelayMs < 0}
+     */
     public PollingBuilder deepIdleDelayMs(long deepIdleDelayMs) {
       this.deepIdleDelayMs = atLeast("deepIdleDelayMs", deepIdleDelayMs, 0L);
       return this;
     }
 
+    /**
+     * @param deepIdleThresholdMs idle duration in milliseconds after which deep-idle backoff
+     *     applies; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code deepIdleThresholdMs < 0}
+     */
     public PollingBuilder deepIdleThresholdMs(long deepIdleThresholdMs) {
       this.deepIdleThresholdMs = atLeast("deepIdleThresholdMs", deepIdleThresholdMs, 0L);
       return this;
     }
 
+    /**
+     * @param idleThreshold consecutive empty ticks before backoff ramps; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code idleThreshold < 0}
+     */
     public PollingBuilder idleThreshold(int idleThreshold) {
       this.idleThreshold = atLeast("idleThreshold", idleThreshold, 0);
       return this;
     }
 
+    /**
+     * @param claimHeadroomFactor headroom multiplier for free-slot calculations; must be
+     *     {@code >= 0} ({@code 0} disables the adjustment)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code claimHeadroomFactor < 0}
+     */
     public PollingBuilder claimHeadroomFactor(int claimHeadroomFactor) {
       this.claimHeadroomFactor = atLeast("claimHeadroomFactor", claimHeadroomFactor, 0);
       return this;
@@ -752,6 +962,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link ExecutionOptions}. */
+  @Incubating
   public static final class ExecutionBuilder {
     private final Map<String, Integer> maxConcurrency = defaultConcurrency();
     private final Map<String, Integer> virtualThreadLimits = new HashMap<>();
@@ -823,22 +1035,49 @@ public class RatchetOptions {
       return this;
     }
 
+    /**
+     * @param queueSize bounded queue length for the in-process fallback executor; must be
+     *     {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code queueSize < 0}
+     */
     public ExecutionBuilder queueSize(int queueSize) {
       this.queueSize = atLeast("queueSize", queueSize, 0);
       return this;
     }
 
+    /**
+     * @param executionTypeName execution-type name; normalized to upper case with {@code -}
+     *     replaced by {@code _}, and must not be blank
+     * @param maxConcurrency maximum concurrent executions for the type; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if the name is blank or {@code maxConcurrency < 0}
+     */
     public ExecutionBuilder maxConcurrency(String executionTypeName, int maxConcurrency) {
       this.maxConcurrency.put(
           normalizeKey(executionTypeName), atLeast("maxConcurrency", maxConcurrency, 0));
       return this;
     }
 
+    /**
+     * @param executionTypeName execution-type name; normalized to upper case with {@code -}
+     *     replaced by {@code _}, and must not be blank
+     * @param limit virtual-thread cap for the type; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if the name is blank or {@code limit < 0}
+     */
     public ExecutionBuilder virtualThreadLimit(String executionTypeName, int limit) {
       this.virtualThreadLimits.put(normalizeKey(executionTypeName), atLeast("limit", limit, 0));
       return this;
     }
 
+    /**
+     * @param executionTypeName execution-type name; normalized to upper case with {@code -}
+     *     replaced by {@code _}, and must not be blank
+     * @param limit per-minute rate limit for the type; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if the name is blank or {@code limit < 0}
+     */
     public ExecutionBuilder rateLimitPerMinute(String executionTypeName, int limit) {
       this.rateLimitsPerMinute.put(normalizeKey(executionTypeName), atLeast("limit", limit, 0));
       return this;
@@ -858,6 +1097,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link NodeOptions}. */
+  @Incubating
   public static final class NodeBuilder {
     private String nodeId;
     private long heartbeatIntervalSeconds = 10L;
@@ -869,43 +1110,85 @@ public class RatchetOptions {
 
     private NodeBuilder() {}
 
+    /**
+     * @param nodeId explicit node id; must not be blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code nodeId} is blank
+     */
     public NodeBuilder nodeId(String nodeId) {
       this.nodeId = requireText("nodeId", nodeId);
       return this;
     }
 
+    /**
+     * Clears any explicit node id so an id is generated at startup.
+     *
+     * @return this builder
+     */
     public NodeBuilder clearNodeId() {
       this.nodeId = null;
       return this;
     }
 
+    /**
+     * @param heartbeatIntervalSeconds liveness-report interval in seconds; must be {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code heartbeatIntervalSeconds < 1}
+     */
     public NodeBuilder heartbeatIntervalSeconds(long heartbeatIntervalSeconds) {
       this.heartbeatIntervalSeconds =
           atLeast("heartbeatIntervalSeconds", heartbeatIntervalSeconds, 1L);
       return this;
     }
 
+    /**
+     * @param orphanGraceSeconds grace period in seconds before a missed-heartbeat node is
+     *     reclaimed; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code orphanGraceSeconds < 0}
+     */
     public NodeBuilder orphanGraceSeconds(long orphanGraceSeconds) {
       this.orphanGraceSeconds = atLeast("orphanGraceSeconds", orphanGraceSeconds, 0L);
       return this;
     }
 
+    /**
+     * @param orphanScanIntervalMinutes interval in minutes between orphan-reclaim scans; must be
+     *     {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code orphanScanIntervalMinutes < 1}
+     */
     public NodeBuilder orphanScanIntervalMinutes(long orphanScanIntervalMinutes) {
       this.orphanScanIntervalMinutes =
           atLeast("orphanScanIntervalMinutes", orphanScanIntervalMinutes, 1L);
       return this;
     }
 
+    /**
+     * @param dynamicHeartbeatEnabled {@code true} to let the heartbeat interval adapt to cluster
+     *     activity
+     * @return this builder
+     */
     public NodeBuilder dynamicHeartbeatEnabled(boolean dynamicHeartbeatEnabled) {
       this.dynamicHeartbeatEnabled = dynamicHeartbeatEnabled;
       return this;
     }
 
+    /**
+     * @param tags job tags that must be present on the node for a job to be claimed here; replaces
+     *     any previously-set require list
+     * @return this builder
+     */
     public NodeBuilder requireTags(String... tags) {
       this.requireTags = List.of(tags);
       return this;
     }
 
+    /**
+     * @param tags job tags that exclude a job from this node; replaces any previously-set exclude
+     *     list
+     * @return this builder
+     */
     public NodeBuilder excludeTags(String... tags) {
       this.excludeTags = List.of(tags);
       return this;
@@ -923,6 +1206,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link RecurringOptions}. */
+  @Incubating
   public static final class RecurringBuilder {
     private int batchLimit = 20;
     private long pollMs = 1000L;
@@ -932,26 +1217,55 @@ public class RatchetOptions {
 
     private RecurringBuilder() {}
 
+    /**
+     * @param batchLimit maximum recurring jobs materialized per tick; must be {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code batchLimit < 1}
+     */
     public RecurringBuilder batchLimit(int batchLimit) {
       this.batchLimit = atLeast("batchLimit", batchLimit, 1);
       return this;
     }
 
+    /**
+     * @param pollMs nominal poll interval in milliseconds; must be {@code >= 1} and
+     *     {@code <= maxPollMs} (enforced when the section is built)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code pollMs < 1}
+     */
     public RecurringBuilder pollMs(long pollMs) {
       this.pollMs = atLeast("pollMs", pollMs, 1L);
       return this;
     }
 
+    /**
+     * @param maxPollMs maximum poll interval in milliseconds when no work is due; must be
+     *     {@code >= 1} and {@code >= pollMs} (enforced when the section is built)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code maxPollMs < 1}
+     */
     public RecurringBuilder maxPollMs(long maxPollMs) {
       this.maxPollMs = atLeast("maxPollMs", maxPollMs, 1L);
       return this;
     }
 
+    /**
+     * @param startupGraceSeconds delay in seconds before the first materialization run; must be
+     *     {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code startupGraceSeconds < 0}
+     */
     public RecurringBuilder startupGraceSeconds(long startupGraceSeconds) {
       this.startupGraceSeconds = atLeast("startupGraceSeconds", startupGraceSeconds, 0L);
       return this;
     }
 
+    /**
+     * @param convergenceWindowSeconds reconciliation window in seconds; must be {@code >= 0}
+     *     ({@code 0} disables reconciliation)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code convergenceWindowSeconds < 0}
+     */
     public RecurringBuilder convergenceWindowSeconds(long convergenceWindowSeconds) {
       this.convergenceWindowSeconds =
           atLeast("convergenceWindowSeconds", convergenceWindowSeconds, 0L);
@@ -965,11 +1279,18 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link RetryBufferOptions}. */
+  @Incubating
   public static final class RetryBufferBuilder {
     private long drainIntervalMs = 1000L;
 
     private RetryBufferBuilder() {}
 
+    /**
+     * @param drainIntervalMs interval in milliseconds between buffer drains; must be {@code >= 50}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code drainIntervalMs < 50}
+     */
     public RetryBufferBuilder drainIntervalMs(long drainIntervalMs) {
       this.drainIntervalMs = atLeast("drainIntervalMs", drainIntervalMs, 50L);
       return this;
@@ -980,6 +1301,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link TimeoutOptions}. */
+  @Incubating
   public static final class TimeoutBuilder {
     private int softTimeoutPercent = 80;
     private long defaultSlaSeconds = 1800L;
@@ -987,6 +1310,12 @@ public class RatchetOptions {
 
     private TimeoutBuilder() {}
 
+    /**
+     * @param softTimeoutPercent percentage of the SLA at which a soft-timeout warning is emitted;
+     *     must be between 1 and 99 inclusive
+     * @return this builder
+     * @throws IllegalArgumentException if {@code softTimeoutPercent} is not in {@code 1..99}
+     */
     public TimeoutBuilder softTimeoutPercent(int softTimeoutPercent) {
       if (softTimeoutPercent <= 0 || softTimeoutPercent >= 100) {
         throw new IllegalArgumentException("softTimeoutPercent must be between 1 and 99");
@@ -995,11 +1324,22 @@ public class RatchetOptions {
       return this;
     }
 
+    /**
+     * @param defaultSlaSeconds default execution SLA in seconds; must be {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code defaultSlaSeconds < 1}
+     */
     public TimeoutBuilder defaultSlaSeconds(long defaultSlaSeconds) {
       this.defaultSlaSeconds = atLeast("defaultSlaSeconds", defaultSlaSeconds, 1L);
       return this;
     }
 
+    /**
+     * @param signalTimeoutBatchSize maximum WAITING jobs scanned per signal-timeout tick; must be
+     *     {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code signalTimeoutBatchSize < 1}
+     */
     public TimeoutBuilder signalTimeoutBatchSize(int signalTimeoutBatchSize) {
       this.signalTimeoutBatchSize = atLeast("signalTimeoutBatchSize", signalTimeoutBatchSize, 1);
       return this;
@@ -1010,6 +1350,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link MaintenanceOptions}. */
+  @Incubating
   public static final class MaintenanceBuilder {
     private boolean dlqPurgeEnabled = true;
     private String dlqPurgeCron = "0 0 2 * * ?";
@@ -1024,51 +1366,101 @@ public class RatchetOptions {
 
     private MaintenanceBuilder() {}
 
+    /**
+     * @param dlqPurgeEnabled {@code true} to run the DLQ purge job
+     * @return this builder
+     */
     public MaintenanceBuilder dlqPurgeEnabled(boolean dlqPurgeEnabled) {
       this.dlqPurgeEnabled = dlqPurgeEnabled;
       return this;
     }
 
+    /**
+     * @param dlqPurgeCron cron expression for the DLQ purge cadence; must not be blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code dlqPurgeCron} is blank
+     */
     public MaintenanceBuilder dlqPurgeCron(String dlqPurgeCron) {
       this.dlqPurgeCron = requireText("dlqPurgeCron", dlqPurgeCron);
       return this;
     }
 
+    /**
+     * @param dlqPurgeDays age in days at which DLQ entries become eligible for purge; must be
+     *     {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code dlqPurgeDays < 0}
+     */
     public MaintenanceBuilder dlqPurgeDays(long dlqPurgeDays) {
       this.dlqPurgeDays = atLeast("dlqPurgeDays", dlqPurgeDays, 0L);
       return this;
     }
 
+    /**
+     * @param jobArchiveEnabled {@code true} to run the job-archive job
+     * @return this builder
+     */
     public MaintenanceBuilder jobArchiveEnabled(boolean jobArchiveEnabled) {
       this.jobArchiveEnabled = jobArchiveEnabled;
       return this;
     }
 
+    /**
+     * @param jobArchiveCron cron expression for the job-archive cadence; must not be blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code jobArchiveCron} is blank
+     */
     public MaintenanceBuilder jobArchiveCron(String jobArchiveCron) {
       this.jobArchiveCron = requireText("jobArchiveCron", jobArchiveCron);
       return this;
     }
 
+    /**
+     * @param jobRetentionDays age in days at which terminal jobs become eligible for archive; must
+     *     be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code jobRetentionDays < 0}
+     */
     public MaintenanceBuilder jobRetentionDays(long jobRetentionDays) {
       this.jobRetentionDays = atLeast("jobRetentionDays", jobRetentionDays, 0L);
       return this;
     }
 
+    /**
+     * @param jobArchiveBatchSize maximum jobs archived per archive pass; must be {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code jobArchiveBatchSize < 1}
+     */
     public MaintenanceBuilder jobArchiveBatchSize(int jobArchiveBatchSize) {
       this.jobArchiveBatchSize = atLeast("jobArchiveBatchSize", jobArchiveBatchSize, 1);
       return this;
     }
 
+    /**
+     * @param logPurgeEnabled {@code true} to run the execution-log purge job
+     * @return this builder
+     */
     public MaintenanceBuilder logPurgeEnabled(boolean logPurgeEnabled) {
       this.logPurgeEnabled = logPurgeEnabled;
       return this;
     }
 
+    /**
+     * @param logPurgeCron cron expression for the log-purge cadence; must not be blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code logPurgeCron} is blank
+     */
     public MaintenanceBuilder logPurgeCron(String logPurgeCron) {
       this.logPurgeCron = requireText("logPurgeCron", logPurgeCron);
       return this;
     }
 
+    /**
+     * @param logRetentionDays age in days at which execution-log rows become eligible for purge;
+     *     must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code logRetentionDays < 0}
+     */
     public MaintenanceBuilder logRetentionDays(long logRetentionDays) {
       this.logRetentionDays = atLeast("logRetentionDays", logRetentionDays, 0L);
       return this;
@@ -1089,6 +1481,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link NotificationOptions}. */
+  @Incubating
   public static final class NotificationBuilder {
     private boolean enabled = true;
     private String dlqAlertChannel = "#job-scheduler-dlq";
@@ -1096,16 +1490,30 @@ public class RatchetOptions {
 
     private NotificationBuilder() {}
 
+    /**
+     * @param enabled {@code true} to publish notifications
+     * @return this builder
+     */
     public NotificationBuilder enabled(boolean enabled) {
       this.enabled = enabled;
       return this;
     }
 
+    /**
+     * @param dlqAlertChannel channel identifier for DLQ alerts; must not be blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code dlqAlertChannel} is blank
+     */
     public NotificationBuilder dlqAlertChannel(String dlqAlertChannel) {
       this.dlqAlertChannel = requireText("dlqAlertChannel", dlqAlertChannel);
       return this;
     }
 
+    /**
+     * @param timeoutAlertChannel channel identifier for timeout alerts; must not be blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code timeoutAlertChannel} is blank
+     */
     public NotificationBuilder timeoutAlertChannel(String timeoutAlertChannel) {
       this.timeoutAlertChannel = requireText("timeoutAlertChannel", timeoutAlertChannel);
       return this;
@@ -1116,6 +1524,8 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link SchemaOptions}. */
+  @Incubating
   public static final class SchemaBuilder {
     private boolean autoMigrate;
     private String migrationDialect = "";
@@ -1123,16 +1533,31 @@ public class RatchetOptions {
 
     private SchemaBuilder() {}
 
+    /**
+     * @param autoMigrate {@code true} to run the migrator from the schema-migration lifecycle hook
+     * @return this builder
+     */
     public SchemaBuilder autoMigrate(boolean autoMigrate) {
       this.autoMigrate = autoMigrate;
       return this;
     }
 
+    /**
+     * @param migrationDialect explicit dialect identifier; {@code null} or blank asks the store to
+     *     autodetect
+     * @return this builder
+     */
     public SchemaBuilder migrationDialect(String migrationDialect) {
       this.migrationDialect = migrationDialect == null ? "" : migrationDialect.trim();
       return this;
     }
 
+    /**
+     * @param migrationPrefix classpath prefix for dialect-specific migration scripts; must not be
+     *     blank
+     * @return this builder
+     * @throws IllegalArgumentException if {@code migrationPrefix} is blank
+     */
     public SchemaBuilder migrationPrefix(String migrationPrefix) {
       this.migrationPrefix = requireText("migrationPrefix", migrationPrefix);
       return this;
@@ -1143,17 +1568,29 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link PayloadOptions}. */
+  @Incubating
   public static final class PayloadBuilder {
     private int maxPayloadKb = 100;
     private long maxResultBytes = 65536L;
 
     private PayloadBuilder() {}
 
+    /**
+     * @param maxPayloadKb maximum job payload size in kilobytes; must be {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code maxPayloadKb < 1}
+     */
     public PayloadBuilder maxPayloadKb(int maxPayloadKb) {
       this.maxPayloadKb = atLeast("maxPayloadKb", maxPayloadKb, 1);
       return this;
     }
 
+    /**
+     * @param maxResultBytes maximum persisted job-result size in bytes; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code maxResultBytes < 0}
+     */
     public PayloadBuilder maxResultBytes(long maxResultBytes) {
       this.maxResultBytes = atLeast("maxResultBytes", maxResultBytes, 0L);
       return this;
@@ -1164,11 +1601,18 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link MetricsOptions}. */
+  @Incubating
   public static final class MetricsBuilder {
     private String clustering = "none";
 
     private MetricsBuilder() {}
 
+    /**
+     * @param clustering clustering-strategy identifier; must not be blank and is lowercased
+     * @return this builder
+     * @throws IllegalArgumentException if {@code clustering} is blank
+     */
     public MetricsBuilder clustering(String clustering) {
       this.clustering = requireText("clustering", clustering).toLowerCase(Locale.ROOT);
       return this;
@@ -1179,17 +1623,28 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link SecurityOptions}. */
+  @Incubating
   public static final class SecurityBuilder {
     private boolean allowEmptyClassPolicy;
     private boolean redactEmails = true;
 
     private SecurityBuilder() {}
 
+    /**
+     * @param allowEmptyClassPolicy {@code true} to permit running without a configured class
+     *     policy; {@code false} fails fast at startup when none is bound
+     * @return this builder
+     */
     public SecurityBuilder allowEmptyClassPolicy(boolean allowEmptyClassPolicy) {
       this.allowEmptyClassPolicy = allowEmptyClassPolicy;
       return this;
     }
 
+    /**
+     * @param redactEmails {@code true} to redact email-shaped strings from observability output
+     * @return this builder
+     */
     public SecurityBuilder redactEmails(boolean redactEmails) {
       this.redactEmails = redactEmails;
       return this;
@@ -1200,18 +1655,31 @@ public class RatchetOptions {
     }
   }
 
+  /** Builder for {@link StoreOptions}. */
+  @Incubating
   public static final class StoreBuilder {
     private IsolationCheckMode isolationCheckMode = IsolationCheckMode.FAIL;
     private int priorityBoostIntervalMinutes = 15;
 
     private StoreBuilder() {}
 
+    /**
+     * @param isolationCheckMode action taken on an isolation-level mismatch; must not be null
+     * @return this builder
+     * @throws NullPointerException if {@code isolationCheckMode} is null
+     */
     public StoreBuilder isolationCheckMode(IsolationCheckMode isolationCheckMode) {
       this.isolationCheckMode =
           Objects.requireNonNull(isolationCheckMode, "isolationCheckMode must not be null");
       return this;
     }
 
+    /**
+     * @param priorityBoostIntervalMinutes interval in minutes at which long-waiting pending jobs
+     *     are promoted; must be {@code >= 0} ({@code 0} disables the boost)
+     * @return this builder
+     * @throws IllegalArgumentException if {@code priorityBoostIntervalMinutes < 0}
+     */
     public StoreBuilder priorityBoostIntervalMinutes(int priorityBoostIntervalMinutes) {
       this.priorityBoostIntervalMinutes =
           atLeast("priorityBoostIntervalMinutes", priorityBoostIntervalMinutes, 0);
@@ -1231,11 +1699,24 @@ public class RatchetOptions {
 
     private CircuitBreakerBuilder() {}
 
+    /**
+     * @param enabled {@code true} to enable circuit-breaker enforcement; when {@code false} all
+     *     calls pass through unmonitored
+     * @return this builder
+     */
     public CircuitBreakerBuilder enabled(boolean enabled) {
       this.enabled = enabled;
       return this;
     }
 
+    /**
+     * Customizes the thresholds for a single profile, creating the profile if absent.
+     *
+     * @param profile profile to customize; must not be null
+     * @param customizer receives the profile builder
+     * @return this builder
+     * @throws NullPointerException if {@code profile} is null
+     */
     public CircuitBreakerBuilder profile(
         CircuitBreakerProfile profile, Consumer<CircuitBreakerProfileBuilder> customizer) {
       CircuitBreakerProfileBuilder builder =
@@ -1267,6 +1748,13 @@ public class RatchetOptions {
 
     private CircuitBreakerProfileBuilder() {}
 
+    /**
+     * @param failureRateThreshold failure-rate percentage at which the breaker opens; must be a
+     *     finite value between 0 and 100 inclusive
+     * @return this builder
+     * @throws IllegalArgumentException if {@code failureRateThreshold} is non-finite or outside
+     *     {@code 0..100}
+     */
     public CircuitBreakerProfileBuilder failureRateThreshold(float failureRateThreshold) {
       if (!Float.isFinite(failureRateThreshold)
           || failureRateThreshold < 0.0f
@@ -1278,22 +1766,46 @@ public class RatchetOptions {
       return this;
     }
 
+    /**
+     * @param slidingWindowSize size of the sliding window used to compute the failure rate; must be
+     *     {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code slidingWindowSize < 1}
+     */
     public CircuitBreakerProfileBuilder slidingWindowSize(int slidingWindowSize) {
       this.slidingWindowSize = atLeast("slidingWindowSize", slidingWindowSize, 1);
       return this;
     }
 
+    /**
+     * @param waitDurationMs duration in milliseconds the breaker stays OPEN before transitioning to
+     *     HALF_OPEN; must be {@code >= 0}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code waitDurationMs < 0}
+     */
     public CircuitBreakerProfileBuilder waitDurationMs(long waitDurationMs) {
       this.waitDurationMs = atLeast("waitDurationMs", waitDurationMs, 0L);
       return this;
     }
 
+    /**
+     * @param permittedCallsInHalfOpen number of trial calls allowed while in HALF_OPEN; must be
+     *     {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code permittedCallsInHalfOpen < 1}
+     */
     public CircuitBreakerProfileBuilder permittedCallsInHalfOpen(int permittedCallsInHalfOpen) {
       this.permittedCallsInHalfOpen =
           atLeast("permittedCallsInHalfOpen", permittedCallsInHalfOpen, 1);
       return this;
     }
 
+    /**
+     * @param minimumCalls minimum recorded calls before the failure rate is evaluated; must be
+     *     {@code >= 1}
+     * @return this builder
+     * @throws IllegalArgumentException if {@code minimumCalls < 1}
+     */
     public CircuitBreakerProfileBuilder minimumCalls(int minimumCalls) {
       this.minimumCalls = atLeast("minimumCalls", minimumCalls, 1);
       return this;

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -340,11 +340,11 @@ public class RatchetOptions {
    * @param jobExecutorJndi JNDI name of the {@code ManagedExecutorService} that runs jobs
    * @param scheduledExecutorJndi JNDI name of the {@code ManagedScheduledExecutorService} used for
    *     scheduled work
-   * @param virtualExecutorJndi JNDI name of an additional {@code ManagedExecutorService} backing the
-   *     virtual pool; absent (null or blank) means virtual-targeted jobs fall back to platform
-   * @param virtualCounterAccounting {@code true} to use lock-free counter accounting for the virtual
-   *     pool instead of the default semaphore bound; only safe when the executor is genuinely
-   *     virtual-thread backed
+   * @param virtualExecutorJndi JNDI name of an additional {@code ManagedExecutorService} backing
+   *     the virtual pool; absent (null or blank) means virtual-targeted jobs fall back to platform
+   * @param virtualCounterAccounting {@code true} to use lock-free counter accounting for the
+   *     virtual pool instead of the default semaphore bound; only safe when the executor is
+   *     genuinely virtual-thread backed
    */
   @Incubating
   public record ExecutionOptions(
@@ -873,8 +873,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param burstDelayMs delay in milliseconds between consecutive busy ticks; must be
-     *     {@code >= 0}
+     * @param burstDelayMs delay in milliseconds between consecutive busy ticks; must be {@code >=
+     *     0}
      * @return this builder
      * @throws IllegalArgumentException if {@code burstDelayMs < 0}
      */
@@ -884,8 +884,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param minDelayMs minimum idle backoff delay in milliseconds; must be {@code >= 0} and
-     *     {@code <= maxDelayMs} (enforced when the section is built)
+     * @param minDelayMs minimum idle backoff delay in milliseconds; must be {@code >= 0} and {@code
+     *     <= maxDelayMs} (enforced when the section is built)
      * @return this builder
      * @throws IllegalArgumentException if {@code minDelayMs < 0}
      */
@@ -895,8 +895,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param maxDelayMs maximum idle backoff delay in milliseconds; must be {@code >= 1} and
-     *     {@code >= minDelayMs} (enforced when the section is built)
+     * @param maxDelayMs maximum idle backoff delay in milliseconds; must be {@code >= 1} and {@code
+     *     >= minDelayMs} (enforced when the section is built)
      * @return this builder
      * @throws IllegalArgumentException if {@code maxDelayMs < 1}
      */
@@ -938,8 +938,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param claimHeadroomFactor headroom multiplier for free-slot calculations; must be
-     *     {@code >= 0} ({@code 0} disables the adjustment)
+     * @param claimHeadroomFactor headroom multiplier for free-slot calculations; must be {@code >=
+     *     0} ({@code 0} disables the adjustment)
      * @return this builder
      * @throws IllegalArgumentException if {@code claimHeadroomFactor < 0}
      */
@@ -1036,8 +1036,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param queueSize bounded queue length for the in-process fallback executor; must be
-     *     {@code >= 0}
+     * @param queueSize bounded queue length for the in-process fallback executor; must be {@code >=
+     *     0}
      * @return this builder
      * @throws IllegalArgumentException if {@code queueSize < 0}
      */
@@ -1228,8 +1228,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param pollMs nominal poll interval in milliseconds; must be {@code >= 1} and
-     *     {@code <= maxPollMs} (enforced when the section is built)
+     * @param pollMs nominal poll interval in milliseconds; must be {@code >= 1} and {@code <=
+     *     maxPollMs} (enforced when the section is built)
      * @return this builder
      * @throws IllegalArgumentException if {@code pollMs < 1}
      */
@@ -1239,8 +1239,8 @@ public class RatchetOptions {
     }
 
     /**
-     * @param maxPollMs maximum poll interval in milliseconds when no work is due; must be
-     *     {@code >= 1} and {@code >= pollMs} (enforced when the section is built)
+     * @param maxPollMs maximum poll interval in milliseconds when no work is due; must be {@code >=
+     *     1} and {@code >= pollMs} (enforced when the section is built)
      * @return this builder
      * @throws IllegalArgumentException if {@code maxPollMs < 1}
      */

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -17,7 +17,6 @@ import java.util.function.Consumer;
  * bean. Instances are still immutable — all fields are {@code final} and set only through {@link
  * Builder}. Use {@link #builder()} or {@link #defaults()} to construct.
  */
-@Incubating
 @SuppressWarnings("ClassCanBeRecord")
 public class RatchetOptions {
 
@@ -90,20 +89,10 @@ public class RatchetOptions {
     this.circuitBreaker = Objects.requireNonNull(circuitBreaker, "circuitBreaker must not be null");
   }
 
-  /**
-   * Returns an options instance with every section set to its built-in default.
-   *
-   * @return a fully-defaulted options instance
-   */
   public static RatchetOptions defaults() {
     return builder().build();
   }
 
-  /**
-   * Returns a new builder seeded with the built-in defaults for every section.
-   *
-   * @return a new builder
-   */
   public static Builder builder() {
     return new Builder();
   }
@@ -268,7 +257,6 @@ public class RatchetOptions {
     return circuitBreaker;
   }
 
-  @Incubating
   public enum IsolationCheckMode {
     WARN,
     FAIL,
@@ -312,7 +300,6 @@ public class RatchetOptions {
    * @param claimHeadroomFactor headroom multiplier applied to free-slot calculations; {@code 0}
    *     disables the headroom adjustment
    */
-  @Incubating
   public record PollingOptions(
       int batchSize,
       long burstDelayMs,
@@ -327,9 +314,8 @@ public class RatchetOptions {
    * Execution-pool wiring: target executor JNDI names, queue size, and per-execution-type
    * concurrency / virtual-thread / rate caps.
    *
-   * @param defaultThreadingMode pool a job runs on when it specifies no target of its own; defaults
-   *     to {@link ThreadingMode#PLATFORM}, and {@link ThreadingMode#VIRTUAL} falls back to platform
-   *     when no virtual executor is configured
+   * @param useVirtualThreads {@code true} to request virtual-thread execution where supported by
+   *     the chosen executor (the container ultimately decides)
    * @param queueSize bounded queue length used by the in-process fallback executor
    * @param maxConcurrency map of execution-type name to maximum concurrent executions; missing keys
    *     fall back to the per-type defaults
@@ -340,13 +326,7 @@ public class RatchetOptions {
    * @param jobExecutorJndi JNDI name of the {@code ManagedExecutorService} that runs jobs
    * @param scheduledExecutorJndi JNDI name of the {@code ManagedScheduledExecutorService} used for
    *     scheduled work
-   * @param virtualExecutorJndi JNDI name of an additional {@code ManagedExecutorService} backing
-   *     the virtual pool; absent (null or blank) means virtual-targeted jobs fall back to platform
-   * @param virtualCounterAccounting {@code true} to use lock-free counter accounting for the
-   *     virtual pool instead of the default semaphore bound; only safe when the executor is
-   *     genuinely virtual-thread backed
    */
-  @Incubating
   public record ExecutionOptions(
       ThreadingMode defaultThreadingMode,
       int queueSize,
@@ -377,40 +357,14 @@ public class RatchetOptions {
       return virtualExecutorJndi != null;
     }
 
-    /**
-     * Returns the configured max-concurrency for an execution type.
-     *
-     * @param executionTypeName execution-type name (normalized to upper case with {@code -}
-     *     replaced by {@code _})
-     * @param defaultValue value returned when no entry is configured for the type
-     * @return the configured limit, or {@code defaultValue} if none is set
-     * @throws IllegalArgumentException if {@code executionTypeName} is blank
-     */
     public int maxConcurrency(String executionTypeName, int defaultValue) {
       return maxConcurrency.getOrDefault(normalizeKey(executionTypeName), defaultValue);
     }
 
-    /**
-     * Returns the configured virtual-thread limit for an execution type.
-     *
-     * @param executionTypeName execution-type name (normalized to upper case with {@code -}
-     *     replaced by {@code _})
-     * @param defaultValue value returned when no entry is configured for the type
-     * @return the configured limit, or {@code defaultValue} if none is set
-     * @throws IllegalArgumentException if {@code executionTypeName} is blank
-     */
     public int virtualThreadLimit(String executionTypeName, int defaultValue) {
       return virtualThreadLimits.getOrDefault(normalizeKey(executionTypeName), defaultValue);
     }
 
-    /**
-     * Returns the configured per-minute rate limit for an execution type.
-     *
-     * @param executionTypeName execution-type name (normalized to upper case with {@code -}
-     *     replaced by {@code _})
-     * @return the configured limit, or {@code 0} (no limit) if none is set
-     * @throws IllegalArgumentException if {@code executionTypeName} is blank
-     */
     public int rateLimitPerMinute(String executionTypeName) {
       return rateLimitsPerMinute.getOrDefault(normalizeKey(executionTypeName), 0);
     }
@@ -430,7 +384,6 @@ public class RatchetOptions {
    *     empty list disables the require-list constraint
    * @param excludeTags job tags that, when present on a job, exclude that job from this node
    */
-  @Incubating
   public record NodeOptions(
       String nodeId,
       long heartbeatIntervalSeconds,
@@ -445,21 +398,10 @@ public class RatchetOptions {
       excludeTags = List.copyOf(excludeTags == null ? List.of() : excludeTags);
     }
 
-    /**
-     * Returns the explicit node id when one was configured.
-     *
-     * @return the explicit node id, or an empty optional when none was set (an id is generated at
-     *     startup)
-     */
     public Optional<String> explicitNodeId() {
       return nodeId == null || nodeId.isBlank() ? Optional.empty() : Optional.of(nodeId);
     }
 
-    /**
-     * Returns the tag filter built from the require/exclude tag lists.
-     *
-     * @return a node tag filter for this configuration
-     */
     public NodeTagFilter tagFilter() {
       return new NodeTagFilter(requireTags, excludeTags);
     }
@@ -477,7 +419,6 @@ public class RatchetOptions {
    * @param convergenceWindowSeconds rolling window in seconds during which competing recurring
    *     registrations are reconciled; {@code 0} disables convergence reconciliation
    */
-  @Incubating
   public record RecurringOptions(
       int batchLimit,
       long pollMs,
@@ -490,7 +431,6 @@ public class RatchetOptions {
    *
    * @param drainIntervalMs interval in milliseconds between buffer drains to the store
    */
-  @Incubating
   public record RetryBufferOptions(long drainIntervalMs) {}
 
   /**
@@ -502,7 +442,6 @@ public class RatchetOptions {
    *     their own
    * @param signalTimeoutBatchSize maximum number of WAITING jobs scanned per signal-timeout tick
    */
-  @Incubating
   public record TimeoutOptions(
       int softTimeoutPercent, long defaultSlaSeconds, int signalTimeoutBatchSize) {}
 
@@ -520,7 +459,6 @@ public class RatchetOptions {
    * @param logPurgeCron cron expression controlling the log-purge cadence
    * @param logRetentionDays age in days at which execution-log rows become eligible for purge
    */
-  @Incubating
   public record MaintenanceOptions(
       boolean dlqPurgeEnabled,
       String dlqPurgeCron,
@@ -541,7 +479,6 @@ public class RatchetOptions {
    * @param dlqAlertChannel channel identifier for DLQ alerts
    * @param timeoutAlertChannel channel identifier for timeout alerts
    */
-  @Incubating
   public record NotificationOptions(
       boolean enabled, String dlqAlertChannel, String timeoutAlertChannel) {}
 
@@ -555,7 +492,6 @@ public class RatchetOptions {
    * @param migrationPrefix classpath prefix under which dialect-specific migration scripts are
    *     resolved
    */
-  @Incubating
   public record SchemaOptions(
       boolean autoMigrate, String migrationDialect, String migrationPrefix) {}
 
@@ -565,7 +501,6 @@ public class RatchetOptions {
    * @param maxPayloadKb maximum job payload size in kilobytes
    * @param maxResultBytes maximum persisted job-result size in bytes
    */
-  @Incubating
   public record PayloadOptions(int maxPayloadKb, long maxResultBytes) {}
 
   /**
@@ -574,7 +509,6 @@ public class RatchetOptions {
    * @param clustering clustering-strategy identifier passed to the metrics collector (for example
    *     {@code none}); values are lowercased
    */
-  @Incubating
   public record MetricsOptions(String clustering) {}
 
   /**
@@ -583,9 +517,12 @@ public class RatchetOptions {
    * @param allowEmptyClassPolicy {@code true} to permit running without a configured {@code
    *     ClassPolicy}; {@code false} (default) fails fast at startup when no policy is bound
    * @param redactEmails {@code true} to redact email-shaped strings from observability output
+   * @param maskPayloads {@code true} to mask sensitive payload fields where a payload would be
+   *     rendered into a log line; {@code false} (default) leaves logged payloads unmasked. The
+   *     durable store payload is never affected.
    */
-  @Incubating
-  public record SecurityOptions(boolean allowEmptyClassPolicy, boolean redactEmails) {}
+  public record SecurityOptions(
+      boolean allowEmptyClassPolicy, boolean redactEmails, boolean maskPayloads) {}
 
   /**
    * Store-layer tuning.
@@ -595,7 +532,6 @@ public class RatchetOptions {
    * @param priorityBoostIntervalMinutes interval in minutes at which long-waiting pending jobs are
    *     promoted to a higher effective priority; {@code 0} disables the boost
    */
-  @Incubating
   public record StoreOptions(
       IsolationCheckMode isolationCheckMode, int priorityBoostIntervalMinutes) {}
 
@@ -646,11 +582,6 @@ public class RatchetOptions {
       int permittedCallsInHalfOpen,
       int minimumCalls) {}
 
-  /**
-   * Mutable builder for {@link RatchetOptions}; each section is customized through a nested
-   * builder.
-   */
-  @Incubating
   public static final class Builder {
     private final PollingBuilder polling = new PollingBuilder();
     private final ExecutionBuilder execution = new ExecutionBuilder();
@@ -669,166 +600,77 @@ public class RatchetOptions {
 
     private Builder() {}
 
-    /**
-     * Customizes the polling section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder polling(Consumer<PollingBuilder> customizer) {
       customizer.accept(polling);
       return this;
     }
 
-    /**
-     * Customizes the execution section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder execution(Consumer<ExecutionBuilder> customizer) {
       customizer.accept(execution);
       return this;
     }
 
-    /**
-     * Customizes the node section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder node(Consumer<NodeBuilder> customizer) {
       customizer.accept(node);
       return this;
     }
 
-    /**
-     * Customizes the recurring-job section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder recurring(Consumer<RecurringBuilder> customizer) {
       customizer.accept(recurring);
       return this;
     }
 
-    /**
-     * Customizes the retry-buffer section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder retryBuffer(Consumer<RetryBufferBuilder> customizer) {
       customizer.accept(retryBuffer);
       return this;
     }
 
-    /**
-     * Customizes the timeout section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder timeout(Consumer<TimeoutBuilder> customizer) {
       customizer.accept(timeout);
       return this;
     }
 
-    /**
-     * Customizes the maintenance section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder maintenance(Consumer<MaintenanceBuilder> customizer) {
       customizer.accept(maintenance);
       return this;
     }
 
-    /**
-     * Customizes the notification section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder notifications(Consumer<NotificationBuilder> customizer) {
       customizer.accept(notifications);
       return this;
     }
 
-    /**
-     * Customizes the schema-migration section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder schema(Consumer<SchemaBuilder> customizer) {
       customizer.accept(schema);
       return this;
     }
 
-    /**
-     * Customizes the payload section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder payload(Consumer<PayloadBuilder> customizer) {
       customizer.accept(payload);
       return this;
     }
 
-    /**
-     * Customizes the metrics section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder metrics(Consumer<MetricsBuilder> customizer) {
       customizer.accept(metrics);
       return this;
     }
 
-    /**
-     * Customizes the security section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder security(Consumer<SecurityBuilder> customizer) {
       customizer.accept(security);
       return this;
     }
 
-    /**
-     * Customizes the store section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     public Builder store(Consumer<StoreBuilder> customizer) {
       customizer.accept(store);
       return this;
     }
 
-    /**
-     * Customizes the circuit-breaker section.
-     *
-     * @param customizer receives the section builder
-     * @return this builder
-     */
     @Incubating
     public Builder circuitBreaker(Consumer<CircuitBreakerBuilder> customizer) {
       customizer.accept(circuitBreaker);
       return this;
     }
 
-    /**
-     * Builds the immutable options instance from the current section state.
-     *
-     * @return the built options
-     */
     public RatchetOptions build() {
       return new RatchetOptions(
           polling.build(),
@@ -848,8 +690,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link PollingOptions}. */
-  @Incubating
   public static final class PollingBuilder {
     private int batchSize = 50;
     private long burstDelayMs = 500L;
@@ -862,87 +702,41 @@ public class RatchetOptions {
 
     private PollingBuilder() {}
 
-    /**
-     * @param batchSize maximum jobs claimed per tick; must be {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code batchSize < 1}
-     */
     public PollingBuilder batchSize(int batchSize) {
       this.batchSize = atLeast("batchSize", batchSize, 1);
       return this;
     }
 
-    /**
-     * @param burstDelayMs delay in milliseconds between consecutive busy ticks; must be {@code >=
-     *     0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code burstDelayMs < 0}
-     */
     public PollingBuilder burstDelayMs(long burstDelayMs) {
       this.burstDelayMs = atLeast("burstDelayMs", burstDelayMs, 0L);
       return this;
     }
 
-    /**
-     * @param minDelayMs minimum idle backoff delay in milliseconds; must be {@code >= 0} and {@code
-     *     <= maxDelayMs} (enforced when the section is built)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code minDelayMs < 0}
-     */
     public PollingBuilder minDelayMs(long minDelayMs) {
       this.minDelayMs = atLeast("minDelayMs", minDelayMs, 0L);
       return this;
     }
 
-    /**
-     * @param maxDelayMs maximum idle backoff delay in milliseconds; must be {@code >= 1} and {@code
-     *     >= minDelayMs} (enforced when the section is built)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code maxDelayMs < 1}
-     */
     public PollingBuilder maxDelayMs(long maxDelayMs) {
       this.maxDelayMs = atLeast("maxDelayMs", maxDelayMs, 1L);
       return this;
     }
 
-    /**
-     * @param deepIdleDelayMs delay in milliseconds applied once deep idle is reached; must be
-     *     {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code deepIdleDelayMs < 0}
-     */
     public PollingBuilder deepIdleDelayMs(long deepIdleDelayMs) {
       this.deepIdleDelayMs = atLeast("deepIdleDelayMs", deepIdleDelayMs, 0L);
       return this;
     }
 
-    /**
-     * @param deepIdleThresholdMs idle duration in milliseconds after which deep-idle backoff
-     *     applies; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code deepIdleThresholdMs < 0}
-     */
     public PollingBuilder deepIdleThresholdMs(long deepIdleThresholdMs) {
       this.deepIdleThresholdMs = atLeast("deepIdleThresholdMs", deepIdleThresholdMs, 0L);
       return this;
     }
 
-    /**
-     * @param idleThreshold consecutive empty ticks before backoff ramps; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code idleThreshold < 0}
-     */
     public PollingBuilder idleThreshold(int idleThreshold) {
       this.idleThreshold = atLeast("idleThreshold", idleThreshold, 0);
       return this;
     }
 
-    /**
-     * @param claimHeadroomFactor headroom multiplier for free-slot calculations; must be {@code >=
-     *     0} ({@code 0} disables the adjustment)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code claimHeadroomFactor < 0}
-     */
     public PollingBuilder claimHeadroomFactor(int claimHeadroomFactor) {
       this.claimHeadroomFactor = atLeast("claimHeadroomFactor", claimHeadroomFactor, 0);
       return this;
@@ -962,8 +756,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link ExecutionOptions}. */
-  @Incubating
   public static final class ExecutionBuilder {
     private final Map<String, Integer> maxConcurrency = defaultConcurrency();
     private final Map<String, Integer> virtualThreadLimits = new HashMap<>();
@@ -1035,49 +827,22 @@ public class RatchetOptions {
       return this;
     }
 
-    /**
-     * @param queueSize bounded queue length for the in-process fallback executor; must be {@code >=
-     *     0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code queueSize < 0}
-     */
     public ExecutionBuilder queueSize(int queueSize) {
       this.queueSize = atLeast("queueSize", queueSize, 0);
       return this;
     }
 
-    /**
-     * @param executionTypeName execution-type name; normalized to upper case with {@code -}
-     *     replaced by {@code _}, and must not be blank
-     * @param maxConcurrency maximum concurrent executions for the type; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if the name is blank or {@code maxConcurrency < 0}
-     */
     public ExecutionBuilder maxConcurrency(String executionTypeName, int maxConcurrency) {
       this.maxConcurrency.put(
           normalizeKey(executionTypeName), atLeast("maxConcurrency", maxConcurrency, 0));
       return this;
     }
 
-    /**
-     * @param executionTypeName execution-type name; normalized to upper case with {@code -}
-     *     replaced by {@code _}, and must not be blank
-     * @param limit virtual-thread cap for the type; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if the name is blank or {@code limit < 0}
-     */
     public ExecutionBuilder virtualThreadLimit(String executionTypeName, int limit) {
       this.virtualThreadLimits.put(normalizeKey(executionTypeName), atLeast("limit", limit, 0));
       return this;
     }
 
-    /**
-     * @param executionTypeName execution-type name; normalized to upper case with {@code -}
-     *     replaced by {@code _}, and must not be blank
-     * @param limit per-minute rate limit for the type; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if the name is blank or {@code limit < 0}
-     */
     public ExecutionBuilder rateLimitPerMinute(String executionTypeName, int limit) {
       this.rateLimitsPerMinute.put(normalizeKey(executionTypeName), atLeast("limit", limit, 0));
       return this;
@@ -1097,8 +862,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link NodeOptions}. */
-  @Incubating
   public static final class NodeBuilder {
     private String nodeId;
     private long heartbeatIntervalSeconds = 10L;
@@ -1110,85 +873,43 @@ public class RatchetOptions {
 
     private NodeBuilder() {}
 
-    /**
-     * @param nodeId explicit node id; must not be blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code nodeId} is blank
-     */
     public NodeBuilder nodeId(String nodeId) {
       this.nodeId = requireText("nodeId", nodeId);
       return this;
     }
 
-    /**
-     * Clears any explicit node id so an id is generated at startup.
-     *
-     * @return this builder
-     */
     public NodeBuilder clearNodeId() {
       this.nodeId = null;
       return this;
     }
 
-    /**
-     * @param heartbeatIntervalSeconds liveness-report interval in seconds; must be {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code heartbeatIntervalSeconds < 1}
-     */
     public NodeBuilder heartbeatIntervalSeconds(long heartbeatIntervalSeconds) {
       this.heartbeatIntervalSeconds =
           atLeast("heartbeatIntervalSeconds", heartbeatIntervalSeconds, 1L);
       return this;
     }
 
-    /**
-     * @param orphanGraceSeconds grace period in seconds before a missed-heartbeat node is
-     *     reclaimed; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code orphanGraceSeconds < 0}
-     */
     public NodeBuilder orphanGraceSeconds(long orphanGraceSeconds) {
       this.orphanGraceSeconds = atLeast("orphanGraceSeconds", orphanGraceSeconds, 0L);
       return this;
     }
 
-    /**
-     * @param orphanScanIntervalMinutes interval in minutes between orphan-reclaim scans; must be
-     *     {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code orphanScanIntervalMinutes < 1}
-     */
     public NodeBuilder orphanScanIntervalMinutes(long orphanScanIntervalMinutes) {
       this.orphanScanIntervalMinutes =
           atLeast("orphanScanIntervalMinutes", orphanScanIntervalMinutes, 1L);
       return this;
     }
 
-    /**
-     * @param dynamicHeartbeatEnabled {@code true} to let the heartbeat interval adapt to cluster
-     *     activity
-     * @return this builder
-     */
     public NodeBuilder dynamicHeartbeatEnabled(boolean dynamicHeartbeatEnabled) {
       this.dynamicHeartbeatEnabled = dynamicHeartbeatEnabled;
       return this;
     }
 
-    /**
-     * @param tags job tags that must be present on the node for a job to be claimed here; replaces
-     *     any previously-set require list
-     * @return this builder
-     */
     public NodeBuilder requireTags(String... tags) {
       this.requireTags = List.of(tags);
       return this;
     }
 
-    /**
-     * @param tags job tags that exclude a job from this node; replaces any previously-set exclude
-     *     list
-     * @return this builder
-     */
     public NodeBuilder excludeTags(String... tags) {
       this.excludeTags = List.of(tags);
       return this;
@@ -1206,8 +927,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link RecurringOptions}. */
-  @Incubating
   public static final class RecurringBuilder {
     private int batchLimit = 20;
     private long pollMs = 1000L;
@@ -1217,55 +936,26 @@ public class RatchetOptions {
 
     private RecurringBuilder() {}
 
-    /**
-     * @param batchLimit maximum recurring jobs materialized per tick; must be {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code batchLimit < 1}
-     */
     public RecurringBuilder batchLimit(int batchLimit) {
       this.batchLimit = atLeast("batchLimit", batchLimit, 1);
       return this;
     }
 
-    /**
-     * @param pollMs nominal poll interval in milliseconds; must be {@code >= 1} and {@code <=
-     *     maxPollMs} (enforced when the section is built)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code pollMs < 1}
-     */
     public RecurringBuilder pollMs(long pollMs) {
       this.pollMs = atLeast("pollMs", pollMs, 1L);
       return this;
     }
 
-    /**
-     * @param maxPollMs maximum poll interval in milliseconds when no work is due; must be {@code >=
-     *     1} and {@code >= pollMs} (enforced when the section is built)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code maxPollMs < 1}
-     */
     public RecurringBuilder maxPollMs(long maxPollMs) {
       this.maxPollMs = atLeast("maxPollMs", maxPollMs, 1L);
       return this;
     }
 
-    /**
-     * @param startupGraceSeconds delay in seconds before the first materialization run; must be
-     *     {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code startupGraceSeconds < 0}
-     */
     public RecurringBuilder startupGraceSeconds(long startupGraceSeconds) {
       this.startupGraceSeconds = atLeast("startupGraceSeconds", startupGraceSeconds, 0L);
       return this;
     }
 
-    /**
-     * @param convergenceWindowSeconds reconciliation window in seconds; must be {@code >= 0}
-     *     ({@code 0} disables reconciliation)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code convergenceWindowSeconds < 0}
-     */
     public RecurringBuilder convergenceWindowSeconds(long convergenceWindowSeconds) {
       this.convergenceWindowSeconds =
           atLeast("convergenceWindowSeconds", convergenceWindowSeconds, 0L);
@@ -1279,18 +969,11 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link RetryBufferOptions}. */
-  @Incubating
   public static final class RetryBufferBuilder {
     private long drainIntervalMs = 1000L;
 
     private RetryBufferBuilder() {}
 
-    /**
-     * @param drainIntervalMs interval in milliseconds between buffer drains; must be {@code >= 50}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code drainIntervalMs < 50}
-     */
     public RetryBufferBuilder drainIntervalMs(long drainIntervalMs) {
       this.drainIntervalMs = atLeast("drainIntervalMs", drainIntervalMs, 50L);
       return this;
@@ -1301,8 +984,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link TimeoutOptions}. */
-  @Incubating
   public static final class TimeoutBuilder {
     private int softTimeoutPercent = 80;
     private long defaultSlaSeconds = 1800L;
@@ -1310,12 +991,6 @@ public class RatchetOptions {
 
     private TimeoutBuilder() {}
 
-    /**
-     * @param softTimeoutPercent percentage of the SLA at which a soft-timeout warning is emitted;
-     *     must be between 1 and 99 inclusive
-     * @return this builder
-     * @throws IllegalArgumentException if {@code softTimeoutPercent} is not in {@code 1..99}
-     */
     public TimeoutBuilder softTimeoutPercent(int softTimeoutPercent) {
       if (softTimeoutPercent <= 0 || softTimeoutPercent >= 100) {
         throw new IllegalArgumentException("softTimeoutPercent must be between 1 and 99");
@@ -1324,22 +999,11 @@ public class RatchetOptions {
       return this;
     }
 
-    /**
-     * @param defaultSlaSeconds default execution SLA in seconds; must be {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code defaultSlaSeconds < 1}
-     */
     public TimeoutBuilder defaultSlaSeconds(long defaultSlaSeconds) {
       this.defaultSlaSeconds = atLeast("defaultSlaSeconds", defaultSlaSeconds, 1L);
       return this;
     }
 
-    /**
-     * @param signalTimeoutBatchSize maximum WAITING jobs scanned per signal-timeout tick; must be
-     *     {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code signalTimeoutBatchSize < 1}
-     */
     public TimeoutBuilder signalTimeoutBatchSize(int signalTimeoutBatchSize) {
       this.signalTimeoutBatchSize = atLeast("signalTimeoutBatchSize", signalTimeoutBatchSize, 1);
       return this;
@@ -1350,8 +1014,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link MaintenanceOptions}. */
-  @Incubating
   public static final class MaintenanceBuilder {
     private boolean dlqPurgeEnabled = true;
     private String dlqPurgeCron = "0 0 2 * * ?";
@@ -1366,101 +1028,51 @@ public class RatchetOptions {
 
     private MaintenanceBuilder() {}
 
-    /**
-     * @param dlqPurgeEnabled {@code true} to run the DLQ purge job
-     * @return this builder
-     */
     public MaintenanceBuilder dlqPurgeEnabled(boolean dlqPurgeEnabled) {
       this.dlqPurgeEnabled = dlqPurgeEnabled;
       return this;
     }
 
-    /**
-     * @param dlqPurgeCron cron expression for the DLQ purge cadence; must not be blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code dlqPurgeCron} is blank
-     */
     public MaintenanceBuilder dlqPurgeCron(String dlqPurgeCron) {
       this.dlqPurgeCron = requireText("dlqPurgeCron", dlqPurgeCron);
       return this;
     }
 
-    /**
-     * @param dlqPurgeDays age in days at which DLQ entries become eligible for purge; must be
-     *     {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code dlqPurgeDays < 0}
-     */
     public MaintenanceBuilder dlqPurgeDays(long dlqPurgeDays) {
       this.dlqPurgeDays = atLeast("dlqPurgeDays", dlqPurgeDays, 0L);
       return this;
     }
 
-    /**
-     * @param jobArchiveEnabled {@code true} to run the job-archive job
-     * @return this builder
-     */
     public MaintenanceBuilder jobArchiveEnabled(boolean jobArchiveEnabled) {
       this.jobArchiveEnabled = jobArchiveEnabled;
       return this;
     }
 
-    /**
-     * @param jobArchiveCron cron expression for the job-archive cadence; must not be blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code jobArchiveCron} is blank
-     */
     public MaintenanceBuilder jobArchiveCron(String jobArchiveCron) {
       this.jobArchiveCron = requireText("jobArchiveCron", jobArchiveCron);
       return this;
     }
 
-    /**
-     * @param jobRetentionDays age in days at which terminal jobs become eligible for archive; must
-     *     be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code jobRetentionDays < 0}
-     */
     public MaintenanceBuilder jobRetentionDays(long jobRetentionDays) {
       this.jobRetentionDays = atLeast("jobRetentionDays", jobRetentionDays, 0L);
       return this;
     }
 
-    /**
-     * @param jobArchiveBatchSize maximum jobs archived per archive pass; must be {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code jobArchiveBatchSize < 1}
-     */
     public MaintenanceBuilder jobArchiveBatchSize(int jobArchiveBatchSize) {
       this.jobArchiveBatchSize = atLeast("jobArchiveBatchSize", jobArchiveBatchSize, 1);
       return this;
     }
 
-    /**
-     * @param logPurgeEnabled {@code true} to run the execution-log purge job
-     * @return this builder
-     */
     public MaintenanceBuilder logPurgeEnabled(boolean logPurgeEnabled) {
       this.logPurgeEnabled = logPurgeEnabled;
       return this;
     }
 
-    /**
-     * @param logPurgeCron cron expression for the log-purge cadence; must not be blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code logPurgeCron} is blank
-     */
     public MaintenanceBuilder logPurgeCron(String logPurgeCron) {
       this.logPurgeCron = requireText("logPurgeCron", logPurgeCron);
       return this;
     }
 
-    /**
-     * @param logRetentionDays age in days at which execution-log rows become eligible for purge;
-     *     must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code logRetentionDays < 0}
-     */
     public MaintenanceBuilder logRetentionDays(long logRetentionDays) {
       this.logRetentionDays = atLeast("logRetentionDays", logRetentionDays, 0L);
       return this;
@@ -1481,8 +1093,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link NotificationOptions}. */
-  @Incubating
   public static final class NotificationBuilder {
     private boolean enabled = true;
     private String dlqAlertChannel = "#job-scheduler-dlq";
@@ -1490,30 +1100,16 @@ public class RatchetOptions {
 
     private NotificationBuilder() {}
 
-    /**
-     * @param enabled {@code true} to publish notifications
-     * @return this builder
-     */
     public NotificationBuilder enabled(boolean enabled) {
       this.enabled = enabled;
       return this;
     }
 
-    /**
-     * @param dlqAlertChannel channel identifier for DLQ alerts; must not be blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code dlqAlertChannel} is blank
-     */
     public NotificationBuilder dlqAlertChannel(String dlqAlertChannel) {
       this.dlqAlertChannel = requireText("dlqAlertChannel", dlqAlertChannel);
       return this;
     }
 
-    /**
-     * @param timeoutAlertChannel channel identifier for timeout alerts; must not be blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code timeoutAlertChannel} is blank
-     */
     public NotificationBuilder timeoutAlertChannel(String timeoutAlertChannel) {
       this.timeoutAlertChannel = requireText("timeoutAlertChannel", timeoutAlertChannel);
       return this;
@@ -1524,8 +1120,6 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link SchemaOptions}. */
-  @Incubating
   public static final class SchemaBuilder {
     private boolean autoMigrate;
     private String migrationDialect = "";
@@ -1533,31 +1127,16 @@ public class RatchetOptions {
 
     private SchemaBuilder() {}
 
-    /**
-     * @param autoMigrate {@code true} to run the migrator from the schema-migration lifecycle hook
-     * @return this builder
-     */
     public SchemaBuilder autoMigrate(boolean autoMigrate) {
       this.autoMigrate = autoMigrate;
       return this;
     }
 
-    /**
-     * @param migrationDialect explicit dialect identifier; {@code null} or blank asks the store to
-     *     autodetect
-     * @return this builder
-     */
     public SchemaBuilder migrationDialect(String migrationDialect) {
       this.migrationDialect = migrationDialect == null ? "" : migrationDialect.trim();
       return this;
     }
 
-    /**
-     * @param migrationPrefix classpath prefix for dialect-specific migration scripts; must not be
-     *     blank
-     * @return this builder
-     * @throws IllegalArgumentException if {@code migrationPrefix} is blank
-     */
     public SchemaBuilder migrationPrefix(String migrationPrefix) {
       this.migrationPrefix = requireText("migrationPrefix", migrationPrefix);
       return this;
@@ -1568,29 +1147,17 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link PayloadOptions}. */
-  @Incubating
   public static final class PayloadBuilder {
     private int maxPayloadKb = 100;
     private long maxResultBytes = 65536L;
 
     private PayloadBuilder() {}
 
-    /**
-     * @param maxPayloadKb maximum job payload size in kilobytes; must be {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code maxPayloadKb < 1}
-     */
     public PayloadBuilder maxPayloadKb(int maxPayloadKb) {
       this.maxPayloadKb = atLeast("maxPayloadKb", maxPayloadKb, 1);
       return this;
     }
 
-    /**
-     * @param maxResultBytes maximum persisted job-result size in bytes; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code maxResultBytes < 0}
-     */
     public PayloadBuilder maxResultBytes(long maxResultBytes) {
       this.maxResultBytes = atLeast("maxResultBytes", maxResultBytes, 0L);
       return this;
@@ -1601,18 +1168,11 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link MetricsOptions}. */
-  @Incubating
   public static final class MetricsBuilder {
     private String clustering = "none";
 
     private MetricsBuilder() {}
 
-    /**
-     * @param clustering clustering-strategy identifier; must not be blank and is lowercased
-     * @return this builder
-     * @throws IllegalArgumentException if {@code clustering} is blank
-     */
     public MetricsBuilder clustering(String clustering) {
       this.clustering = requireText("clustering", clustering).toLowerCase(Locale.ROOT);
       return this;
@@ -1623,63 +1183,50 @@ public class RatchetOptions {
     }
   }
 
-  /** Builder for {@link SecurityOptions}. */
-  @Incubating
   public static final class SecurityBuilder {
     private boolean allowEmptyClassPolicy;
     private boolean redactEmails = true;
+    private boolean maskPayloads;
 
     private SecurityBuilder() {}
 
-    /**
-     * @param allowEmptyClassPolicy {@code true} to permit running without a configured class
-     *     policy; {@code false} fails fast at startup when none is bound
-     * @return this builder
-     */
     public SecurityBuilder allowEmptyClassPolicy(boolean allowEmptyClassPolicy) {
       this.allowEmptyClassPolicy = allowEmptyClassPolicy;
       return this;
     }
 
-    /**
-     * @param redactEmails {@code true} to redact email-shaped strings from observability output
-     * @return this builder
-     */
     public SecurityBuilder redactEmails(boolean redactEmails) {
       this.redactEmails = redactEmails;
       return this;
     }
 
+    /**
+     * Masks sensitive payload fields where a payload would be rendered into a log line when {@code
+     * true}; {@code false} (default) leaves logged payloads unmasked. The durable store payload is
+     * never affected.
+     */
+    public SecurityBuilder maskPayloads(boolean maskPayloads) {
+      this.maskPayloads = maskPayloads;
+      return this;
+    }
+
     private SecurityOptions build() {
-      return new SecurityOptions(allowEmptyClassPolicy, redactEmails);
+      return new SecurityOptions(allowEmptyClassPolicy, redactEmails, maskPayloads);
     }
   }
 
-  /** Builder for {@link StoreOptions}. */
-  @Incubating
   public static final class StoreBuilder {
     private IsolationCheckMode isolationCheckMode = IsolationCheckMode.FAIL;
     private int priorityBoostIntervalMinutes = 15;
 
     private StoreBuilder() {}
 
-    /**
-     * @param isolationCheckMode action taken on an isolation-level mismatch; must not be null
-     * @return this builder
-     * @throws NullPointerException if {@code isolationCheckMode} is null
-     */
     public StoreBuilder isolationCheckMode(IsolationCheckMode isolationCheckMode) {
       this.isolationCheckMode =
           Objects.requireNonNull(isolationCheckMode, "isolationCheckMode must not be null");
       return this;
     }
 
-    /**
-     * @param priorityBoostIntervalMinutes interval in minutes at which long-waiting pending jobs
-     *     are promoted; must be {@code >= 0} ({@code 0} disables the boost)
-     * @return this builder
-     * @throws IllegalArgumentException if {@code priorityBoostIntervalMinutes < 0}
-     */
     public StoreBuilder priorityBoostIntervalMinutes(int priorityBoostIntervalMinutes) {
       this.priorityBoostIntervalMinutes =
           atLeast("priorityBoostIntervalMinutes", priorityBoostIntervalMinutes, 0);
@@ -1699,24 +1246,11 @@ public class RatchetOptions {
 
     private CircuitBreakerBuilder() {}
 
-    /**
-     * @param enabled {@code true} to enable circuit-breaker enforcement; when {@code false} all
-     *     calls pass through unmonitored
-     * @return this builder
-     */
     public CircuitBreakerBuilder enabled(boolean enabled) {
       this.enabled = enabled;
       return this;
     }
 
-    /**
-     * Customizes the thresholds for a single profile, creating the profile if absent.
-     *
-     * @param profile profile to customize; must not be null
-     * @param customizer receives the profile builder
-     * @return this builder
-     * @throws NullPointerException if {@code profile} is null
-     */
     public CircuitBreakerBuilder profile(
         CircuitBreakerProfile profile, Consumer<CircuitBreakerProfileBuilder> customizer) {
       CircuitBreakerProfileBuilder builder =
@@ -1748,13 +1282,6 @@ public class RatchetOptions {
 
     private CircuitBreakerProfileBuilder() {}
 
-    /**
-     * @param failureRateThreshold failure-rate percentage at which the breaker opens; must be a
-     *     finite value between 0 and 100 inclusive
-     * @return this builder
-     * @throws IllegalArgumentException if {@code failureRateThreshold} is non-finite or outside
-     *     {@code 0..100}
-     */
     public CircuitBreakerProfileBuilder failureRateThreshold(float failureRateThreshold) {
       if (!Float.isFinite(failureRateThreshold)
           || failureRateThreshold < 0.0f
@@ -1766,46 +1293,22 @@ public class RatchetOptions {
       return this;
     }
 
-    /**
-     * @param slidingWindowSize size of the sliding window used to compute the failure rate; must be
-     *     {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code slidingWindowSize < 1}
-     */
     public CircuitBreakerProfileBuilder slidingWindowSize(int slidingWindowSize) {
       this.slidingWindowSize = atLeast("slidingWindowSize", slidingWindowSize, 1);
       return this;
     }
 
-    /**
-     * @param waitDurationMs duration in milliseconds the breaker stays OPEN before transitioning to
-     *     HALF_OPEN; must be {@code >= 0}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code waitDurationMs < 0}
-     */
     public CircuitBreakerProfileBuilder waitDurationMs(long waitDurationMs) {
       this.waitDurationMs = atLeast("waitDurationMs", waitDurationMs, 0L);
       return this;
     }
 
-    /**
-     * @param permittedCallsInHalfOpen number of trial calls allowed while in HALF_OPEN; must be
-     *     {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code permittedCallsInHalfOpen < 1}
-     */
     public CircuitBreakerProfileBuilder permittedCallsInHalfOpen(int permittedCallsInHalfOpen) {
       this.permittedCallsInHalfOpen =
           atLeast("permittedCallsInHalfOpen", permittedCallsInHalfOpen, 1);
       return this;
     }
 
-    /**
-     * @param minimumCalls minimum recorded calls before the failure rate is evaluated; must be
-     *     {@code >= 1}
-     * @return this builder
-     * @throws IllegalArgumentException if {@code minimumCalls < 1}
-     */
     public CircuitBreakerProfileBuilder minimumCalls(int minimumCalls) {
       this.minimumCalls = atLeast("minimumCalls", minimumCalls, 1);
       return this;

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -517,9 +517,10 @@ public class RatchetOptions {
    * @param allowEmptyClassPolicy {@code true} to permit running without a configured {@code
    *     ClassPolicy}; {@code false} (default) fails fast at startup when no policy is bound
    * @param redactEmails {@code true} to redact email-shaped strings from observability output
-   * @param maskPayloads {@code true} to mask sensitive payload fields where a payload would be
-   *     rendered into a log line; {@code false} (default) leaves logged payloads unmasked. The
-   *     durable store payload is never affected.
+   * @param maskPayloads {@code true} to mask sensitive payload fields wherever a payload would be
+   *     exposed — rendered into a log line or returned from a read API such as the {@code params}
+   *     on a job detail; {@code false} (default) leaves exposed payloads unmasked. The durable
+   *     store payload is never affected.
    */
   public record SecurityOptions(
       boolean allowEmptyClassPolicy, boolean redactEmails, boolean maskPayloads) {}
@@ -1201,9 +1202,10 @@ public class RatchetOptions {
     }
 
     /**
-     * Masks sensitive payload fields where a payload would be rendered into a log line when {@code
-     * true}; {@code false} (default) leaves logged payloads unmasked. The durable store payload is
-     * never affected.
+     * Masks sensitive payload fields wherever a payload would be exposed — rendered into a log line
+     * or returned from a read API such as the {@code params} on a job detail — when {@code true};
+     * {@code false} (default) leaves exposed payloads unmasked. The durable store payload is never
+     * affected.
      */
     public SecurityBuilder maskPayloads(boolean maskPayloads) {
       this.maskPayloads = maskPayloads;

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -517,10 +517,11 @@ public class RatchetOptions {
    * @param allowEmptyClassPolicy {@code true} to permit running without a configured {@code
    *     ClassPolicy}; {@code false} (default) fails fast at startup when no policy is bound
    * @param redactEmails {@code true} to redact email-shaped strings from observability output
-   * @param maskPayloads {@code true} to mask sensitive payload fields wherever a payload would be
-   *     exposed — rendered into a log line or returned from a read API such as the {@code params}
-   *     on a job detail; {@code false} (default) leaves exposed payloads unmasked. The durable
-   *     store payload is never affected.
+   * @param maskPayloads {@code true} to mask sensitive fields in structured payloads returned from
+   *     a read API — the {@code params} map and trace context on a job detail, plus the serialized
+   *     job result; {@code false} (default) leaves them unmasked. Map masking is key-based and
+   *     result masking walks the serialized JSON; free-text fields such as {@code lastError} are
+   *     not masked. The durable store payload is never affected.
    */
   public record SecurityOptions(
       boolean allowEmptyClassPolicy, boolean redactEmails, boolean maskPayloads) {}
@@ -1202,10 +1203,11 @@ public class RatchetOptions {
     }
 
     /**
-     * Masks sensitive payload fields wherever a payload would be exposed — rendered into a log line
-     * or returned from a read API such as the {@code params} on a job detail — when {@code true};
-     * {@code false} (default) leaves exposed payloads unmasked. The durable store payload is never
-     * affected.
+     * Masks sensitive fields in structured payloads returned from a read API — the {@code params}
+     * map and trace context on a job detail, plus the serialized job result — when {@code true};
+     * {@code false} (default) leaves them unmasked. Map masking is key-based and result masking
+     * walks the serialized JSON; free-text fields such as {@code lastError} are not masked. The
+     * durable store payload is never affected.
      */
     public SecurityBuilder maskPayloads(boolean maskPayloads) {
       this.maskPayloads = maskPayloads;

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
@@ -109,7 +109,8 @@ public final class RatchetOptionsFactory {
             security ->
                 security
                     .allowEmptyClassPolicy(config.get(RatchetConfigKeys.ALLOW_EMPTY_CLASS_POLICY))
-                    .redactEmails(config.get(RatchetConfigKeys.REDACT_EMAILS)))
+                    .redactEmails(config.get(RatchetConfigKeys.REDACT_EMAILS))
+                    .maskPayloads(config.get(RatchetConfigKeys.MASK_PAYLOADS)))
         .store(
             store ->
                 store

--- a/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobCancellationEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobCancellationEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Base class for job cancellation lifecycle events. */
+@Incubating
 public abstract class AbstractJobCancellationEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 6253413059723522683L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobSchedulerEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobSchedulerEvent.java
@@ -4,6 +4,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -14,6 +15,7 @@ import run.ratchet.api.JobType;
  * such as {@code businessKey}, {@code jobType}, {@code priority}, and {@code nodeId} may be {@code
  * null} when Ratchet can no longer load the job row after a successful state transition.
  */
+@Incubating
 public abstract class AbstractJobSchedulerEvent implements Serializable {
 
   @Serial private static final long serialVersionUID = 6853988277084004625L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletedEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -13,6 +14,7 @@ import run.ratchet.api.JobType;
  * ended in a failed state. The event is still emitted when one or more children failed, after the
  * batch has no remaining pending/running children.
  */
+@Incubating
 public class BatchCompletedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 843735174177646423L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
@@ -3,12 +3,14 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /**
  * Fired after all batch children are terminal and before the batch completion event is published.
  */
+@Incubating
 public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 2629383623872540166L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainCompletedEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -12,6 +13,7 @@ import run.ratchet.api.JobType;
  * <p>{@code jobId} identifies the step whose completion closed the chain. {@code parentJobId}
  * identifies the root job that initiated the chain.
  */
+@Incubating
 public class ChainCompletedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -8140882369003276835L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainFailedEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired when a job chain fails. */
+@Incubating
 public class ChainFailedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 5542623623918947230L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainStartedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainStartedEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -12,6 +13,7 @@ import run.ratchet.api.JobType;
  * <p>{@code jobId} identifies the first chain step being started. {@code parentJobId} identifies
  * the root job that triggered the chain.
  */
+@Incubating
 public class ChainStartedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -4450548507481291423L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired when a lifecycle callback ({@code onSuccess} / {@code onFailure}) throws an exception. */
+@Incubating
 public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 1L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCancelledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCancelledEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -11,6 +12,7 @@ import run.ratchet.api.JobType;
  *
  * <p>Fired after the job record reaches CANCELED state.
  */
+@Incubating
 public class JobCancelledEvent extends AbstractJobCancellationEvent {
 
   @Serial private static final long serialVersionUID = -3714116971496582534L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCompletedEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired when a job completes successfully. */
+@Incubating
 public class JobCompletedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 6928539910648242733L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired after Ratchet moves a permanently failed job to the dead letter queue. */
+@Incubating
 public class JobDlqEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -2578972098474327757L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -13,6 +14,7 @@ import run.ratchet.api.JobType;
  * JobRetryingEvent}; they do not publish this event unless the failed attempt exhausts retry
  * handling and terminalizes the job.
  */
+@Incubating
 public class JobFailedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -8745178784765705117L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobResumedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobResumedEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired when a paused job is resumed. */
+@Incubating
 public class JobResumedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -5969069800791733733L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobRetryingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobRetryingEvent.java
@@ -3,10 +3,12 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired when a failed job is about to be retried. */
+@Incubating
 public class JobRetryingEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -3500975641125637480L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
@@ -4,10 +4,12 @@ import java.io.Serial;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Fired when a WAITING job's signal timeout elapses and it is transitioned to FAILED. */
+@Incubating
 public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 3876540291834670029L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalWaitingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalWaitingEvent.java
@@ -4,6 +4,7 @@ import java.io.Serial;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -13,6 +14,7 @@ import run.ratchet.api.JobType;
  * <p>{@code signalTimeout} is the maximum time the job may wait before timing out. A {@code null}
  * timeout means the job waits until a matching signal is delivered or the job is canceled.
  */
+@Incubating
 public class JobSignalWaitingEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 7412309856012374810L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignaledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignaledEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 import run.ratchet.api.SignalDecision;
@@ -16,6 +17,7 @@ import run.ratchet.api.SignalDecision;
  * system component that delivered it, {@code outcome} records approval/rejection metadata, and
  * {@code rejectionReason} is present only for rejected decisions.
  */
+@Incubating
 public class JobSignaledEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -2918473650123490087L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobStartedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobStartedEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -13,6 +14,7 @@ import run.ratchet.api.JobType;
  * Inherited fields identify the job, business key, type, priority, executor node, and event
  * timestamp.
  */
+@Incubating
 public class JobStartedEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = -1805923320335775574L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkCancelledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkCancelledEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
+import run.ratchet.api.Incubating;
 
 /**
  * Fired exactly once per successful bulk cancel-by-tag operation when at least one job was
@@ -16,6 +17,7 @@ import java.time.Instant;
  * @see run.ratchet.api.JobSchedulerService#cancelJobsByTag(String)
  * @see run.ratchet.api.JobSchedulerService#cancelRecurringJobsByTag(String)
  */
+@Incubating
 public class JobsBulkCancelledEvent implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkSignaledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobsBulkSignaledEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.SignalDecision;
 
 /**
@@ -16,6 +17,7 @@ import run.ratchet.api.SignalDecision;
  * @see run.ratchet.api.JobSchedulerService#deliverSignal(String, Serializable)
  * @see run.ratchet.api.JobSchedulerService#deliverSignal(String, SignalDecision)
  */
+@Incubating
 public class JobsBulkSignaledEvent implements Serializable {
 
   @Serial private static final long serialVersionUID = 1L;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/WorkflowBranchTriggeredEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/WorkflowBranchTriggeredEvent.java
@@ -3,6 +3,7 @@ package run.ratchet.api.event;
 import java.io.Serial;
 import java.time.Instant;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
@@ -12,6 +13,7 @@ import run.ratchet.api.JobType;
  * <p>{@code branchCondition} is the persisted condition description or expression that matched.
  * {@code nextJobId} identifies the job scheduled for the triggered branch.
  */
+@Incubating
 public class WorkflowBranchTriggeredEvent extends AbstractJobSchedulerEvent {
 
   @Serial private static final long serialVersionUID = 1721949020293115008L;

--- a/ratchet-api/src/main/java/run/ratchet/api/internal/RatchetConfigKeys.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/internal/RatchetConfigKeys.java
@@ -202,6 +202,8 @@ public final class RatchetConfigKeys {
       boolKey("ratchet.allow-empty-class-policy", "RATCHET_ALLOW_EMPTY_CLASS_POLICY", false);
   public static final RatchetConfigKey<Boolean> REDACT_EMAILS =
       boolKey("ratchet.security.redact-emails", "RATCHET_REDACT_EMAILS", true);
+  public static final RatchetConfigKey<Boolean> MASK_PAYLOADS =
+      boolKey("ratchet.security.mask-payloads", "RATCHET_MASK_PAYLOADS", false);
   public static final RatchetConfigKey<RatchetOptions.IsolationCheckMode> ISOLATION_CHECK_MODE =
       new RatchetConfigKey<>(
           "ratchet.isolation-check",

--- a/ratchet-api/src/main/java/run/ratchet/spi/LambdaDescriptor.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/LambdaDescriptor.java
@@ -47,7 +47,7 @@ public record LambdaDescriptor(
         methodName(),
         methodDescriptor(),
         isStatic(),
-        Arrays.hashCode(capturedArgs()));
+        Arrays.deepHashCode(capturedArgs()));
   }
 
   @Override

--- a/ratchet-api/src/main/java/run/ratchet/spi/NoOpMetricsCollector.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/NoOpMetricsCollector.java
@@ -3,10 +3,12 @@ package run.ratchet.spi;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import java.util.UUID;
+import run.ratchet.api.Incubating;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 
 /** Default no-op {@link MetricsCollector} for deployments without a monitoring integration. */
+@Incubating
 @ApplicationScoped
 @Default
 public class NoOpMetricsCollector implements MetricsCollector {

--- a/ratchet-api/src/main/java/run/ratchet/spi/PayloadMaskingPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/PayloadMaskingPolicy.java
@@ -3,9 +3,10 @@ package run.ratchet.spi;
 import run.ratchet.api.Incubating;
 
 /**
- * SPI that decides which payload fields are sensitive and should be masked before a payload is
- * rendered into a log line. Field-level masking is applied only on the logging path; the durable
- * store payload and anything a worker needs to execute are never altered.
+ * SPI that decides which payload fields are sensitive and should be masked before a payload leaves
+ * the framework — whether rendered into a log line or returned from a read API such as the {@code
+ * params} on a job detail. Masking is applied only on these read and observability paths; the
+ * durable store payload and anything a worker needs to execute are never altered.
  *
  * <p>The built-in policy matches a fixed set of common credential and PII field names (for example
  * {@code password}, {@code token}, {@code ssn}). Deployers that need a different field set produce
@@ -18,8 +19,8 @@ public interface PayloadMaskingPolicy {
   /**
    * Reports whether a payload field with the given name holds sensitive data.
    *
-   * @param fieldName the JSON field name as it appears in the payload; never {@code null}
-   * @return {@code true} if the field's value should be masked in log output, {@code false}
+   * @param fieldName the field or parameter name as it appears in the payload; never {@code null}
+   * @return {@code true} if the field's value should be masked in read or log output, {@code false}
    *     otherwise
    */
   boolean isSensitiveField(String fieldName);

--- a/ratchet-api/src/main/java/run/ratchet/spi/PayloadMaskingPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/PayloadMaskingPolicy.java
@@ -1,0 +1,26 @@
+package run.ratchet.spi;
+
+import run.ratchet.api.Incubating;
+
+/**
+ * SPI that decides which payload fields are sensitive and should be masked before a payload is
+ * rendered into a log line. Field-level masking is applied only on the logging path; the durable
+ * store payload and anything a worker needs to execute are never altered.
+ *
+ * <p>The built-in policy matches a fixed set of common credential and PII field names (for example
+ * {@code password}, {@code token}, {@code ssn}). Deployers that need a different field set produce
+ * their own implementation; the reference implementation installs the produced bean in place of the
+ * built-in default.
+ */
+@Incubating
+public interface PayloadMaskingPolicy {
+
+  /**
+   * Reports whether a payload field with the given name holds sensitive data.
+   *
+   * @param fieldName the JSON field name as it appears in the payload; never {@code null}
+   * @return {@code true} if the field's value should be masked in log output, {@code false}
+   *     otherwise
+   */
+  boolean isSensitiveField(String fieldName);
+}

--- a/ratchet-api/src/test/java/run/ratchet/api/MaskPayloadsOptionTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/MaskPayloadsOptionTest.java
@@ -1,0 +1,35 @@
+package run.ratchet.api;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.RatchetOptions.SecurityOptions;
+
+class MaskPayloadsOptionTest {
+
+  @Test
+  void securityOptions_carriesMaskPayloadsFlag() {
+    SecurityOptions enabled = new SecurityOptions(false, true, true);
+    SecurityOptions disabled = new SecurityOptions(false, true, false);
+
+    assertTrue(enabled.maskPayloads());
+    assertFalse(disabled.maskPayloads());
+  }
+
+  @Test
+  void securityBuilder_maskPayloadsDefaultsToFalse() {
+    RatchetOptions options =
+        RatchetOptions.builder().security(security -> security.redactEmails(true)).build();
+
+    assertFalse(options.security().maskPayloads());
+  }
+
+  @Test
+  void securityBuilder_maskPayloadsOptInIsHonored() {
+    RatchetOptions options =
+        RatchetOptions.builder().security(security -> security.maskPayloads(true)).build();
+
+    assertTrue(options.security().maskPayloads());
+  }
+}

--- a/ratchet-arch-tests/src/test/java/run/ratchet/architecture/TransactionBoundaryArchitectureTest.java
+++ b/ratchet-arch-tests/src/test/java/run/ratchet/architecture/TransactionBoundaryArchitectureTest.java
@@ -1,0 +1,120 @@
+package run.ratchet.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Locks in the two transaction-boundary decisions Ratchet's portability depends on, so a future PR
+ * cannot quietly undo them across the matrix of Jakarta EE servers.
+ *
+ * <ul>
+ *   <li><b>No {@code @Transactional(SUPPORTS)} in the store layer.</b> A store method invoked
+ *       outside a JTA transaction on EclipseLink-managed containers (Payara, GlassFish,
+ *       OpenLiberty) leaks the borrowed pool connection with auto-commit disabled, leaving an open
+ *       transaction that holds metadata locks on later writes. Store reads therefore stay on the
+ *       class-level {@code REQUIRED} boundary instead of declaring {@code SUPPORTS}.
+ *   <li><b>No {@code @Transactional} on the public API.</b> The {@code JobSchedulerService} surface
+ *       is a pure contract: each method documents its transaction attribute in Javadoc, and the
+ *       attribute is declared on the reference implementation, never on the exported interface.
+ * </ul>
+ *
+ * <p>The per-store {@code REQUIRES_NEW} lock-and-heartbeat rule lives in the store TCK's {@code
+ * AbstractJobStoreTransactionBoundaryContract}, which the JPA stores opt into and which cleanly
+ * exempts non-JTA stores; a package-scoped rule here could not make that distinction.
+ */
+@AnalyzeClasses(packages = "run.ratchet", importOptions = ImportOption.DoNotIncludeTests.class)
+public class TransactionBoundaryArchitectureTest {
+
+  private static final String API = "run.ratchet.api..";
+  private static final String STORE = "run.ratchet.store..";
+
+  /**
+   * Defends against a vacuous pass: if the importer returns no store or API classes (a known
+   * surefire/JaCoCo parallel-fork interaction), the rules below would pass with zero subjects.
+   */
+  @Test
+  void archunitImporterSeesStoreAndApi() {
+    JavaClasses imported =
+        new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("run.ratchet");
+    assertTrue(
+        imported.size() > 50, "ArchUnit importer loaded only " + imported.size() + " classes");
+    assertTrue(
+        imported.stream().anyMatch(c -> c.getPackageName().startsWith("run.ratchet.store")),
+        "no run.ratchet.store classes imported; the store rule would pass vacuously");
+    assertTrue(
+        imported.stream().anyMatch(c -> c.getPackageName().startsWith("run.ratchet.api")),
+        "no run.ratchet.api classes imported; the API rule would pass vacuously");
+  }
+
+  @ArchTest
+  static final ArchRule storeMethodsDoNotDeclareSupportsTransaction =
+      methods()
+          .that()
+          .areDeclaredInClassesThat()
+          .resideInAPackage(STORE)
+          .should(notUseSupportsTransaction())
+          .because(
+              "a @Transactional(SUPPORTS) store method invoked outside a JTA transaction on "
+                  + "EclipseLink containers leaks the borrowed pool connection with auto-commit "
+                  + "disabled; store reads stay on the class-level REQUIRED boundary")
+          .allowEmptyShould(true);
+
+  @ArchTest
+  static final ArchRule publicApiMethodsDeclareNoTransactional =
+      noMethods()
+          .that()
+          .areDeclaredInClassesThat()
+          .resideInAPackage(API)
+          .should()
+          .beAnnotatedWith(Transactional.class)
+          .because(
+              "the JobSchedulerService API is a pure contract; a method's transaction attribute is "
+                  + "documented in Javadoc and declared on the reference implementation, never on "
+                  + "the exported interface");
+
+  @ArchTest
+  static final ArchRule publicApiTypesDeclareNoTransactional =
+      noClasses()
+          .that()
+          .resideInAPackage(API)
+          .should()
+          .beAnnotatedWith(Transactional.class)
+          .because(
+              "transaction attributes belong on the reference implementation, not the exported API "
+                  + "types");
+
+  private static ArchCondition<JavaMethod> notUseSupportsTransaction() {
+    return new ArchCondition<>("not be annotated @Transactional(SUPPORTS)") {
+      @Override
+      public void check(JavaMethod method, ConditionEvents events) {
+        if (method.isAnnotatedWith(Transactional.class)
+            && method.getAnnotationOfType(Transactional.class).value()
+                == Transactional.TxType.SUPPORTS) {
+          events.add(
+              SimpleConditionEvent.violated(
+                  method,
+                  method.getFullName()
+                      + " declares @Transactional(SUPPORTS); on EclipseLink containers this leaks"
+                      + " the pooled connection when called outside a JTA transaction"));
+        }
+      }
+    };
+  }
+}

--- a/ratchet-coordinator-hazelcast/pom.xml
+++ b/ratchet-coordinator-hazelcast/pom.xml
@@ -98,6 +98,14 @@
             <version>2.0.13</version>
             <scope>test</scope>
         </dependency>
+        <!-- Weld SE: boots a real CDI container in-process to prove the coordinator deploys with
+             no unsatisfied dependency. -->
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>6.0.2.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
+++ b/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
@@ -69,9 +69,19 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
   static final String COORDINATOR_KIND = "hazelcast";
 
   @Inject NodeIdentityProvider identityProvider;
-  @Inject HazelcastCoordinatorConfig config;
+
+  /**
+   * Resolved lazily in {@link #init()}. The config record has a {@code defaults()} factory but is
+   * not a managed bean, so it is injected as an {@link Instance} with a defaults() fallback; a
+   * direct {@code @Inject HazelcastCoordinatorConfig} would be an unsatisfied dependency that fails
+   * deployment validation out of the box.
+   */
+  @Inject Instance<HazelcastCoordinatorConfig> configInstance;
+
   @Inject @Any Instance<HazelcastInstanceProvider> providerInstance;
   @Inject MetricsCollector metrics;
+
+  private HazelcastCoordinatorConfig config;
 
   private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
   private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
@@ -103,6 +113,12 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
 
   @PostConstruct
   void init() {
+    if (config == null) {
+      config =
+          configInstance != null && configInstance.isResolvable()
+              ? configInstance.get()
+              : HazelcastCoordinatorConfig.defaults();
+    }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
     requireJsonProvider();

--- a/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/HazelcastCoordinatorCdiDeploymentTest.java
+++ b/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/HazelcastCoordinatorCdiDeploymentTest.java
@@ -1,0 +1,55 @@
+package run.ratchet.coordinator.hazelcast;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.junit.jupiter.api.Test;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NoOpMetricsCollector;
+import run.ratchet.spi.NodeIdentityProvider;
+
+/**
+ * Boots a real CDI container to prove the coordinator deploys with no unsatisfied dependency.
+ *
+ * <p>The tuning config record has no producing bean, so a direct {@code @Inject
+ * HazelcastCoordinatorConfig} is an unsatisfied dependency that fails deployment validation out of
+ * the box. Resolving it through an {@link jakarta.enterprise.inject.Instance} with a {@code
+ * defaults()} fallback makes the coordinator deployable with zero application wiring. The container
+ * here provides only the SPI collaborators an application would already supply; the config is left
+ * deliberately unproduced.
+ */
+class HazelcastCoordinatorCdiDeploymentTest {
+
+  @Test
+  void coordinatorDeploysWithoutAProducerForItsConfigRecord() {
+    SeContainerInitializer initializer =
+        SeContainerInitializer.newInstance()
+            .disableDiscovery()
+            .addBeanClasses(HazelcastClusterCoordinator.class, SpiCollaborators.class);
+
+    try (SeContainer container = assertDoesNotThrow(initializer::initialize)) {
+      assertTrue(
+          container.select(HazelcastClusterCoordinator.class).isResolvable(),
+          "coordinator must resolve as an enabled bean with every injection point satisfied");
+    }
+  }
+
+  @ApplicationScoped
+  static class SpiCollaborators {
+
+    @Produces
+    NodeIdentityProvider nodeIdentityProvider() {
+      return () -> "test-node";
+    }
+
+    @Produces
+    @ApplicationScoped
+    MetricsCollector metricsCollector() {
+      return new NoOpMetricsCollector();
+    }
+  }
+}

--- a/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/TwoNodeHazelcastCluster.java
+++ b/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/TwoNodeHazelcastCluster.java
@@ -20,12 +20,21 @@ public final class TwoNodeHazelcastCluster implements AutoCloseable {
 
   public TwoNodeHazelcastCluster() {
     this.clusterName = "ratchet-tck-" + Long.toHexString(System.nanoTime());
-    int portA = 25700 + (int) (System.nanoTime() & 0x7F);
-    int portB = portA + 1;
+    // Spread the base port across a wide window to avoid collisions/TIME_WAIT between tests, and
+    // keep auto-increment on so a bound port falls back to the next free one instead of failing
+    // hard. The TcpIp member list covers the whole auto-increment window so discovery still works.
+    int portA = 25700 + (int) (Long.remainderUnsigned(System.nanoTime(), PORT_RANGE)) * PORT_COUNT;
+    int portB = portA + PORT_COUNT;
     this.memberA = Hazelcast.newHazelcastInstance(memberConfig("memberA", portA, portA, portB));
     this.memberB = Hazelcast.newHazelcastInstance(memberConfig("memberB", portB, portA, portB));
     awaitClusterFormed();
   }
+
+  /** Number of ports auto-increment may walk through from each base port. */
+  private static final int PORT_COUNT = 20;
+
+  /** Number of distinct base-port pairs the cluster spreads across. */
+  private static final int PORT_RANGE = 1000;
 
   public HazelcastInstance memberA() {
     return memberA;
@@ -61,13 +70,19 @@ public final class TwoNodeHazelcastCluster implements AutoCloseable {
     c.setInstanceName(name + "-" + Long.toHexString(System.nanoTime()));
     c.setClusterName(clusterName);
     NetworkConfig net = c.getNetworkConfig();
-    net.setPort(port).setPortAutoIncrement(false);
+    net.setPort(port).setPortAutoIncrement(true).setPortCount(PORT_COUNT);
     JoinConfig join = net.getJoin();
     join.getMulticastConfig().setEnabled(false);
     join.getAutoDetectionConfig().setEnabled(false);
     TcpIpConfig tcp = join.getTcpIpConfig();
     tcp.setEnabled(true);
-    tcp.addMember("127.0.0.1:" + portA).addMember("127.0.0.1:" + portB);
+    // List every port the two members might auto-increment onto so discovery survives a fallback.
+    for (int p = portA; p < portA + PORT_COUNT; p++) {
+      tcp.addMember("127.0.0.1:" + p);
+    }
+    for (int p = portB; p < portB + PORT_COUNT; p++) {
+      tcp.addMember("127.0.0.1:" + p);
+    }
     // Silence the verbose Hazelcast banner & metrics noise on the test JVM.
     c.setProperty("hazelcast.logging.type", "none");
     c.setProperty("hazelcast.shutdownhook.enabled", "false");

--- a/ratchet-coordinator-infinispan/pom.xml
+++ b/ratchet-coordinator-infinispan/pom.xml
@@ -98,6 +98,14 @@
             <version>2.0.13</version>
             <scope>test</scope>
         </dependency>
+        <!-- Weld SE: boots a real CDI container in-process to prove the coordinator deploys with
+             no unsatisfied dependency. -->
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>6.0.2.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
@@ -65,9 +65,19 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
   static final String COORDINATOR_KIND = "infinispan";
 
   @Inject NodeIdentityProvider identityProvider;
-  @Inject InfinispanCoordinatorConfig config;
+
+  /**
+   * Resolved lazily in {@link #init()}. The config record has a {@code defaults()} factory but is
+   * not a managed bean, so it is injected as an {@link Instance} with a defaults() fallback; a
+   * direct {@code @Inject InfinispanCoordinatorConfig} would be an unsatisfied dependency that
+   * fails deployment validation out of the box.
+   */
+  @Inject Instance<InfinispanCoordinatorConfig> configInstance;
+
   @Inject @Any Instance<InfinispanCacheManagerProvider> providerInstance;
   @Inject MetricsCollector metrics;
+
+  private InfinispanCoordinatorConfig config;
 
   private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
   private final AtomicLong sendSequence = new AtomicLong();
@@ -99,6 +109,12 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
 
   @PostConstruct
   void init() {
+    if (config == null) {
+      config =
+          configInstance != null && configInstance.isResolvable()
+              ? configInstance.get()
+              : InfinispanCoordinatorConfig.defaults();
+    }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
     requireJsonProvider();

--- a/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanCoordinatorCdiDeploymentTest.java
+++ b/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/InfinispanCoordinatorCdiDeploymentTest.java
@@ -1,0 +1,55 @@
+package run.ratchet.coordinator.infinispan;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.junit.jupiter.api.Test;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NoOpMetricsCollector;
+import run.ratchet.spi.NodeIdentityProvider;
+
+/**
+ * Boots a real CDI container to prove the coordinator deploys with no unsatisfied dependency.
+ *
+ * <p>The tuning config record has no producing bean, so a direct {@code @Inject
+ * InfinispanCoordinatorConfig} is an unsatisfied dependency that fails deployment validation out of
+ * the box. Resolving it through an {@link jakarta.enterprise.inject.Instance} with a {@code
+ * defaults()} fallback makes the coordinator deployable with zero application wiring. The container
+ * here provides only the SPI collaborators an application would already supply; the config is left
+ * deliberately unproduced.
+ */
+class InfinispanCoordinatorCdiDeploymentTest {
+
+  @Test
+  void coordinatorDeploysWithoutAProducerForItsConfigRecord() {
+    SeContainerInitializer initializer =
+        SeContainerInitializer.newInstance()
+            .disableDiscovery()
+            .addBeanClasses(InfinispanClusterCoordinator.class, SpiCollaborators.class);
+
+    try (SeContainer container = assertDoesNotThrow(initializer::initialize)) {
+      assertTrue(
+          container.select(InfinispanClusterCoordinator.class).isResolvable(),
+          "coordinator must resolve as an enabled bean with every injection point satisfied");
+    }
+  }
+
+  @ApplicationScoped
+  static class SpiCollaborators {
+
+    @Produces
+    NodeIdentityProvider nodeIdentityProvider() {
+      return () -> "test-node";
+    }
+
+    @Produces
+    @ApplicationScoped
+    MetricsCollector metricsCollector() {
+      return new NoOpMetricsCollector();
+    }
+  }
+}

--- a/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/TwoNodeInfinispanCluster.java
+++ b/ratchet-coordinator-infinispan/src/test/java/run/ratchet/coordinator/infinispan/TwoNodeInfinispanCluster.java
@@ -21,9 +21,11 @@ public final class TwoNodeInfinispanCluster implements AutoCloseable {
   private final EmbeddedCacheManager managerA;
   private final EmbeddedCacheManager managerB;
   private final String cacheName;
+  private final String clusterName;
 
   public TwoNodeInfinispanCluster(String cacheName) throws IOException {
     this.cacheName = cacheName;
+    this.clusterName = "ratchet-tck-" + Long.toHexString(System.nanoTime());
     Configuration cacheConfig = newCacheConfig();
     this.managerA = new DefaultCacheManager(newGlobalConfig());
     this.managerA.defineConfiguration(cacheName, cacheConfig);
@@ -92,17 +94,15 @@ public final class TwoNodeInfinispanCluster implements AutoCloseable {
     throw new IllegalStateException("cluster did not form 2 members within 10s");
   }
 
-  private static GlobalConfiguration newGlobalConfig() {
+  private GlobalConfiguration newGlobalConfig() {
     GlobalConfigurationBuilder builder = GlobalConfigurationBuilder.defaultClusteredBuilder();
     builder
         .transport()
-        .clusterName(CLUSTER_NAME)
+        .clusterName(clusterName)
         .nodeName("node-" + Long.toHexString(System.nanoTime()))
         .addProperty("jgroups.bind.address", "127.0.0.1");
     return builder.build();
   }
-
-  private static final String CLUSTER_NAME = "ratchet-tck-" + Long.toHexString(System.nanoTime());
 
   private static Configuration newCacheConfig() {
     return new ConfigurationBuilder()

--- a/ratchet-coordinator-jms/pom.xml
+++ b/ratchet-coordinator-jms/pom.xml
@@ -108,6 +108,14 @@
             <version>2.0.13</version>
             <scope>test</scope>
         </dependency>
+        <!-- Weld SE: boots a real CDI container in-process to prove the coordinator deploys with
+             no unsatisfied dependency. -->
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>6.0.2.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ratchet-coordinator-jms/pom.xml
+++ b/ratchet-coordinator-jms/pom.xml
@@ -134,4 +134,90 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+          Deploys the JMS coordinator into a managed WildFly (standalone-full, so the
+          messaging-activemq subsystem is present) to prove it starts and round-trips
+          wakeups on a strict Jakarta EE JMS provider — the §12.3 container check the
+          SE-mode embedded-Artemis ITs cannot make. The container IT lives in its own
+          source root so the default build never compiles it (no Arquillian on the
+          normal test classpath). Run with: mvn verify -P wildfly-jms -pl
+          ratchet-coordinator-jms -am
+        -->
+        <profile>
+            <id>wildfly-jms</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.junit5</groupId>
+                    <artifactId>arquillian-junit5-container</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <!--
+                  Filter arquillian.xml so ${project.build.directory} and
+                  ${wildfly.version} resolve to the unpacked jbossHome at copy
+                  time (Arquillian does not interpolate Maven properties itself).
+                -->
+                <testResources>
+                    <testResource>
+                        <directory>src/test/resources</directory>
+                        <filtering>true</filtering>
+                    </testResource>
+                </testResources>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <version>${build-helper-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>add-wildfly-it-source</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java-wildfly</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-wildfly</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>${wildfly.version}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
@@ -79,9 +79,19 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
   static final String COORDINATOR_KIND = "jms";
 
   @Inject NodeIdentityProvider identityProvider;
-  @Inject JmsCoordinatorConfig config;
+
+  /**
+   * Resolved lazily in {@link #init()}. The config record has a {@code defaults()} factory but is
+   * not a managed bean, so it is injected as an {@link Instance} with a defaults() fallback; a
+   * direct {@code @Inject JmsCoordinatorConfig} would be an unsatisfied dependency that fails
+   * deployment validation out of the box.
+   */
+  @Inject Instance<JmsCoordinatorConfig> configInstance;
+
   @Inject @Any Instance<JmsConnectionFactoryProvider> providerInstance;
   @Inject MetricsCollector metrics;
+
+  private JmsCoordinatorConfig config;
 
   private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
   private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
@@ -137,6 +147,12 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
 
   @PostConstruct
   void init() {
+    if (config == null) {
+      config =
+          configInstance != null && configInstance.isResolvable()
+              ? configInstance.get()
+              : JmsCoordinatorConfig.defaults();
+    }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
     requireJsonProvider();

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsConnectionLifecycle.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsConnectionLifecycle.java
@@ -61,6 +61,14 @@ final class JmsConnectionLifecycle {
    */
   private static final long RECEIVE_TIMEOUT_MS = 1_000L;
 
+  /**
+   * Bound on how long {@link #close()} waits for the reconnect and receive threads to exit after
+   * interrupting them. Long enough to cover a {@code receive()} poll plus an in-flight {@code
+   * dispatch()} so the inbound handler stops touching CDI-managed beans before the context is
+   * destroyed; short enough that a wedged handler cannot stall container shutdown.
+   */
+  private static final long SHUTDOWN_JOIN_TIMEOUT_MS = 2_000L;
+
   private final ConnectionFactory connectionFactory;
   private final Topic topic;
   private final JmsCoordinatorConfig config;
@@ -158,20 +166,33 @@ final class JmsConnectionLifecycle {
     t.start();
   }
 
-  /** Release the context the lifecycle owns. Idempotent. */
+  /**
+   * Release the context the lifecycle owns and wait for the worker threads to exit. Idempotent.
+   *
+   * <p>The join matters: an in-flight {@link #dispatch(Message)} calls into the inbound handler,
+   * which touches CDI-managed beans (the metrics collector among them). The caller is {@code
+   * RatchetLifecycle#afterStop}, which lets the CDI context be destroyed once {@code close()}
+   * returns. Returning while a receive thread is still inside the handler is what produces a {@code
+   * WELD-000229} at container shutdown, so we drain the threads instead of only signalling them.
+   * Joins are bounded so a wedged handler cannot stall shutdown.
+   */
   void close() {
     if (!closed.compareAndSet(false, true)) {
       return;
     }
+    closeContextRef();
+    // Drain the reconnect thread first: an in-flight connectOnce may still be spawning a receive
+    // thread, so settle it before reading and joining the receive thread itself.
     Thread reconnect = this.reconnectThread;
     if (reconnect != null) {
       reconnect.interrupt();
+      joinQuietly(reconnect);
     }
     Thread receive = this.receiveThread;
     if (receive != null) {
       receive.interrupt();
+      joinQuietly(receive);
     }
-    closeContextRef();
   }
 
   // ---- internals ----------------------------------------------------------
@@ -199,10 +220,19 @@ final class JmsConnectionLifecycle {
       }
       Pair pair = new Pair(ctx, p, consumer);
       Pair stale = connectionRef.getAndSet(pair);
-      consecutiveFailures.set(0);
       if (stale != null) {
         closeQuietly(stale.context());
       }
+      // close() may have flipped `closed` and drained the ref between the guard above and this
+      // swap. If so, retract the pair we just published and tear it down rather than start a
+      // receive thread that close() has already finished waiting for.
+      if (closed.get()) {
+        if (connectionRef.compareAndSet(pair, null)) {
+          closeQuietly(ctx);
+        }
+        return false;
+      }
+      consecutiveFailures.set(0);
       startReceiveThread(pair);
       return true;
     } catch (RuntimeException ex) {
@@ -263,6 +293,12 @@ final class JmsConnectionLifecycle {
    * handler cannot kill the receive thread.
    */
   private void dispatch(Message message) {
+    // A message can arrive in the window between close() flipping `closed` and the receive loop
+    // re-checking it. Skip delivery once closed so the handler never touches a CDI context the
+    // caller is about to destroy.
+    if (closed.get()) {
+      return;
+    }
     try {
       inboundHandler.accept(message);
     } catch (RuntimeException ignored) {
@@ -308,6 +344,14 @@ final class JmsConnectionLifecycle {
       ctx.close();
     } catch (Exception ignored) {
       // best-effort; the context may already be in a half-broken state
+    }
+  }
+
+  private static void joinQuietly(Thread thread) {
+    try {
+      thread.join(SHUTDOWN_JOIN_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsConnectionLifecycle.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsConnectionLifecycle.java
@@ -5,8 +5,8 @@ import jakarta.jms.JMSConsumer;
 import jakarta.jms.JMSContext;
 import jakarta.jms.JMSException;
 import jakarta.jms.JMSProducer;
+import jakarta.jms.JMSRuntimeException;
 import jakarta.jms.Message;
-import jakarta.jms.MessageListener;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
 import java.util.Objects;
@@ -19,21 +19,24 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.NodeIdentity;
 
 /**
- * Owns the {@link JMSContext} and {@link JMSProducer} for one JMS coordinator instance. The {@code
- * JMSConsumer} the lifecycle creates is registered with the context via {@code setMessageListener}
- * and lives for the lifetime of that context — closing the context cascades to the consumer per the
- * JMS spec, so we do not hold a separate reference. Reads-after-write atomicity is preserved by
- * holding context and producer in a single {@link AtomicReference}: a reconnect path swaps both in
- * one publish, and {@link JmsClusterCoordinator#notifyNewWork} never observes a mixed pair.
+ * Owns the {@link JMSContext}, {@link JMSProducer}, and {@link JMSConsumer} for one JMS coordinator
+ * instance, and runs a dedicated thread that pulls inbound messages with synchronous {@link
+ * JMSConsumer#receive(long)}.
+ *
+ * <p>Inbound delivery is synchronous on purpose. Jakarta Messaging 3.0 §12.3 forbids an
+ * application-created {@code JMSContext}/{@code JMSConsumer} in a web or EJB container from
+ * registering asynchronous delivery — {@code setMessageListener} and {@code setExceptionListener}
+ * must throw — so the async model only works in Java SE or against lenient brokers. A blocking
+ * {@code receive(timeout)} on a dedicated thread is permitted everywhere and mirrors the PostgreSQL
+ * coordinator's listen thread.
  *
  * <p>Reconnect is driven by two paths:
  *
  * <ol>
- *   <li>JMS provider's {@code ExceptionListener} firing on a connection-level fault (the primary
- *       failure indicator the spec requires).
- *   <li>An active background retry loop started when reconnect first fails — the {@code
- *       ExceptionListener} only fires once per real fault, so an outage that outlives the first
- *       backoff window needs a self-paced retry source to recover.
+ *   <li>The receive thread observing a {@link JMSRuntimeException} from {@code receive()} on a
+ *       connection-level fault (replacing the spec-illegal {@code ExceptionListener}).
+ *   <li>An active background retry loop started when reconnect first fails — a fault surfaces once,
+ *       so an outage that outlives the first backoff window needs a self-paced retry source.
  * </ol>
  *
  * <p>{@link #close()} is idempotent and releases the context the lifecycle owns. The {@link
@@ -50,6 +53,14 @@ final class JmsConnectionLifecycle {
    */
   static final int CONSECUTIVE_FAILURES_ERROR_THRESHOLD = 10;
 
+  /**
+   * Upper bound on a single {@code receive()} wait. It only bounds how quickly the receive thread
+   * notices {@link #close()} / a pair swap on a quiet topic; real wakeups arrive as soon as the
+   * broker pushes a message. Kept local because {@link JmsCoordinatorConfig} carries no receive
+   * timeout (the PostgreSQL coordinator's default is the same 1s).
+   */
+  private static final long RECEIVE_TIMEOUT_MS = 1_000L;
+
   private final ConnectionFactory connectionFactory;
   private final Topic topic;
   private final JmsCoordinatorConfig config;
@@ -63,6 +74,7 @@ final class JmsConnectionLifecycle {
 
   private volatile NodeIdentity localIdentity;
   private volatile Thread reconnectThread;
+  private volatile Thread receiveThread;
 
   JmsConnectionLifecycle(
       ConnectionFactory connectionFactory,
@@ -151,9 +163,13 @@ final class JmsConnectionLifecycle {
     if (!closed.compareAndSet(false, true)) {
       return;
     }
-    Thread t = this.reconnectThread;
-    if (t != null) {
-      t.interrupt();
+    Thread reconnect = this.reconnectThread;
+    if (reconnect != null) {
+      reconnect.interrupt();
+    }
+    Thread receive = this.receiveThread;
+    if (receive != null) {
+      receive.interrupt();
     }
     closeContextRef();
   }
@@ -166,7 +182,6 @@ final class JmsConnectionLifecycle {
     }
     try {
       JMSContext ctx = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE);
-      ctx.setExceptionListener(this::onConnectionException);
       JMSProducer p = ctx.createProducer();
       String selector =
           config.brokerSideSelfFilter()
@@ -174,7 +189,6 @@ final class JmsConnectionLifecycle {
               : null;
       JMSConsumer consumer =
           selector == null ? ctx.createConsumer(topic) : ctx.createConsumer(topic, selector);
-      consumer.setMessageListener(new InboundListener(inboundHandler));
 
       // Close-during-reconnect race: if close() flipped `closed` after our guard above but
       // before we got here, the freshly-built context would leak — close() has already drained
@@ -183,11 +197,13 @@ final class JmsConnectionLifecycle {
         closeQuietly(ctx);
         return false;
       }
-      Pair stale = connectionRef.getAndSet(new Pair(ctx, p));
+      Pair pair = new Pair(ctx, p, consumer);
+      Pair stale = connectionRef.getAndSet(pair);
       consecutiveFailures.set(0);
       if (stale != null) {
         closeQuietly(stale.context());
       }
+      startReceiveThread(pair);
       return true;
     } catch (RuntimeException ex) {
       long consecutive = consecutiveFailures.incrementAndGet();
@@ -204,17 +220,54 @@ final class JmsConnectionLifecycle {
     }
   }
 
-  private void onConnectionException(JMSException ex) {
-    if (closed.get()) {
-      return;
+  private void startReceiveThread(Pair pair) {
+    Thread t = new Thread(() -> receiveLoop(pair), "ratchet-coordinator-jms-receive");
+    t.setDaemon(true);
+    this.receiveThread = t;
+    t.start();
+  }
+
+  /**
+   * Pulls inbound messages for {@code pair} until the lifecycle closes, the pair is swapped out by
+   * a reconnect, or {@code receive()} reports a connection fault. A fault on the still-current pair
+   * nulls the ref and kicks off reconnect — the synchronous-receive equivalent of the {@code
+   * ExceptionListener} the EE spec forbids.
+   */
+  private void receiveLoop(Pair pair) {
+    JMSConsumer consumer = pair.consumer();
+    while (!closed.get() && connectionRef.get() == pair) {
+      try {
+        Message message = consumer.receive(RECEIVE_TIMEOUT_MS);
+        if (message != null) {
+          dispatch(message);
+        }
+      } catch (JMSRuntimeException fault) {
+        // A context closed by close() or a reconnect swap also surfaces here; only a fault on the
+        // pair that is still current is a real transport failure worth reconnecting.
+        if (closed.get() || connectionRef.get() != pair) {
+          return;
+        }
+        onTransportFailure.run();
+        log.warnf("JMS coordinator receive failed, scheduling reconnect: %s", fault.getMessage());
+        if (connectionRef.compareAndSet(pair, null)) {
+          closeQuietly(pair.context());
+        }
+        triggerReconnect();
+        return;
+      }
     }
-    onTransportFailure.run();
-    log.warnf("JMS coordinator connection exception, scheduling reconnect: %s", ex.getMessage());
-    Pair stale = connectionRef.getAndSet(null);
-    if (stale != null) {
-      closeQuietly(stale.context());
+  }
+
+  /**
+   * Hands one inbound message to the coordinator. Swallows every handler exception so a misbehaving
+   * handler cannot kill the receive thread.
+   */
+  private void dispatch(Message message) {
+    try {
+      inboundHandler.accept(message);
+    } catch (RuntimeException ignored) {
+      // The handler already recorded any transport_failure metric; swallow to keep receiving.
     }
-    triggerReconnect();
   }
 
   private void reconnectLoop() {
@@ -248,7 +301,7 @@ final class JmsConnectionLifecycle {
     }
   }
 
-  private record Pair(JMSContext context, JMSProducer producer) {}
+  private record Pair(JMSContext context, JMSProducer producer, JMSConsumer consumer) {}
 
   private static void closeQuietly(JMSContext ctx) {
     try {
@@ -266,28 +319,5 @@ final class JmsConnectionLifecycle {
    */
   static String escapeSelector(String value) {
     return value.replace("\\", "\\\\").replace("'", "''");
-  }
-
-  /**
-   * Adapter so the {@code MessageListener} signature can call a {@link Consumer} the coordinator
-   * supplies. Catches every exception inside {@code onMessage} so a misbehaving handler does not
-   * trigger the JMS provider's "close the connection on listener exception" behaviour.
-   */
-  static final class InboundListener implements MessageListener {
-    private final Consumer<Message> handler;
-
-    InboundListener(Consumer<Message> handler) {
-      this.handler = handler;
-    }
-
-    @Override
-    public void onMessage(Message message) {
-      try {
-        handler.accept(message);
-      } catch (RuntimeException ignored) {
-        // The handler already recorded any transport_failure metric. Swallow to avoid the
-        // provider tearing down the connection on listener-throws.
-      }
-    }
   }
 }

--- a/ratchet-coordinator-jms/src/test/java-wildfly/run/ratchet/coordinator/jms/JmsClusterCoordinatorWildflyContainerIT.java
+++ b/ratchet-coordinator-jms/src/test/java-wildfly/run/ratchet/coordinator/jms/JmsClusterCoordinatorWildflyContainerIT.java
@@ -1,0 +1,227 @@
+package run.ratchet.coordinator.jms;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.annotation.Resource;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSConsumer;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSDestinationDefinition;
+import jakarta.jms.JMSRuntimeException;
+import jakarta.jms.Message;
+import jakarta.jms.TextMessage;
+import jakarta.jms.Topic;
+import java.io.File;
+import java.io.FileFilter;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.NotifyPayload;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
+import run.ratchet.spi.JobWakeupHint;
+import run.ratchet.spi.NodeIdentityProvider;
+
+/**
+ * Deploys {@link JmsClusterCoordinator} into a managed WildFly instance booted with the {@code
+ * standalone-full} profile (which enables the {@code messaging-activemq} subsystem and binds {@code
+ * java:comp/DefaultJMSConnectionFactory}). This is the one test that exercises the coordinator's
+ * startup and message paths against a strict Jakarta EE JMS provider — the embedded-Artemis ITs run
+ * in Java SE mode, which does not enforce the §12.3 ban on asynchronous delivery.
+ *
+ * <p>The proof is two-sided so neither half is vacuous:
+ *
+ * <ol>
+ *   <li>{@code containerEnforcesAsyncDeliveryBan} confirms WildFly really does reject {@code
+ *       setExceptionListener}/{@code setMessageListener} on an application-created context in this
+ *       web component. If this ever stops throwing, the container is not enforcing §12.3 and the
+ *       second assertion proves nothing.
+ *   <li>{@code coordinatorStartsAndRoundTripsAcrossNodes} confirms the coordinator starts, runs its
+ *       synchronous receive loop, and delivers wakeups in both directions on that same strict
+ *       container — which it can only do because it never registers asynchronous delivery.
+ * </ol>
+ */
+@ExtendWith(ArquillianExtension.class)
+public class JmsClusterCoordinatorWildflyContainerIT {
+
+  private static final long RECEIVE_TIMEOUT_MS = 15_000L;
+  private static final String LOCAL_NODE = "node-A";
+  private static final String TOPIC_JNDI = "java:app/jms/ratchetWakeupContainerIt";
+
+  @Deployment
+  public static WebArchive deployment() {
+    return ShrinkWrap.create(WebArchive.class, "ratchet-jms-coordinator-it.war")
+        .addClasses(
+            JmsClusterCoordinatorWildflyContainerIT.class,
+            ContainerJmsProvider.class,
+            ContainerSpiCollaborators.class)
+        // Bundle the ratchet artifacts as built jars rather than re-resolving from the local
+        // repository: this stays correct under a reactor (-am) build without an intervening
+        // `install`, and each jar carries only ratchet code (no jakarta.* API jars that would
+        // collide with the container's own modules).
+        .addAsLibraries(
+            reactorJar("../ratchet-api/target", "ratchet-api-"),
+            reactorJar("../ratchet-coordinator-common/target", "ratchet-coordinator-common-"),
+            reactorJar("target", "ratchet-coordinator-jms-"))
+        .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+  }
+
+  @Inject JmsClusterCoordinator coordinator;
+
+  @Resource(lookup = "java:comp/DefaultJMSConnectionFactory")
+  ConnectionFactory connectionFactory;
+
+  @Resource(lookup = TOPIC_JNDI)
+  Topic topic;
+
+  @AfterEach
+  void stopCoordinator() {
+    // This bare WAR has no RatchetLifecycle to drive afterStop(), so close the coordinator here.
+    // Without it the synchronous receive thread outlives the CDI context at container shutdown and
+    // logs a WELD-000229 when it next touches the MetricsCollector. close() is idempotent.
+    coordinator.close();
+  }
+
+  @Test
+  public void containerEnforcesAsyncDeliveryBan() {
+    // Direct evidence the container is §12.3-strict. The methods the old async model called must
+    // throw on an application-created context in this (web) component; if they do not, WildFly is
+    // not enforcing the ban and the coordinator's compliance can't be demonstrated here.
+    try (JMSContext ctx = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+      assertThrows(
+          JMSRuntimeException.class,
+          () -> ctx.setExceptionListener(e -> {}),
+          "a managed JMSContext must reject setExceptionListener per Jakarta Messaging §12.3");
+      JMSConsumer consumer = ctx.createConsumer(topic);
+      assertThrows(
+          JMSRuntimeException.class,
+          () -> consumer.setMessageListener(m -> {}),
+          "a managed JMSConsumer must reject setMessageListener per Jakarta Messaging §12.3");
+    }
+  }
+
+  @Test
+  public void coordinatorStartsAndRoundTripsAcrossNodes() throws Exception {
+    // afterStart() drives connect(): createContext + createConsumer + the synchronous receive
+    // loop. The async model would have called the §12.3-banned setMessageListener here and the
+    // coordinator would have failed to come up on this container.
+    assertDoesNotThrow(coordinator::afterStart);
+
+    // Inbound: a wakeup from a different node clears both the broker-side selector and the
+    // receive-side self-filter and reaches a registered listener via the sync receive loop.
+    BlockingQueue<JobWakeupHint> delivered = new LinkedBlockingQueue<>();
+    coordinator.registerWakeupListener(delivered::add);
+    publishWakeupAs("node-EXTERNAL", JobPriority.NORMAL, "inbound-target");
+
+    JobWakeupHint inbound = delivered.poll(RECEIVE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    assertNotNull(
+        inbound, "the synchronous receive loop must deliver a cross-node wakeup on a strict container");
+    assertEquals("inbound-target", inbound.executionTarget());
+
+    // Outbound: notifyNewWork publishes an envelope a plain consumer can read back. The
+    // coordinator stamps the message with the local node, so its own selector drops the self-copy
+    // while this unfiltered probe still receives it.
+    try (JMSContext probe = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+      JMSConsumer raw = probe.createConsumer(topic);
+      coordinator.notifyNewWork(JobPriority.HIGH, new NodeIdentity(LOCAL_NODE), "outbound-target");
+      Message received = raw.receive(RECEIVE_TIMEOUT_MS);
+      assertNotNull(received, "notifyNewWork must publish a wakeup envelope to the topic");
+      String body = ((TextMessage) received).getText();
+      assertEquals("outbound-target", new NotifyPayloadCodec().decode(body).executionTarget());
+    }
+  }
+
+  private void publishWakeupAs(String node, JobPriority priority, String target) {
+    String body =
+        new NotifyPayloadCodec().encode(NotifyPayload.current(new NodeIdentity(node), priority, target));
+    try (JMSContext ctx = connectionFactory.createContext(JMSContext.AUTO_ACKNOWLEDGE)) {
+      TextMessage message = ctx.createTextMessage(body);
+      // The coordinator's consumer selects on `node <> '<localId>'`; stamp it so the broker-side
+      // self-filter lets a foreign-node wakeup through.
+      message.setStringProperty("node", node);
+      message.setStringProperty("prio", priority.name());
+      ctx.createProducer().send(topic, message);
+    } catch (Exception e) {
+      throw new IllegalStateException("failed to publish test wakeup", e);
+    }
+  }
+
+  private static File reactorJar(String dir, String prefix) {
+    File target = new File(dir);
+    File[] matches =
+        target.listFiles(
+            (FileFilter)
+                f ->
+                    f.getName().startsWith(prefix)
+                        && f.getName().endsWith(".jar")
+                        && !f.getName().contains("-sources")
+                        && !f.getName().contains("-javadoc")
+                        && !f.getName().contains("-tests"));
+    if (matches == null || matches.length == 0) {
+      throw new IllegalStateException(
+          "reactor jar " + prefix + "*.jar not found in " + target.getAbsolutePath());
+    }
+    return matches[0];
+  }
+
+  /**
+   * Supplies the JMS resources from the container: the platform default connection factory and an
+   * application-declared topic. {@link JMSDestinationDefinition} provisions the topic at deploy time
+   * so the test needs no server-side CLI setup.
+   */
+  @JMSDestinationDefinition(
+      name = TOPIC_JNDI,
+      interfaceName = "jakarta.jms.Topic",
+      destinationName = "ratchetWakeupContainerIt")
+  @ApplicationScoped
+  public static class ContainerJmsProvider implements JmsConnectionFactoryProvider {
+
+    @Resource(lookup = "java:comp/DefaultJMSConnectionFactory")
+    ConnectionFactory connectionFactory;
+
+    @Resource(lookup = TOPIC_JNDI)
+    Topic topic;
+
+    @Override
+    public ConnectionFactory connectionFactory() {
+      return connectionFactory;
+    }
+
+    @Override
+    public Topic topic() {
+      return topic;
+    }
+  }
+
+  /**
+   * Produces the one SPI collaborator the WAR does not already carry. The coordinator's {@code
+   * MetricsCollector} resolves to the bundled {@code NoOpMetricsCollector} (an {@code
+   * @ApplicationScoped @Default} bean in ratchet-api) under the container's full bean discovery —
+   * adding a producer for it here would make the type ambiguous (WELD-001409). {@code
+   * NodeIdentityProvider} has no bundled default in this WAR (the RI is not deployed), so it is
+   * produced explicitly.
+   */
+  @ApplicationScoped
+  public static class ContainerSpiCollaborators {
+
+    @Produces
+    NodeIdentityProvider nodeIdentityProvider() {
+      return () -> LOCAL_NODE;
+    }
+  }
+}

--- a/ratchet-coordinator-jms/src/test/java-wildfly/run/ratchet/coordinator/jms/JmsClusterCoordinatorWildflyContainerIT.java
+++ b/ratchet-coordinator-jms/src/test/java-wildfly/run/ratchet/coordinator/jms/JmsClusterCoordinatorWildflyContainerIT.java
@@ -92,8 +92,9 @@ public class JmsClusterCoordinatorWildflyContainerIT {
   @AfterEach
   void stopCoordinator() {
     // This bare WAR has no RatchetLifecycle to drive afterStop(), so close the coordinator here.
-    // Without it the synchronous receive thread outlives the CDI context at container shutdown and
-    // logs a WELD-000229 when it next touches the MetricsCollector. close() is idempotent.
+    // close() drains the synchronous receive thread before returning, so it does not outlive the
+    // CDI context and touch the MetricsCollector after teardown (the WELD-000229 it used to leave).
+    // close() is idempotent.
     coordinator.close();
   }
 

--- a/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsConnectionLifecycleTest.java
+++ b/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsConnectionLifecycleTest.java
@@ -1,5 +1,6 @@
 package run.ratchet.coordinator.jms;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -8,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
@@ -21,22 +23,26 @@ import jakarta.jms.ConnectionFactory;
 import jakarta.jms.ExceptionListener;
 import jakarta.jms.JMSConsumer;
 import jakarta.jms.JMSContext;
-import jakarta.jms.JMSException;
 import jakarta.jms.JMSProducer;
 import jakarta.jms.JMSRuntimeException;
 import jakarta.jms.Message;
 import jakarta.jms.MessageListener;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import run.ratchet.api.NodeIdentity;
 
 class JmsConnectionLifecycleTest {
+
+  private final List<JmsConnectionLifecycle> created = new ArrayList<>();
 
   private ConnectionFactory cf;
   private Topic topic;
@@ -58,6 +64,14 @@ class JmsConnectionLifecycleTest {
     when(ctx.createProducer()).thenReturn(producer);
     when(ctx.createConsumer(any(Topic.class))).thenReturn(consumer);
     when(ctx.createConsumer(any(Topic.class), anyString())).thenReturn(consumer);
+    // Default: a quiet topic. The receive loop blocks briefly and returns nothing, so it polls
+    // without busy-spinning. Tests that need an inbound message or a fault override this.
+    when(consumer.receive(anyLong())).thenAnswer(blockingQuietReceive());
+  }
+
+  @AfterEach
+  void tearDown() {
+    created.forEach(JmsConnectionLifecycle::close);
   }
 
   // ─── start() ─────────────────────────────────────────────────────────────────
@@ -69,9 +83,12 @@ class JmsConnectionLifecycleTest {
   }
 
   @Test
-  void startInstallsExceptionListener() {
+  void startDoesNotRegisterAsyncDelivery() {
     newLifecycle().start(identity("nodeA"));
-    verify(ctx).setExceptionListener(any(ExceptionListener.class));
+    // Jakarta Messaging 3.0 §12.3 forbids setExceptionListener / setMessageListener on an
+    // application-created context in a web or EJB container. Inbound delivery is synchronous.
+    verify(ctx, never()).setExceptionListener(any(ExceptionListener.class));
+    verify(consumer, never()).setMessageListener(any(MessageListener.class));
   }
 
   @Test
@@ -84,9 +101,8 @@ class JmsConnectionLifecycleTest {
   @Test
   void startInstallsBrokerSideSelfFilterSelectorWhenEnabled() {
     newLifecycle().start(identity("nodeA"));
-    ArgumentCaptor<String> selector = ArgumentCaptor.forClass(String.class);
-    verify(ctx).createConsumer(any(Topic.class), selector.capture());
-    assertEquals("node <> 'nodeA'", selector.getValue());
+    verify(ctx)
+        .createConsumer(any(Topic.class), org.mockito.ArgumentMatchers.eq("node <> 'nodeA'"));
   }
 
   @Test
@@ -99,21 +115,16 @@ class JmsConnectionLifecycleTest {
 
   @Test
   void startBuildsSelectorFromNodeIdentity() {
-    // NodeIdentity rejects single-quote / backslash at construction, so escapeSelector's escape
-    // logic is exercised in isolation (see escapeSelectorDoublesSingleQuotes etc); this test
-    // pins the rendered selector format for an unremarkable identity.
     newLifecycle().start(identity("nodeA"));
-    ArgumentCaptor<String> selector = ArgumentCaptor.forClass(String.class);
-    verify(ctx, atLeastOnce()).createConsumer(any(Topic.class), selector.capture());
-    assertEquals("node <> 'nodeA'", selector.getValue());
+    verify(ctx, atLeastOnce())
+        .createConsumer(any(Topic.class), org.mockito.ArgumentMatchers.eq("node <> 'nodeA'"));
   }
 
   @Test
   void startWithFailingContextFactoryLeavesRefsNullAndDoesNotThrow() {
     when(cf.createContext(anyInt())).thenThrow(new JMSRuntimeException("boom"));
     AtomicInteger transportFailures = new AtomicInteger();
-    JmsConnectionLifecycle lifecycle =
-        new JmsConnectionLifecycle(cf, topic, config, m -> {}, transportFailures::incrementAndGet);
+    JmsConnectionLifecycle lifecycle = newLifecycle(m -> {}, transportFailures::incrementAndGet);
     assertDoesNotThrow(() -> lifecycle.start(identity("nodeA")));
     assertNull(lifecycle.currentContext());
     assertNull(lifecycle.currentProducer());
@@ -127,36 +138,32 @@ class JmsConnectionLifecycleTest {
     assertNotNull(lifecycle.currentProducer());
   }
 
-  // ─── exception-listener-driven reconnect ─────────────────────────────────────
+  // ─── receive-fault-driven reconnect ──────────────────────────────────────────
 
   @Test
-  void exceptionListenerFiringNullsRefsAndCallsTransportFailure() throws Exception {
+  void receiveFaultNullsRefsAndCallsTransportFailure() {
+    when(consumer.receive(anyLong())).thenThrow(new JMSRuntimeException("transport down"));
     AtomicInteger transportFailures = new AtomicInteger();
-    JmsConnectionLifecycle lifecycle =
-        new JmsConnectionLifecycle(cf, topic, config, m -> {}, transportFailures::incrementAndGet);
-    ArgumentCaptor<ExceptionListener> listenerCaptor =
-        ArgumentCaptor.forClass(ExceptionListener.class);
+    JmsConnectionLifecycle lifecycle = newLifecycle(m -> {}, transportFailures::incrementAndGet);
+
     lifecycle.start(identity("nodeA"));
-    verify(ctx).setExceptionListener(listenerCaptor.capture());
 
-    // Fire the listener with a JMSException.
-    listenerCaptor.getValue().onException(new JMSException("transport down"));
-
-    // Allow reconnect thread to attempt at least once before we assert.
-    Thread.sleep(150);
-    assertTrue(transportFailures.get() >= 1, "transport_failure must increment on disconnect");
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () ->
+                assertTrue(
+                    transportFailures.get() >= 1,
+                    "transport_failure must increment when receive() faults"));
   }
 
   @Test
-  void exceptionListenerClosesStaleContext() {
+  void receiveFaultClosesStaleContext() {
+    when(consumer.receive(anyLong())).thenThrow(new JMSRuntimeException("transport down"));
     JmsConnectionLifecycle lifecycle = newLifecycle();
-    ArgumentCaptor<ExceptionListener> listenerCaptor =
-        ArgumentCaptor.forClass(ExceptionListener.class);
     lifecycle.start(identity("nodeA"));
-    verify(ctx).setExceptionListener(listenerCaptor.capture());
 
-    listenerCaptor.getValue().onException(new JMSException("transport down"));
-    verify(ctx, atLeastOnce()).close();
+    await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> verify(ctx, atLeastOnce()).close());
   }
 
   @Test
@@ -175,39 +182,30 @@ class JmsConnectionLifecycleTest {
   }
 
   @Test
-  void reconnectRecoversAfterTransientFailure() throws Exception {
+  void reconnectRecoversAfterTransientReceiveFault() {
     JMSContext freshCtx = mock(JMSContext.class);
     JMSProducer freshProducer = mock(JMSProducer.class);
     JMSConsumer freshConsumer = mock(JMSConsumer.class);
     when(freshCtx.createProducer()).thenReturn(freshProducer);
     when(freshCtx.createConsumer(any(Topic.class), anyString())).thenReturn(freshConsumer);
+    when(freshConsumer.receive(anyLong())).thenAnswer(blockingQuietReceive());
+    // First context's receive() faults; the reconnect cycle then yields a fresh context.
+    when(consumer.receive(anyLong())).thenThrow(new JMSRuntimeException("connection lost"));
     AtomicInteger calls = new AtomicInteger();
     when(cf.createContext(anyInt()))
-        .thenAnswer(
-            inv -> {
-              int n = calls.incrementAndGet();
-              if (n == 1) {
-                return ctx;
-              }
-              if (n == 2) {
-                throw new JMSRuntimeException("still down");
-              }
-              return freshCtx;
-            });
+        .thenAnswer(inv -> calls.incrementAndGet() == 1 ? ctx : freshCtx);
 
     JmsConnectionLifecycle lifecycle = newLifecycle();
-    ArgumentCaptor<ExceptionListener> listenerCaptor =
-        ArgumentCaptor.forClass(ExceptionListener.class);
     lifecycle.start(identity("nodeA"));
-    verify(ctx).setExceptionListener(listenerCaptor.capture());
 
-    listenerCaptor.getValue().onException(new JMSException("connection lost"));
-
-    long deadline = System.currentTimeMillis() + 2_000L;
-    while (lifecycle.currentContext() != freshCtx && System.currentTimeMillis() < deadline) {
-      Thread.sleep(20);
-    }
-    assertEquals(freshCtx, lifecycle.currentContext(), "reconnect must publish fresh context");
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    freshCtx,
+                    lifecycle.currentContext(),
+                    "reconnect must publish a fresh context after a receive fault"));
     assertEquals(freshProducer, lifecycle.currentProducer());
   }
 
@@ -227,7 +225,6 @@ class JmsConnectionLifecycleTest {
     lifecycle.start(identity("nodeA"));
     lifecycle.close();
     assertDoesNotThrow(lifecycle::close);
-    // Second close must not call ctx.close again.
     verify(ctx, times(1)).close();
   }
 
@@ -247,24 +244,6 @@ class JmsConnectionLifecycleTest {
     assertFalse(lifecycle.isClosed());
     lifecycle.close();
     assertTrue(lifecycle.isClosed());
-  }
-
-  @Test
-  void exceptionListenerAfterCloseIsNoOp() throws Exception {
-    AtomicInteger transportFailures = new AtomicInteger();
-    JmsConnectionLifecycle lifecycle =
-        new JmsConnectionLifecycle(cf, topic, config, m -> {}, transportFailures::incrementAndGet);
-    ArgumentCaptor<ExceptionListener> listenerCaptor =
-        ArgumentCaptor.forClass(ExceptionListener.class);
-    lifecycle.start(identity("nodeA"));
-    verify(ctx).setExceptionListener(listenerCaptor.capture());
-
-    lifecycle.close();
-    listenerCaptor.getValue().onException(new JMSException("post-close fault"));
-
-    // No reconnect attempt, no new transport-failure tick.
-    Thread.sleep(50);
-    assertEquals(0, transportFailures.get());
   }
 
   @Test
@@ -291,36 +270,44 @@ class JmsConnectionLifecycleTest {
   // ─── inbound dispatch ────────────────────────────────────────────────────────
 
   @Test
-  void inboundHandlerIsInvokedWhenMessageListenerFires() throws Exception {
-    AtomicReference<Message> received = new AtomicReference<>();
-    JmsConnectionLifecycle lifecycle =
-        new JmsConnectionLifecycle(cf, topic, config, received::set, () -> {});
-    ArgumentCaptor<MessageListener> listenerCaptor = ArgumentCaptor.forClass(MessageListener.class);
-    lifecycle.start(identity("nodeA"));
-    verify(consumer).setMessageListener(listenerCaptor.capture());
-
+  void inboundHandlerIsInvokedForReceivedMessage() {
     TextMessage tm = mock(TextMessage.class);
-    listenerCaptor.getValue().onMessage(tm);
+    when(consumer.receive(anyLong())).thenReturn(tm).thenAnswer(blockingQuietReceive());
+    AtomicReference<Message> received = new AtomicReference<>();
+    JmsConnectionLifecycle lifecycle = newLifecycle(received::set, () -> {});
 
-    assertEquals(tm, received.get());
+    lifecycle.start(identity("nodeA"));
+
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> assertEquals(tm, received.get(), "received message must reach handler"));
   }
 
   @Test
-  void inboundHandlerExceptionsAreSwallowed() throws Exception {
+  void inboundHandlerExceptionsDoNotKillReceiveLoop() {
+    TextMessage first = mock(TextMessage.class);
+    TextMessage second = mock(TextMessage.class);
+    when(consumer.receive(anyLong()))
+        .thenReturn(first)
+        .thenReturn(second)
+        .thenAnswer(blockingQuietReceive());
+    List<Message> seen = new java.util.concurrent.CopyOnWriteArrayList<>();
     JmsConnectionLifecycle lifecycle =
-        new JmsConnectionLifecycle(
-            cf,
-            topic,
-            config,
+        newLifecycle(
             m -> {
+              seen.add(m);
               throw new RuntimeException("handler blew up");
             },
             () -> {});
-    ArgumentCaptor<MessageListener> listenerCaptor = ArgumentCaptor.forClass(MessageListener.class);
-    lifecycle.start(identity("nodeA"));
-    verify(consumer).setMessageListener(listenerCaptor.capture());
 
-    assertDoesNotThrow(() -> listenerCaptor.getValue().onMessage(mock(TextMessage.class)));
+    lifecycle.start(identity("nodeA"));
+
+    // A throwing handler on the first message must not stop the second from being delivered.
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(
+            () -> assertTrue(seen.contains(second), "receive loop must survive a throw"));
   }
 
   // ─── selector escaping helper ────────────────────────────────────────────────
@@ -339,7 +326,6 @@ class JmsConnectionLifecycleTest {
 
   @Test
   void escapeSelectorEscapesBackslashBeforeSingleQuote() {
-    // Backslash must double first; otherwise a value of \' would become \''  → broken literal.
     assertEquals("\\\\''", JmsConnectionLifecycle.escapeSelector("\\'"));
   }
 
@@ -352,8 +338,23 @@ class JmsConnectionLifecycleTest {
 
   // ─── helpers ─────────────────────────────────────────────────────────────────
 
+  private static org.mockito.stubbing.Answer<Message> blockingQuietReceive() {
+    return inv -> {
+      Thread.sleep(20);
+      return null;
+    };
+  }
+
   private JmsConnectionLifecycle newLifecycle() {
-    return new JmsConnectionLifecycle(cf, topic, config, m -> {}, () -> {});
+    return newLifecycle(m -> {}, () -> {});
+  }
+
+  private JmsConnectionLifecycle newLifecycle(
+      java.util.function.Consumer<Message> inboundHandler, Runnable onTransportFailure) {
+    JmsConnectionLifecycle lifecycle =
+        new JmsConnectionLifecycle(cf, topic, config, inboundHandler, onTransportFailure);
+    created.add(lifecycle);
+    return lifecycle;
   }
 
   private static JmsCoordinatorConfig newConfig(boolean brokerSideSelfFilter) {

--- a/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsConnectionLifecycleTest.java
+++ b/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsConnectionLifecycleTest.java
@@ -33,6 +33,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -324,6 +327,55 @@ class JmsConnectionLifecycleTest {
         .atMost(Duration.ofSeconds(2))
         .untilAsserted(
             () -> assertTrue(seen.contains(second), "receive loop must survive a throw"));
+  }
+
+  @Test
+  void closeWaitsForInFlightDispatchToFinish() throws InterruptedException {
+    TextMessage tm = mock(TextMessage.class);
+    when(consumer.receive(anyLong())).thenReturn(tm).thenAnswer(blockingQuietReceive());
+
+    CountDownLatch handlerEntered = new CountDownLatch(1);
+    CountDownLatch releaseHandler = new CountDownLatch(1);
+    AtomicBoolean handlerFinished = new AtomicBoolean(false);
+    JmsConnectionLifecycle lifecycle =
+        newLifecycle(
+            m -> {
+              handlerEntered.countDown();
+              // Wait through interruption: close() interrupts the receive thread, but a real
+              // handler doing synchronous work (e.g. a metrics call) would not unwind on it. This
+              // models that so the test exercises close()'s join, not the interrupt.
+              boolean released = false;
+              while (!released) {
+                try {
+                  released = releaseHandler.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                  // keep waiting
+                }
+              }
+              handlerFinished.set(true);
+            },
+            () -> {});
+
+    lifecycle.start(identity("nodeA"));
+    assertTrue(handlerEntered.await(2, TimeUnit.SECONDS), "handler must be entered before close()");
+
+    AtomicBoolean closeReturned = new AtomicBoolean(false);
+    Thread closer =
+        new Thread(
+            () -> {
+              lifecycle.close();
+              closeReturned.set(true);
+            });
+    closer.start();
+
+    // close() must block in join() while the dispatch is still inside the handler.
+    Thread.sleep(150);
+    assertFalse(closeReturned.get(), "close() must not return while a dispatch is in flight");
+
+    releaseHandler.countDown();
+    closer.join(Duration.ofSeconds(3).toMillis());
+    assertTrue(closeReturned.get(), "close() must return once the in-flight dispatch completes");
+    assertTrue(handlerFinished.get(), "the in-flight handler must finish before close() returns");
   }
 
   // ─── selector escaping helper ────────────────────────────────────────────────

--- a/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsConnectionLifecycleTest.java
+++ b/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsConnectionLifecycleTest.java
@@ -92,6 +92,22 @@ class JmsConnectionLifecycleTest {
   }
 
   @Test
+  void publishUsesSynchronousSendNotAsyncCompletionListener() throws Exception {
+    TextMessage outbound = mock(TextMessage.class);
+    when(ctx.createTextMessage(anyString())).thenReturn(outbound);
+    JmsConnectionLifecycle lifecycle = newLifecycle();
+    lifecycle.start(identity("nodeA"));
+
+    assertTrue(lifecycle.sendTextMessage("body", "nodeA", "NORMAL"));
+
+    // §12.3 forbids asynchronous send (a CompletionListener) from a container-created producer just
+    // as it forbids async receive. Publish must take the blocking send overload and never enable
+    // async delivery on the producer.
+    verify(producer).send(any(Topic.class), any(Message.class));
+    verify(producer, never()).setAsync(any());
+  }
+
+  @Test
   void startCreatesProducerAndConsumer() {
     newLifecycle().start(identity("nodeA"));
     verify(ctx).createProducer();

--- a/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsCoordinatorCdiDeploymentTest.java
+++ b/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsCoordinatorCdiDeploymentTest.java
@@ -1,0 +1,55 @@
+package run.ratchet.coordinator.jms;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.junit.jupiter.api.Test;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NoOpMetricsCollector;
+import run.ratchet.spi.NodeIdentityProvider;
+
+/**
+ * Boots a real CDI container to prove the coordinator deploys with no unsatisfied dependency.
+ *
+ * <p>The tuning config record has no producing bean, so a direct {@code @Inject
+ * JmsCoordinatorConfig} is an unsatisfied dependency that fails deployment validation out of the
+ * box. Resolving it through an {@link jakarta.enterprise.inject.Instance} with a {@code defaults()}
+ * fallback makes the coordinator deployable with zero application wiring. The container here
+ * provides only the SPI collaborators an application would already supply; the config is left
+ * deliberately unproduced.
+ */
+class JmsCoordinatorCdiDeploymentTest {
+
+  @Test
+  void coordinatorDeploysWithoutAProducerForItsConfigRecord() {
+    SeContainerInitializer initializer =
+        SeContainerInitializer.newInstance()
+            .disableDiscovery()
+            .addBeanClasses(JmsClusterCoordinator.class, SpiCollaborators.class);
+
+    try (SeContainer container = assertDoesNotThrow(initializer::initialize)) {
+      assertTrue(
+          container.select(JmsClusterCoordinator.class).isResolvable(),
+          "coordinator must resolve as an enabled bean with every injection point satisfied");
+    }
+  }
+
+  @ApplicationScoped
+  static class SpiCollaborators {
+
+    @Produces
+    NodeIdentityProvider nodeIdentityProvider() {
+      return () -> "test-node";
+    }
+
+    @Produces
+    @ApplicationScoped
+    MetricsCollector metricsCollector() {
+      return new NoOpMetricsCollector();
+    }
+  }
+}

--- a/ratchet-coordinator-jms/src/test/resources/arquillian.xml
+++ b/ratchet-coordinator-jms/src/test/resources/arquillian.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+                http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <defaultProtocol type="Servlet 5.0"/>
+
+  <engine>
+    <property name="deploymentExportPath">target/deployments</property>
+  </engine>
+
+  <!--
+    Single managed WildFly for the JMS coordinator container test. Booted with
+    standalone-full.xml so the messaging-activemq subsystem is present and the
+    platform default java:comp/DefaultJMSConnectionFactory is bound — the store
+    matrix's standalone.xml has no JMS subsystem. A distinct port offset keeps
+    this run from colliding with a store-matrix WildFly on the same machine.
+  -->
+  <container qualifier="wildfly-jms" default="true">
+    <configuration>
+      <property name="jbossHome">${project.build.directory}/wildfly-${wildfly.version}</property>
+      <property name="serverConfig">standalone-full.xml</property>
+      <property name="javaVmArguments">
+        -Xms256m -Xmx768m
+        -Djboss.socket.binding.port-offset=25000
+      </property>
+      <property name="managementPort">34990</property>
+      <property name="allowConnectingToRunningServer">false</property>
+    </configuration>
+  </container>
+
+</arquillian>

--- a/ratchet-coordinator-postgresql/pom.xml
+++ b/ratchet-coordinator-postgresql/pom.xml
@@ -117,6 +117,14 @@
             <version>2.0.13</version>
             <scope>test</scope>
         </dependency>
+        <!-- Weld SE: boots a real CDI container in-process to prove the coordinator deploys with
+             no unsatisfied dependency. -->
+        <dependency>
+            <groupId>org.jboss.weld.se</groupId>
+            <artifactId>weld-se-core</artifactId>
+            <version>6.0.2.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
+++ b/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
@@ -72,9 +72,20 @@ public class PostgresqlListenNotifyCoordinator
   private static final String COORDINATOR_KIND = "postgresql";
 
   @Inject NodeIdentityProvider identityProvider;
-  @Inject PostgresqlCoordinatorConfig config;
+
+  /**
+   * Resolved lazily in {@link #init()}. The config record is a plain value type with a {@code
+   * defaults()} factory, not a managed bean, so it is injected as an {@link Instance} and the
+   * coordinator falls back to {@link PostgresqlCoordinatorConfig#defaults()} when no application
+   * producer is present. A direct {@code @Inject PostgresqlCoordinatorConfig} would be an
+   * unsatisfied dependency and fail deployment validation out of the box.
+   */
+  @Inject Instance<PostgresqlCoordinatorConfig> configInstance;
+
   @Inject @Any Instance<DataSource> dataSourceInstance;
   @Inject MetricsCollector metrics;
+
+  private PostgresqlCoordinatorConfig config;
 
   private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
   private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
@@ -123,6 +134,12 @@ public class PostgresqlListenNotifyCoordinator
 
   @PostConstruct
   void init() {
+    if (config == null) {
+      config =
+          configInstance != null && configInstance.isResolvable()
+              ? configInstance.get()
+              : PostgresqlCoordinatorConfig.defaults();
+    }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
     requireJsonProvider();

--- a/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlCoordinatorCdiDeploymentTest.java
+++ b/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlCoordinatorCdiDeploymentTest.java
@@ -1,0 +1,55 @@
+package run.ratchet.coordinator.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.se.SeContainer;
+import jakarta.enterprise.inject.se.SeContainerInitializer;
+import org.junit.jupiter.api.Test;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NoOpMetricsCollector;
+import run.ratchet.spi.NodeIdentityProvider;
+
+/**
+ * Boots a real CDI container to prove the coordinator deploys with no unsatisfied dependency.
+ *
+ * <p>The tuning config record has no producing bean, so a direct {@code @Inject
+ * PostgresqlCoordinatorConfig} is an unsatisfied dependency that fails deployment validation out of
+ * the box. Resolving it through an {@link jakarta.enterprise.inject.Instance} with a {@code
+ * defaults()} fallback makes the coordinator deployable with zero application wiring. The container
+ * here provides only the SPI collaborators an application would already supply; the config is left
+ * deliberately unproduced.
+ */
+class PostgresqlCoordinatorCdiDeploymentTest {
+
+  @Test
+  void coordinatorDeploysWithoutAProducerForItsConfigRecord() {
+    SeContainerInitializer initializer =
+        SeContainerInitializer.newInstance()
+            .disableDiscovery()
+            .addBeanClasses(PostgresqlListenNotifyCoordinator.class, SpiCollaborators.class);
+
+    try (SeContainer container = assertDoesNotThrow(initializer::initialize)) {
+      assertTrue(
+          container.select(PostgresqlListenNotifyCoordinator.class).isResolvable(),
+          "coordinator must resolve as an enabled bean with every injection point satisfied");
+    }
+  }
+
+  @ApplicationScoped
+  static class SpiCollaborators {
+
+    @Produces
+    NodeIdentityProvider nodeIdentityProvider() {
+      return () -> "test-node";
+    }
+
+    @Produces
+    @ApplicationScoped
+    MetricsCollector metricsCollector() {
+      return new NoOpMetricsCollector();
+    }
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/converter/JsonObjectMapConverter.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/converter/JsonObjectMapConverter.java
@@ -10,17 +10,17 @@ import java.util.Map;
  * JPA {@link AttributeConverter} that converts {@code Map<String, Object>} to/from JSON for
  * database storage.
  *
- * <p>A single {@link Jsonb} instance is reused across all calls. Jakarta JSON Binding 3.0 does not
- * mandate thread-safety for {@code Jsonb}, so access is serialized through a {@link ThreadLocal} to
- * avoid contention on the shared instance while still avoiding per-call {@code
- * JsonbBuilder.create()} overhead (which involves ServiceLoader resolution).
+ * <p>A single {@link Jsonb} instance is reused across all calls. Holding one shared instance avoids
+ * the per-call {@code JsonbBuilder.create()} overhead (which involves ServiceLoader resolution)
+ * without attaching per-thread state to pooled/virtual execution threads, matching the shared
+ * fallback instance maintained by {@link PayloadSerializerHolder}.
  */
 @Converter
 public class JsonObjectMapConverter extends AbstractJsonAttributeConverter<Map<String, Object>> {
 
-  // ThreadLocal avoids per-call JsonbBuilder.create() (ServiceLoader + config) while
-  // remaining safe for providers that do not guarantee Jsonb thread-safety.
-  private static final ThreadLocal<Jsonb> JSONB = ThreadLocal.withInitial(JsonbBuilder::create);
+  // Single shared instance: avoids per-call JsonbBuilder.create() (ServiceLoader + config) without
+  // pinning a never-cleaned Jsonb to each pooled/virtual thread. Held for the JVM lifetime.
+  private static final Jsonb JSONB = JsonbBuilder.create();
 
   public String convertToDatabaseColumn(Map<String, Object> attribute) {
     return super.convertToDatabaseColumn(attribute);
@@ -28,13 +28,13 @@ public class JsonObjectMapConverter extends AbstractJsonAttributeConverter<Map<S
 
   @Override
   protected String serialize(Map<String, Object> attribute) {
-    return JSONB.get().toJson(attribute);
+    return JSONB.toJson(attribute);
   }
 
   @SuppressWarnings("unchecked")
   @Override
   protected Map<String, Object> deserialize(String dbData) {
-    return (Map<String, Object>) JSONB.get().fromJson(dbData, Map.class);
+    return (Map<String, Object>) JSONB.fromJson(dbData, Map.class);
   }
 
   @Override

--- a/ratchet-store-core/src/main/java/run/ratchet/store/query/JobQueryCursor.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/query/JobQueryCursor.java
@@ -4,16 +4,24 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.UUID;
+import run.ratchet.api.JobFilter;
 import run.ratchet.api.JobPage;
 import run.ratchet.api.JobQuerySortField;
 
 /**
- * Opaque keyset-pagination cursor encoding {@code (sortField, sortValue, jobId)}.
+ * Opaque keyset-pagination cursor encoding {@code (sortField, sortAscending, sortValue, jobId)}.
  *
  * <p>Encoded as URL-safe base64 with {@code |} delimiters so it can be passed in query parameters
  * without further escaping. Use {@link #encode()} to produce the opaque string for {@link
  * JobPage#nextCursor()} and {@link #decode(String)} to parse it back before building the store seek
  * predicate.
+ *
+ * <p>A cursor is only valid for the exact sort it was minted under. The store seek predicate
+ * filters on {@link #sortField()} while the {@code ORDER BY} comes from the live filter, so a
+ * caller that changes the sort field or direction mid-pagination would otherwise seek on one axis
+ * while the query orders by another — silently skipping or repeating rows. {@link
+ * #matchesFilterSort(JobFilter)} lets a store detect that mismatch and fall back to offset
+ * pagination (a clean restart) instead.
  *
  * <p>Sort value encoding by field type:
  *
@@ -23,7 +31,8 @@ import run.ratchet.api.JobQuerySortField;
  *   <li>{@code STATUS}: enum name string
  * </ul>
  */
-public record JobQueryCursor(JobQuerySortField sortField, String sortValue, UUID jobId) {
+public record JobQueryCursor(
+    JobQuerySortField sortField, boolean sortAscending, String sortValue, UUID jobId) {
 
   public static JobQueryCursor decode(String cursor) {
     byte[] bytes;
@@ -35,14 +44,16 @@ public record JobQueryCursor(JobQuerySortField sortField, String sortValue, UUID
     String raw = new String(bytes, StandardCharsets.UTF_8);
     int first = raw.indexOf('|');
     int second = raw.indexOf('|', first + 1);
-    if (first < 0 || second < 0) {
+    int third = raw.indexOf('|', second + 1);
+    if (first < 0 || second < 0 || third < 0) {
       throw malformedCursor(null);
     }
     try {
       JobQuerySortField field = JobQuerySortField.valueOf(raw.substring(0, first));
-      String sortValue = raw.substring(first + 1, second);
-      UUID jobId = UUID.fromString(raw.substring(second + 1));
-      return new JobQueryCursor(field, sortValue, jobId);
+      boolean ascending = parseAscending(raw.substring(first + 1, second));
+      String sortValue = raw.substring(second + 1, third);
+      UUID jobId = UUID.fromString(raw.substring(third + 1));
+      return new JobQueryCursor(field, ascending, sortValue, jobId);
     } catch (IllegalArgumentException e) {
       throw malformedCursor(e);
     }
@@ -50,10 +61,33 @@ public record JobQueryCursor(JobQuerySortField sortField, String sortValue, UUID
 
   public String encode() {
     // The supported sort encodings reserve '|' as the field delimiter.
-    String raw = sortField.name() + "|" + sortValue + "|" + jobId;
+    String raw = sortField.name() + "|" + sortAscending + "|" + sortValue + "|" + jobId;
     return Base64.getUrlEncoder()
         .withoutPadding()
         .encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+  }
+
+  /**
+   * True when this cursor matches the sort the given filter will order by. A keyset cursor is only
+   * valid for the exact {@code (field, direction)} it was minted under; reusing one against a
+   * different ordering would seek on one axis while the query sorts on another. An unset filter
+   * sort field defaults to {@link JobQuerySortField#CREATED_AT}, matching the store {@code ORDER
+   * BY} builders.
+   */
+  public boolean matchesFilterSort(JobFilter filter) {
+    JobQuerySortField effective =
+        filter.sortField() != null ? filter.sortField() : JobQuerySortField.CREATED_AT;
+    return this.sortField == effective && this.sortAscending == filter.sortAscending();
+  }
+
+  private static boolean parseAscending(String token) {
+    if ("true".equals(token)) {
+      return true;
+    }
+    if ("false".equals(token)) {
+      return false;
+    }
+    throw new IllegalArgumentException("Invalid cursor sort direction: " + token);
   }
 
   private static IllegalArgumentException malformedCursor(Throwable cause) {

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/DefaultPayloadMaskingPolicy.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/DefaultPayloadMaskingPolicy.java
@@ -1,0 +1,89 @@
+package run.ratchet.store.util;
+
+import java.util.Locale;
+import java.util.Set;
+import run.ratchet.spi.PayloadMaskingPolicy;
+
+/**
+ * Built-in {@link PayloadMaskingPolicy} that matches a fixed set of common credential and PII field
+ * names. Most markers match as a case-insensitive substring (so {@code apiKey} and {@code
+ * config.apiKeyHeader} both match). Short markers that are common English substrings ({@code pin},
+ * {@code cvv}, {@code ssn}) match only on word boundaries to avoid false positives like {@code
+ * spinner} or {@code session}.
+ *
+ * <p>This is the policy {@link PayloadMaskingPolicyHolder} returns when no policy has been
+ * installed, so the default masking behavior is identical whether or not a CDI container is
+ * present.
+ */
+public final class DefaultPayloadMaskingPolicy implements PayloadMaskingPolicy {
+
+  private static final Set<String> SENSITIVE_FIELDS =
+      Set.of(
+          "password",
+          "passwd",
+          "pwd",
+          "secret",
+          "token",
+          "apikey",
+          "api_key",
+          "apisecret",
+          "api_secret",
+          "accesskey",
+          "access_key",
+          "accesstoken",
+          "access_token",
+          "refreshtoken",
+          "refresh_token",
+          "auth",
+          "authorization",
+          "credential",
+          "credentials",
+          "privatekey",
+          "private_key",
+          "ssn",
+          "socialsecuritynumber",
+          "social_security_number",
+          "creditcard",
+          "credit_card",
+          "cardnumber",
+          "card_number",
+          "cvv",
+          "pin");
+
+  // Short markers that are common English substrings (e.g. "pin" inside "spinner")
+  // and so must match only on word boundaries; everything else uses plain substring.
+  private static final Set<String> SHORT_BOUNDARY_MARKERS = Set.of("pin", "cvv", "ssn");
+
+  @Override
+  public boolean isSensitiveField(String fieldName) {
+    if (fieldName == null) {
+      return false;
+    }
+    String lower = fieldName.toLowerCase(Locale.ROOT);
+    for (String marker : SENSITIVE_FIELDS) {
+      if (SHORT_BOUNDARY_MARKERS.contains(marker)) {
+        if (containsAsWord(lower, marker)) {
+          return true;
+        }
+      } else if (lower.contains(marker)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsAsWord(String haystack, String needle) {
+    int idx = haystack.indexOf(needle);
+    while (idx >= 0) {
+      boolean leftOk = idx == 0 || !Character.isLetterOrDigit(haystack.charAt(idx - 1));
+      int after = idx + needle.length();
+      boolean rightOk =
+          after == haystack.length() || !Character.isLetterOrDigit(haystack.charAt(after));
+      if (leftOk && rightOk) {
+        return true;
+      }
+      idx = haystack.indexOf(needle, idx + 1);
+    }
+    return false;
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/JobHydrationSupport.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/JobHydrationSupport.java
@@ -1,0 +1,97 @@
+package run.ratchet.store.util;
+
+import java.util.UUID;
+
+/**
+ * Shared row-coercion helpers for hydrating jobs from native-query projections. The per-store row
+ * mappers extract identical typed values from the projection; only the dialect label in the failure
+ * message differs, so it is supplied per store.
+ */
+public final class JobHydrationSupport {
+
+  private final String dialectLabel;
+
+  /**
+   * @param dialectLabel store name used in hydration failure messages (for example {@code
+   *     "MySQL"}).
+   */
+  public JobHydrationSupport(String dialectLabel) {
+    this.dialectLabel = dialectLabel;
+  }
+
+  public <E extends Enum<E>> E enumValue(
+      Object[] row, int index, String column, Class<E> enumType) {
+    String raw = RowValues.stringOrNull(row[index]);
+    if (raw == null) {
+      throw hydrationFailure(row, index, column, null, null);
+    }
+    try {
+      return Enum.valueOf(enumType, raw);
+    } catch (IllegalArgumentException e) {
+      throw hydrationFailure(row, index, column, raw, e);
+    }
+  }
+
+  public <E extends Enum<E>> E enumValueOrNull(
+      Object[] row, int index, String column, Class<E> enumType) {
+    String raw = RowValues.stringOrNull(row[index]);
+    if (raw == null) {
+      return null;
+    }
+    try {
+      return Enum.valueOf(enumType, raw);
+    } catch (IllegalArgumentException e) {
+      throw hydrationFailure(row, index, column, raw, e);
+    }
+  }
+
+  public Number requiredNumber(Object[] row, int index, String column) {
+    Number number = numberOrNull(row, index, column);
+    if (number == null) {
+      throw hydrationFailure(row, index, column, null, null);
+    }
+    return number;
+  }
+
+  public Number numberOrNull(Object[] row, int index, String column) {
+    Object value = row[index];
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Number number) {
+      return number;
+    }
+    throw hydrationFailure(row, index, column, value, null);
+  }
+
+  private JobHydrationException hydrationFailure(
+      Object[] row, int index, String column, Object value, Throwable cause) {
+    return new JobHydrationException(
+        "Failed to hydrate "
+            + dialectLabel
+            + " job "
+            + safeJobId(row)
+            + ": column "
+            + column
+            + " at index "
+            + index
+            + " has value "
+            + value,
+        cause);
+  }
+
+  private static UUID safeJobId(Object[] row) {
+    try {
+      return RowValues.uuidOrNull(row[0]);
+    } catch (RuntimeException ignored) {
+      return null;
+    }
+  }
+
+  /** Thrown when a native-query projection cannot be mapped to a job entity. */
+  public static final class JobHydrationException extends IllegalStateException {
+    public JobHydrationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
@@ -8,49 +8,18 @@ import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
 import java.io.StringReader;
-import java.util.Locale;
-import java.util.Set;
 import org.jboss.logging.Logger;
 import run.ratchet.store.converter.PayloadSerializerHolder;
 
-/** Utility for masking sensitive fields in serialized payload JSON. */
+/**
+ * Utility for masking sensitive fields in serialized payload JSON before it is rendered into a log
+ * line. Which fields count as sensitive is decided by the active {@link
+ * run.ratchet.spi.PayloadMaskingPolicy}, resolved through {@link PayloadMaskingPolicyHolder}.
+ */
 public final class PayloadMasker {
 
   private static final Logger log = Logger.getLogger(PayloadMasker.class);
   private static final String MASKED_VALUE = "***REDACTED***";
-
-  private static final Set<String> SENSITIVE_FIELDS =
-      Set.of(
-          "password",
-          "passwd",
-          "pwd",
-          "secret",
-          "token",
-          "apikey",
-          "api_key",
-          "apisecret",
-          "api_secret",
-          "accesskey",
-          "access_key",
-          "accesstoken",
-          "access_token",
-          "refreshtoken",
-          "refresh_token",
-          "auth",
-          "authorization",
-          "credential",
-          "credentials",
-          "privatekey",
-          "private_key",
-          "ssn",
-          "socialsecuritynumber",
-          "social_security_number",
-          "creditcard",
-          "credit_card",
-          "cardnumber",
-          "card_number",
-          "cvv",
-          "pin");
 
   private PayloadMasker() {}
 
@@ -91,40 +60,8 @@ public final class PayloadMasker {
     }
   }
 
-  // Short markers that are common English substrings (e.g. "pin" inside "spinner")
-  // and so must match only on word boundaries; everything else uses plain substring.
-  private static final Set<String> SHORT_BOUNDARY_MARKERS = Set.of("pin", "cvv", "ssn");
-
   private static boolean isSensitiveField(String fieldName) {
-    if (fieldName == null) {
-      return false;
-    }
-    String lower = fieldName.toLowerCase(Locale.ROOT);
-    for (String marker : SENSITIVE_FIELDS) {
-      if (SHORT_BOUNDARY_MARKERS.contains(marker)) {
-        if (containsAsWord(lower, marker)) {
-          return true;
-        }
-      } else if (lower.contains(marker)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean containsAsWord(String haystack, String needle) {
-    int idx = haystack.indexOf(needle);
-    while (idx >= 0) {
-      boolean leftOk = idx == 0 || !Character.isLetterOrDigit(haystack.charAt(idx - 1));
-      int after = idx + needle.length();
-      boolean rightOk =
-          after == haystack.length() || !Character.isLetterOrDigit(haystack.charAt(after));
-      if (leftOk && rightOk) {
-        return true;
-      }
-      idx = haystack.indexOf(needle, idx + 1);
-    }
-    return false;
+    return PayloadMaskingPolicyHolder.get().isSensitiveField(fieldName);
   }
 
   private static JsonObjectBuilder maskObject(JsonObject object) {

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
@@ -14,10 +14,9 @@ import org.jboss.logging.Logger;
 import run.ratchet.store.converter.PayloadSerializerHolder;
 
 /**
- * Utility for masking sensitive fields in payload data before it leaves the framework — whether
- * rendered into a log line or returned from a read API. Which fields count as sensitive is decided
- * by the active {@link run.ratchet.spi.PayloadMaskingPolicy}, resolved through {@link
- * PayloadMaskingPolicyHolder}.
+ * Utility for masking sensitive fields in payload data before it is returned from a read API. Which
+ * fields count as sensitive is decided by the active {@link run.ratchet.spi.PayloadMaskingPolicy},
+ * resolved through {@link PayloadMaskingPolicyHolder}.
  */
 public final class PayloadMasker {
 

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
@@ -8,13 +8,16 @@ import jakarta.json.JsonObjectBuilder;
 import jakarta.json.JsonReader;
 import jakarta.json.JsonValue;
 import java.io.StringReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.jboss.logging.Logger;
 import run.ratchet.store.converter.PayloadSerializerHolder;
 
 /**
- * Utility for masking sensitive fields in serialized payload JSON before it is rendered into a log
- * line. Which fields count as sensitive is decided by the active {@link
- * run.ratchet.spi.PayloadMaskingPolicy}, resolved through {@link PayloadMaskingPolicyHolder}.
+ * Utility for masking sensitive fields in payload data before it leaves the framework — whether
+ * rendered into a log line or returned from a read API. Which fields count as sensitive is decided
+ * by the active {@link run.ratchet.spi.PayloadMaskingPolicy}, resolved through {@link
+ * PayloadMaskingPolicyHolder}.
  */
 public final class PayloadMasker {
 
@@ -58,6 +61,25 @@ public final class PayloadMasker {
       log.warn("Payload serialization error, redacting entire payload", e);
       return MASKED_VALUE;
     }
+  }
+
+  /**
+   * Masks the values of sensitive entries in a parameter map. Each key is tested against the active
+   * {@link run.ratchet.spi.PayloadMaskingPolicy}; matching entries get a redacted value while
+   * everything else is copied verbatim. The input map is never modified; a {@code null} or empty
+   * map is returned unchanged. Unlike {@link #maskPayload(String)}, matching is purely key-based —
+   * parameter values are opaque strings, not nested JSON.
+   */
+  public static Map<String, String> maskParams(Map<String, String> params) {
+    if (params == null || params.isEmpty()) {
+      return params;
+    }
+    Map<String, String> masked = new LinkedHashMap<>(params.size());
+    for (var entry : params.entrySet()) {
+      masked.put(
+          entry.getKey(), isSensitiveField(entry.getKey()) ? MASKED_VALUE : entry.getValue());
+    }
+    return masked;
   }
 
   private static boolean isSensitiveField(String fieldName) {

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMaskingPolicyHolder.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMaskingPolicyHolder.java
@@ -1,0 +1,42 @@
+package run.ratchet.store.util;
+
+import run.ratchet.spi.PayloadMaskingPolicy;
+
+/**
+ * Static holder that resolves the active {@link PayloadMaskingPolicy} used by {@link
+ * PayloadMasker}.
+ *
+ * <p>Mirrors {@link run.ratchet.store.converter.PayloadSerializerHolder}: {@link PayloadMasker}
+ * lives in {@code store-core} and may run outside a CDI container (raw unit tests, pre-deployment
+ * tooling), so it cannot {@code @Inject} the policy. At container startup the reference
+ * implementation's producer calls {@link #set(PayloadMaskingPolicy)} with the discovered CDI bean.
+ * When no policy has been installed the holder returns {@link DefaultPayloadMaskingPolicy}, so the
+ * default field set masks identically with or without a container.
+ */
+public final class PayloadMaskingPolicyHolder {
+
+  private static final PayloadMaskingPolicy DEFAULT = new DefaultPayloadMaskingPolicy();
+
+  private static volatile PayloadMaskingPolicy delegate;
+
+  private PayloadMaskingPolicyHolder() {}
+
+  /**
+   * Installs the framework-managed {@link PayloadMaskingPolicy}. Called once at container startup
+   * by the reference implementation's producer.
+   *
+   * @param policy the policy to install; MAY be {@code null} to revert to the built-in default
+   */
+  public static void set(PayloadMaskingPolicy policy) {
+    delegate = policy;
+  }
+
+  /**
+   * Returns the currently-installed {@link PayloadMaskingPolicy}, or the built-in {@link
+   * DefaultPayloadMaskingPolicy} if none has been registered.
+   */
+  public static PayloadMaskingPolicy get() {
+    PayloadMaskingPolicy current = delegate;
+    return current != null ? current : DEFAULT;
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/RecurringJobRows.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/RecurringJobRows.java
@@ -1,0 +1,71 @@
+package run.ratchet.store.util;
+
+import java.time.Instant;
+import java.util.UUID;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.store.converter.JobPayloadConverter;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.RecurringJobDefinition;
+
+/**
+ * Shared hydration of {@link RecurringJobDefinition} from a {@code scheduler_recurring_job}
+ * projection. The column order matches {@code SELECT_COLUMNS} in the per-store recurring
+ * operations.
+ */
+public final class RecurringJobRows {
+
+  private static final JobPayloadConverter PAYLOAD_CONVERTER = new JobPayloadConverter();
+
+  private RecurringJobRows() {}
+
+  /**
+   * Maps a single recurring-master row. Column coercions go through {@link RowValues} so the same
+   * projection hydrates identically across SQL dialects (binary vs native UUID, tinyint vs native
+   * boolean, text vs native JSON columns).
+   */
+  public static RecurringJobDefinition hydrate(Object[] row) {
+    UUID id = RowValues.uuidOrNull(row[0]);
+    int priority = ((Number) row[1]).intValue();
+    int maxRetries = ((Number) row[2]).intValue();
+    BackoffPolicy backoffPolicy = BackoffPolicy.valueOf((String) row[3]);
+    int backoffParamMs = ((Number) row[4]).intValue();
+    int timeoutSec = ((Number) row[5]).intValue();
+    String cronExpr = (String) row[6];
+    String zoneId = (String) row[7];
+    Instant nextFire = RowValues.instantOrNull(row[8]);
+    boolean isPaused = RowValues.booleanOrFalse(row[9]);
+    Instant pausedAt = RowValues.instantOrNull(row[10]);
+    JobPayload payload =
+        PAYLOAD_CONVERTER.convertToEntityAttribute(RowValues.stringOrNull(row[11]));
+    JobPayload onSuccess =
+        PAYLOAD_CONVERTER.convertToEntityAttribute(RowValues.stringOrNull(row[12]));
+    JobPayload onFailure =
+        PAYLOAD_CONVERTER.convertToEntityAttribute(RowValues.stringOrNull(row[13]));
+    String businessKey = (String) row[14];
+    String resourceName = (String) row[15];
+    String executionTarget = (String) row[16];
+    Instant createdAt = RowValues.instantOrNull(row[17]);
+    String callerPrincipal = (String) row[18];
+
+    return new RecurringJobDefinition(
+        id,
+        cronExpr,
+        zoneId,
+        nextFire,
+        isPaused,
+        pausedAt,
+        priority,
+        maxRetries,
+        backoffPolicy,
+        backoffParamMs,
+        timeoutSec,
+        payload,
+        onSuccess,
+        onFailure,
+        businessKey,
+        resourceName,
+        executionTarget,
+        createdAt,
+        callerPrincipal);
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/RowValues.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/RowValues.java
@@ -1,5 +1,11 @@
 package run.ratchet.store.util;
 
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
 import java.util.UUID;
 import run.ratchet.api.JobPriority;
 
@@ -16,6 +22,51 @@ public final class RowValues {
 
   public static Long longOrNull(Object value) {
     return value == null ? null : ((Number) value).longValue();
+  }
+
+  /**
+   * Coerces a JDBC temporal column value to an {@link Instant}, accepting every type the supported
+   * drivers may return ({@link Instant}, {@link Timestamp}, {@link LocalDateTime}, {@link
+   * OffsetDateTime}, {@link Date}). {@code LocalDateTime} is interpreted as UTC. Returns {@code
+   * null} for {@code null} or an unrecognized type.
+   */
+  public static Instant instantOrNull(Object value) {
+    if (value == null) {
+      return null;
+    }
+    if (value instanceof Instant instant) {
+      return instant;
+    }
+    if (value instanceof Timestamp timestamp) {
+      return timestamp.toInstant();
+    }
+    if (value instanceof OffsetDateTime offsetDateTime) {
+      return offsetDateTime.toInstant();
+    }
+    if (value instanceof LocalDateTime localDateTime) {
+      return localDateTime.toInstant(ZoneOffset.UTC);
+    }
+    if (value instanceof Date date) {
+      return date.toInstant();
+    }
+    return null;
+  }
+
+  /**
+   * Coerces a JDBC boolean column value to a primitive boolean, accepting {@link Boolean}, numeric
+   * (non-zero is {@code true}), or string representations. Returns {@code false} for {@code null}.
+   */
+  public static boolean booleanOrFalse(Object value) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof Boolean bool) {
+      return bool;
+    }
+    if (value instanceof Number number) {
+      return number.intValue() != 0;
+    }
+    return Boolean.parseBoolean(value.toString());
   }
 
   public static JobPriority safeJobPriority(int ordinal) {

--- a/ratchet-store-core/src/test/java/run/ratchet/store/query/JobQueryCursorTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/query/JobQueryCursorTest.java
@@ -1,12 +1,21 @@
 package run.ratchet.store.query;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobQuerySortField;
 
 class JobQueryCursorTest {
+
+  private static final UUID JOB_ID = UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465");
 
   @Test
   void decodeWrapsInvalidBase64AsMalformedCursor() {
@@ -15,5 +24,50 @@ class JobQueryCursorTest {
 
     assertEquals("Malformed pagination cursor", ex.getMessage());
     assertInstanceOf(IllegalArgumentException.class, ex.getCause());
+  }
+
+  @Test
+  void encodeDecodeRoundTripsEveryField() {
+    JobQueryCursor original = new JobQueryCursor(JobQuerySortField.PRIORITY, true, "3", JOB_ID);
+
+    JobQueryCursor decoded = JobQueryCursor.decode(original.encode());
+
+    assertEquals(JobQuerySortField.PRIORITY, decoded.sortField());
+    assertTrue(decoded.sortAscending(), "ascending flag must survive a round trip");
+    assertEquals("3", decoded.sortValue());
+    assertEquals(JOB_ID, decoded.jobId());
+  }
+
+  @Test
+  void decodeRejectsCursorWithoutDirectionSegment() {
+    // A legacy three-field cursor (field|value|jobId) is missing the direction segment.
+    String legacy =
+        Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(
+                ("CREATED_AT|2026-01-01T00:00:00Z|" + JOB_ID).getBytes(StandardCharsets.UTF_8));
+
+    assertThrows(IllegalArgumentException.class, () -> JobQueryCursor.decode(legacy));
+  }
+
+  @Test
+  void matchesFilterSortDetectsFieldChange() {
+    JobQueryCursor cursor =
+        new JobQueryCursor(JobQuerySortField.CREATED_AT, false, "2026-01-01T00:00:00Z", JOB_ID);
+
+    assertTrue(cursor.matchesFilterSort(JobFilter.builder().build()));
+    assertFalse(
+        cursor.matchesFilterSort(JobFilter.builder().sortField(JobQuerySortField.PRIORITY).build()),
+        "a cursor minted for CREATED_AT must not match a PRIORITY query");
+  }
+
+  @Test
+  void matchesFilterSortDetectsDirectionChange() {
+    JobQueryCursor cursor =
+        new JobQueryCursor(JobQuerySortField.CREATED_AT, false, "2026-01-01T00:00:00Z", JOB_ID);
+
+    assertFalse(
+        cursor.matchesFilterSort(JobFilter.builder().sortAscending(true).build()),
+        "a descending cursor must not match an ascending query");
   }
 }

--- a/ratchet-store-core/src/test/java/run/ratchet/store/util/PayloadMaskerTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/util/PayloadMaskerTest.java
@@ -72,6 +72,30 @@ class PayloadMaskerTest {
   }
 
   @Test
+  void maskParams_redactsSensitiveKeysAndKeepsTheRest() {
+    Map<String, String> masked =
+        PayloadMasker.maskParams(Map.of("password", "hunter2", "host", "db"));
+
+    assertEquals("***REDACTED***", masked.get("password"));
+    assertEquals("db", masked.get("host"));
+  }
+
+  @Test
+  void maskParams_nullOrEmptyInput_returnedUnchanged() {
+    assertNull(PayloadMasker.maskParams(null));
+    assertTrue(PayloadMasker.maskParams(Map.of()).isEmpty());
+  }
+
+  @Test
+  void maskParams_doesNotMutateInput() {
+    Map<String, String> original = Map.of("token", "abc");
+
+    PayloadMasker.maskParams(original);
+
+    assertEquals("abc", original.get("token"));
+  }
+
+  @Test
   void maskPayload_usesLocaleRootForSensitiveFieldMatching() {
     Locale previous = Locale.getDefault();
     try {

--- a/ratchet-store-core/src/test/java/run/ratchet/store/util/PayloadMaskingPolicyTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/util/PayloadMaskingPolicyTest.java
@@ -1,0 +1,89 @@
+package run.ratchet.store.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.spi.PayloadMaskingPolicy;
+
+class PayloadMaskingPolicyTest {
+
+  @AfterEach
+  void resetHolder() {
+    // Tests install a custom policy; revert so other tests see the built-in default.
+    PayloadMaskingPolicyHolder.set(null);
+  }
+
+  @Test
+  void defaultPolicy_masksBuiltInFields() {
+    PayloadMaskingPolicy policy = new DefaultPayloadMaskingPolicy();
+
+    assertTrue(policy.isSensitiveField("password"));
+    assertTrue(policy.isSensitiveField("apiKey"));
+    assertTrue(policy.isSensitiveField("refresh_token"));
+    assertTrue(policy.isSensitiveField("privateKeyPem"));
+    assertTrue(policy.isSensitiveField("ssn"));
+    assertTrue(policy.isSensitiveField("cvv"));
+    assertTrue(policy.isSensitiveField("pin"));
+  }
+
+  @Test
+  void defaultPolicy_shortMarkersMatchOnWordBoundariesOnly() {
+    PayloadMaskingPolicy policy = new DefaultPayloadMaskingPolicy();
+
+    assertFalse(policy.isSensitiveField("spinner"));
+    assertFalse(policy.isSensitiveField("session"));
+    assertFalse(policy.isSensitiveField("username"));
+    assertFalse(policy.isSensitiveField("endpoint"));
+  }
+
+  @Test
+  void defaultPolicy_nullFieldIsNotSensitive() {
+    assertFalse(new DefaultPayloadMaskingPolicy().isSensitiveField(null));
+  }
+
+  @Test
+  void holder_returnsDefaultPolicyWhenNoneInstalled() {
+    PayloadMaskingPolicyHolder.set(null);
+
+    assertTrue(PayloadMaskingPolicyHolder.get().isSensitiveField("password"));
+    assertFalse(PayloadMaskingPolicyHolder.get().isSensitiveField("username"));
+  }
+
+  @Test
+  void customPolicy_viaHolder_overridesWhichFieldsMask() {
+    // A policy that flags exactly "username" and nothing the default would flag.
+    PayloadMaskingPolicyHolder.set(
+        fieldName -> "username".equals(fieldName.toLowerCase(Locale.ROOT)));
+
+    String masked = PayloadMasker.maskPayload("{\"username\":\"alice\",\"password\":\"hunter2\"}");
+
+    assertTrue(masked.contains("\"username\":\"***REDACTED***\""));
+    assertTrue(masked.contains("\"password\":\"hunter2\""));
+  }
+
+  @Test
+  void customPolicy_isConsultedForNestedFields() {
+    PayloadMaskingPolicyHolder.set(fieldName -> "secretSauce".equals(fieldName));
+
+    String masked =
+        PayloadMasker.maskPayload(
+            "{\"config\":{\"secretSauce\":\"x\"},\"other\":{\"password\":\"y\"}}");
+
+    assertTrue(masked.contains("\"secretSauce\":\"***REDACTED***\""));
+    // The custom policy does not flag "password", so it passes through.
+    assertTrue(masked.contains("\"password\":\"y\""));
+  }
+
+  @Test
+  void afterClearingCustomPolicy_holderRevertsToDefault() {
+    PayloadMaskingPolicyHolder.set(fieldName -> false);
+    assertFalse(PayloadMaskingPolicyHolder.get().isSensitiveField("password"));
+
+    PayloadMaskingPolicyHolder.set(null);
+    assertEquals(true, PayloadMaskingPolicyHolder.get().isSensitiveField("password"));
+  }
+}

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
@@ -165,6 +165,11 @@ final class MongoJobQueryOperations {
     }
     try {
       JobQueryCursor c = JobQueryCursor.decode(filter.cursor());
+      if (!c.matchesFilterSort(filter)) {
+        // Cursor was minted for a different sort field/direction; seeking on it while the sort
+        // uses the live ordering would skip or repeat rows. Fall back to offset pagination.
+        return;
+      }
       String field = archive ? archiveSortField(c.sortField()) : sortField(c.sortField());
       // The keyset tiebreaker must seek the same id the cursor records and the sort orders by. An
       // archived row carries its original job id as its JobEntity id, so the archive path seeks

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
@@ -166,14 +166,16 @@ final class MongoJobQueryOperations {
     try {
       JobQueryCursor c = JobQueryCursor.decode(filter.cursor());
       String field = archive ? archiveSortField(c.sortField()) : sortField(c.sortField());
+      // The keyset tiebreaker must seek the same id the cursor records and the sort orders by. An
+      // archived row carries its original job id as its JobEntity id, so the archive path seeks
+      // original_job_id rather than the archive document's own _id.
+      String tieField = archive ? MongoFieldNames.ORIGINAL_JOB_ID : MongoFieldNames.ID;
       Object sortVal = parseSortValue(c);
-      // (field < sortVal) OR (field == sortVal AND _id > jobId)
+      // (field < sortVal) OR (field == sortVal AND tieField > jobId)
       if (filter.sortAscending()) {
-        conditions.add(
-            or(gt(field, sortVal), and(eq(field, sortVal), gt(MongoFieldNames.ID, c.jobId()))));
+        conditions.add(or(gt(field, sortVal), and(eq(field, sortVal), gt(tieField, c.jobId()))));
       } else {
-        conditions.add(
-            or(lt(field, sortVal), and(eq(field, sortVal), gt(MongoFieldNames.ID, c.jobId()))));
+        conditions.add(or(lt(field, sortVal), and(eq(field, sortVal), gt(tieField, c.jobId()))));
       }
     } catch (IllegalArgumentException e) {
       // Malformed cursors are treated as absent so callers fall back to offset-based pagination.
@@ -204,15 +206,19 @@ final class MongoJobQueryOperations {
   }
 
   private static Bson buildArchiveSort(JobFilter filter) {
+    // Tiebreak on original_job_id, not the archive document's own _id: that is the id an archived
+    // row exposes as its JobEntity id and the value a keyset cursor records, so sort and seek stay
+    // in lock-step across page boundaries (mirrors the SQL stores' archive ORDER BY).
     if (filter == null) {
       return orderBy(
-          descending(MongoFieldNames.ORIGINAL_CREATED_AT), ascending(MongoFieldNames.ID));
+          descending(MongoFieldNames.ORIGINAL_CREATED_AT),
+          ascending(MongoFieldNames.ORIGINAL_JOB_ID));
     }
     JobQuerySortField field =
         filter.sortField() != null ? filter.sortField() : JobQuerySortField.CREATED_AT;
     String col = archiveSortField(field);
     Bson primary = filter.sortAscending() ? ascending(col) : descending(col);
-    return orderBy(primary, ascending(MongoFieldNames.ID));
+    return orderBy(primary, ascending(MongoFieldNames.ORIGINAL_JOB_ID));
   }
 
   private static String sortField(JobQuerySortField field) {

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
@@ -590,6 +590,11 @@ final class MysqlJobQueryOperations {
     }
     try {
       JobQueryCursor c = JobQueryCursor.decode(filter.cursor());
+      if (!c.matchesFilterSort(filter)) {
+        // Cursor was minted for a different sort field/direction; seeking on it while ORDER BY
+        // uses the live sort would skip or repeat rows. Fall back to offset pagination instead.
+        return;
+      }
       String sortCol = sortColumn(c.sortField());
       String op = filter.sortAscending() ? ">" : "<";
       and(where, "(" + sortCol + " " + op + " ? OR (" + sortCol + " = ? AND c.job_id > ?))");
@@ -609,6 +614,11 @@ final class MysqlJobQueryOperations {
     }
     try {
       JobQueryCursor c = JobQueryCursor.decode(filter.cursor());
+      if (!c.matchesFilterSort(filter)) {
+        // Cursor was minted for a different sort field/direction; seeking on it while ORDER BY
+        // uses the live sort would skip or repeat rows. Fall back to offset pagination instead.
+        return;
+      }
       String sortCol = archiveSortColumn(c.sortField());
       String op = filter.sortAscending() ? ">" : "<";
       and(

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
@@ -59,6 +59,12 @@ final class MysqlJobQueryOperations {
   /**
    * Archive rows projected to match {@link MysqlJobRowMapper#HYDRATION_SELECT} column positions.
    * NULL placeholders occupy positions whose data is unavailable in the archive.
+   *
+   * <p>This projection MUST emit exactly the same number of columns as {@code HYDRATION_SELECT}
+   * ({@link MysqlJobRowMapper#HYDRATION_COL_COUNT}). The two SELECTs are combined with {@code UNION
+   * ALL}; a column-count mismatch is rejected by MySQL before any row is returned, breaking every
+   * archive-inclusive search. The leading two NULLs cover {@code payload}/{@code params}, which the
+   * archive does not retain.
    */
   // language=MySQL
   private static final String ARCHIVE_PROJECTION =
@@ -72,7 +78,6 @@ final class MysqlJobQueryOperations {
       a.timeout_sec,
       a.cron_expr,
       a.zone_id,
-      NULL,
       NULL,
       NULL,
       a.target_class,
@@ -120,13 +125,15 @@ final class MysqlJobQueryOperations {
 
   private static final int MAX_IN_CLAUSE = 1000;
 
-  // Positional column numbers (1-indexed) in the hydration SELECT for UNION ORDER BY
+  // Positional column numbers (1-indexed) in the hydration SELECT for UNION ORDER BY. Each is the
+  // matching row-mapper IDX_* constant plus one; they must track
+  // HYDRATION_SELECT/ARCHIVE_PROJECTION.
   private static final int POS_JOB_ID = 1;
   private static final int POS_PRIORITY = 3;
-  private static final int POS_CREATED_AT = 22;
-  private static final int POS_TERMINAL_STATUS = 24;
-  private static final int POS_Q_SCHEDULED_TIME = 37;
-  private static final int POS_Q_UPDATED_AT = 44;
+  private static final int POS_CREATED_AT = 21;
+  private static final int POS_TERMINAL_STATUS = 23;
+  private static final int POS_Q_SCHEDULED_TIME = 36;
+  private static final int POS_Q_UPDATED_AT = 43;
 
   private final MysqlStoreContext ctx;
   private final MysqlJobRowMapper mapper;

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobRowMapper.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobRowMapper.java
@@ -17,6 +17,7 @@ import run.ratchet.store.converter.JsonMapConverter;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.util.JobHydrationSupport;
 import run.ratchet.store.util.RowValues;
 import run.ratchet.store.util.StatusClassifier;
 
@@ -44,6 +45,7 @@ final class MysqlJobRowMapper {
   private static final Logger log = Logger.getLogger(MysqlJobRowMapper.class);
   private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
   private static final JsonMapConverter JSON_MAP_CONVERTER = new JsonMapConverter();
+  private static final JobHydrationSupport HYDRATION = new JobHydrationSupport("MySQL");
   private static final int IDX_JOB_ID = 0;
   private static final int IDX_JOB_TYPE = 1;
   private static final int IDX_PRIORITY = 2;
@@ -279,74 +281,19 @@ final class MysqlJobRowMapper {
 
   private static <E extends Enum<E>> E enumValue(
       Object[] row, int index, String column, Class<E> enumType) {
-    String raw = stringOrNull(row[index]);
-    if (raw == null) {
-      throw hydrationFailure(row, index, column, null, null);
-    }
-    try {
-      return Enum.valueOf(enumType, raw);
-    } catch (IllegalArgumentException e) {
-      throw hydrationFailure(row, index, column, raw, e);
-    }
+    return HYDRATION.enumValue(row, index, column, enumType);
   }
 
   private static <E extends Enum<E>> E enumValueOrNull(
       Object[] row, int index, String column, Class<E> enumType) {
-    String raw = stringOrNull(row[index]);
-    if (raw == null) {
-      return null;
-    }
-    try {
-      return Enum.valueOf(enumType, raw);
-    } catch (IllegalArgumentException e) {
-      throw hydrationFailure(row, index, column, raw, e);
-    }
+    return HYDRATION.enumValueOrNull(row, index, column, enumType);
   }
 
   private static Number requiredNumber(Object[] row, int index, String column) {
-    Number number = numberOrNull(row, index, column);
-    if (number == null) {
-      throw hydrationFailure(row, index, column, null, null);
-    }
-    return number;
+    return HYDRATION.requiredNumber(row, index, column);
   }
 
   private static Number numberOrNull(Object[] row, int index, String column) {
-    Object value = row[index];
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Number number) {
-      return number;
-    }
-    throw hydrationFailure(row, index, column, value, null);
-  }
-
-  private static JobHydrationException hydrationFailure(
-      Object[] row, int index, String column, Object value, Throwable cause) {
-    return new JobHydrationException(
-        "Failed to hydrate MySQL job "
-            + safeJobId(row)
-            + ": column "
-            + column
-            + " at index "
-            + index
-            + " has value "
-            + value,
-        cause);
-  }
-
-  private static UUID safeJobId(Object[] row) {
-    try {
-      return uuidOrNull(row[IDX_JOB_ID]);
-    } catch (RuntimeException ignored) {
-      return null;
-    }
-  }
-
-  static final class JobHydrationException extends IllegalStateException {
-    JobHydrationException(String message, Throwable cause) {
-      super(message, cause);
-    }
+    return HYDRATION.numberOrNull(row, index, column);
   }
 }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
@@ -484,21 +484,25 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public boolean tryLock(String name, Duration ttl, String nodeId) {
     return nodeLocks.tryLock(name, ttl, nodeId);
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public void unlock(String name, String nodeId) {
     nodeLocks.unlock(name, nodeId);
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public boolean renewLock(String name, Duration extension, String nodeId) {
     return nodeLocks.renewLock(name, extension, nodeId);
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public void upsertHeartbeat(String nodeId, Instant ts) {
     nodeLocks.upsertHeartbeat(nodeId, ts);
   }
@@ -514,11 +518,13 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public int deleteInactiveNodesSince(Instant cutoff) {
     return nodeLocks.deleteInactiveNodesSince(cutoff);
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public int deleteInactiveNodesByIds(java.util.Collection<String> nodeIds) {
     return nodeLocks.deleteInactiveNodesByIds(nodeIds);
   }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlRecurringJobOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlRecurringJobOperations.java
@@ -9,16 +9,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.converter.JobPayloadConverter;
-import run.ratchet.store.entity.JobPayload;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
 import run.ratchet.store.util.JobClaimSqlSupport;
+import run.ratchet.store.util.RecurringJobRows;
 
 /**
  * MySQL implementation of {@link RecurringJobStore} against the dedicated {@code
@@ -395,61 +394,6 @@ final class MysqlRecurringJobOperations implements RecurringJobStore {
   }
 
   private static RecurringJobDefinition hydrate(Object[] row) {
-    UUID id = MysqlJobRowMapper.uuidOrNull(row[0]);
-    int priority = ((Number) row[1]).intValue();
-    int maxRetries = ((Number) row[2]).intValue();
-    BackoffPolicy backoffPolicy = BackoffPolicy.valueOf((String) row[3]);
-    int backoffParamMs = ((Number) row[4]).intValue();
-    int timeoutSec = ((Number) row[5]).intValue();
-    String cronExpr = (String) row[6];
-    String zoneId = (String) row[7];
-    Instant nextFire = MysqlJobRowMapper.toInstant(row[8]);
-    boolean isPaused = toBoolean(row[9]);
-    Instant pausedAt = MysqlJobRowMapper.toInstant(row[10]);
-    JobPayload payload =
-        PAYLOAD_CONVERTER.convertToEntityAttribute(MysqlJobRowMapper.stringOrNull(row[11]));
-    JobPayload onSuccess =
-        PAYLOAD_CONVERTER.convertToEntityAttribute(MysqlJobRowMapper.stringOrNull(row[12]));
-    JobPayload onFailure =
-        PAYLOAD_CONVERTER.convertToEntityAttribute(MysqlJobRowMapper.stringOrNull(row[13]));
-    String businessKey = (String) row[14];
-    String resourceName = (String) row[15];
-    String executionTarget = (String) row[16];
-    Instant createdAt = MysqlJobRowMapper.toInstant(row[17]);
-    String callerPrincipal = (String) row[18];
-
-    return new RecurringJobDefinition(
-        id,
-        cronExpr,
-        zoneId,
-        nextFire,
-        isPaused,
-        pausedAt,
-        priority,
-        maxRetries,
-        backoffPolicy,
-        backoffParamMs,
-        timeoutSec,
-        payload,
-        onSuccess,
-        onFailure,
-        businessKey,
-        resourceName,
-        executionTarget,
-        createdAt,
-        callerPrincipal);
-  }
-
-  private static boolean toBoolean(Object val) {
-    if (val == null) {
-      return false;
-    }
-    if (val instanceof Boolean b) {
-      return b;
-    }
-    if (val instanceof Number n) {
-      return n.intValue() != 0;
-    }
-    return Boolean.parseBoolean(val.toString());
+    return RecurringJobRows.hydrate(row);
   }
 }

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobStoreImplTransactionTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobStoreImplTransactionTest.java
@@ -1,23 +1,16 @@
 package run.ratchet.store.mysql;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
+import run.ratchet.tck.store.AbstractJobStoreTransactionBoundaryContract;
 
-class MysqlJobStoreImplTransactionTest {
+class MysqlJobStoreImplTransactionTest extends AbstractJobStoreTransactionBoundaryContract {
 
-  @Test
-  void classLevelTransactionalDefaultsToRequired() {
-    // The class-level @Transactional gives every method a default REQUIRED tx boundary unless a
-    // method declares its own. Lock the contract here: if the class-level annotation ever gets
-    // removed, read methods would silently fall into a no-tx code path on JTA-managed
-    // EclipseLink containers and re-introduce the connection leak this test is guarding against.
-    Transactional classLevel = MysqlJobStoreImpl.class.getAnnotation(Transactional.class);
-    assertNotNull(classLevel);
-    assertEquals(Transactional.TxType.REQUIRED, classLevel.value());
+  @Override
+  protected Class<?> jobStoreImplClass() {
+    return MysqlJobStoreImpl.class;
   }
 
   @Test
@@ -29,7 +22,7 @@ class MysqlJobStoreImplTransactionTest {
     // class-level @Transactional default (REQUIRED) makes each read have a clean tx boundary
     // that commits before returning the connection to the pool.
     //
-    // getDatabaseTime is the specific read that triggered the original hang — it runs during
+    // getDatabaseTime is the specific read that triggered the original hang -- it runs during
     // startup via DefaultNodeIdentityProvider.checkClockSkew before any outer JTA tx exists.
     assertNoMethodLevelTransactional("getDatabaseTime");
     assertNoMethodLevelTransactional("countPendingJobs");

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
@@ -52,6 +52,11 @@ final class PostgresqlJobQueryOperations {
   /**
    * Archive rows projected to match {@link PostgresqlJobRowMapper#hydrationSelect()} column
    * positions. NULL placeholders occupy columns not present in the archive.
+   *
+   * <p>This projection MUST emit exactly the same number of columns as {@code hydrationSelect()}.
+   * The two SELECTs are combined with {@code UNION ALL}; a column-count mismatch is rejected by
+   * PostgreSQL before any row is returned, breaking every archive-inclusive search. The leading two
+   * NULLs cover {@code payload}/{@code params}, which the archive does not retain.
    */
   // language=PostgreSQL
   private static final String ARCHIVE_PROJECTION =
@@ -65,7 +70,6 @@ final class PostgresqlJobQueryOperations {
       a.timeout_sec,
       a.cron_expr,
       a.zone_id,
-      NULL,
       NULL,
       NULL,
       a.target_class,
@@ -121,10 +125,10 @@ final class PostgresqlJobQueryOperations {
    */
   private static final int POS_JOB_ID = 1;
   private static final int POS_PRIORITY = 3;
-  private static final int POS_CREATED_AT = 22;
-  private static final int POS_TERMINAL_STATUS = 24;
-  private static final int POS_Q_SCHEDULED_TIME = 37;
-  private static final int POS_Q_UPDATED_AT = 44;
+  private static final int POS_CREATED_AT = 21;
+  private static final int POS_TERMINAL_STATUS = 23;
+  private static final int POS_Q_SCHEDULED_TIME = 36;
+  private static final int POS_Q_UPDATED_AT = 43;
 
   private final PostgresqlStoreContext ctx;
   private final PostgresqlTagOperations tags;

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
@@ -153,6 +153,11 @@ final class PostgresqlJobQueryOperations {
     }
     try {
       JobQueryCursor cursor = JobQueryCursor.decode(filter.cursor());
+      if (!cursor.matchesFilterSort(filter)) {
+        // Cursor was minted for a different sort field/direction; seeking on it while ORDER BY
+        // uses the live sort would skip or repeat rows. Fall back to offset pagination instead.
+        return null;
+      }
       return new ParsedCursor(cursor, parseSortValue(cursor));
     } catch (IllegalArgumentException | DateTimeParseException ignored) {
       return null;

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRowMapper.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRowMapper.java
@@ -14,6 +14,7 @@ import run.ratchet.store.converter.JsonMapConverter;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.util.JobHydrationSupport;
 import run.ratchet.store.util.RowValues;
 import run.ratchet.store.util.StatusClassifier;
 
@@ -34,6 +35,7 @@ final class PostgresqlJobRowMapper {
   static final int IDX_Q_STATUS = 34;
   private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
   private static final JsonMapConverter JSON_MAP_CONVERTER = new JsonMapConverter();
+  private static final JobHydrationSupport HYDRATION = new JobHydrationSupport("PostgreSQL");
   private static final int IDX_JOB_ID = 0;
   private static final int IDX_JOB_TYPE = 1;
   private static final int IDX_PRIORITY = 2;
@@ -260,75 +262,20 @@ final class PostgresqlJobRowMapper {
 
   private static <E extends Enum<E>> E enumValue(
       Object[] row, int index, String column, Class<E> enumType) {
-    String raw = stringOrNull(row[index]);
-    if (raw == null) {
-      throw hydrationFailure(row, index, column, null, null);
-    }
-    try {
-      return Enum.valueOf(enumType, raw);
-    } catch (IllegalArgumentException e) {
-      throw hydrationFailure(row, index, column, raw, e);
-    }
+    return HYDRATION.enumValue(row, index, column, enumType);
   }
 
   private static <E extends Enum<E>> E enumValueOrNull(
       Object[] row, int index, String column, Class<E> enumType) {
-    String raw = stringOrNull(row[index]);
-    if (raw == null) {
-      return null;
-    }
-    try {
-      return Enum.valueOf(enumType, raw);
-    } catch (IllegalArgumentException e) {
-      throw hydrationFailure(row, index, column, raw, e);
-    }
+    return HYDRATION.enumValueOrNull(row, index, column, enumType);
   }
 
   private static Number requiredNumber(Object[] row, int index, String column) {
-    Number number = numberOrNull(row, index, column);
-    if (number == null) {
-      throw hydrationFailure(row, index, column, null, null);
-    }
-    return number;
+    return HYDRATION.requiredNumber(row, index, column);
   }
 
   private static Number numberOrNull(Object[] row, int index, String column) {
-    Object value = row[index];
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Number number) {
-      return number;
-    }
-    throw hydrationFailure(row, index, column, value, null);
-  }
-
-  private static JobHydrationException hydrationFailure(
-      Object[] row, int index, String column, Object value, Throwable cause) {
-    return new JobHydrationException(
-        "Failed to hydrate PostgreSQL job "
-            + safeJobId(row)
-            + ": column "
-            + column
-            + " at index "
-            + index
-            + " has value "
-            + value,
-        cause);
-  }
-
-  private static UUID safeJobId(Object[] row) {
-    try {
-      return uuidOrNull(row[IDX_JOB_ID]);
-    } catch (RuntimeException ignored) {
-      return null;
-    }
-  }
-
-  static final class JobHydrationException extends IllegalStateException {
-    JobHydrationException(String message, Throwable cause) {
-      super(message, cause);
-    }
+    return HYDRATION.numberOrNull(row, index, column);
   }
 
   static String payloadToJson(JobEntity job) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
@@ -499,6 +499,7 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public boolean renewLock(String name, Duration extension, String nodeId) {
     return nodeLocks.renewLock(name, extension, nodeId);
   }

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlRecurringJobOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlRecurringJobOperations.java
@@ -9,15 +9,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.converter.JobPayloadConverter;
-import run.ratchet.store.entity.JobPayload;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
 import run.ratchet.store.util.JobClaimSqlSupport;
+import run.ratchet.store.util.RecurringJobRows;
 
 /**
  * PostgreSQL implementation of {@link RecurringJobStore} against the dedicated {@code
@@ -385,68 +384,6 @@ final class PostgresqlRecurringJobOperations implements RecurringJobStore {
   }
 
   private static RecurringJobDefinition hydrate(Object[] row) {
-    UUID id = toUuid(row[0]);
-    int priority = ((Number) row[1]).intValue();
-    int maxRetries = ((Number) row[2]).intValue();
-    BackoffPolicy backoffPolicy = BackoffPolicy.valueOf((String) row[3]);
-    int backoffParamMs = ((Number) row[4]).intValue();
-    int timeoutSec = ((Number) row[5]).intValue();
-    String cronExpr = (String) row[6];
-    String zoneId = (String) row[7];
-    Instant nextFire = toInstant(row[8]);
-    boolean isPaused = (Boolean) row[9];
-    Instant pausedAt = toInstant(row[10]);
-    JobPayload payload = PAYLOAD_CONVERTER.convertToEntityAttribute((String) row[11]);
-    JobPayload onSuccess = PAYLOAD_CONVERTER.convertToEntityAttribute((String) row[12]);
-    JobPayload onFailure = PAYLOAD_CONVERTER.convertToEntityAttribute((String) row[13]);
-    String businessKey = (String) row[14];
-    String resourceName = (String) row[15];
-    String executionTarget = (String) row[16];
-    Instant createdAt = toInstant(row[17]);
-    String callerPrincipal = (String) row[18];
-
-    return new RecurringJobDefinition(
-        id,
-        cronExpr,
-        zoneId,
-        nextFire,
-        isPaused,
-        pausedAt,
-        priority,
-        maxRetries,
-        backoffPolicy,
-        backoffParamMs,
-        timeoutSec,
-        payload,
-        onSuccess,
-        onFailure,
-        businessKey,
-        resourceName,
-        executionTarget,
-        createdAt,
-        callerPrincipal);
-  }
-
-  private static UUID toUuid(Object val) {
-    if (val == null) {
-      return null;
-    }
-    if (val instanceof UUID u) {
-      return u;
-    }
-    return UUID.fromString(val.toString());
-  }
-
-  private static Instant toInstant(Object val) {
-    if (val == null) {
-      return null;
-    }
-    if (val instanceof Timestamp ts) {
-      return ts.toInstant();
-    }
-    if (val instanceof Instant inst) {
-      return inst;
-    }
-    return null;
+    return RecurringJobRows.hydrate(row);
   }
 }

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperationsTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperationsTest.java
@@ -22,6 +22,7 @@ class PostgresqlJobQueryOperationsTest {
     String cursor =
         new JobQueryCursor(
                 JobQuerySortField.CREATED_AT,
+                false,
                 "not-an-instant",
                 UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"))
             .encode();
@@ -38,10 +39,39 @@ class PostgresqlJobQueryOperationsTest {
   }
 
   @Test
+  void searchJobsIgnoresCursorMintedForADifferentSort() {
+    // Cursor was produced for PRIORITY ascending, but this query sorts by the default
+    // CREATED_AT descending. Applying it would seek on priority while ORDER BY uses created_at,
+    // so the seek must be dropped and offset pagination kept.
+    String cursor =
+        new JobQueryCursor(
+                JobQuerySortField.PRIORITY,
+                true,
+                "3",
+                UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"))
+            .encode();
+    NativeSqlRecorder recorder = new NativeSqlRecorder();
+    PostgresqlStoreContext ctx = new PostgresqlStoreContext(recorder.entityManager());
+    PostgresqlJobQueryOperations operations =
+        new PostgresqlJobQueryOperations(ctx, new PostgresqlTagOperations(ctx));
+
+    operations.searchJobs(JobFilter.builder().cursor(cursor).build(), 10, 7);
+
+    String sql = recorder.lastSql();
+    assertTrue(
+        sql.contains("OFFSET 7"),
+        "A cursor minted for a different sort must fall back to offset pagination");
+    assertFalse(
+        sql.contains("c.priority >") || sql.contains("c.priority <"),
+        "A mismatched cursor must not contribute a keyset seek predicate");
+  }
+
+  @Test
   void searchJobsWithArchiveCursorFiltersBothUnionBranches() {
     String cursor =
         new JobQueryCursor(
                 JobQuerySortField.CREATED_AT,
+                false,
                 "2026-01-01T00:00:00Z",
                 UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"))
             .encode();

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlJobStoreImplTransactionTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlJobStoreImplTransactionTest.java
@@ -1,47 +1,17 @@
 package run.ratchet.store.postgresql;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import jakarta.transaction.Transactional;
-import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobFilter;
+import run.ratchet.tck.store.AbstractJobStoreTransactionBoundaryContract;
 
-class PostgresqlJobStoreImplTransactionTest {
+class PostgresqlJobStoreImplTransactionTest extends AbstractJobStoreTransactionBoundaryContract {
 
-  @Test
-  void unlockUsesIndependentTransactionBoundary() throws NoSuchMethodException {
-    Transactional transactional =
-        PostgresqlJobStoreImpl.class
-            .getMethod("unlock", String.class, String.class)
-            .getAnnotation(Transactional.class);
-
-    assertNotNull(transactional);
-    assertEquals(Transactional.TxType.REQUIRES_NEW, transactional.value());
-  }
-
-  @Test
-  void tryLockUsesIndependentTransactionBoundary() throws NoSuchMethodException {
-    Transactional transactional =
-        PostgresqlJobStoreImpl.class
-            .getMethod("tryLock", String.class, Duration.class, String.class)
-            .getAnnotation(Transactional.class);
-
-    assertNotNull(transactional);
-    assertEquals(Transactional.TxType.REQUIRES_NEW, transactional.value());
-  }
-
-  @Test
-  void classLevelTransactionalDefaultsToRequired() {
-    // The class-level @Transactional gives every method a default REQUIRED tx boundary unless a
-    // method declares its own. Lock the contract here: if the class-level annotation ever gets
-    // removed, read methods would silently fall into a no-tx code path on JTA-managed
-    // EclipseLink containers and re-introduce the connection leak this test is guarding against.
-    Transactional classLevel = PostgresqlJobStoreImpl.class.getAnnotation(Transactional.class);
-    assertNotNull(classLevel);
-    assertEquals(Transactional.TxType.REQUIRED, classLevel.value());
+  @Override
+  protected Class<?> jobStoreImplClass() {
+    return PostgresqlJobStoreImpl.class;
   }
 
   @Test
@@ -53,7 +23,7 @@ class PostgresqlJobStoreImplTransactionTest {
     // @Transactional default (REQUIRED) makes each read have a clean tx boundary that commits
     // before returning the connection to the pool.
     //
-    // getDatabaseTime is the specific read that triggered the original hang — it runs during
+    // getDatabaseTime is the specific read that triggered the original hang -- it runs during
     // startup via DefaultNodeIdentityProvider.checkClockSkew before any outer JTA tx exists.
     assertNoMethodLevelTransactional("getDatabaseTime");
     assertNoMethodLevelTransactional("searchJobs", JobFilter.class, int.class, int.class);

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -32,7 +32,9 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractDelayedSchedulingContract",
                   "AbstractIdempotencyContract",
                   "AbstractSimpleWorkflowContract",
-                  "AbstractResilienceStrategyContract")));
+                  "AbstractResilienceStrategyContract",
+                  "AbstractJobAuthorizationContract",
+                  "AbstractSignalDecisionContract")));
 
   @Override
   protected String tierTitle() {

--- a/ratchet-tck/api/src/test/java/run/ratchet/tck/api/ApiConformanceReportExtensionTest.java
+++ b/ratchet-tck/api/src/test/java/run/ratchet/tck/api/ApiConformanceReportExtensionTest.java
@@ -1,0 +1,52 @@
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import run.ratchet.tck.util.AbstractConformanceReportExtension.ContractGroup;
+
+class ApiConformanceReportExtensionTest {
+
+  /**
+   * Every shipped {@code Abstract*Contract} in the API tier must appear in the report catalog.
+   * Missing-contract detection and the final "Ratchet API Compatible" verdict are driven entirely
+   * by the catalog, so a contract left out runs but never counts toward PASS/FAIL accounting. The
+   * scan is anchored on a contract class's own resource so it reads the main output directory where
+   * the contracts live, not the test-classes copy of the package.
+   */
+  @Test
+  void allApiContractsAreCataloged() throws Exception {
+    var resource =
+        AbstractJobLifecycleContract.class.getResource("AbstractJobLifecycleContract.class");
+    var packageDir = Paths.get(resource.toURI()).getParent();
+
+    Set<String> cataloged =
+        new ApiConformanceReportExtension()
+            .contractGroups().stream()
+                .flatMap(
+                    (ContractGroup g) ->
+                        Stream.concat(g.contracts().stream(), g.optionalContracts().stream()))
+                .collect(Collectors.toSet());
+
+    List<String> uncataloged;
+    try (var classes = Files.list(packageDir)) {
+      uncataloged =
+          classes
+              .map(path -> path.getFileName().toString())
+              .filter(name -> name.startsWith("Abstract"))
+              .filter(name -> name.endsWith("Contract.class"))
+              .map(name -> name.substring(0, name.length() - ".class".length()))
+              .filter(name -> !cataloged.contains(name))
+              .sorted()
+              .toList();
+    }
+
+    assertEquals(List.of(), uncataloged, "all API Abstract*Contract classes are cataloged");
+  }
+}

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
@@ -288,9 +288,11 @@ public abstract class AbstractClusterCoordinatorContract {
     fixture.nodeB().registerWakeupListener(listenerB);
 
     long before = fixture.metricsB().transportFailure();
+    // A version far above any the codec will ever support. Hardcoding the then-current+1 (e.g. 2)
+    // silently became a *valid* envelope once the wire version was bumped, so pin it well clear.
     harness.injectRawMessage(
         fixture.nodeB(),
-        "{\"v\":2,\"node\":\"" + fixture.identityA().value() + "\",\"prio\":\"HIGH\"}");
+        "{\"v\":999,\"node\":\"" + fixture.identityA().value() + "\",\"prio\":\"HIGH\"}");
 
     sleepPastLatencyWindow();
     assertTrue(

--- a/ratchet-tck/store/pom.xml
+++ b/ratchet-tck/store/pom.xml
@@ -34,6 +34,16 @@
             <scope>provided</scope>
         </dependency>
         <!--
+          jakarta.transaction-api lets the transaction-boundary contract assert the @Transactional
+          attribute JPA stores declare on their lock/heartbeat operations. Provided scope: the store
+          under test already supplies it.
+        -->
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!--
           jakarta.enterprise.cdi-api is required because ratchet-api's module descriptor declares
           `requires transitive jakarta.cdi;` (driven by @CircuitBreakerProtected). Provided scope:
           consumers' container supplies the implementation. Not present in plan v2 — added when the

--- a/ratchet-tck/store/src/main/java/module-info.java
+++ b/ratchet-tck/store/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module run.ratchet.tck.store {
   requires run.ratchet.api;
   requires run.ratchet.store.core;
   requires jakarta.persistence;
+  requires jakarta.transaction;
   requires java.sql;
   requires org.junit.jupiter.api;
   requires org.junit.platform.launcher;

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
@@ -9,9 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -452,6 +454,150 @@ public abstract class AbstractJobQueryStoreContract implements JobStoreContractF
 
     assertEquals(1, results.size(), "parentJobId filter should return only direct dependants");
     assertEquals(child.getId(), results.get(0).getId(), "Returned job should be the child job");
+  }
+
+  // ── Archive-inclusive search (UNION over live + archive tables) ─────────
+
+  @Test
+  void searchIncludeArchived_returnsLiveAndArchivedRowsOnce() {
+    JobEntity live = persist(newPendingJob());
+    UUID archivedId = archiveOnly(newPendingJob());
+
+    List<JobEntity> results =
+        store().searchJobs(JobFilter.builder().includeArchived(true).build(), 100, 0);
+
+    List<UUID> ids = results.stream().map(JobEntity::getId).toList();
+    assertTrue(ids.contains(live.getId()), "includeArchived search must still return live jobs");
+    assertTrue(ids.contains(archivedId), "includeArchived search must return archived jobs");
+    assertEquals(
+        ids.size(),
+        new HashSet<>(ids).size(),
+        "An archived job must appear once, not duplicated across the live/archive UNION");
+  }
+
+  @Test
+  void searchIncludeArchived_hydratesArchivedColumnsToCorrectFields() {
+    JobEntity pending = newPendingJob();
+    pending.setBusinessKey("bk-archived-search");
+    UUID archivedId = archiveOnly(pending);
+
+    List<JobEntity> results =
+        store().searchJobs(JobFilter.builder().includeArchived(true).build(), 100, 0);
+
+    JobEntity archived =
+        results.stream()
+            .filter(j -> archivedId.equals(j.getId()))
+            .findFirst()
+            .orElseThrow(
+                () -> new AssertionError("archived job missing from includeArchived search"));
+    assertEquals(
+        "bk-archived-search",
+        archived.getBusinessKey(),
+        "archive business_key must hydrate at the correct projection column");
+    assertEquals(
+        "com.example.TestJob",
+        archived.getTargetClass(),
+        "archive target_class must hydrate at the correct projection column");
+    assertEquals(
+        JobStatus.SUCCEEDED,
+        archived.getStatus(),
+        "archive final_status must hydrate as the job status");
+    assertNotNull(archived.getCreatedAt(), "archive original_created_at must hydrate as createdAt");
+  }
+
+  @Test
+  void searchIncludeArchived_sortsByPriorityDescendingAcrossBoundary() {
+    JobEntity low = newPendingJob();
+    low.setPriority(JobPriority.LOW);
+    UUID liveLow = persist(low).getId();
+
+    JobEntity high = newPendingJob();
+    high.setPriority(JobPriority.HIGH);
+    UUID archivedHigh = archiveOnly(high);
+
+    List<JobEntity> results =
+        store()
+            .searchJobs(
+                JobFilter.builder()
+                    .includeArchived(true)
+                    .sortField(JobQuerySortField.PRIORITY)
+                    .sortAscending(false)
+                    .build(),
+                100,
+                0);
+
+    List<UUID> ids =
+        results.stream().map(JobEntity::getId).filter(idsOf(liveLow, archivedHigh)).toList();
+    assertEquals(
+        List.of(archivedHigh, liveLow),
+        ids,
+        "PRIORITY-desc sort must place the archived HIGH job ahead of the live LOW job");
+  }
+
+  @Test
+  void searchIncludeArchived_sortsByCreatedAtDescendingAcrossBoundary() {
+    // Persist the live job first, then the archived job, so the archived job is the newest. With
+    // both caller_principal values NULL, an ORDER BY that points at the wrong column collapses to
+    // the job_id tiebreaker, which (UuidV7 being time-ordered) yields creation order — the reverse
+    // of a correct created_at-descending sort.
+    UUID liveOlder = persist(newPendingJob()).getId();
+    spaceCreationTimestamps();
+    UUID archivedNewer = archiveOnly(newPendingJob());
+
+    List<JobEntity> results =
+        store()
+            .searchJobs(
+                JobFilter.builder()
+                    .includeArchived(true)
+                    .sortField(JobQuerySortField.CREATED_AT)
+                    .sortAscending(false)
+                    .build(),
+                100,
+                0);
+
+    List<JobEntity> mine =
+        results.stream().filter(j -> idsOf(liveOlder, archivedNewer).test(j.getId())).toList();
+    assertEquals(2, mine.size(), "Both the live and archived job must appear in the search");
+    for (int i = 1; i < mine.size(); i++) {
+      assertDefaultCreatedAtOrder(mine.get(i - 1), mine.get(i));
+    }
+    assertEquals(
+        archivedNewer,
+        mine.get(0).getId(),
+        "CREATED_AT-desc sort must place the newer archived job first");
+  }
+
+  /**
+   * Creates a terminal job, archives it, and deletes the live cold row so the job exists only in
+   * the archive table — the state an archive-inclusive search must surface from the archive branch.
+   */
+  private UUID archiveOnly(JobEntity pending) {
+    JobEntity saved = persist(pending);
+    UUID id = saved.getId();
+    store().compareAndSwapStatus(id, JobStatus.PENDING, JobStatus.RUNNING, null);
+    store()
+        .markJobSucceeded(id, null, null, Instant.EPOCH, Instant.EPOCH.plusSeconds(1), 100L, 50L);
+    JobEntity completed = store().findById(id).orElseThrow();
+    store().archiveJob(completed, "tck-archive-search", "tck");
+    store().deleteJobsByIds(List.of(id));
+    return id;
+  }
+
+  private static java.util.function.Predicate<UUID> idsOf(UUID... ids) {
+    Set<UUID> set = new HashSet<>(Arrays.asList(ids));
+    return set::contains;
+  }
+
+  private static void spaceCreationTimestamps() {
+    // The store stamps created_at server-side at insert (a caller-set createdAt is ignored), so two
+    // jobs persisted back-to-back can land in the same millisecond. A short pause guarantees a
+    // distinct, ordered created_at for the cross-boundary sort assertion.
+    try {
+      Thread.sleep(50);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("interrupted while spacing creation timestamps", e);
+    }
   }
 
   private static void assertDefaultCreatedAtOrder(JobEntity previous, JobEntity current) {

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
@@ -24,6 +24,7 @@ import run.ratchet.api.JobQuerySortField;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobType;
 import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.query.JobQueryCursor;
 
 /**
  * Base contract tests for {@link run.ratchet.store.spi.JobQueryStore} — dashboard-oriented search
@@ -565,6 +566,57 @@ public abstract class AbstractJobQueryStoreContract implements JobStoreContractF
         archivedNewer,
         mine.get(0).getId(),
         "CREATED_AT-desc sort must place the newer archived job first");
+  }
+
+  @Test
+  void searchIncludeArchived_cursorPaginationOverArchiveVisitsEveryRowOnce() {
+    // Give every archived row the same priority so the keyset tiebreaker — not the primary sort —
+    // decides ordering. That is the slot where an archive cursor seeking the wrong id field drops
+    // or repeats rows at the page boundary.
+    int total = 7;
+    Set<UUID> archivedIds = new HashSet<>();
+    for (int i = 0; i < total; i++) {
+      JobEntity job = newPendingJob();
+      job.setPriority(JobPriority.NORMAL);
+      archivedIds.add(archiveOnly(job));
+    }
+
+    int pageSize = 2;
+    List<UUID> seen = new ArrayList<>();
+    String cursor = null;
+    for (int guard = 0; guard <= total; guard++) {
+      var builder =
+          JobFilter.builder()
+              .includeArchived(true)
+              .sortField(JobQuerySortField.PRIORITY)
+              .sortAscending(false);
+      if (cursor != null) {
+        builder.cursor(cursor);
+      }
+      List<JobEntity> pageRows = store().searchJobs(builder.build(), pageSize, 0);
+      if (pageRows.isEmpty()) {
+        break;
+      }
+      pageRows.forEach(r -> seen.add(r.getId()));
+      JobEntity last = pageRows.get(pageRows.size() - 1);
+      cursor =
+          new JobQueryCursor(
+                  JobQuerySortField.PRIORITY,
+                  Integer.toString(last.getPriority().ordinal()),
+                  last.getId())
+              .encode();
+      if (pageRows.size() < pageSize) {
+        break;
+      }
+    }
+
+    Set<UUID> distinct = new HashSet<>(seen);
+    assertEquals(
+        seen.size(), distinct.size(), "Cursor pages over the archive must not repeat a row");
+    assertEquals(
+        archivedIds,
+        distinct,
+        "Cursor pages over the archive must visit every archived row exactly once");
   }
 
   /**

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
@@ -602,6 +602,7 @@ public abstract class AbstractJobQueryStoreContract implements JobStoreContractF
       cursor =
           new JobQueryCursor(
                   JobQuerySortField.PRIORITY,
+                  /* sortAscending= */ false,
                   Integer.toString(last.getPriority().ordinal()),
                   last.getId())
               .encode();
@@ -617,6 +618,57 @@ public abstract class AbstractJobQueryStoreContract implements JobStoreContractF
         archivedIds,
         distinct,
         "Cursor pages over the archive must visit every archived row exactly once");
+  }
+
+  @Test
+  void searchJobs_cursorMintedForADifferentSortIsIgnored() {
+    // A keyset cursor records the sort it was produced under. The seek predicate filters on the
+    // cursor's sort field while the ORDER BY comes from the live filter, so reusing a cursor after
+    // changing the sort would seek on one axis while the query orders by another — silently
+    // dropping or repeating rows. Page once under CREATED_AT, then reuse that cursor on a query
+    // sorted by PRIORITY: the store must ignore the mismatched cursor and fall back to offset
+    // paging, so the PRIORITY query returns the same rows with or without the stale cursor.
+    List<JobEntity> persisted = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      persisted.add(persist(newPendingJob()));
+      spaceCreationTimestamps();
+    }
+    Set<UUID> mine =
+        persisted.stream().map(JobEntity::getId).collect(java.util.stream.Collectors.toSet());
+    JobEntity anchor = persisted.get(2);
+
+    String staleCursor =
+        new JobQueryCursor(
+                JobQuerySortField.CREATED_AT,
+                /* sortAscending= */ true,
+                anchor.getCreatedAt().toString(),
+                anchor.getId())
+            .encode();
+
+    JobFilter priorityNoCursor =
+        JobFilter.builder().sortField(JobQuerySortField.PRIORITY).sortAscending(false).build();
+    JobFilter priorityStaleCursor =
+        JobFilter.builder()
+            .sortField(JobQuerySortField.PRIORITY)
+            .sortAscending(false)
+            .cursor(staleCursor)
+            .build();
+
+    List<UUID> baseline =
+        store().searchJobs(priorityNoCursor, 100, 0).stream()
+            .map(JobEntity::getId)
+            .filter(mine::contains)
+            .toList();
+    List<UUID> withStaleCursor =
+        store().searchJobs(priorityStaleCursor, 100, 0).stream()
+            .map(JobEntity::getId)
+            .filter(mine::contains)
+            .toList();
+
+    assertEquals(
+        baseline,
+        withStaleCursor,
+        "A cursor minted for a different sort must be ignored, not applied as a seek");
   }
 
   /**

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobStoreTransactionBoundaryContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobStoreTransactionBoundaryContract.java
@@ -1,0 +1,81 @@
+package run.ratchet.tck.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract for JPA-backed {@code JobStore} implementations that express their lock and node-liveness
+ * transaction boundaries through Jakarta Transactions.
+ *
+ * <p>Lock acquisition and release, lease renewal, heartbeat upserts, and inactive-node cleanup must
+ * commit in a transaction independent of any caller transaction. That way a distributed lock or a
+ * liveness write becomes visible to other nodes as soon as the operation returns and is not undone
+ * if the caller later rolls back. JPA stores satisfy this with {@code @Transactional(REQUIRES_NEW)}
+ * on those methods, and this contract pins the attribute so the SQL stores cannot silently drift
+ * apart again (one store once carried the annotation while its sibling did not).
+ *
+ * <p>Stores that achieve independent commit through single-operation atomicity rather than Jakarta
+ * Transactions (for example document stores) are exempt and do not extend this contract.
+ */
+public abstract class AbstractJobStoreTransactionBoundaryContract {
+
+  /** The concrete {@code JobStore} implementation class whose annotations are under test. */
+  protected abstract Class<?> jobStoreImplClass();
+
+  @Test
+  void tryLockCommitsInItsOwnTransaction() throws NoSuchMethodException {
+    assertRequiresNew("tryLock", String.class, Duration.class, String.class);
+  }
+
+  @Test
+  void unlockCommitsInItsOwnTransaction() throws NoSuchMethodException {
+    assertRequiresNew("unlock", String.class, String.class);
+  }
+
+  @Test
+  void renewLockCommitsInItsOwnTransaction() throws NoSuchMethodException {
+    assertRequiresNew("renewLock", String.class, Duration.class, String.class);
+  }
+
+  @Test
+  void upsertHeartbeatCommitsInItsOwnTransaction() throws NoSuchMethodException {
+    assertRequiresNew("upsertHeartbeat", String.class, Instant.class);
+  }
+
+  @Test
+  void deleteInactiveNodesSinceCommitsInItsOwnTransaction() throws NoSuchMethodException {
+    assertRequiresNew("deleteInactiveNodesSince", Instant.class);
+  }
+
+  @Test
+  void deleteInactiveNodesByIdsCommitsInItsOwnTransaction() throws NoSuchMethodException {
+    assertRequiresNew("deleteInactiveNodesByIds", Collection.class);
+  }
+
+  @Test
+  void classLevelBoundaryIsRequired() {
+    Transactional classLevel = jobStoreImplClass().getAnnotation(Transactional.class);
+    assertNotNull(classLevel, "the store impl must carry a class-level @Transactional default");
+    assertEquals(
+        Transactional.TxType.REQUIRED,
+        classLevel.value(),
+        "every store method without its own attribute must default to a REQUIRED tx boundary");
+  }
+
+  private void assertRequiresNew(String method, Class<?>... parameterTypes)
+      throws NoSuchMethodException {
+    Transactional tx =
+        jobStoreImplClass().getMethod(method, parameterTypes).getAnnotation(Transactional.class);
+    assertNotNull(tx, method + " must declare @Transactional so it gets its own transaction");
+    assertEquals(
+        Transactional.TxType.REQUIRES_NEW,
+        tx.value(),
+        method + " must commit in a transaction independent of the caller (REQUIRES_NEW)");
+  }
+}

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobStoreTransactionBoundaryContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobStoreTransactionBoundaryContract.java
@@ -10,8 +10,8 @@ import java.util.Collection;
 import org.junit.jupiter.api.Test;
 
 /**
- * Contract for JPA-backed {@code JobStore} implementations that express their lock and node-liveness
- * transaction boundaries through Jakarta Transactions.
+ * Contract for JPA-backed {@code JobStore} implementations that express their lock and
+ * node-liveness transaction boundaries through Jakarta Transactions.
  *
  * <p>Lock acquisition and release, lease renewal, heartbeat upserts, and inactive-node cleanup must
  * commit in a transaction independent of any caller transaction. That way a distributed lock or a

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/ConformanceLevel.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/ConformanceLevel.java
@@ -8,6 +8,13 @@ import java.util.Map;
  * Groups store-TCK contracts into three categories and serves as the static inventory that {@link
  * ConformanceReportExtension} checks against — enabling detection of missing contracts, not just
  * failing ones.
+ *
+ * <p>Each level separates <em>required</em> contracts, which every conforming store must run and
+ * pass, from <em>optional</em> contracts that apply only to stores supporting the capability. A
+ * document store has no schema-migration step and is not JTA-managed, so the schema-migrator,
+ * JPA-recurring-claim-concurrency, schema-conformance, and transaction-boundary contracts are
+ * optional: a store that runs one is held to it, and a store that does not is reported {@code N/A}
+ * rather than {@code MISSING}.
  */
 public enum ConformanceLevel {
   CORE(
@@ -19,50 +26,67 @@ public enum ConformanceLevel {
           "AbstractJobClaimStoreContract",
           "AbstractLockStoreContract",
           "AbstractNodeStoreContract",
-          "AbstractTagStoreContract")),
+          "AbstractTagStoreContract"),
+      List.of()),
 
   BEHAVIORAL(
       "Behavioral",
-      "Job lifecycle operations: execution tracking, retry, pause/resume, and batch"
-          + " orchestration.",
+      "Job lifecycle operations: execution tracking, retry, pause/resume, recurring scheduling, and"
+          + " batch orchestration.",
       List.of(
           "AbstractExecutionStoreContract",
           "AbstractJobLogStoreContract",
           "AbstractJobRetryStoreContract",
           "AbstractJobPauseStoreContract",
           "AbstractJobTerminalStoreContract",
+          "AbstractRecurringJobStoreContract",
           "AbstractBatchStoreContract",
           "AbstractWorkflowConditionStoreContract",
           "AbstractJobBatchStatusStoreContract",
           "AbstractBatchMetricsStoreContract",
-          "AbstractJobQueryStoreContract")),
+          "AbstractJobQueryStoreContract"),
+      List.of()),
 
   ADVANCED(
       "Advanced",
-      "Optional capabilities: archival, dead-letter queues, bulk operations, schema"
-          + " conformance, and business-key uniqueness.",
+      "Optional capabilities: archival, dead-letter queues, bulk operations, business-key"
+          + " uniqueness, and — for SQL stores — schema conformance, schema migration, and JTA"
+          + " transaction boundaries.",
       List.of(
           "AbstractArchiveStoreContract",
           "AbstractDlqAlertStoreContract",
           "AbstractJobBulkStoreContract",
           "AbstractActiveBusinessKeyContract",
-          "AbstractSchemaConformanceContract",
           "AbstractDualWriteInvariantContract",
-          "AbstractResourcePermitStoreContract"));
+          "AbstractResourcePermitStoreContract"),
+      List.of(
+          "AbstractSchemaConformanceContract",
+          "AbstractSchemaMigratorContract",
+          "AbstractJpaRecurringClaimConcurrencyContract",
+          "AbstractJobStoreTransactionBoundaryContract"));
 
   private static final Map<String, ConformanceLevel> BY_CONTRACT = buildIndex();
 
   private final String label;
   private final String description;
   private final List<String> requiredContracts;
+  private final List<String> optionalContracts;
 
-  ConformanceLevel(String label, String description, List<String> requiredContracts) {
+  ConformanceLevel(
+      String label,
+      String description,
+      List<String> requiredContracts,
+      List<String> optionalContracts) {
     this.label = label;
     this.description = description;
     this.requiredContracts = requiredContracts;
+    this.optionalContracts = optionalContracts;
   }
 
-  /** Returns the level that owns {@code simpleClassName}, or {@code null} if unrecognized. */
+  /**
+   * Returns the level that owns {@code simpleClassName} (required or optional), or {@code null} if
+   * unrecognized.
+   */
   public static ConformanceLevel forContract(String simpleClassName) {
     return BY_CONTRACT.get(simpleClassName);
   }
@@ -71,6 +95,9 @@ public enum ConformanceLevel {
     Map<String, ConformanceLevel> index = new HashMap<>();
     for (ConformanceLevel level : values()) {
       for (String name : level.requiredContracts) {
+        index.put(name, level);
+      }
+      for (String name : level.optionalContracts) {
         index.put(name, level);
       }
     }
@@ -87,5 +114,9 @@ public enum ConformanceLevel {
 
   public List<String> getRequiredContracts() {
     return requiredContracts;
+  }
+
+  public List<String> getOptionalContracts() {
+    return optionalContracts;
   }
 }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/ConformanceReportExtension.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/ConformanceReportExtension.java
@@ -19,7 +19,13 @@ public class ConformanceReportExtension extends AbstractConformanceReportExtensi
 
   private static final List<ContractGroup> GROUPS =
       Arrays.stream(ConformanceLevel.values())
-          .map(l -> new ContractGroup(l.getLabel(), l.getDescription(), l.getRequiredContracts()))
+          .map(
+              l ->
+                  new ContractGroup(
+                      l.getLabel(),
+                      l.getDescription(),
+                      l.getRequiredContracts(),
+                      l.getOptionalContracts()))
           .toList();
 
   /**

--- a/ratchet-tck/store/src/test/java/run/ratchet/tck/store/ConformanceReportExtensionTest.java
+++ b/ratchet-tck/store/src/test/java/run/ratchet/tck/store/ConformanceReportExtensionTest.java
@@ -89,9 +89,11 @@ class ConformanceReportExtensionTest {
 
   @Test
   void conformanceLevel_allAbstractContractsAreRegistered() throws Exception {
-    String packagePath = ConformanceLevel.class.getPackageName().replace('.', '/');
-    var resource = Thread.currentThread().getContextClassLoader().getResource(packagePath);
-    var packageDir = Paths.get(resource.toURI());
+    // Anchor the scan on a class that lives beside the contracts in main output. Resolving the
+    // package via the context classloader returned the test-classes copy of the directory, which
+    // holds no Abstract*Contract.class, so the scan saw nothing and passed vacuously.
+    var resource = ConformanceLevel.class.getResource("ConformanceLevel.class");
+    var packageDir = Paths.get(resource.toURI()).getParent();
 
     List<String> unregisteredContracts;
     try (var classes = Files.list(packageDir)) {

--- a/ratchet-tck/util/src/main/java/run/ratchet/tck/util/AbstractConformanceReportExtension.java
+++ b/ratchet-tck/util/src/main/java/run/ratchet/tck/util/AbstractConformanceReportExtension.java
@@ -53,6 +53,9 @@ public abstract class AbstractConformanceReportExtension implements TestExecutio
       for (String name : group.contracts()) {
         contractIndex.put(name, group.label());
       }
+      for (String name : group.optionalContracts()) {
+        contractIndex.put(name, group.label());
+      }
     }
   }
 
@@ -140,9 +143,10 @@ public abstract class AbstractConformanceReportExtension implements TestExecutio
     pw.println();
 
     // Per-group summary counts: [required, passed]
+    // Per-group summary counts: [required, required-passed, optional-failed]
     Map<String, int[]> summary = new LinkedHashMap<>();
     for (ContractGroup group : contractGroups()) {
-      summary.put(group.label(), new int[] {0, 0});
+      summary.put(group.label(), new int[] {0, 0, 0});
     }
 
     for (ContractGroup group : contractGroups()) {
@@ -160,8 +164,29 @@ public abstract class AbstractConformanceReportExtension implements TestExecutio
         if (r == null) {
           pw.printf("| `%s` | — | — | — | — | ✗ MISSING |%n", contractName);
         } else {
-          boolean passed = r.failed == 0 && r.aborted == 0;
+          // Aborted tests are JUnit assumption-skips (a contract may skip a case a fixture cannot
+          // surface, e.g. optimistic-lock failures on a standalone document store). They are
+          // neutral, not failures. A contract conforms when at least one case verified and none
+          // failed; an all-skipped contract still does not pass.
+          boolean passed = r.failed == 0 && r.passed > 0;
           if (passed) counts[1]++;
+          pw.printf(
+              "| `%s` | %d | %d | %d | %d | %s |%n",
+              contractName, r.total(), r.passed, r.failed, r.aborted, passed ? "✓ PASS" : "✗ FAIL");
+        }
+      }
+      for (String contractName : group.optionalContracts()) {
+        ContractResult r = results.get(contractName);
+        if (r == null) {
+          // Optional contract not run: applies only to runtimes that support the capability.
+          pw.printf("| `%s` | — | — | — | — | ⚪ N/A |%n", contractName);
+        } else {
+          // Aborted tests are JUnit assumption-skips (a contract may skip a case a fixture cannot
+          // surface, e.g. optimistic-lock failures on a standalone document store). They are
+          // neutral, not failures. A contract conforms when at least one case verified and none
+          // failed; an all-skipped contract still does not pass.
+          boolean passed = r.failed == 0 && r.passed > 0;
+          if (!passed) counts[2]++;
           pw.printf(
               "| `%s` | %d | %d | %d | %d | %s |%n",
               contractName, r.total(), r.passed, r.failed, r.aborted, passed ? "✓ PASS" : "✗ FAIL");
@@ -177,7 +202,7 @@ public abstract class AbstractConformanceReportExtension implements TestExecutio
     boolean allPassed = true;
     for (ContractGroup group : contractGroups()) {
       int[] counts = summary.get(group.label());
-      boolean groupPassed = counts[0] == counts[1];
+      boolean groupPassed = counts[0] == counts[1] && counts[2] == 0;
       if (!groupPassed) allPassed = false;
       pw.printf(
           "| %s | %d | %d | %s |%n",
@@ -194,8 +219,21 @@ public abstract class AbstractConformanceReportExtension implements TestExecutio
   /**
    * A named group of related contracts within a tier (e.g., "Core", "Behavioral"). Tiers with few
    * contracts may use a single group.
+   *
+   * <p>{@code contracts} are required of every runtime in the tier: a runtime that does not run one
+   * is reported {@code MISSING} and fails the claim. {@code optionalContracts} apply only to
+   * runtimes that support the capability (e.g. schema-migration and JTA-transaction-boundary
+   * contracts apply to SQL stores but not a document store): a runtime that runs one is held to
+   * PASS/FAIL, while one that does not is reported {@code N/A} without failing the claim.
    */
-  public record ContractGroup(String label, String description, List<String> contracts) {}
+  public record ContractGroup(
+      String label, String description, List<String> contracts, List<String> optionalContracts) {
+
+    /** Convenience constructor for a group whose contracts are all required. */
+    public ContractGroup(String label, String description, List<String> contracts) {
+      this(label, description, contracts, List.of());
+    }
+  }
 
   /** Result accumulator for a single abstract contract class. */
   static final class ContractResult {

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/PayloadMaskingPolicyInstaller.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/PayloadMaskingPolicyInstaller.java
@@ -28,6 +28,14 @@ public class PayloadMaskingPolicyInstaller {
 
   private final Instance<PayloadMaskingPolicy> policy;
 
+  /**
+   * No-arg constructor so Weld can instantiate the client-proxy subclass (CDI 4.0 §3.15); never
+   * used for a real instance, so the policy is left unset.
+   */
+  protected PayloadMaskingPolicyInstaller() {
+    this.policy = null;
+  }
+
   @Inject
   public PayloadMaskingPolicyInstaller(Instance<PayloadMaskingPolicy> policy) {
     this.policy = policy;

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/PayloadMaskingPolicyInstaller.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/PayloadMaskingPolicyInstaller.java
@@ -1,0 +1,46 @@
+package run.ratchet.ri.cdi;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import run.ratchet.spi.PayloadMaskingPolicy;
+import run.ratchet.store.util.PayloadMaskingPolicyHolder;
+
+/**
+ * Installs the framework-resolved {@link PayloadMaskingPolicy} into {@link
+ * PayloadMaskingPolicyHolder} at application startup, and clears it at shutdown so a redeploy does
+ * not leak a stale policy across the static holder.
+ *
+ * <p>{@link PayloadMasker} lives in {@code store-core} and may run outside a CDI container, so it
+ * resolves its policy through the static holder rather than {@code @Inject}. This installer is the
+ * bridge: a deployer that produces its own {@link PayloadMaskingPolicy} bean overrides the built-in
+ * default; when no bean is produced the holder keeps returning the built-in policy and behavior is
+ * unchanged.
+ *
+ * <p>Resolution is best-effort and null-safe: if no unambiguous policy bean is available the holder
+ * is left on its built-in default.
+ */
+@ApplicationScoped
+public class PayloadMaskingPolicyInstaller {
+
+  private final Instance<PayloadMaskingPolicy> policy;
+
+  @Inject
+  public PayloadMaskingPolicyInstaller(Instance<PayloadMaskingPolicy> policy) {
+    this.policy = policy;
+  }
+
+  void onStartup(@Observes @Initialized(ApplicationScoped.class) Object event) {
+    if (policy != null && policy.isResolvable()) {
+      PayloadMaskingPolicyHolder.set(policy.get());
+    }
+  }
+
+  @PreDestroy
+  void onShutdown() {
+    PayloadMaskingPolicyHolder.set(null);
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -606,10 +606,13 @@ class DefaultJobCreationService
     // Persist-time ClassPolicy gate: mirrors WorkflowConditionEvaluator and JobSecurityValidator
     // at execution time. Closes the TOCTOU window between persistence and execution — a malicious
     // lambda's target class is rejected before reaching the database, not after a worker dequeues
-    // it.
+    // it. Framework coordination payloads (the batch-parent noop) target an internal placeholder,
+    // never run user code, and so are not subject to the application allowlist — gating them would
+    // break batch submission for any app that allowlists only its own packages.
     if (classPolicy != null
         && payload != null
         && payload.target() != null
+        && !JobPayloadFactory.isCoordinationPlaceholder(payload)
         && !classPolicy.isAllowed(payload.target())) {
       throw new SecurityException(
           "Class " + payload.target() + " is not allowed for job execution.");

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
@@ -21,8 +21,10 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobSummary;
 import run.ratchet.api.JobType;
 import run.ratchet.api.QueueHealthSnapshot;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.ri.security.PayloadMasker;
 import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobPayload;
@@ -44,6 +46,7 @@ class DefaultJobQueryService implements JobQueryService {
   private final JobAuthorizationPolicy authPolicy;
   private final CallerPrincipalProvider principalProvider;
   private final Clock clock;
+  private final boolean maskPayloads;
 
   protected DefaultJobQueryService() {
     this.queryStore = null;
@@ -53,6 +56,7 @@ class DefaultJobQueryService implements JobQueryService {
     this.authPolicy = null;
     this.principalProvider = null;
     this.clock = null;
+    this.maskPayloads = false;
   }
 
   public DefaultJobQueryService(
@@ -72,7 +76,6 @@ class DefaultJobQueryService implements JobQueryService {
         Clock.systemUTC());
   }
 
-  @Inject
   public DefaultJobQueryService(
       JobQueryStore queryStore,
       JobCrudStore crudStore,
@@ -81,6 +84,27 @@ class DefaultJobQueryService implements JobQueryService {
       JobAuthorizationPolicy authPolicy,
       CallerPrincipalProvider principalProvider,
       Clock clock) {
+    this(
+        queryStore,
+        crudStore,
+        executionStore,
+        recurringJobStore,
+        authPolicy,
+        principalProvider,
+        clock,
+        null);
+  }
+
+  @Inject
+  public DefaultJobQueryService(
+      JobQueryStore queryStore,
+      JobCrudStore crudStore,
+      ExecutionStore executionStore,
+      RecurringJobStore recurringJobStore,
+      JobAuthorizationPolicy authPolicy,
+      CallerPrincipalProvider principalProvider,
+      Clock clock,
+      RatchetOptions options) {
     this.queryStore = queryStore;
     this.crudStore = crudStore;
     this.executionStore = executionStore;
@@ -88,6 +112,7 @@ class DefaultJobQueryService implements JobQueryService {
     this.authPolicy = authPolicy;
     this.principalProvider = principalProvider;
     this.clock = clock;
+    this.maskPayloads = options != null && options.security().maskPayloads();
   }
 
   private static String extractSortValue(JobEntity last, JobQuerySortField field) {
@@ -188,10 +213,16 @@ class DefaultJobQueryService implements JobQueryService {
             .map(JobEntity::getId)
             .collect(Collectors.toList());
 
+    // Read-projection masking: getJobDetail is the only read that returns raw caller-supplied
+    // params, so when mask-payloads is enabled we redact sensitive keys here before they reach
+    // the caller. The durable row is untouched; target#method (the summary) stays unmasked.
+    Map<String, String> params =
+        maskPayloads ? PayloadMasker.maskParams(e.getParams()) : e.getParams();
+
     JobDetail detail =
         new JobDetail(
             JobEntityMapper.toSummary(e),
-            e.getParams(),
+            params,
             e.getTraceContext(),
             e.getJobResult(),
             e.getResultType(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
@@ -213,18 +213,26 @@ class DefaultJobQueryService implements JobQueryService {
             .map(JobEntity::getId)
             .collect(Collectors.toList());
 
-    // Read-projection masking: getJobDetail is the only read that returns raw caller-supplied
-    // params, so when mask-payloads is enabled we redact sensitive keys here before they reach
-    // the caller. The durable row is untouched; target#method (the summary) stays unmasked.
+    // Read-projection masking: getJobDetail exposes the raw caller-supplied params, the trace
+    // context carrier (whose baggage entries can hold caller data), and the serialized job result.
+    // When mask-payloads is enabled we redact sensitive entries here before they reach the caller;
+    // the durable row is untouched and the summary's target#method stays unmasked. Map masking is
+    // key-based and result masking walks the serialized JSON object (a non-object result passes
+    // through). Free-text fields such as lastError are out of scope — see
+    // RatchetOptions.SecurityOptions#maskPayloads.
     Map<String, String> params =
         maskPayloads ? PayloadMasker.maskParams(e.getParams()) : e.getParams();
+    Map<String, String> traceContext =
+        maskPayloads ? PayloadMasker.maskParams(e.getTraceContext()) : e.getTraceContext();
+    String jobResult =
+        maskPayloads ? PayloadMasker.maskPayload(e.getJobResult()) : e.getJobResult();
 
     JobDetail detail =
         new JobDetail(
             JobEntityMapper.toSummary(e),
             params,
-            e.getTraceContext(),
-            e.getJobResult(),
+            traceContext,
+            jobResult,
             e.getResultType(),
             e.getExecutionStartTime(),
             e.getExecutionEndTime(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
@@ -182,7 +182,12 @@ class DefaultJobQueryService implements JobQueryService {
       JobQuerySortField sortField =
           scoped.sortField() != null ? scoped.sortField() : JobQuerySortField.CREATED_AT;
       nextCursor =
-          new JobQueryCursor(sortField, extractSortValue(last, sortField), last.getId()).encode();
+          new JobQueryCursor(
+                  sortField,
+                  scoped.sortAscending(),
+                  extractSortValue(last, sortField),
+                  last.getId())
+              .encode();
     }
 
     return new JobPage<>(items, total, limit, offset, hasMore, nextCursor);

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -272,114 +272,122 @@ public class JobTask implements Callable<Void> {
         jobType != null ? jobType.name() : null,
         deserializedSignalPayload);
 
-    if (jobEntity.getCallerPrincipal() != null) {
-      log.debugf("Job %s created by user (present)", jobId);
-    } else {
-      log.debugf("Job %s created by system (no user context)", jobId);
-    }
-
-    observabilityFacade.recordJobStart(jobEntity);
-
-    int attemptNumber = jobEntity.getAttempts() + 1;
-    currentExecution =
-        observabilityFacade.startExecution(jobId, attemptNumber, nodeIdProvider.getNodeId());
-
-    Instant start = effective().instant();
-    observabilityFacade.publishEvent(
-        new JobStartedEvent(
-            jobEntity.getId(),
-            jobEntity.getBusinessKey(),
-            jobEntity.getPublicJobType(),
-            jobEntity.getPriority(),
-            jobEntity.getPickedBy(),
-            start));
-
-    if (log.isInfoEnabled()) {
-      log.infov(
-          "Job {0} starting execution [type={1}, priority={2}, attempt={3}/{4}, payload={5}.{6}]",
-          jobId,
-          jobEntity.getJobType(),
-          jobEntity.getPriority(),
-          jobEntity.getAttempts() + 1,
-          jobEntity.getMaxRetries() + 1,
-          jobEntity.getPayload().target(),
-          jobEntity.getPayload().method());
-    }
-
-    Object jobResult;
-    permitAcquired = false;
-    String resilienceServiceName = resolveResilienceServiceName(jobEntity.getPayload());
+    // The JobContext/MDC bound above must be cleared on every exit. Open the clearing try right
+    // after the bind so a throw from the startup observability calls (metrics, execution recording)
+    // cannot leak this job's identity onto the pooled worker thread. The inner try owns
+    // execution-failure handling; this outer try only guarantees the bound context is cleared.
     try {
-      currentScope = observabilityFacade.startExecutionScope(jobEntity);
-      if (wasJobCanceledDuringExecution()) {
-        handleCanceledDuringExecution(start);
-        return null;
-      }
-
-      if (!resilienceStrategy.isServiceAvailable(resilienceServiceName)) {
-        log.infof(
-            "Job %s skipped - circuit breaker OPEN for service: %s", jobId, resilienceServiceName);
-        rescheduleForCircuitBreaker(jobEntity, resilienceServiceName);
-        return null;
-      }
-
-      if (!tryAcquireResourcePermit()) {
-        return null;
-      }
-
-      // Authorization check before breaker scope — denial must not trip the circuit breaker
-      if (authorizationPolicy != null) {
-        authorizationPolicy.checkExecute(jobEntity.getId(), jobEntity.getCallerPrincipal());
-      }
-      // Validate before breaker scope — config errors must not trip the circuit breaker
-      validationFacade.validateSecurity(jobEntity.getPayload());
-
-      jobResult =
-          resilienceStrategy.execute(
-              resilienceServiceName, () -> runPayload(jobEntity.getPayload()));
-
-      if (wasJobCanceledDuringExecution()) {
-        handleCanceledDuringExecution(start);
+      if (jobEntity.getCallerPrincipal() != null) {
+        log.debugf("Job %s created by user (present)", jobId);
       } else {
-        handleSuccess(start, jobResult);
+        log.debugf("Job %s created by system (no user context)", jobId);
       }
-    } catch (CircuitBreakerOpenException e) {
-      log.infof(
-          "Job %s rescheduled - circuit breaker OPEN for service: %s",
-          jobId, resilienceServiceName);
-      rescheduleForCircuitBreaker(jobEntity, resilienceServiceName, e);
-    } catch (Throwable t) {
+
+      observabilityFacade.recordJobStart(jobEntity);
+
+      int attemptNumber = jobEntity.getAttempts() + 1;
+      currentExecution =
+          observabilityFacade.startExecution(jobId, attemptNumber, nodeIdProvider.getNodeId());
+
+      Instant start = effective().instant();
+      observabilityFacade.publishEvent(
+          new JobStartedEvent(
+              jobEntity.getId(),
+              jobEntity.getBusinessKey(),
+              jobEntity.getPublicJobType(),
+              jobEntity.getPriority(),
+              jobEntity.getPickedBy(),
+              start));
+
+      if (log.isInfoEnabled()) {
+        log.infov(
+            "Job {0} starting execution [type={1}, priority={2}, attempt={3}/{4}, payload={5}.{6}]",
+            jobId,
+            jobEntity.getJobType(),
+            jobEntity.getPriority(),
+            jobEntity.getAttempts() + 1,
+            jobEntity.getMaxRetries() + 1,
+            jobEntity.getPayload().target(),
+            jobEntity.getPayload().method());
+      }
+
+      Object jobResult;
+      permitAcquired = false;
+      String resilienceServiceName = resolveResilienceServiceName(jobEntity.getPayload());
       try {
-        handleFailure(t);
-      } catch (Throwable failureHandlingError) {
-        log.errorf(
-            failureHandlingError,
-            "Job %s failure handling itself failed, forcing FAILED status",
-            job.getId());
-        String safeError;
-        try {
-          safeError = errorSanitizer.sanitize(t);
-        } catch (Throwable sanitizerError) {
-          safeError = t.getClass().getName();
+        currentScope = observabilityFacade.startExecutionScope(jobEntity);
+        if (wasJobCanceledDuringExecution()) {
+          handleCanceledDuringExecution(start);
+          return null;
         }
+
+        if (!resilienceStrategy.isServiceAvailable(resilienceServiceName)) {
+          log.infof(
+              "Job %s skipped - circuit breaker OPEN for service: %s",
+              jobId, resilienceServiceName);
+          rescheduleForCircuitBreaker(jobEntity, resilienceServiceName);
+          return null;
+        }
+
+        if (!tryAcquireResourcePermit()) {
+          return null;
+        }
+
+        // Authorization check before breaker scope — denial must not trip the circuit breaker
+        if (authorizationPolicy != null) {
+          authorizationPolicy.checkExecute(jobEntity.getId(), jobEntity.getCallerPrincipal());
+        }
+        // Validate before breaker scope — config errors must not trip the circuit breaker
+        validationFacade.validateSecurity(jobEntity.getPayload());
+
+        jobResult =
+            resilienceStrategy.execute(
+                resilienceServiceName, () -> runPayload(jobEntity.getPayload()));
+
+        if (wasJobCanceledDuringExecution()) {
+          handleCanceledDuringExecution(start);
+        } else {
+          handleSuccess(start, jobResult);
+        }
+      } catch (CircuitBreakerOpenException e) {
+        log.infof(
+            "Job %s rescheduled - circuit breaker OPEN for service: %s",
+            jobId, resilienceServiceName);
+        rescheduleForCircuitBreaker(jobEntity, resilienceServiceName, e);
+      } catch (Throwable t) {
         try {
-          if (jobStore.compareAndSwapStatus(
-              job.getId(), JobStatus.RUNNING, JobStatus.FAILED, safeError)) {
-            publishForcedTerminalFailure(t, safeError);
-          }
-        } catch (Throwable lastResort) {
+          handleFailure(t);
+        } catch (Throwable failureHandlingError) {
           log.errorf(
-              lastResort,
-              "Job %s could not be transitioned to FAILED — will require orphan recovery",
+              failureHandlingError,
+              "Job %s failure handling itself failed, forcing FAILED status",
               job.getId());
+          String safeError;
+          try {
+            safeError = errorSanitizer.sanitize(t);
+          } catch (Throwable sanitizerError) {
+            safeError = t.getClass().getName();
+          }
+          try {
+            if (jobStore.compareAndSwapStatus(
+                job.getId(), JobStatus.RUNNING, JobStatus.FAILED, safeError)) {
+              publishForcedTerminalFailure(t, safeError);
+            }
+          } catch (Throwable lastResort) {
+            log.errorf(
+                lastResort,
+                "Job %s could not be transitioned to FAILED — will require orphan recovery",
+                job.getId());
+          }
         }
+      } finally {
+        if (permitAcquired) {
+          releaseResourcePermit();
+        }
+        log.infof("Job %s execution complete - cleaning up context", jobId);
+        currentScope.close();
       }
     } finally {
-      if (permitAcquired) {
-        releaseResourcePermit();
-      }
-      log.infof("Job %s execution complete - cleaning up context", jobId);
-      currentScope.close();
       // Must be Throwable, not Exception — Error must still clear MDC. See
       // JobMdcContextThrowableTest
       JobMdcContext.clear();

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/LogPurgeTimer.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/LogPurgeTimer.java
@@ -37,6 +37,7 @@ public class LogPurgeTimer {
   private Cron cron;
   private ZoneId zone;
   private volatile boolean initialized;
+  private volatile boolean stopped = false;
 
   protected LogPurgeTimer() {
     this.jobLogStore = null;
@@ -80,7 +81,7 @@ public class LogPurgeTimer {
   }
 
   public void stop() {
-    // Cron-based scheduling uses one-shot delays; nothing to cancel between runs
+    stopped = true;
   }
 
   void run() {
@@ -117,7 +118,7 @@ public class LogPurgeTimer {
   }
 
   private void scheduleNext() {
-    if (!initialized) {
+    if (!initialized || stopped) {
       return;
     }
 

--- a/ratchet/src/main/java/run/ratchet/ri/payload/JobPayloadFactory.java
+++ b/ratchet/src/main/java/run/ratchet/ri/payload/JobPayloadFactory.java
@@ -35,8 +35,16 @@ public final class JobPayloadFactory {
 
   private static final Logger log = Logger.getLogger(JobPayloadFactory.class);
 
+  /**
+   * Fully-qualified name of the framework's coordination-only placeholder target ({@code
+   * run.ratchet.ri.util.JobPlaceholders}). Payloads pointing here are constructed internally (e.g.
+   * batch-parent rows), never invoke user code, and so are not subject to the application {@code
+   * ClassPolicy}.
+   */
+  static final String COORDINATION_PLACEHOLDER_TARGET = "run.ratchet.ri.util.JobPlaceholders";
+
   private static final JobPayload NOOP =
-      new JobPayload("run.ratchet.ri.util.JobPlaceholders", "noop", "()V", true, List.of());
+      new JobPayload(COORDINATION_PLACEHOLDER_TARGET, "noop", "()V", true, List.of());
 
   private static final int REFLECTION_CACHE_MAX_ENTRIES = 512;
 
@@ -123,6 +131,15 @@ public final class JobPayloadFactory {
 
   public static JobPayload noop() {
     return NOOP;
+  }
+
+  /**
+   * Returns true if {@code payload} targets the framework's internal coordination placeholder. Such
+   * payloads — the batch-parent {@link #noop()} — are framework-constructed and never invoke user
+   * code, so the persist-time {@code ClassPolicy} gate does not apply to them.
+   */
+  public static boolean isCoordinationPlaceholder(JobPayload payload) {
+    return payload != null && COORDINATION_PLACEHOLDER_TARGET.equals(payload.target());
   }
 
   private static String singleInvocationError(Serializable lambda, int stepCount) {

--- a/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
@@ -1,10 +1,13 @@
 package run.ratchet.ri.security;
 
+import java.util.Map;
+
 /**
- * Public entry point for masking sensitive fields (passwords, tokens, PII) in job payload JSON
- * before it is rendered into a log line or other output. Which fields are sensitive is decided by
- * the active {@link run.ratchet.spi.PayloadMaskingPolicy}; deployers can override the default field
- * set by producing their own policy. The original payload in the database is never modified.
+ * Public entry point for masking sensitive fields (passwords, tokens, PII) in job payload data
+ * before it is rendered into a log line or returned from a read API. Which fields are sensitive is
+ * decided by the active {@link run.ratchet.spi.PayloadMaskingPolicy}; deployers can override the
+ * default field set by producing their own policy. The original payload in the database is never
+ * modified.
  */
 public final class PayloadMasker {
 
@@ -20,5 +23,14 @@ public final class PayloadMasker {
    */
   public static String maskPayload(Object payload) {
     return run.ratchet.store.util.PayloadMasker.maskPayload(payload);
+  }
+
+  /**
+   * Masks the values of sensitive entries in a parameter map; a {@code null} or empty map is
+   * returned unchanged. Keys are matched against the active policy, so the original map is never
+   * modified.
+   */
+  public static Map<String, String> maskParams(Map<String, String> params) {
+    return run.ratchet.store.util.PayloadMasker.maskParams(params);
   }
 }

--- a/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
@@ -1,8 +1,10 @@
 package run.ratchet.ri.security;
 
 /**
- * Masks sensitive fields (passwords, tokens, PII) in job payload JSON before API/log exposure. The
- * original payload in the database is never modified.
+ * Public entry point for masking sensitive fields (passwords, tokens, PII) in job payload JSON
+ * before it is rendered into a log line or other output. Which fields are sensitive is decided by
+ * the active {@link run.ratchet.spi.PayloadMaskingPolicy}; deployers can override the default field
+ * set by producing their own policy. The original payload in the database is never modified.
  */
 public final class PayloadMasker {
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceExecutionTargetTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceExecutionTargetTest.java
@@ -1,5 +1,6 @@
 package run.ratchet.ri.core;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,6 +28,7 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.ri.core.internal.JobWakeupService;
 import run.ratchet.ri.payload.DefaultJobInvocationResolver;
 import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.spi.ClassPolicy;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.BatchStore;
@@ -113,6 +115,43 @@ class DefaultJobCreationServiceExecutionTargetTest {
     ArgumentCaptor<List<JobEntity>> childrenCaptor = ArgumentCaptor.forClass(List.class);
     verify(jobBulkStore).bulkInsert(childrenCaptor.capture());
     assertExecutionTarget(childrenCaptor.getValue(), ExecutorTargets.VIRTUAL);
+  }
+
+  @Test
+  void batchSubmit_doesNotGateFrameworkCoordinationPayloadThroughClassPolicy() {
+    // An application allowlists only its own packages, which do not cover the framework's
+    // coordination class. The batch-parent noop targets that framework class, so gating it would
+    // reject every batch submission. This policy allows the child target's package but not
+    // run.ratchet.ri.util (JobPlaceholders), isolating the parent-noop path.
+    ClassPolicy appPolicy =
+        className -> className != null && className.startsWith("run.ratchet.ri.core.");
+    DefaultJobCreationService gated =
+        new DefaultJobCreationService(
+            jobBatchStatusStore,
+            jobTerminalStore,
+            jobCrudStore,
+            jobBulkStore,
+            batchStore,
+            tagStore,
+            workflowConditionStore,
+            recurringJobStore,
+            new NoopJobWakeupService(),
+            recurringScheduler,
+            new DefaultJobInvocationResolver(),
+            new JobPayloadInputValidator(),
+            null,
+            null,
+            null,
+            appPolicy,
+            null,
+            null,
+            Clock.fixed(Instant.parse("2026-05-27T12:00:00Z"), ZoneOffset.UTC));
+
+    DefaultBatchBuilder builder = new DefaultBatchBuilder("batch", gated);
+    builder.forEach(
+        List.of("one", "two"), DefaultJobCreationServiceExecutionTargetTest::consumeString);
+
+    assertDoesNotThrow(() -> gated.submit(builder));
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
@@ -39,6 +39,7 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobSummary;
 import run.ratchet.api.JobType;
 import run.ratchet.api.QueueHealthSnapshot;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.spi.JobAuthorizationPolicy;
@@ -446,6 +447,56 @@ class DefaultJobQueryServiceTest {
     assertTrue(result.isPresent());
     assertEquals(jobId, result.get().summary().id());
     verify(authPolicy, never()).checkRead(any(), any());
+  }
+
+  @Test
+  void getJobDetail_masksSensitiveParams_whenMaskPayloadsEnabled() {
+    UUID jobId = UUID.randomUUID();
+    JobEntity entity = minimalJobWithId(jobId);
+    entity.setParams(Map.of("password", "hunter2", "host", "db"));
+    when(crudStore.findById(jobId)).thenReturn(Optional.of(entity));
+    when(executionStore.findExecutionsByJobId(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+    when(crudStore.findDependants(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    DefaultJobQueryService masking =
+        new DefaultJobQueryService(
+            queryStore,
+            crudStore,
+            executionStore,
+            recurringJobStore,
+            authPolicy,
+            principalProvider,
+            FIXED_CLOCK,
+            RatchetOptions.builder().security(s -> s.maskPayloads(true)).build());
+
+    Map<String, String> params = masking.getJobDetail(jobId).orElseThrow().params();
+
+    assertEquals(
+        "***REDACTED***",
+        params.get("password"),
+        "sensitive key must be redacted when masking is on");
+    assertEquals("db", params.get("host"), "non-sensitive key must survive masking unchanged");
+  }
+
+  @Test
+  void getJobDetail_leavesParamsRaw_whenMaskPayloadsDisabled() {
+    UUID jobId = UUID.randomUUID();
+    JobEntity entity = minimalJobWithId(jobId);
+    entity.setParams(Map.of("password", "hunter2", "host", "db"));
+    when(crudStore.findById(jobId)).thenReturn(Optional.of(entity));
+    when(executionStore.findExecutionsByJobId(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+    when(crudStore.findDependants(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    // `service` (from setUp) is built with default options, so masking is off.
+    Map<String, String> params = service.getJobDetail(jobId).orElseThrow().params();
+
+    assertEquals(
+        "hunter2", params.get("password"), "params must be raw when masking is off (default)");
+    assertEquals("db", params.get("host"));
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
@@ -481,6 +481,71 @@ class DefaultJobQueryServiceTest {
   }
 
   @Test
+  void getJobDetail_masksResultAndTraceContext_whenMaskPayloadsEnabled() {
+    UUID jobId = UUID.randomUUID();
+    JobEntity entity = minimalJobWithId(jobId);
+    entity.setTraceContext(Map.of("token", "abc123", "traceparent", "00-trace-span-01"));
+    entity.setJobResult("{\"password\":\"hunter2\",\"status\":\"OK\"}");
+    when(crudStore.findById(jobId)).thenReturn(Optional.of(entity));
+    when(executionStore.findExecutionsByJobId(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+    when(crudStore.findDependants(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    DefaultJobQueryService masking =
+        new DefaultJobQueryService(
+            queryStore,
+            crudStore,
+            executionStore,
+            recurringJobStore,
+            authPolicy,
+            principalProvider,
+            FIXED_CLOCK,
+            RatchetOptions.builder().security(s -> s.maskPayloads(true)).build());
+
+    JobDetail detail = masking.getJobDetail(jobId).orElseThrow();
+
+    assertEquals(
+        "***REDACTED***",
+        detail.traceContext().get("token"),
+        "sensitive trace-context key must be redacted when masking is on");
+    assertEquals(
+        "00-trace-span-01",
+        detail.traceContext().get("traceparent"),
+        "standard trace headers must survive masking unchanged");
+    assertTrue(
+        detail.jobResult().contains("***REDACTED***"),
+        "sensitive field in the serialized result must be redacted");
+    assertFalse(
+        detail.jobResult().contains("hunter2"),
+        "raw sensitive value must not survive in the masked result");
+    assertTrue(detail.jobResult().contains("OK"), "non-sensitive result fields must survive");
+  }
+
+  @Test
+  void getJobDetail_leavesResultAndTraceContextRaw_whenMaskPayloadsDisabled() {
+    UUID jobId = UUID.randomUUID();
+    JobEntity entity = minimalJobWithId(jobId);
+    entity.setTraceContext(Map.of("token", "abc123"));
+    entity.setJobResult("{\"password\":\"hunter2\"}");
+    when(crudStore.findById(jobId)).thenReturn(Optional.of(entity));
+    when(executionStore.findExecutionsByJobId(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+    when(crudStore.findDependants(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    // `service` (from setUp) is built with default options, so masking is off.
+    JobDetail detail = service.getJobDetail(jobId).orElseThrow();
+
+    assertEquals(
+        "abc123", detail.traceContext().get("token"), "trace context must be raw when masking off");
+    assertEquals(
+        "{\"password\":\"hunter2\"}",
+        detail.jobResult(),
+        "result must be raw when masking off (default)");
+  }
+
+  @Test
   void getJobDetail_leavesParamsRaw_whenMaskPayloadsDisabled() {
     UUID jobId = UUID.randomUUID();
     JobEntity entity = minimalJobWithId(jobId);

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
@@ -358,6 +358,7 @@ class DefaultJobQueryServiceTest {
 
     JobQueryCursor cursor = JobQueryCursor.decode(page.nextCursor());
     assertEquals(JobQuerySortField.CREATED_AT, cursor.sortField());
+    assertFalse(cursor.sortAscending(), "default filter sort is descending, so must round-trip");
     assertEquals(secondCreated.toString(), cursor.sortValue());
     assertEquals(secondId, cursor.jobId());
   }

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import org.jboss.logging.MDC;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -185,6 +186,30 @@ class JobTaskTest {
 
     verify(resilienceStrategy)
         .execute(eq(JobTaskTest.class.getSimpleName() + ".testJobMethod"), any(Callable.class));
+  }
+
+  @Test
+  void call_clearsBoundContextWhenStartupObservabilityThrows() {
+    // JobContext/MDC are bound before the per-execution try/finally that clears them. A throw from
+    // the startup observability calls must not leave this job's identity on the pooled worker.
+    JobMdcContext.clear();
+    JobEntity job = createTestJob();
+    jobTask.init(job);
+    when(nodeIdProvider.getNodeId()).thenReturn("node-1");
+    doThrow(new RuntimeException("metrics collector down"))
+        .when(observabilityFacade)
+        .recordJobStart(any(JobEntity.class));
+
+    // The startup failure propagates: the payload never ran, so orphan recovery retries the job.
+    Assertions.assertThrows(RuntimeException.class, () -> jobTask.call());
+
+    Assertions.assertNull(
+        MDC.get(JobMdcContext.MDC_JOB_ID),
+        "MDC job id must be cleared after a startup failure, not leaked to the next job");
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        JobContext::current,
+        "JobContext must be unbound after a startup failure, not leaked to the next job");
   }
 
   @Test

--- a/website/docs/advanced/circuit-breakers.md
+++ b/website/docs/advanced/circuit-breakers.md
@@ -115,7 +115,6 @@ General-purpose profile for internal services.
 | Failure rate threshold | 50% |
 | Sliding window size | 100 calls |
 | Wait duration (OPEN) | 30 seconds |
-| Slow call threshold | 10 seconds |
 | Permitted calls in HALF_OPEN | 3 |
 | Minimum calls before evaluation | 5 |
 
@@ -128,7 +127,6 @@ Aggressive failure detection for latency-sensitive paths.
 | Failure rate threshold | 50% |
 | Sliding window size | 20 calls |
 | Wait duration (OPEN) | 10 seconds |
-| Slow call threshold | 2 seconds |
 | Permitted calls in HALF_OPEN | 2 |
 | Minimum calls before evaluation | 3 |
 
@@ -141,7 +139,6 @@ Conservative profile for high-availability services where false positives are co
 | Failure rate threshold | 75% |
 | Sliding window size | 200 calls |
 | Wait duration (OPEN) | 60 seconds |
-| Slow call threshold | 30 seconds |
 | Permitted calls in HALF_OPEN | 5 |
 | Minimum calls before evaluation | 10 |
 
@@ -154,7 +151,6 @@ Tuned for third-party integrations with higher latency tolerance and longer reco
 | Failure rate threshold | 60% |
 | Sliding window size | 50 calls |
 | Wait duration (OPEN) | 60 seconds |
-| Slow call threshold | 5 seconds |
 | Permitted calls in HALF_OPEN | 3 |
 | Minimum calls before evaluation | 5 |
 
@@ -167,7 +163,6 @@ Internal profile used by the poller when claiming work from the store. It trips 
 | Failure rate threshold | 50% |
 | Sliding window size | 20 calls |
 | Wait duration (OPEN) | 5 seconds |
-| Slow call threshold | 2 seconds |
 | Permitted calls in HALF_OPEN | 1 |
 | Minimum calls before evaluation | 5 |
 
@@ -182,7 +177,6 @@ RatchetOptions.builder()
             .failureRateThreshold(60)
             .slidingWindowSize(50)
             .waitDurationMs(20_000)
-            .slowCallThresholdMs(5_000)
             .permittedCallsInHalfOpen(5)
             .minimumCalls(10))
         .profile(CircuitBreakerProfile.EXTERNAL_API, p -> p
@@ -238,7 +232,7 @@ CircuitBreaker breaker = registry.getBreaker("my-service");
 // Get or create with a specific profile
 CircuitBreaker breaker = registry.getBreaker("my-service", CircuitBreakerProfile.FAST);
 
-// Check current state (returns null if breaker not yet created)
+// Check current state (lazily creates the breaker if absent, returning CLOSED)
 CircuitBreaker.State state = registry.getBreakerState("my-service");
 
 // Manually open a circuit (e.g., during maintenance)
@@ -252,7 +246,6 @@ registry.registerConfig("custom", new CircuitBreakerConfiguration(
     40.0f,   // failureRateThreshold
     30,      // slidingWindowSize
     45_000L, // waitDurationMs
-    8_000L,  // slowCallThresholdMs
     4,       // permittedCallsInHalfOpen
     8        // minimumCalls
 ));

--- a/website/docs/advanced/custom-retry-policies.md
+++ b/website/docs/advanced/custom-retry-policies.md
@@ -18,7 +18,7 @@ When a job fails, the engine evaluates retry eligibility through a pipeline:
 
 3. **Max retries check** -- If the job has exhausted its configured `maxRetries`, it moves to the dead letter flow.
 
-4. **Delay calculation** -- The delay before the next attempt is the *maximum* of the job's backoff policy delay and the `RetryPolicy.getDelay()` value.
+4. **Delay calculation** -- The `RetryPolicy.getDelay()` value takes precedence. If it returns a non-zero `Duration`, that value is used directly as the delay before the next attempt. Only when it returns `Duration.ZERO` does the engine fall back to the job's backoff policy delay.
 
 ## RetryPolicy SPI Interface
 
@@ -78,10 +78,12 @@ The job-level `BackoffPolicy` enum controls the delay pattern between retries:
 | `FIXED` | Constant delay | 1s, 1s, 1s, ... |
 | `EXPONENTIAL` | Doubling delay with 24-hour cap | 1s, 2s, 4s, 8s, ... |
 
-When a custom `RetryPolicy` returns a non-zero delay from `getDelay()`, the engine uses the **maximum** of the backoff policy delay and the SPI delay. This means your custom policy can impose a minimum wait time without overriding the backoff escalation:
+When a custom `RetryPolicy` returns a non-zero delay from `getDelay()`, the engine uses **that value directly** and ignores the job's backoff policy. The backoff policy is consulted only when the SPI returns `Duration.ZERO`. This means a custom policy that returns a non-zero delay takes full control of the wait time and overrides the backoff escalation:
 
 ```
-Final delay = max(BackoffPolicyHandler.computeDelay(policy, baseMs, attempt), retryPolicy.getDelay(attempt))
+Final delay = retryPolicy.getDelay(attempt).isZero()
+    ? BackoffPolicyHandler.computeDelay(policy, baseMs, attempt)
+    : retryPolicy.getDelay(attempt)
 ```
 
 ## @DoNotRetry Annotation

--- a/website/docs/advanced/metrics-collection.md
+++ b/website/docs/advanced/metrics-collection.md
@@ -133,7 +133,7 @@ The Micrometer adapter publishes the following metrics:
 |-------------|------|-------------|
 | `ratchet.jobs.started` | `type`, `priority` | Incremented each time a job begins execution |
 | `ratchet.jobs.completed` | `type` | Incremented each time a job completes successfully |
-| `ratchet.jobs.failed` | `type`, `exception` | Incremented each time a job fails. The `exception` tag contains the simple class name of the causing exception. |
+| `ratchet.jobs.failed` | `type`, `family` | Incremented each time a job fails. The `family` tag contains the `ExceptionFamily` classification of the causing exception (`TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, or `UNKNOWN`). |
 
 #### Timers
 
@@ -145,14 +145,14 @@ The Micrometer adapter publishes the following metrics:
 
 The `type` tag corresponds to `JobType` enum values:
 
-- `SINGLE` -- One-time fire-and-forget jobs
+- `SINGLE` -- One-shot background task executed once and not rescheduled
 - `RECURRING` -- Cron-scheduled or interval-based jobs
-- `BATCH_CHILD` -- Individual items within a batch
-- `BATCH_PARENT` -- Batch parent coordination jobs
-- `CHAIN_STEP` -- Steps in a job chain
-- `WORKFLOW_BRANCH` -- Branches in a workflow
+- `BATCH` -- Batch-processing job comprising multiple child items
+- `CHAIN` -- A sequenced chain of tasks executed in order
+- `WORKFLOW` -- Workflow-driven execution with conditional branches or join semantics
+- `SYSTEM` -- Scheduler-managed system work, not user-creatable
 
-The `priority` tag corresponds to `JobPriority` enum values (`LOW`, `NORMAL`, `HIGH`, `CRITICAL`).
+The `priority` tag corresponds to `JobPriority` enum values (`LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL`).
 
 ### Prometheus Scrape Endpoint Example
 
@@ -191,8 +191,8 @@ rate(ratchet_jobs_started_total[5m])
 rate(ratchet_jobs_completed_total[5m])
   / rate(ratchet_jobs_started_total[5m])
 
-# Failure rate by exception type
-rate(ratchet_jobs_failed_total[5m])
+# Failure rate by exception family
+sum by (family) (rate(ratchet_jobs_failed_total[5m]))
 
 # P95 execution time
 histogram_quantile(0.95, rate(ratchet_jobs_duration_seconds_bucket[5m]))
@@ -317,13 +317,13 @@ Use the metrics to set up alerts for common operational issues:
 | Failure rate > 50% over 5 minutes | Critical: job processing is degraded |
 | P95 execution time > 2x baseline | Warning: job execution slowdown |
 | No jobs started in 15 minutes (when expected) | Critical: scheduler may be stalled |
-| `ratchet.jobs.failed` with specific `exception` tag spikes | Investigate the failing exception type |
+| `ratchet.jobs.failed` with a specific `family` tag spikes | Investigate the failing exception family |
 
 ## Best Practices
 
 **Use tags for dimensionality, not metric names.** Prefer `ratchet.jobs.started{type=SINGLE}` over `ratchet.single_jobs.started`. Tags enable flexible aggregation and filtering in dashboards.
 
-**Keep exception tags bounded.** The Micrometer adapter uses the exception's simple class name as a tag. If your application throws many dynamically-generated exception types, this could create high-cardinality metrics. Consider normalizing exception names in a custom collector.
+**Keep exception tags bounded.** The Micrometer adapter classifies failures into the bounded `ExceptionFamily` enum (`TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, `UNKNOWN`) for the `family` tag, so its cardinality stays fixed. If a custom collector instead tags by the exception's class name and your application throws many dynamically-generated exception types, this could create high-cardinality metrics. Consider normalizing exception names in that case.
 
 **Monitor attempt counts.** A spike in `attempt > 1` failures indicates that retries are being consumed. Pair this with retry policy metrics to understand whether jobs are eventually succeeding or exhausting retries.
 

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -646,7 +646,8 @@ public interface JobStore
             BatchMetricsStore,   // Batch-level metrics
             DlqAlertStore,       // Dead letter queue alerting
             ResourcePermitStore, // Resource permit management
-            SignalStore          // Signal-waiting delivery and timeout operations
+            SignalStore,         // Signal-waiting delivery and timeout operations
+            RecurringJobStore    // Recurring-master persistence (claim, advance, cancel/archive)
 { }
 ```
 
@@ -676,6 +677,7 @@ Ratchet ships with MySQL, PostgreSQL, and MongoDB implementations. To implement 
 | `DlqAlertStore` | DLQ alerting | `saveDlqAlert()`, `existsRecentDlqAlert()` |
 | `ResourcePermitStore` | Resource permits | `tryAcquirePermit()`, `releasePermit()` |
 | `SignalStore` | Signal-waiting jobs | `deliverSignalById()`, `deliverSignalByKey()`, `findTimedOutSignalJobs()` |
+| `RecurringJobStore` | Recurring-master persistence | `claimDueRecurring()`, `advanceNextFire()`, `cancelRecurringAndArchive()` |
 
 ### Implementing a Custom Store
 

--- a/website/docs/api-reference/batch-builder.md
+++ b/website/docs/api-reference/batch-builder.md
@@ -234,13 +234,10 @@ Obtained from [`JobSchedulerService.streamingBatch()`](./job-scheduler-service#s
 ### fromStream
 
 ```java
-<U extends Serializable> StreamingBatchBuilder<U> fromStream(Stream<U> stream)
+StreamingBatchBuilder<T> fromStream(Stream<T> stream)
 ```
 
-Sets the input data source for the batch.
-
-**Type Parameters:**
-- `U` -- the type of items; must implement `Serializable`.
+Sets the input data source for the batch. The stream item type `T` is fixed when the builder is created via [`streamingBatch()`](./job-scheduler-service#streamingbatch) and must implement `Serializable`.
 
 **Parameters:**
 - `stream` -- the stream of items to process.

--- a/website/docs/api-reference/batch-context.md
+++ b/website/docs/api-reference/batch-context.md
@@ -153,31 +153,7 @@ public record StreamingBatchContext(
 | `processedItems` | `int` | Cumulative number of items read from the stream |
 | `chunksInserted` | `int` | Number of bulk insert operations performed |
 
-### Convenience Methods
-
-#### itemsStreamed
-
-```java
-public int itemsStreamed()
-```
-
-Alias for `processedItems()`. Returns the number of items read from the stream so far.
-
-```java
-int streamed = ctx.itemsStreamed(); // same as ctx.processedItems()
-```
-
-#### insertOperations
-
-```java
-public int insertOperations()
-```
-
-Alias for `chunksInserted()`. Returns the number of bulk insert operations performed.
-
-```java
-int ops = ctx.insertOperations(); // same as ctx.chunksInserted()
-```
+`StreamingBatchContext` is a bare record. Read its progress values directly through the canonical accessors `processedItems()` and `chunksInserted()`.
 
 ### Usage
 

--- a/website/docs/api-reference/event-system.md
+++ b/website/docs/api-reference/event-system.md
@@ -162,24 +162,6 @@ public void onRetrying(@Observes JobRetryingEvent event) {
 }
 ```
 
-### JobCancellingEvent
-
-Fired when a job cancellation is initiated (before the state transition completes).
-
-```java
-public class JobCancellingEvent extends AbstractJobCancellationEvent
-```
-
-```java
-public String getPreviousStatus()
-public Long getExecutionTimeMs()
-```
-
-| Method | Return Type | Description |
-|---|---|---|
-| `getPreviousStatus()` | `String` | Status before cancellation |
-| `getExecutionTimeMs()` | `Long` | Execution duration in milliseconds when known |
-
 ### JobCancelledEvent
 
 Fired when a job cancellation is confirmed.
@@ -201,6 +183,32 @@ public Long getExecutionTimeMs()
 ```java
 public void onCancelled(@Observes JobCancelledEvent event) {
     log.info("Job {} canceled", event.getJobId());
+}
+```
+
+### JobsBulkCancelledEvent
+
+Fired exactly once per successful bulk cancel-by-tag operation, when at least one job was cancelled. Produced by [`cancelJobsByTag()`](./job-scheduler-service) and [`cancelRecurringJobsByTag()`](./job-scheduler-service).
+
+Bulk cancellation does not carry a single job id, business key, or priority, so this event does **not** extend `AbstractJobSchedulerEvent`.
+
+```java
+public class JobsBulkCancelledEvent implements Serializable {
+    public String getTag()
+    public int getCount()
+    public Instant getCancelledAt()
+}
+```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getTag()` | `String` | Tag used to select jobs for cancellation |
+| `getCount()` | `int` | Number of jobs successfully cancelled |
+| `getCancelledAt()` | `Instant` | When the bulk operation completed |
+
+```java
+public void onBulkCancelled(@Observes JobsBulkCancelledEvent event) {
+    log.info("Cancelled {} jobs tagged {}", event.getCount(), event.getTag());
 }
 ```
 
@@ -244,6 +252,34 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
 public void onDlq(@Observes JobDlqEvent event) {
     alertService.sendDlqAlert(event.getJobId(), event.getErrorMessage());
     metrics.counter("jobs.dlq").increment();
+}
+```
+
+### JobCallbackFailedEvent
+
+Fired when a lifecycle callback (`onSuccess` / `onFailure`) throws an exception. The callback failure does not affect the job's recorded outcome.
+
+```java
+public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
+    public CallbackType getCallbackType()
+    public String getErrorMessage()
+    public String getCauseClassName()
+    public int getCallbackAttempt()
+}
+```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getCallbackType()` | `CallbackType` | Which callback failed: `ON_SUCCESS` or `ON_FAILURE` |
+| `getErrorMessage()` | `String` | Message from the thrown callback exception (may be null) |
+| `getCauseClassName()` | `String` | Class name of the thrown callback exception |
+| `getCallbackAttempt()` | `int` | 1-based callback invocation attempt |
+
+```java
+public void onCallbackFailed(@Observes JobCallbackFailedEvent event) {
+    log.warn("Job {} {} callback failed: {} ({})",
+        event.getJobId(), event.getCallbackType(),
+        event.getErrorMessage(), event.getCauseClassName());
 }
 ```
 
@@ -347,7 +383,7 @@ public void onChainFailed(@Observes ChainFailedEvent event) {
 }
 ```
 
-## Workflow and Observability Events
+## Workflow Events
 
 ### WorkflowBranchTriggeredEvent
 
@@ -367,43 +403,89 @@ public UUID getNextJobId()
 | `getBranchCondition()` | `String` | Description of the branch condition that matched |
 | `getNextJobId()` | `UUID` | Child job ID scheduled for the branch |
 
-### PerformanceMetricsEvent
+## Signal Events
 
-System-level performance metrics snapshot. Unlike other events, this does **not** extend `AbstractJobSchedulerEvent` because it represents aggregate system metrics, not a per-job event.
+These events accompany the [signal-waiting job](./job-scheduler-service) lifecycle (`WAITING` status and `deliverSignal()`).
 
-```java
-public record PerformanceMetricsEvent(
-    Map<String, Object> performanceData
-) implements Serializable
-```
+### JobSignalWaitingEvent
 
-The `performanceData` map is defensively copied and immutable after construction. Keys and values must be non-null and serializable by your event transport.
-
-The `performanceData` map typically contains:
-
-| Key | Type | Description |
-|---|---|---|
-| `queueDepth` | Number | Pending jobs in the queue |
-| `readyJobs` | Number | Jobs ready for immediate execution |
-| `oldestJobAge` | Number | Age of oldest pending job (seconds) |
-| `processingRate` | Number | Jobs processed per minute |
-| `successRate` | Number | Percentage of successful completions |
-| `avgDuration` | Number | Average execution duration (ms) |
-| `threadUtilization` | Number | Thread pool utilization percentage |
-| `activeThreads` | Number | Currently active worker threads |
-| `queuedTasks` | Number | Tasks waiting in thread pool queue |
-| `cpuUsage` | Number | CPU utilization |
-| `memoryUsage` | Number | Memory usage (bytes) |
-| `memoryPercent` | Number | Memory as percentage of available |
+Fired when a job has been created in `WAITING` state, blocked on a named signal.
 
 ```java
-public void onMetrics(@Observes PerformanceMetricsEvent event) {
-    Map<String, Object> data = event.performanceData();
-    dashboard.update("queue_depth", data.get("queueDepth"));
-    dashboard.update("processing_rate", data.get("processingRate"));
-    dashboard.update("success_rate", data.get("successRate"));
+public class JobSignalWaitingEvent extends AbstractJobSchedulerEvent {
+    public String getSignalKey()
+    public Duration getSignalTimeout()
 }
 ```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getSignalKey()` | `String` | Signal key the job is waiting on |
+| `getSignalTimeout()` | `Duration` | Maximum wait duration, or null for no timeout |
+
+### JobSignaledEvent
+
+Fired after a signal is successfully delivered to a `WAITING` job, transitioning it to `PENDING`. Published only on a successful delivery; a delivery that finds the job already terminal or non-`WAITING` produces no event.
+
+```java
+public class JobSignaledEvent extends AbstractJobSchedulerEvent {
+    public String getSignalKey()
+    public String getSignalDeliveredBy()
+    public SignalDecision.Outcome getOutcome()
+    public String getRejectionReason()
+}
+```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getSignalKey()` | `String` | Signal key delivered to the waiting job |
+| `getSignalDeliveredBy()` | `String` | Principal or component that delivered the signal |
+| `getOutcome()` | `SignalDecision.Outcome` | Approval/rejection outcome |
+| `getRejectionReason()` | `String` | Rejection reason, or null when approved |
+
+### JobsBulkSignaledEvent
+
+Fired exactly once per successful key-based signal delivery when at least one `WAITING` job is unblocked. Like [`JobsBulkCancelledEvent`](#jobsbulkcancelledevent), a key-based delivery can unblock many jobs, so this event does **not** extend `AbstractJobSchedulerEvent`.
+
+```java
+public class JobsBulkSignaledEvent implements Serializable {
+    public String getSignalKey()
+    public int getCount()
+    public String getSignalDeliveredBy()
+    public SignalDecision.Outcome getOutcome()
+    public String getRejectionReason()
+    public Instant getSignaledAt()
+}
+```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getSignalKey()` | `String` | Signal key that was delivered |
+| `getCount()` | `int` | Number of WAITING jobs unblocked |
+| `getSignalDeliveredBy()` | `String` | Principal or component that delivered the signal |
+| `getOutcome()` | `SignalDecision.Outcome` | Approval/rejection outcome |
+| `getRejectionReason()` | `String` | Rejection reason, or null when approved |
+| `getSignaledAt()` | `Instant` | When the signal was delivered |
+
+### JobSignalTimedOutEvent
+
+Fired when a `WAITING` job's signal timeout elapses and it is transitioned to `FAILED`.
+
+```java
+public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
+    public String getSignalKey()
+    public Duration getSignalTimeout()
+}
+```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getSignalKey()` | `String` | Signal key the job was waiting on |
+| `getSignalTimeout()` | `Duration` | Configured maximum wait duration that elapsed (never null) |
+
+## System Metrics
+
+Ratchet does not publish aggregate system-metrics through the event listener API. For per-job metrics (start, completion, failure, retry timings), implement the [`MetricsCollector`](./spi-interfaces#metricscollector) SPI and wire it to your monitoring backend (Micrometer, StatsD, Prometheus, etc.).
 
 ## Example: Comprehensive Monitoring
 
@@ -443,12 +525,9 @@ public class SchedulerMonitoring {
             (double) e.getCompletedItems() / Math.max(e.getTotalItems(), 1));
     }
 
-    public void onMetrics(@Observes PerformanceMetricsEvent e) {
-        e.performanceData().forEach((key, value) -> {
-            if (value instanceof Number num) {
-                metrics.gauge("scheduler." + key, num.doubleValue());
-            }
-        });
+    public void onBulkCancelled(@Observes JobsBulkCancelledEvent e) {
+        metrics.counter("jobs.cancelled.bulk", "tag", e.getTag())
+            .increment(e.getCount());
     }
 }
 ```

--- a/website/docs/api-reference/job-scheduler-service.md
+++ b/website/docs/api-reference/job-scheduler-service.md
@@ -229,9 +229,9 @@ boolean pauseJob(UUID jobId)
 
 Pauses a job, preventing it from being picked up for execution.
 
-- Only **PENDING** or **FAILED** jobs can be paused.
+- Only **PENDING** jobs can be paused.
 - The job's previous status is recorded so it can be restored on resume.
-- **RUNNING** jobs cannot be paused (cancel them instead).
+- Jobs in **RUNNING**, **WAITING**, or terminal states cannot be paused.
 - **Idempotent:** pausing an already-PAUSED job returns `true` without error.
 
 **Parameters:**
@@ -255,7 +255,6 @@ Resumes a paused job, making it eligible for execution again.
 
 - The job returns to the status it had before being paused.
 - Resuming a previously **PENDING** job makes it eligible for polling again.
-- Resuming a previously **FAILED** job restores it to FAILED without retrying.
 - **Idempotent:** resuming a non-paused job returns `false` without error.
 
 **Parameters:**

--- a/website/docs/api-reference/overview.md
+++ b/website/docs/api-reference/overview.md
@@ -67,7 +67,6 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`JobCompletedEvent`](./event-system#jobcompletedevent) | Job completes successfully |
 | [`JobFailedEvent`](./event-system#jobfailedevent) | Job fails after final attempt |
 | [`JobRetryingEvent`](./event-system#jobretryingevent) | Job is being retried |
-| [`JobCancellingEvent`](./event-system#jobcancellingevent) | Job cancellation initiated |
 | [`JobCancelledEvent`](./event-system#jobcancelledevent) | Job cancellation confirmed |
 | [`JobPausedEvent`](./event-system#jobpausedevent) | Job paused |
 | [`JobResumedEvent`](./event-system#jobresumedevent) | Job resumed |
@@ -81,7 +80,6 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`ChainCompletedEvent`](./event-system#chainevent-types) | Workflow chain succeeds |
 | [`ChainFailedEvent`](./event-system#chainevent-types) | Workflow chain fails |
 | [`WorkflowBranchTriggeredEvent`](./event-system#workflowbranchtriggeredevent) | A workflow condition matches |
-| [`PerformanceMetricsEvent`](./event-system#performancemetricsevent) | System metrics snapshot available |
 
 ### `run.ratchet.spi` — Extension Points
 

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -422,7 +422,7 @@ public class VirtualThreadExecutorProvider implements ExecutorProvider {
 
 ## BeanResolver
 
-Resolves bean instances by type, abstracting the dependency injection mechanism. The CDI implementation delegates to `CDI.current().select(type).get()`. The default RI implementation uses reflection.
+Resolves bean instances by type, abstracting the dependency injection mechanism. The default RI implementation, `CdiBeanResolver`, delegates to a CDI `Instance<Object>` (`select(type).get()`).
 
 :::info
 This interface is marked `@Incubating` and may change.

--- a/website/docs/comparison/vs-spring-batch.md
+++ b/website/docs/comparison/vs-spring-batch.md
@@ -68,10 +68,11 @@ scheduler.enqueueBatch("invoices")
     .submit();
 
 // Streaming batch: chunked iteration over a large dataset
-scheduler.enqueueStreamingBatch("monthly-report")
-    .chunked(invoiceRepository::findUnprocessed, 1000)
+scheduler.streamingBatch("monthly-report")
+    .fromStream(invoiceRepository.streamUnprocessed())
     .process(this::generateReportEntry)
-    .submit();
+    .withChunkSize(1000)
+    .start();
 ```
 
 For a lot of real "process a big dataset" work, these are enough on their own. Chunked iteration, parallel execution across worker JVMs (every item is a persisted child job that any worker can claim), progress tracking, per-item retries, automatic recovery from worker crashes via the `OrphanRecoveryTimer`, persisted state so you can see what's been processed. Don't undersell that. The streaming batch primitive will handle millions of rows of straightforward "read, transform, write" without breaking a sweat.

--- a/website/docs/concepts/error-handling.md
+++ b/website/docs/concepts/error-handling.md
@@ -205,7 +205,7 @@ The failure callback is invoked **only on permanent failure** (DLQ entry), not o
 |-------|------|------------|
 | `JobRetryingEvent` | Each retry attempt | `jobId`, `errorMessage`, `attemptCount`, `nextScheduledTime` |
 | `JobDlqEvent` | Permanent failure (DLQ entry) | `jobId`, `errorMessage`, `attemptCount` |
-| `JobFailedEvent` | Any failure (retry or permanent) | `jobId`, `errorMessage` |
+| `JobFailedEvent` | Terminal failure only (job reaches FAILED state) -- not fired on retryable attempts | `jobId`, `errorMessage`, `retryAttempt` |
 
 ## Circuit Breaker Integration
 

--- a/website/docs/concepts/job-lifecycle.md
+++ b/website/docs/concepts/job-lifecycle.md
@@ -64,7 +64,7 @@ Every job in Ratchet follows a well-defined state machine from creation to termi
       <small>Automatic retry with backoff, or manual `retryJob()` reset.</small>
     </div>
     <div className="docs-diagram-card">
-      <strong>PENDING/FAILED -> PAUSED</strong>
+      <strong>PENDING -> PAUSED</strong>
       <small>`pauseJob()` records `paused_from_status` for accurate resume.</small>
     </div>
     <div className="docs-diagram-card">
@@ -108,14 +108,15 @@ The job threw an exception during execution. A FAILED job may or may not have re
 
 Transitions:
 - **Back to PENDING:** Automatic retry (retries remain) or manual `retryJob()` call
-- **To PAUSED:** Via `pauseJob()` (records `pausedFromStatus = FAILED`)
+
+A FAILED job cannot be paused -- it is terminal, so `pauseJob()` returns `false`.
 
 ### PAUSED
 
 The job is temporarily suspended and invisible to the Poller. The `paused_from_status` column records the state the job had before pausing, so it can be accurately restored.
 
 - **Visible to Poller:** No
-- **Transitions to:** Previous state via `resumeJob()` -- restores PENDING or FAILED
+- **Transitions to:** Previous state via `resumeJob()` -- restores PENDING
 - **Idempotent:** Pausing an already-paused job returns `true` without error
 
 ### WAITING
@@ -214,15 +215,14 @@ When retries are exhausted or `@DoNotRetry` applies:
 Pausing suspends a job without losing its state:
 
 ```java
-scheduler.pauseJob(jobId);   // PENDING or FAILED -> PAUSED
+scheduler.pauseJob(jobId);   // PENDING -> PAUSED
 scheduler.resumeJob(jobId);  // PAUSED -> original state
 ```
 
 The `paused_from_status` field preserves context:
 - A paused PENDING job resumes to PENDING (eligible for polling again)
-- A paused FAILED job resumes to FAILED (can then be manually retried)
 
-Only PENDING and FAILED jobs can be paused. RUNNING jobs cannot be paused -- cancel them instead.
+Only PENDING jobs can be paused. FAILED is terminal, so `pauseJob()` returns `false` for it; RUNNING jobs cannot be paused -- cancel them instead.
 
 ### Manual Retry
 

--- a/website/docs/concepts/overview.md
+++ b/website/docs/concepts/overview.md
@@ -269,7 +269,7 @@ Ratchet uses a **pull model** where worker threads poll the database for availab
 
 ### Store as the Queue
 
-Unlike message-broker-based schedulers, Ratchet uses your selected store backend as the job queue. SQL stores keep jobs in the `scheduler_job` table and claim with `SELECT ... FOR UPDATE SKIP LOCKED`; MongoDB keeps jobs in the `scheduler_job` collection and claims with atomic document updates. This gives you:
+Unlike message-broker-based schedulers, Ratchet uses your selected store backend as the job queue. SQL stores split storage across a cold `scheduler_job` metadata table and a hot `scheduler_job_queue` table that holds live state and is claimed with `SELECT ... FOR UPDATE SKIP LOCKED`; MongoDB keeps jobs in the `scheduler_job` collection and claims with atomic document updates. This gives you:
 
 - **Transactional enqueueing** -- SQL job creation participates in your existing transaction; MongoDB uses store-level atomic writes
 - **Durability** -- jobs survive application restarts

--- a/website/docs/deployment/cluster-configuration.md
+++ b/website/docs/deployment/cluster-configuration.md
@@ -272,8 +272,9 @@ ORDER BY started_at;
 ### Jobs Per Node
 
 ```sql
+-- picked_by / RUNNING are live state on scheduler_job_queue.
 SELECT picked_by AS node, COUNT(*) AS running_jobs
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE status = 'RUNNING'
 GROUP BY picked_by;
 ```

--- a/website/docs/deployment/clustering.md
+++ b/website/docs/deployment/clustering.md
@@ -73,7 +73,7 @@ Ratchet provides two claim paths:
 | Method | Returns | Use case |
 |--------|---------|----------|
 | `claimNextBatch(limit, nodeId)` | Full `JobEntity` with payload | When you need the complete job immediately |
-| `claimNextBatchOptimized(limit, nodeId)` | Lightweight `JobClaimDto` | When you want to claim fast and load payloads lazily |
+| `claimNextBatchOptimized(jobType, limit, nodeId)` | Lightweight `JobClaimDto` | When you want to claim fast and load payloads lazily |
 
 The optimized path skips deserializing large payload blobs during the claim query, reducing lock hold time in high-throughput clusters.
 
@@ -125,9 +125,10 @@ The `NodeStore.getDatabaseTime()` method returns the database server's current t
 By default, each node polls on its own interval. For time-sensitive jobs (CRITICAL priority, immediate submissions), Ratchet supports cross-node wakeup via the `ClusterCoordinator` SPI:
 
 ```java
-public interface ClusterCoordinator {
-    void notifyNewWork(JobPriority priority);
-    void registerWakeupListener(Runnable listener);
+public interface ClusterCoordinator extends AutoCloseable {
+    void notifyNewWork(JobPriority priority, NodeIdentity source);
+    void registerWakeupListener(BiConsumer<JobPriority, NodeIdentity> listener);
+    void close();
 }
 ```
 
@@ -161,7 +162,8 @@ Out of the box, Ratchet uses `NoOpClusterCoordinator`. That is fine for any depl
 public class JGroupsClusterCoordinator implements ClusterCoordinator {
 
     private JChannel channel;
-    private final List<Runnable> listeners = new CopyOnWriteArrayList<>();
+    private final List<BiConsumer<JobPriority, NodeIdentity>> listeners =
+        new CopyOnWriteArrayList<>();
 
     @PostConstruct
     void init() throws Exception {
@@ -169,14 +171,15 @@ public class JGroupsClusterCoordinator implements ClusterCoordinator {
         channel.setReceiver(new ReceiverAdapter() {
             @Override
             public void receive(Message msg) {
-                listeners.forEach(Runnable::run);
+                NodeIdentity sender = new NodeIdentity(msg.getSrc().toString());
+                listeners.forEach(l -> l.accept(JobPriority.CRITICAL, sender));
             }
         });
         channel.connect("ratchet-cluster");
     }
 
     @Override
-    public void notifyNewWork(JobPriority priority) {
+    public void notifyNewWork(JobPriority priority, NodeIdentity source) {
         try {
             channel.send(new ObjectMessage(null, "WAKEUP"));
         } catch (Exception e) {
@@ -185,8 +188,15 @@ public class JGroupsClusterCoordinator implements ClusterCoordinator {
     }
 
     @Override
-    public void registerWakeupListener(Runnable listener) {
+    public void registerWakeupListener(BiConsumer<JobPriority, NodeIdentity> listener) {
         listeners.add(listener);
+    }
+
+    @Override
+    public void close() {
+        if (channel != null) {
+            channel.close();
+        }
     }
 }
 ```

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -138,8 +138,8 @@ create-jdbc-resource --connectionpoolid=RatchetPool java:/RatchetDS
 
 - Ratchet uses `SKIP LOCKED` for lock-free job claiming across multiple nodes
 - Generated columns extract `target_class` and `method_name` from the JSON payload
-- A partial unique index enforces business key uniqueness for active jobs only (`PENDING`, `RUNNING`, `PAUSED`)
-- JSONB is not used for the payload column (it uses TEXT), but you can query parameters via casting: `payload::jsonb ->> 'target'`
+- Business key uniqueness for active jobs is enforced by the `scheduler_business_key_reservation` table, not by an index on `scheduler_job`
+- The payload column uses `JSONB`, so you can query parameters directly: `payload ->> 'target'`
 
 ## MySQL
 
@@ -221,7 +221,7 @@ MySQL defaults to `REPEATABLE READ`, which acquires gap locks on `SELECT ... FOR
 - Uses `ENUM` types for status, job type, and backoff policy columns
 - Uses `JSON` column type for payload, params, and result data
 - `GENERATED ALWAYS AS ... STORED` columns extract `target_class` and `method_name` from payload JSON
-- `active_business_key` is a generated column that enforces uniqueness only for active jobs
+- Business key uniqueness for active jobs is enforced by the `scheduler_business_key_reservation` table, not by a column on `scheduler_job`
 - All tables use `InnoDB` engine with `utf8mb4_unicode_ci` collation
 
 ## MongoDB
@@ -273,7 +273,7 @@ db.scheduler_job.createIndex(
     name: "idx_job_active_business_key",
     unique: true,
     partialFilterExpression: {
-      status: { $in: ["PENDING", "RUNNING", "PAUSED"] },
+      status: { $in: ["PENDING", "RUNNING", "PAUSED", "WAITING"] },
       business_key: { $type: "string" }
     }
   }

--- a/website/docs/deployment/mongodb.md
+++ b/website/docs/deployment/mongodb.md
@@ -62,11 +62,9 @@ The initializer creates these indexes for query performance:
 | Index | Fields | Notes |
 |-------|--------|-------|
 | `idx_job_claim_exec` | `status`, `job_type`, `priority` DESC, `scheduled_time`, `_id` | Executable claim candidate filtering |
-| `idx_job_claim_recurring` | `status`, `job_type`, `priority` DESC, `next_fire`, `_id` | Recurring claim candidate filtering |
 | `idx_job_poll_composite` | `status`, `priority` DESC, `scheduled_time` | General due-job lookup |
-| `idx_job_recurring_composite` | `job_type`, `status`, `next_fire` | Recurring due-time lookup |
 | `idx_job_idempotency_key` | `idempotency_key` | **Unique** — global dedup |
-| `idx_job_active_business_key` | `business_key` | **Unique partial** — only for PENDING/RUNNING/PAUSED |
+| `idx_job_active_business_key` | `business_key` | **Unique partial** — only for PENDING/RUNNING/PAUSED/WAITING |
 | `idx_job_tags` | `tags` | Multikey index for tag-based queries |
 | `idx_job_picked_by` | `picked_by` | Find jobs claimed by a specific node |
 

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -40,10 +40,10 @@ The `MicrometerMetricsCollector` is annotated `@Alternative @Priority(1000)`, so
 |--------|------|------|-------------|
 | `ratchet.jobs.started` | Counter | `type`, `priority` | Jobs that began execution |
 | `ratchet.jobs.completed` | Counter | `type` | Jobs that finished successfully |
-| `ratchet.jobs.failed` | Counter | `type`, `exception` | Jobs that failed (exception class name as tag) |
+| `ratchet.jobs.failed` | Counter | `type`, `family` | Jobs that failed (exception-family classification as tag) |
 | `ratchet.jobs.duration` | Timer | `type` | Execution time in milliseconds |
 
-The `type` tag corresponds to `JobType` (e.g., `SINGLE`, `RECURRING`, `BATCH_CHILD`). The `priority` tag corresponds to `JobPriority` (e.g., `NORMAL`, `HIGH`, `CRITICAL`).
+The `type` tag corresponds to `JobType` (`SINGLE`, `RECURRING`, `BATCH`, `CHAIN`, `WORKFLOW`, `SYSTEM`). The `priority` tag corresponds to `JobPriority` (`LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL`). The `family` tag corresponds to `ExceptionFamily` — a coarse classification of the failure cause rather than the raw exception class name.
 
 ### Grafana Dashboard Queries
 
@@ -63,20 +63,27 @@ rate(ratchet_jobs_failed_total[5m])
 histogram_quantile(0.95, rate(ratchet_jobs_duration_seconds_bucket[5m]))
 ```
 
-**Failures by exception type:**
+**Failures by exception family:**
 ```promql
-topk(5, sum by (exception) (rate(ratchet_jobs_failed_total[5m])))
+topk(5, sum by (family) (rate(ratchet_jobs_failed_total[5m])))
 ```
 
 ### Custom MetricsCollector
 
-If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI directly:
+If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. The SPI declares several callbacks beyond the three core job-lifecycle hooks (`jobStarted`, `jobCompleted`, `jobFailed`) — including `successFinalizationRetried`/`successFinalizationMinimal`/`successFinalizationStuck`, `claimTransientFailure`, `jobsClaimed`, `gateRejected`, and `localWakeup`, plus default no-op hooks for cluster wakeup, callback failures, signal events, store operations, and poller circuit-breaker state. The simplest approach is to extend `NoOpMetricsCollector` and override only the callbacks you emit:
 
 ```java
-public interface MetricsCollector {
-    void jobStarted(UUID jobId, JobType type, JobPriority priority);
-    void jobCompleted(UUID jobId, JobType type, long executionTimeMs);
-    void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt);
+public class MyMetricsCollector extends NoOpMetricsCollector {
+
+    @Override
+    public void jobStarted(UUID jobId, JobType type, JobPriority priority) {
+        // record your metric
+    }
+
+    @Override
+    public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
+        // record your metric
+    }
 }
 ```
 
@@ -124,12 +131,14 @@ For dynamic registration (useful in frameworks or libraries that can't use CDI o
 
 ```java
 scheduler.addEventListener(event -> {
-    if (event instanceof PerformanceMetricsEvent perf) {
-        log.info("Poll cycle: claimed={}, executed={}, duration={}ms",
-            perf.getClaimedCount(), perf.getExecutedCount(), perf.getDurationMs());
+    if (event instanceof JobFailedEvent failed) {
+        log.error("Job {} failed (attempt {}): {}",
+            failed.getJobId(), failed.getRetryAttempt(), failed.getErrorMessage());
     }
 });
 ```
+
+For aggregate poll-cycle and throughput metrics, use the `MetricsCollector` SPI (or the Micrometer module) rather than the event system — events carry per-job context, not cycle-level summaries.
 
 ### Event Types
 
@@ -144,7 +153,6 @@ scheduler.addEventListener(event -> {
 | `BatchCompletingEvent` | All children in a batch have finished |
 | `ChainStartedEvent` | A chained job was triggered by its parent |
 | `WorkflowBranchTriggeredEvent` | A conditional branch was activated |
-| `PerformanceMetricsEvent` | End-of-cycle summary from the poller |
 
 ## Health Checks
 
@@ -153,10 +161,10 @@ scheduler.addEventListener(event -> {
 Query the `scheduler_node` table to verify all expected nodes are alive:
 
 ```sql
-SELECT node_id, last_heartbeat,
-       TIMESTAMPDIFF(SECOND, last_heartbeat, NOW()) AS seconds_stale
+SELECT node_id, heartbeat_ts,
+       TIMESTAMPDIFF(SECOND, heartbeat_ts, NOW()) AS seconds_stale
 FROM scheduler_node
-WHERE last_heartbeat < NOW() - INTERVAL 2 MINUTE;
+WHERE heartbeat_ts < NOW() - INTERVAL 2 MINUTE;
 ```
 
 Any rows returned indicate stale nodes. For programmatic health checks:
@@ -193,7 +201,7 @@ Alert if `CRITICAL` or `HIGH` jobs have been pending for more than a few seconds
 Jobs in the dead-letter queue need human attention:
 
 ```sql
-SELECT COUNT(*) FROM scheduler_job WHERE status = 'DEAD_LETTER';
+SELECT COUNT(*) FROM scheduler_dlq_alerts;
 ```
 
 Wire this into your alerting system — a non-zero DLQ count means something failed permanently.

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -188,8 +188,9 @@ public class RatchetHealthCheck {
 Monitor the number of pending jobs to detect backlog:
 
 ```sql
+-- PENDING is live state on scheduler_job_queue (priority is denormalized there).
 SELECT priority, COUNT(*) as pending_count
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE status = 'PENDING'
 GROUP BY priority;
 ```

--- a/website/docs/deployment/mysql.md
+++ b/website/docs/deployment/mysql.md
@@ -227,8 +227,9 @@ transaction_isolation = READ-COMMITTED
 ### Monitor Job Queue Depth
 
 ```sql
+-- PENDING is live state on scheduler_job_queue (the row is deleted at terminal).
 SELECT COUNT(*) AS pending_jobs
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE status = 'PENDING';
 ```
 

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -265,11 +265,13 @@ Verify that the polling query uses indexes:
 ```sql
 -- PostgreSQL
 EXPLAIN ANALYZE
-SELECT * FROM scheduler_job
+SELECT * FROM scheduler_job_queue
 WHERE status = 'PENDING'
-  AND scheduled_time <= NOW()
-ORDER BY priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time)) / 60) / 15) DESC,
-         scheduled_time ASC
+  AND scheduled_time <= statement_timestamp()
+  AND job_type = 'SINGLE'
+ORDER BY (priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time))) / (60.0 * 15))) DESC,
+         scheduled_time ASC,
+         job_id ASC
 LIMIT 100
 FOR UPDATE SKIP LOCKED;
 
@@ -279,20 +281,21 @@ SELECT * FROM scheduler_job_queue FORCE INDEX (idx_claim_executable)
 WHERE status = 'PENDING'
   AND job_type = 'SINGLE'
   AND scheduled_time <= NOW()
-ORDER BY priority + FLOOR(GREATEST(0, TIMESTAMPDIFF(MINUTE, scheduled_time, NOW(3))) / 15) DESC,
-         scheduled_time ASC
+ORDER BY (priority + FLOOR(GREATEST(0, TIMESTAMPDIFF(MINUTE, scheduled_time, NOW(3))) / 15)) DESC,
+         scheduled_time ASC,
+         job_id ASC
 LIMIT 100
 FOR UPDATE SKIP LOCKED;
 ```
 
-The query should use `idx_job_claim_cover` on PostgreSQL or `idx_claim_executable` on MySQL. A sort on computed effective priority is expected; a full scan of the pending queue is not. If you see a sequential scan, check that statistics are up to date:
+The query should use `idx_claim_executable` on `scheduler_job_queue` on both PostgreSQL and MySQL — it is the hot-path claim index, partial on `status = 'PENDING'`. A sort on computed effective priority is expected; a full scan of the pending queue is not. If you see a sequential scan, check that statistics are up to date:
 
 ```sql
 -- PostgreSQL
-ANALYZE scheduler_job;
+ANALYZE scheduler_job_queue;
 
 -- MySQL
-ANALYZE TABLE scheduler_job;
+ANALYZE TABLE scheduler_job_queue;
 ```
 
 ## Job Retention and Archiving

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -221,9 +221,9 @@ ALTER SYSTEM SET work_mem = '256MB';
 ALTER SYSTEM SET effective_cache_size = '12GB';
 ```
 
-**Autovacuum** — Ratchet performs frequent updates. Tune autovacuum to keep up:
+**Autovacuum** — Ratchet performs frequent updates and deletes on the hot queue table. Tune autovacuum to keep up:
 ```sql
-ALTER TABLE scheduler_job SET (
+ALTER TABLE scheduler_job_queue SET (
   autovacuum_vacuum_scale_factor = 0.05,  -- vacuum after 5% of rows change
   autovacuum_analyze_scale_factor = 0.02  -- analyze after 2% of rows change
 );
@@ -315,17 +315,19 @@ The `scheduler_job_archive` table stores historical data for completed and faile
 ### Manual Cleanup
 
 ```sql
--- PostgreSQL: archive old completed jobs
+-- PostgreSQL: archive old completed jobs. Terminated jobs are cold rows on
+-- scheduler_job (the hot scheduler_job_queue row is deleted at the terminal
+-- transition), so filter on terminal_status / terminated_at.
 INSERT INTO scheduler_job_archive (archive_id, original_job_id, final_status, ...)
 SELECT ...
 FROM scheduler_job
-WHERE status IN ('SUCCEEDED', 'FAILED', 'CANCELED')
-  AND updated_at < NOW() - INTERVAL '30 days';
+WHERE terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')
+  AND terminated_at < NOW() - INTERVAL '30 days';
 
--- Then delete from the active table
+-- Then delete the cold rows
 DELETE FROM scheduler_job
-WHERE status IN ('SUCCEEDED', 'FAILED', 'CANCELED')
-  AND updated_at < NOW() - INTERVAL '30 days';
+WHERE terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')
+  AND terminated_at < NOW() - INTERVAL '30 days';
 ```
 
 ## Monitoring Performance
@@ -387,19 +389,21 @@ public class MicrometerCollector implements MetricsCollector {
 SELECT AVG(duration_ms) FROM scheduler_job_execution
 WHERE started_at > NOW() - INTERVAL '1 hour';
 
--- Jobs processed per minute
+-- Jobs processed per minute. SUCCEEDED is terminal: status survives as
+-- terminal_status on the cold scheduler_job row, alongside execution_end_time.
 SELECT
   date_trunc('minute', execution_end_time) AS minute,
   COUNT(*) AS completed
 FROM scheduler_job
-WHERE status = 'SUCCEEDED'
+WHERE terminal_status = 'SUCCEEDED'
   AND execution_end_time > NOW() - INTERVAL '1 hour'
 GROUP BY minute
 ORDER BY minute;
 
--- Thread pool pressure (jobs waiting for execution)
+-- Thread pool pressure (jobs waiting for execution). PENDING is live state on
+-- scheduler_job_queue.
 SELECT COUNT(*) AS queued_jobs
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE status = 'PENDING'
   AND scheduled_time <= NOW();
 ```

--- a/website/docs/deployment/postgresql.md
+++ b/website/docs/deployment/postgresql.md
@@ -125,7 +125,7 @@ jdbc:postgresql://localhost:5432/ratchet
 Ratchet uses PostgreSQL's `SKIP LOCKED` clause for lock-free job claiming:
 
 ```sql
-SELECT * FROM scheduler_job
+SELECT * FROM scheduler_job_queue
 WHERE status = 'PENDING'
   AND scheduled_time <= NOW()
 ORDER BY priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time)) / 60) / 15) DESC,
@@ -219,10 +219,10 @@ SELECT pg_reload_conf();
 
 ### Autovacuum Tuning
 
-Ratchet performs frequent updates to `scheduler_job`. Tune autovacuum to keep up:
+Ratchet performs frequent updates and deletes on the hot `scheduler_job_queue` table. Tune autovacuum to keep up:
 
 ```sql
-ALTER TABLE scheduler_job SET (
+ALTER TABLE scheduler_job_queue SET (
   autovacuum_vacuum_scale_factor = 0.05,
   autovacuum_analyze_scale_factor = 0.02
 );
@@ -233,12 +233,19 @@ ALTER TABLE scheduler_job SET (
 ### Monitor Job Queue
 
 ```sql
+-- Live statuses (PENDING/RUNNING) are on scheduler_job_queue; FAILED is terminal and
+-- survives as terminal_status on the cold scheduler_job row after the queue row is
+-- deleted. UNION the two to count both in one pass.
 SELECT
   COUNT(*) AS total,
   COUNT(CASE WHEN status = 'PENDING' THEN 1 END) AS pending,
   COUNT(CASE WHEN status = 'RUNNING' THEN 1 END) AS running,
   COUNT(CASE WHEN status = 'FAILED' THEN 1 END) AS failed
-FROM scheduler_job;
+FROM (
+  SELECT status FROM scheduler_job_queue
+  UNION ALL
+  SELECT terminal_status AS status FROM scheduler_job WHERE terminal_status IS NOT NULL
+) all_jobs;
 ```
 
 ### Query Performance

--- a/website/docs/deployment/postgresql.md
+++ b/website/docs/deployment/postgresql.md
@@ -136,18 +136,22 @@ FOR UPDATE SKIP LOCKED;
 
 This allows multiple Ratchet nodes to safely claim different jobs simultaneously without blocking each other.
 
-### Partial Indexes
+### Active Business-Key Uniqueness
 
-The schema uses partial indexes for performance. Instead of indexing all rows, partial indexes only cover the rows that matter for active queries:
+Active-key uniqueness is enforced by a dedicated `scheduler_business_key_reservation` table, not by an index on `scheduler_job`. The reservation table holds one row per active business key, with `business_key` as its primary key:
 
 ```sql
--- Unique business key only for active jobs (PENDING, RUNNING, PAUSED)
-CREATE UNIQUE INDEX idx_job_active_business_key
-ON scheduler_job (business_key)
-WHERE status IN ('PENDING', 'RUNNING', 'PAUSED') AND business_key IS NOT NULL;
+CREATE TABLE IF NOT EXISTS scheduler_business_key_reservation
+(
+    business_key TEXT NOT NULL,
+    owner_table  TEXT NOT NULL,
+    owner_job_id uuid NOT NULL,
+    CONSTRAINT pk_scheduler_business_key_reservation PRIMARY KEY (business_key),
+    CONSTRAINT chk_bk_owner_table CHECK (owner_table IN ('QUEUE', 'RECURRING'))
+);
 ```
 
-This approach replaces MySQL's generated `active_business_key` column with a more space-efficient partial unique index.
+A duplicate active business key fails against `pk_scheduler_business_key_reservation`. The `business_key` column on `scheduler_job` is observability-only and carries a plain (non-unique) `idx_job_business_key` index.
 
 ### Generated Columns
 
@@ -160,12 +164,16 @@ method_name  TEXT GENERATED ALWAYS AS (payload::jsonb ->> 'method') STORED
 
 ### CHECK Constraints
 
-PostgreSQL uses `CHECK` constraints for data validation instead of MySQL's `ENUM` types:
+PostgreSQL uses `CHECK` constraints for data validation instead of MySQL's `ENUM` types. Live status is tracked on `scheduler_job_queue` (`chk_queue_status`), while `scheduler_job` records only the terminal status (`chk_terminal_status`):
 
 ```sql
-CONSTRAINT chk_job_status CHECK (status IN ('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELED', 'PAUSED'))
+-- scheduler_job (cold metadata + terminal fields)
+CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED'))
 CONSTRAINT chk_job_type CHECK (job_type IN ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD', ...))
 CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4)
+
+-- scheduler_job_queue (live claim path)
+CONSTRAINT chk_queue_status CHECK (status IN ('PENDING', 'RUNNING', 'PAUSED', 'WAITING'))
 ```
 
 ## Performance Tuning

--- a/website/docs/deployment/troubleshooting.md
+++ b/website/docs/deployment/troubleshooting.md
@@ -36,8 +36,8 @@ SQL stores ship plain SQL files, not migrations. Apply them however your project
 ```sql
 -- PostgreSQL
 EXPLAIN ANALYZE
-SELECT * FROM scheduler_job
-WHERE status = 'PENDING' AND scheduled_time <= NOW()
+SELECT * FROM scheduler_job_queue
+WHERE status = 'PENDING' AND job_type = 'SINGLE' AND scheduled_time <= NOW()
 ORDER BY priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time)) / 60) / 15) DESC,
          scheduled_time ASC
 FOR UPDATE SKIP LOCKED LIMIT 10;
@@ -48,8 +48,8 @@ If you see a sequential scan instead of an index scan, the composite index is mi
 **Fix:** Re-apply the DDL or create the index manually:
 ```sql
 -- PostgreSQL
-CREATE INDEX IF NOT EXISTS idx_job_claim_cover
-ON scheduler_job (job_type, scheduled_time ASC, priority DESC, job_id ASC)
+CREATE INDEX IF NOT EXISTS idx_claim_executable
+ON scheduler_job_queue (job_type, scheduled_time ASC, priority DESC, job_id ASC)
 WHERE status = 'PENDING';
 ```
 
@@ -142,7 +142,7 @@ nodeStore.deleteInactiveNodesSince(Instant.now().minus(Duration.ofHours(1)));
 
 ### Jobs stuck in RUNNING
 
-**Symptom:** Jobs have `status = 'RUNNING'` and `picked_by` set to a node that's no longer alive.
+**Symptom:** Rows in `scheduler_job_queue` have `status = 'RUNNING'` and `picked_by` set to a node that's no longer alive.
 
 **Cause:** The node crashed mid-execution. The job's timeout hasn't expired yet, or there's no timeout set.
 
@@ -151,7 +151,7 @@ nodeStore.deleteInactiveNodesSince(Instant.now().minus(Duration.ofHours(1)));
 2. **Recover:** After the timeout expires, the poller will automatically reclaim the job. To force recovery:
 
 ```sql
-UPDATE scheduler_job
+UPDATE scheduler_job_queue
 SET status = 'PENDING', picked_by = NULL, picked_at = NULL
 WHERE status = 'RUNNING'
   AND picked_at < NOW() - INTERVAL '30 minutes';
@@ -171,8 +171,8 @@ Only reset jobs if you're certain the claiming node is truly dead. Resetting a j
 
 ```sql
 EXPLAIN ANALYZE
-SELECT * FROM scheduler_job
-WHERE status = 'PENDING' AND scheduled_time <= NOW()
+SELECT * FROM scheduler_job_queue
+WHERE status = 'PENDING' AND job_type = 'SINGLE' AND scheduled_time <= NOW()
 ORDER BY priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time)) / 60) / 15) DESC,
          scheduled_time ASC
 FOR UPDATE SKIP LOCKED LIMIT 10;
@@ -194,11 +194,11 @@ FOR UPDATE SKIP LOCKED LIMIT 10;
 
 **Diagnosis:**
 ```sql
-SELECT status, COUNT(*) FROM scheduler_job
+SELECT status, COUNT(*) FROM scheduler_job_queue
 GROUP BY status ORDER BY status;
 
 -- Check future-scheduled jobs
-SELECT COUNT(*) FROM scheduler_job
+SELECT COUNT(*) FROM scheduler_job_queue
 WHERE status = 'PENDING' AND scheduled_time > NOW();
 ```
 

--- a/website/docs/getting-started/basic-concepts.md
+++ b/website/docs/getting-started/basic-concepts.md
@@ -21,8 +21,8 @@ Every job has:
 
 | Property | Description |
 |----------|-------------|
-| **ID** | Auto-assigned numeric identifier |
-| **Status** | Current lifecycle state (`PENDING`, `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `PAUSED`) |
+| **ID** | Auto-assigned UUIDv7 identifier |
+| **Status** | Current lifecycle state (`PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`, `CANCELED`, `PAUSED`, `WAITING`) |
 | **Priority** | Execution ordering — `LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL` |
 | **Payload** | The serialized lambda or method reference |
 | **Parameters** | Key-value pairs available at execution time via `JobContext` |

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -137,7 +137,7 @@ That's the entire integration. Let's break down what happens when `placeOrder` i
 When you call `scheduler.enqueueNow(() -> processOrder(orderId))`, Ratchet:
 
 1. **Serializes the lambda** -- The method reference `processOrder(orderId)` is analyzed via ASM bytecode analysis, capturing the target class, method name, and argument values.
-2. **Persists the job** -- A new row is inserted into the `scheduler_job` table with status `PENDING`, the serialized payload, and an auto-generated idempotency key.
+2. **Persists the job** -- A new row is inserted into the `scheduler_job` table with the serialized payload and an auto-generated idempotency key, alongside a matching `scheduler_job_queue` row that holds the live status `PENDING`. (Live queue state lives on `scheduler_job_queue`; `scheduler_job` keeps the cold metadata and terminal fields.)
 3. **Returns immediately** -- `enqueueNow` returns a `JobHandle` with the job's UUIDv7 database ID. Your calling code doesn't block.
 4. **Poller picks it up** -- The Ratchet poller (started automatically at application startup by `RatchetLifecycle`) claims the job and submits it to a worker thread.
 5. **Worker executes** -- The worker thread deserializes the payload, resolves `OrderService` via CDI, and calls `processOrder(orderId)`.
@@ -166,16 +166,27 @@ INFO [com.example.app.OrderService] Processing order 42 in background...
 
 ### Check the Database
 
-You can also verify by querying the `scheduler_job` table directly:
+You can also verify by querying the tables directly. While a job is live, its
+status sits on `scheduler_job_queue`:
 
 ```sql
-SELECT job_id, status, created_at, execution_start_time, execution_end_time
+SELECT job_id, status, scheduled_time
+FROM scheduler_job_queue
+ORDER BY job_id DESC
+LIMIT 5;
+```
+
+When a job reaches a terminal state, the queue row is removed and the outcome is
+recorded on `scheduler_job` via `terminal_status` and the timing columns:
+
+```sql
+SELECT job_id, terminal_status, created_at, execution_start_time, execution_end_time
 FROM scheduler_job
 ORDER BY job_id DESC
 LIMIT 5;
 ```
 
-A completed job will show status `SUCCEEDED` with populated timing columns.
+A completed job will show `terminal_status` `SUCCEEDED` with populated timing columns.
 
 ## The Fire-and-Forget Pattern
 

--- a/website/docs/troubleshooting/common-issues.md
+++ b/website/docs/troubleshooting/common-issues.md
@@ -162,15 +162,21 @@ Do not add broad prefixes like `java.` or `javax.` to your allowed packages. The
 
 **Symptom:** The same recurring job runs multiple times per scheduled interval.
 
-Recurring jobs use a **business key** for active-uniqueness. The database enforces a partial unique index:
+Recurring jobs use a **business key** for active-uniqueness. The database enforces this through a dedicated reservation table whose primary key is the business key, so only one active owner can hold a given key at a time:
 
 ```sql
--- PostgreSQL: only one active job per business key
-CREATE UNIQUE INDEX idx_job_active_business_key
-    ON scheduler_job (business_key)
-    WHERE status IN ('PENDING', 'RUNNING', 'PAUSED')
-      AND business_key IS NOT NULL;
+-- Active business-key uniqueness lives in scheduler_business_key_reservation,
+-- not in an index on scheduler_job. The primary key serializes ownership.
+CREATE TABLE scheduler_business_key_reservation (
+    business_key TEXT        NOT NULL,
+    owner_job_id uuid        NOT NULL,
+    owner_table  TEXT        NOT NULL,
+    reserved_at  TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_scheduler_business_key_reservation PRIMARY KEY (business_key)
+);
 ```
+
+The `scheduler_job.business_key` column remains for observability and archive/search projections; it is not the uniqueness mechanism. Cancel paths delete the reservation row to release the key.
 
 Duplicates happen when:
 
@@ -245,17 +251,17 @@ The circuit breaker transitions:
 ERROR: duplicate key value violates unique constraint "uk_idempotency_key"
 ```
 
-Each job gets a unique idempotency key (UUID). This error means you are submitting the same job twice. Ratchet includes retry logic for idempotency conflicts (configurable via `RATCHET_IDEMPOTENCY_RETRY_MAX_ATTEMPTS`, default 3).
+Each job gets a unique idempotency key (UUID). On submission Ratchet first looks up the key (`findByIdempotencyKey`) and, if a job with that key already exists, returns a handle to the existing job instead of inserting a duplicate. This constraint violation therefore only surfaces on a concurrent race -- two submissions with the same idempotency key both pass the pre-insert lookup, and the second insert hits the `uk_idempotency_key` unique constraint.
 
-If you see persistent failures, check if your code is double-submitting in a retry loop.
+If you see persistent failures, check if your code is double-submitting in a retry loop, or reusing the same explicit idempotency key across concurrent submissions.
 
 ### Active Business Key Violation
 
 ```
-ERROR: duplicate key value violates unique constraint "idx_job_active_business_key"
+ERROR: duplicate key value violates unique constraint "pk_scheduler_business_key_reservation"
 ```
 
-Two active jobs (PENDING, RUNNING, or PAUSED) share the same business key. This is expected behavior -- the constraint prevents duplicate scheduling. The job that violated the constraint was correctly rejected.
+Two active jobs share the same business key. This is expected behavior -- the `scheduler_business_key_reservation` primary key prevents duplicate scheduling. The job that violated the constraint was correctly rejected.
 
 If this is unexpected, query for the existing active job:
 

--- a/website/docs/troubleshooting/common-issues.md
+++ b/website/docs/troubleshooting/common-issues.md
@@ -35,8 +35,10 @@ If you do not see it, the `RatchetLifecycle` CDI bean may not be initializing. E
 ### Check 2: Are Jobs Stuck in PENDING?
 
 ```sql
+-- Live queue state lives on scheduler_job_queue (the row is deleted at the terminal
+-- transition); PENDING is a live status, so query the queue, not cold scheduler_job.
 SELECT job_id, status, scheduled_time, job_type, attempts, last_error
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE status = 'PENDING'
   AND scheduled_time <= NOW()
 ORDER BY scheduled_time ASC
@@ -144,11 +146,13 @@ The `PackagePrefixClassPolicy` checks if the target class name starts with any o
 **Diagnosis:**
 
 ```sql
--- Find which classes are being rejected
-SELECT DISTINCT payload::jsonb ->> 'target' as target_class, last_error
+-- Find which classes are being rejected. A FAILED job is terminal: its hot queue row
+-- has been deleted and last_error was copied to terminal_error on the cold scheduler_job
+-- row, so filter on terminal_status / terminal_error here.
+SELECT DISTINCT payload::jsonb ->> 'target' as target_class, terminal_error
 FROM scheduler_job
-WHERE status = 'FAILED'
-  AND last_error LIKE '%not allowed%'
+WHERE terminal_status = 'FAILED'
+  AND terminal_error LIKE '%not allowed%'
 ORDER BY target_class;
 ```
 
@@ -187,9 +191,10 @@ Duplicates happen when:
 **Diagnosis:**
 
 ```sql
--- Check for duplicate active recurring jobs
+-- Check for duplicate active recurring jobs. Live status lives on scheduler_job_queue
+-- (job_type and business_key are denormalized there for the claim path).
 SELECT business_key, COUNT(*) as active_count
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE job_type = 'RECURRING'
   AND status IN ('PENDING', 'RUNNING', 'PAUSED')
   AND business_key IS NOT NULL
@@ -266,10 +271,13 @@ Two active jobs share the same business key. This is expected behavior -- the `s
 If this is unexpected, query for the existing active job:
 
 ```sql
-SELECT job_id, status, scheduled_time, created_at
-FROM scheduler_job
-WHERE business_key = 'your-business-key'
-  AND status IN ('PENDING', 'RUNNING', 'PAUSED');
+-- Live status / scheduled_time are on scheduler_job_queue; created_at is cold metadata
+-- on scheduler_job. Join the two to see the active job holding the key.
+SELECT q.job_id, q.status, q.scheduled_time, c.created_at
+FROM scheduler_job_queue q
+JOIN scheduler_job c ON c.job_id = q.job_id
+WHERE q.business_key = 'your-business-key'
+  AND q.status IN ('PENDING', 'RUNNING', 'PAUSED');
 ```
 
 ## Timeout Behavior
@@ -319,9 +327,10 @@ ThreadPoolManager initialized with managed executors with semaphore-based limiti
 **Diagnosis:**
 
 ```sql
--- Check how many jobs are currently RUNNING per type
+-- Check how many jobs are currently RUNNING per type. RUNNING is live state on
+-- scheduler_job_queue (job_type is denormalized there).
 SELECT job_type, COUNT(*) as running
-FROM scheduler_job
+FROM scheduler_job_queue
 WHERE status = 'RUNNING'
 GROUP BY job_type
 ORDER BY running DESC;
@@ -339,9 +348,10 @@ If the running count equals the pool size for a type, the pool is saturated.
    Virtual threads still have configurable concurrency limits (default 1000 per type) to prevent unbounded growth.
 3. **Check for stuck jobs** -- long-running jobs hold their thread slot until they complete or timeout:
    ```sql
+   -- RUNNING / picked_at are live state on scheduler_job_queue.
    SELECT job_id, job_type, picked_at,
           EXTRACT(EPOCH FROM (NOW() - picked_at)) / 60 as running_minutes
-   FROM scheduler_job
+   FROM scheduler_job_queue
    WHERE status = 'RUNNING'
    ORDER BY picked_at ASC
    LIMIT 10;

--- a/website/docs/troubleshooting/debugging.md
+++ b/website/docs/troubleshooting/debugging.md
@@ -49,10 +49,16 @@ ORDER BY ts ASC;
 ```
 
 ```sql
--- Find jobs that logged errors in the last hour
-SELECT DISTINCT jl.job_id, j.status, j.last_error, jl.message
+-- Find jobs that logged errors in the last hour. A job may already have terminated
+-- (its scheduler_job_queue row deleted), so LEFT JOIN the queue and fall back to the
+-- cold scheduler_job terminal columns for status/error.
+SELECT DISTINCT jl.job_id,
+       COALESCE(q.status, j.terminal_status) AS status,
+       COALESCE(q.last_error, j.terminal_error) AS last_error,
+       jl.message
 FROM scheduler_job_log jl
 JOIN scheduler_job j ON j.job_id = jl.job_id
+LEFT JOIN scheduler_job_queue q ON q.job_id = jl.job_id
 WHERE jl.level = 'ERROR'
   AND jl.ts >= NOW() - INTERVAL '1 hour'
 ORDER BY jl.ts DESC;
@@ -73,10 +79,14 @@ scheduler.enqueue(importService::importData)
 These parameters are accessible via `JobContext.current().param("key")` and stored in the `params` column of `scheduler_job`:
 
 ```sql
--- Find jobs by parameter values
-SELECT job_id, status, params::jsonb ->> 'source' as source
-FROM scheduler_job
-WHERE params::jsonb ->> 'source' = 'quarterly-report';
+-- Find jobs by parameter values. params lives on the cold scheduler_job row;
+-- status is live state on scheduler_job_queue (NULL once the job terminates), so
+-- LEFT JOIN and fall back to terminal_status.
+SELECT j.job_id, COALESCE(q.status, j.terminal_status) AS status,
+       j.params::jsonb ->> 'source' as source
+FROM scheduler_job j
+LEFT JOIN scheduler_job_queue q ON q.job_id = j.job_id
+WHERE j.params::jsonb ->> 'source' = 'quarterly-report';
 ```
 
 ## Event Listeners for Tracing Job Lifecycle
@@ -186,30 +196,39 @@ public class SchedulerMonitor {
 ### Find a Specific Job
 
 ```sql
--- Full job details by ID
-SELECT job_id, status, job_type, priority,
-       attempts, max_retries, backoff_policy,
-       scheduled_time, picked_by, picked_at,
-       execution_start_time, execution_end_time, execution_duration_ms,
-       last_error, business_key, resource_name,
-       payload::jsonb ->> 'target' as target_class,
-       payload::jsonb ->> 'method' as method_name
-FROM scheduler_job
-WHERE job_id = '01902c4e-c4f3-7b8a-9d3e-fedcba987654';
+-- Full job details by ID.
+-- Live state (status, attempts, scheduled_time, picked_by, picked_at, last_error)
+-- lives on scheduler_job_queue while the job is live; the queue row is deleted at
+-- the terminal transition. The cold scheduler_job row keeps immutable shape plus
+-- terminal_status/terminal_error/total_attempts. LEFT JOIN so a terminated job
+-- (no queue row) still returns its cold details.
+SELECT c.job_id, q.status, c.terminal_status, c.job_type, c.priority,
+       q.attempts, c.total_attempts, c.max_retries, c.backoff_policy,
+       q.scheduled_time, q.picked_by, q.picked_at,
+       c.execution_start_time, c.execution_end_time, c.execution_duration_ms,
+       q.last_error, c.terminal_error, c.business_key, c.resource_name,
+       c.payload::jsonb ->> 'target' as target_class,
+       c.payload::jsonb ->> 'method' as method_name
+FROM scheduler_job c
+LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+WHERE c.job_id = '01902c4e-c4f3-7b8a-9d3e-fedcba987654';
 ```
 
 ### Find Failed Jobs by Error Pattern
 
 ```sql
--- Find jobs that failed with a specific exception type
-SELECT job_id, status, attempts, max_retries, last_error,
+-- Find jobs that failed with a specific exception type.
+-- A FAILED job is terminal: its hot queue row has been deleted and lifecycle has
+-- copied last_error -> terminal_error on the cold scheduler_job row, so query
+-- terminal_status / terminal_error here (not the queue).
+SELECT job_id, terminal_status, total_attempts, max_retries, terminal_error,
        payload::jsonb ->> 'target' as target_class,
        payload::jsonb ->> 'method' as method_name,
-       created_at, updated_at
+       created_at, terminated_at
 FROM scheduler_job
-WHERE status = 'FAILED'
-  AND last_error LIKE '%ConnectionTimeout%'
-ORDER BY updated_at DESC
+WHERE terminal_status = 'FAILED'
+  AND terminal_error LIKE '%ConnectionTimeout%'
+ORDER BY terminated_at DESC
 LIMIT 20;
 ```
 
@@ -235,7 +254,7 @@ SELECT date_trunc('hour', execution_end_time) as hour,
        AVG(execution_duration_ms) as avg_ms,
        MAX(execution_duration_ms) as max_ms
 FROM scheduler_job
-WHERE status = 'SUCCEEDED'
+WHERE terminal_status = 'SUCCEEDED'
   AND execution_end_time >= NOW() - INTERVAL '24 hours'
 GROUP BY hour
 ORDER BY hour DESC;
@@ -256,29 +275,34 @@ A `seconds_since_heartbeat` greater than the orphan grace period (default 60s) i
 ### Inspect Batch Progress
 
 ```sql
--- Batch completion status
-SELECT b.batch_id, j.status as parent_status, j.business_key,
+-- Batch completion status. The parent's live status is on scheduler_job_queue;
+-- joining the queue also restricts the result to still-live batches (the queue
+-- row is deleted once the parent terminates).
+SELECT b.batch_id, q.status as parent_status, j.business_key,
        b.total_items, b.completed_items, b.failed_items,
        b.completion_processed,
        ROUND(100.0 * (b.completed_items + b.failed_items) / GREATEST(b.total_items, 1), 1) as pct_done
 FROM scheduler_batch b
 JOIN scheduler_job j ON j.job_id = b.batch_id
-WHERE j.status IN ('PENDING', 'RUNNING')
+JOIN scheduler_job_queue q ON q.job_id = b.batch_id
+WHERE q.status IN ('PENDING', 'RUNNING')
 ORDER BY b.batch_id DESC;
 ```
 
 ### Find Orphaned Jobs
 
 ```sql
--- Jobs stuck in RUNNING on nodes that have gone stale
-SELECT j.job_id, j.picked_by, j.picked_at,
-       EXTRACT(EPOCH FROM (NOW() - j.picked_at)) / 60 as stuck_minutes,
+-- Jobs stuck in RUNNING on nodes that have gone stale. RUNNING is live state, so
+-- status / picked_by / picked_at are read from scheduler_job_queue (this matches
+-- the idx_queue_orphan scan the OrphanRecoveryTimer uses).
+SELECT q.job_id, q.picked_by, q.picked_at,
+       EXTRACT(EPOCH FROM (NOW() - q.picked_at)) / 60 as stuck_minutes,
        n.heartbeat_ts
-FROM scheduler_job j
-LEFT JOIN scheduler_node n ON n.node_id = j.picked_by
-WHERE j.status = 'RUNNING'
+FROM scheduler_job_queue q
+LEFT JOIN scheduler_node n ON n.node_id = q.picked_by
+WHERE q.status = 'RUNNING'
   AND (n.node_id IS NULL OR n.heartbeat_ts < NOW() - INTERVAL '60 seconds')
-ORDER BY j.picked_at ASC;
+ORDER BY q.picked_at ASC;
 ```
 
 ## Enabling Debug Logging
@@ -349,7 +373,7 @@ SEVERE JobTask - Job 12345 moved to DLQ after 4 attempts
 
 When a job is not behaving as expected, work through this checklist:
 
-1. **Check the job status:** `SELECT status, last_error FROM scheduler_job WHERE job_id = ?`
+1. **Check the job status:** `SELECT COALESCE(q.status, c.terminal_status) AS status, COALESCE(q.last_error, c.terminal_error) AS last_error FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id WHERE c.job_id = ?`
 2. **Check execution history:** `SELECT * FROM scheduler_job_execution WHERE job_id = ? ORDER BY attempt`
 3. **Check per-job logs (if enabled):** `SELECT * FROM scheduler_job_log WHERE job_id = ? ORDER BY ts`
 4. **Check if the node is alive:** `SELECT * FROM scheduler_node WHERE node_id = ?`

--- a/website/docs/troubleshooting/faq.md
+++ b/website/docs/troubleshooting/faq.md
@@ -57,8 +57,7 @@ When a job fails, Ratchet follows this decision path:
 ```java
 scheduler.enqueue(paymentService::processRefund)
     .withMaxRetries(3)
-    .withBackoffPolicy(BackoffPolicy.EXPONENTIAL)
-    .withBackoffParam(1000)  // 1 second base
+    .withBackoff(BackoffPolicy.EXPONENTIAL, Duration.ofSeconds(1))  // 1 second base
     .submit();
 // Retry delays: 1s, 2s, 4s (then DLQ)
 ```

--- a/website/docs/troubleshooting/overview.md
+++ b/website/docs/troubleshooting/overview.md
@@ -52,10 +52,10 @@ public void enableDiagnostics() {
             log.error("Job {} failed: {}", failed.getJobId(), failed.getErrorMessage());
         } else if (event instanceof JobRetryingEvent retrying) {
             log.warn("Job {} retrying (attempt {}), next at: {}",
-                retrying.getJobId(), retrying.getAttempt(), retrying.getNextScheduledTime());
+                retrying.getJobId(), retrying.getRetryAttempt(), retrying.getScheduledTime());
         } else if (event instanceof JobDlqEvent dlq) {
             log.error("Job {} moved to DLQ after {} attempts: {}",
-                dlq.getJobId(), dlq.getAttempt(), dlq.getErrorMessage());
+                dlq.getJobId(), dlq.getRetryAttempt(), dlq.getErrorMessage());
         }
     });
 }

--- a/website/docs/troubleshooting/overview.md
+++ b/website/docs/troubleshooting/overview.md
@@ -12,7 +12,7 @@ When something goes wrong with your Ratchet jobs, there are several layers of ob
 
 Follow this general strategy when troubleshooting Ratchet issues:
 
-1. **Check the job status in the database** -- most issues are visible in the `scheduler_job` table
+1. **Check the job status in the database** -- live state (`PENDING`/`RUNNING`/`PAUSED`/`WAITING`) is on the `scheduler_job_queue` table; terminal outcome lives on `scheduler_job`
 2. **Review the logs** -- Ratchet uses `java.util.logging` (JUL) with detailed lifecycle messages
 3. **Listen to events** -- the event system provides real-time visibility into job state transitions
 4. **Inspect execution history** -- the `scheduler_job_execution` table records every attempt
@@ -22,8 +22,15 @@ Follow this general strategy when troubleshooting Ratchet issues:
 Run this query to get a snapshot of your scheduler's current state:
 
 ```sql
+-- Live status (PENDING/RUNNING/PAUSED/WAITING) is on scheduler_job_queue; the row
+-- is deleted at the terminal transition. Terminal outcome (SUCCEEDED/FAILED/CANCELED)
+-- survives on scheduler_job.terminal_status. UNION the two for a full snapshot.
 SELECT status, COUNT(*) as count
-FROM scheduler_job
+FROM (
+    SELECT status FROM scheduler_job_queue
+    UNION ALL
+    SELECT terminal_status AS status FROM scheduler_job WHERE terminal_status IS NOT NULL
+) all_jobs
 GROUP BY status
 ORDER BY count DESC;
 ```
@@ -197,6 +204,6 @@ If you cannot resolve an issue using these guides:
    - Ratchet version and Jakarta EE runtime (WildFly, Payara, GlassFish, etc.)
    - Database vendor and version
    - Relevant log output (with `run.ratchet` set to `FINE`)
-   - The SQL output of `SELECT status, COUNT(*) FROM scheduler_job GROUP BY status`
+   - The SQL output of `SELECT status, COUNT(*) FROM (SELECT status FROM scheduler_job_queue UNION ALL SELECT terminal_status FROM scheduler_job WHERE terminal_status IS NOT NULL) j GROUP BY status`
    - Steps to reproduce the issue
 3. **Check the [Common Issues](./common-issues) page** for known problems and their solutions


### PR DESCRIPTION
This branch collects the fixes and hardening from a review of the stores, cluster coordinators, and runtime. The public API stays backward compatible; the new masking feature is opt-in and off by default.

## Payload masking
- Field masking is opt-in (`RatchetOptions.security().maskPayloads`, default off) and customizable through a `PayloadMaskingPolicy` SPI. The built-in policy covers common credential and PII field names.
- `getJobDetail` now masks every payload it returns (`params`, the trace-context carrier, and the serialized result), not just `params`. Masking happens on the read projection only; the durable row is never touched. Free-text fields such as `lastError` are documented as out of scope.

## Cluster coordinators
- The JMS coordinator pulls inbound messages with a synchronous `receive()` on a dedicated thread instead of an async listener, which is what Jakarta Messaging allows for an application-created context inside an EE container. A WildFly container test proves it deploys and runs under those rules.
- `close()` drains the receive thread before returning, so an in-flight handler can no longer touch a CDI context that is already being torn down.
- Every coordinator (JMS, Hazelcast, Infinispan, PostgreSQL listen/notify) deploys without an application-supplied config producer, and the two-node test clusters no longer share state.

## Query layer
- Archive-inclusive search works again on the SQL stores (the UNION projection emitted one column too many), and archive cursor pagination on MongoDB seeks the right id field.
- Keyset cursors record the sort they were minted under and are ignored when the caller changes the sort field or direction mid-pagination, instead of silently skipping or repeating rows.
- Live status queries read the queue table.

## Stores
- Lock and heartbeat writes get their own transaction on every SQL store.
- Row hydration is shared between the SQL stores rather than duplicated per store.
- ArchUnit rules pin the transaction-boundary and module-layering decisions so they cannot drift.

## Smaller correctness fixes
- `LambdaDescriptor` hashCode handles nested-array captures.
- The JSON-B map converter holds one shared instance instead of pinning one to each pooled or virtual thread.
- `LogPurgeTimer.stop()` actually stops the timer.
- The job context is cleared even when startup observability throws.
- Batch submission is allowed past an application-only class policy.
- The accepted envelope version sits above the current wire version.

## Tests
Unit suites pass across the touched modules. The store query contracts, including a new case that flips the sort mid-pagination, pass against PostgreSQL, MySQL, and MongoDB on Testcontainers. The JMS portability claim is backed by a WildFly container test.
