### PR TITLE
Consolidate duplicated store and coordinator code

### DIFF
--- a/ratchet-coordinator-common/pom.xml
+++ b/ratchet-coordinator-common/pom.xml
@@ -24,6 +24,15 @@
             <artifactId>jakarta.json-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
 
         <!-- Test scope -->
         <dependency>

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/AbstractPushCoordinator.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/AbstractPushCoordinator.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.coordinator.common;
+
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.jboss.logging.Logger;
+import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
+import run.ratchet.spi.JobWakeupHint;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NodeIdentityProvider;
+
+/**
+ * Shared push-dispatch machinery for the bundled cluster coordinators. Owns the listener registry,
+ * the pre-registration buffer, the dispatch executor, and the self-suppression / metric tail that
+ * is identical across every transport. Subclasses supply the transport-specific publish path and
+ * the inbound message extraction, then hand a decoded {@link NotifyPayload} to {@link
+ * #deliverDecodedPayload(NotifyPayload)}.
+ *
+ * <p>Each subclass MUST call {@link #configureDispatch} at the top of its {@code init()} — after
+ * its config is resolved but before any transport setup — so the dispatch executor exists before
+ * the transport can deliver an inbound message.
+ */
+public abstract class AbstractPushCoordinator {
+
+  private static final Logger log = Logger.getLogger(AbstractPushCoordinator.class);
+
+  private static final int PRE_REGISTRATION_BUFFER_CAPACITY = 256;
+
+  protected final NotifyPayloadCodec codec = new NotifyPayloadCodec();
+  private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
+      new CopyOnWriteArrayList<>();
+  private final BlockingQueue<NotifyPayload> preRegistrationBuffer =
+      new ArrayBlockingQueue<>(PRE_REGISTRATION_BUFFER_CAPACITY);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  private String coordinatorKind;
+  private String displayName;
+  private MetricsCollector metrics;
+  private NodeIdentityProvider identityProvider;
+  private int maxInboundPayloadChars;
+  private long shutdownGraceMs;
+  private volatile ExecutorService listenerExecutor;
+
+  protected AbstractPushCoordinator() {}
+
+  /**
+   * Wires the shared dispatch machinery and adopts the listener executor. Subclasses build the
+   * bounded dispatch pool from their {@link CoordinatorThreading} and hand it in here, at the top
+   * of {@code init()} after resolving their config and before any transport setup, so the executor
+   * exists before the transport can deliver an inbound message.
+   */
+  protected final void configureDispatch(
+      String coordinatorKind,
+      String displayName,
+      MetricsCollector metrics,
+      NodeIdentityProvider identityProvider,
+      int maxInboundPayloadChars,
+      ExecutorService dispatchPool,
+      long shutdownGraceMs) {
+    this.coordinatorKind = coordinatorKind;
+    this.displayName = displayName;
+    this.metrics = metrics;
+    this.identityProvider = identityProvider;
+    this.maxInboundPayloadChars = maxInboundPayloadChars;
+    this.shutdownGraceMs = shutdownGraceMs;
+    this.listenerExecutor = Objects.requireNonNull(dispatchPool, "dispatchPool");
+  }
+
+  /**
+   * The dispatch executor, for transports that need to schedule their own callbacks on it (e.g. an
+   * async-publish completion handler). Available after {@link #configureDispatch} runs.
+   */
+  protected final ExecutorService listenerExecutor() {
+    return listenerExecutor;
+  }
+
+  public void registerWakeupListener(Consumer<JobWakeupHint> listener) {
+    Objects.requireNonNull(listener, "listener");
+    if (closed.get()) {
+      return;
+    }
+    listeners.add(listener);
+    drainPreRegistrationBuffer();
+  }
+
+  /**
+   * Self-suppression and metric tail shared by every transport. Resolves the local identity, drops
+   * self-broadcasts, then either buffers (no listeners yet) or dispatches.
+   */
+  protected final void deliverDecodedPayload(NotifyPayload payload) {
+    NodeIdentity local;
+    try {
+      local = new NodeIdentity(identityProvider.getNodeId());
+    } catch (RuntimeException e) {
+      onNodeIdentityProviderError(e);
+      clusterWakeupReceived("ignored_provider_error");
+      return;
+    }
+    if (payload.node().equals(local)) {
+      clusterWakeupReceived("ignored_self");
+      return;
+    }
+    clusterWakeupReceived("delivered");
+    if (listeners.isEmpty()) {
+      bufferOrDropOldest(payload);
+      return;
+    }
+    dispatchToListeners(payload);
+  }
+
+  /**
+   * Hook invoked when {@link NodeIdentityProvider#getNodeId()} throws while resolving the local
+   * identity for self-suppression. Default is a no-op; transports that logged at this site before
+   * the dispatch machinery was hoisted override this to preserve that log.
+   */
+  protected void onNodeIdentityProviderError(RuntimeException e) {
+    // no-op by default
+  }
+
+  private void dispatchToListeners(NotifyPayload msg) {
+    JobWakeupHint hint = new JobWakeupHint(msg.priority(), msg.node(), msg.executionTarget());
+    for (Consumer<JobWakeupHint> listener : listeners) {
+      try {
+        listenerExecutor.execute(
+            () -> {
+              try {
+                listener.accept(hint);
+              } catch (RuntimeException listenerEx) {
+                clusterWakeupReceived("listener_failure");
+                log.warnf(
+                    listenerEx,
+                    "%s coordinator listener threw: %s — suppressing per SPI contract",
+                    displayName,
+                    listenerEx.getMessage());
+              }
+            });
+      } catch (RuntimeException submitEx) {
+        log.debugf(
+            submitEx,
+            "%s coordinator could not enqueue listener task: %s",
+            displayName,
+            submitEx.getMessage());
+      }
+    }
+  }
+
+  // Counts as overflow regardless of the second offer's outcome — the boolean is irrelevant.
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  private void bufferOrDropOldest(NotifyPayload msg) {
+    if (preRegistrationBuffer.offer(msg)) {
+      return;
+    }
+    preRegistrationBuffer.poll();
+    preRegistrationBuffer.offer(msg);
+    clusterWakeupReceived("pre_registration_overflow");
+    log.warnf(
+        "%s coordinator pre-registration buffer overflowed; oldest wakeup dropped", displayName);
+  }
+
+  private void drainPreRegistrationBuffer() {
+    NotifyPayload msg;
+    while ((msg = preRegistrationBuffer.poll()) != null) {
+      dispatchToListeners(msg);
+    }
+  }
+
+  protected final void clusterWakeupPublished(String outcome) {
+    metrics.clusterWakeupPublished(coordinatorKind, outcome);
+  }
+
+  protected final void clusterWakeupReceived(String outcome) {
+    metrics.clusterWakeupReceived(coordinatorKind, outcome);
+  }
+
+  /**
+   * Rejects an inbound body that exceeds the configured character cap. Returns {@code true}
+   * (already metric- and log-recorded) when the caller should drop the message.
+   */
+  protected final boolean rejectIfOversized(String body) {
+    if (body != null && body.length() > maxInboundPayloadChars) {
+      clusterWakeupReceived("parse_failure");
+      log.warnf(
+          "%s coordinator rejected oversized inbound payload (%d chars > cap %d)",
+          displayName, body.length(), maxInboundPayloadChars);
+      return true;
+    }
+    return false;
+  }
+
+  protected final void shutdownListenerExecutor() {
+    ExecutorService executor = this.listenerExecutor;
+    if (executor != null) {
+      executor.shutdown();
+      try {
+        if (!executor.awaitTermination(shutdownGraceMs, TimeUnit.MILLISECONDS)) {
+          executor.shutdownNow();
+        }
+      } catch (InterruptedException ignored) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  protected final boolean markClosed() {
+    return closed.compareAndSet(false, true);
+  }
+
+  protected final boolean isClosed() {
+    return closed.get();
+  }
+}

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/AbstractPushCoordinator.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/AbstractPushCoordinator.java
@@ -54,12 +54,16 @@ public abstract class AbstractPushCoordinator {
       new ArrayBlockingQueue<>(PRE_REGISTRATION_BUFFER_CAPACITY);
   private final AtomicBoolean closed = new AtomicBoolean(false);
 
-  private String coordinatorKind;
-  private String displayName;
-  private MetricsCollector metrics;
-  private NodeIdentityProvider identityProvider;
-  private int maxInboundPayloadChars;
-  private long shutdownGraceMs;
+  // Written once in configureDispatch (the init thread) and read from the transport listener and
+  // shutdown threads. volatile gives each read the most recent write and makes the 64-bit
+  // shutdownGraceMs write atomic, so the dispatch config is safely published without leaning on
+  // the transport library's internal synchronization for the happens-before.
+  private volatile String coordinatorKind;
+  private volatile String displayName;
+  private volatile MetricsCollector metrics;
+  private volatile NodeIdentityProvider identityProvider;
+  private volatile int maxInboundPayloadChars;
+  private volatile long shutdownGraceMs;
   private volatile ExecutorService listenerExecutor;
 
   protected AbstractPushCoordinator() {}

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorCells.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorCells.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.coordinator.common;
+
+import java.util.Optional;
+
+/**
+ * Shared per-cell identifier suffixing for the bundled cluster coordinators.
+ *
+ * <p>Multi-cell deployments sharing one cluster resource (Hazelcast topic, Infinispan cache,
+ * PostgreSQL LISTEN/NOTIFY channel) append an optional {@code cellId} to a base identifier to
+ * isolate wakeup traffic. Before consolidation the separator had drifted: Hazelcast used {@code
+ * "-"} while Infinispan and PostgreSQL used {@code "_"}.
+ *
+ * <p>The separator is pinned to {@code "_"} (underscore). Rationale: the suffixed value feeds a
+ * PostgreSQL unquoted-identifier NOTIFY channel, whose charset is {@code [A-Za-z_][A-Za-z0-9_]*} —
+ * a hyphen is not a legal PostgreSQL identifier character, but underscore is. Underscore is also
+ * valid as a Hazelcast topic name and an Infinispan cache name, so it is the one separator safe for
+ * every consumer. It is additionally the pre-existing majority (Infinispan and PostgreSQL already
+ * used it); only Hazelcast changes behavior, from {@code base-cell} to {@code base_cell}.
+ */
+public final class CoordinatorCells {
+
+  /**
+   * Separator placed between the base identifier and the cell id. Pinned to underscore because it
+   * is the only separator legal in an unquoted PostgreSQL identifier while remaining valid for the
+   * Hazelcast and Infinispan consumers.
+   */
+  public static final String SEPARATOR = "_";
+
+  private CoordinatorCells() {}
+
+  /**
+   * Returns {@code base + SEPARATOR + cellId} when a cell id is present, otherwise {@code base}.
+   *
+   * @param base the base identifier (topic, cache, or channel name)
+   * @param cellId the optional per-cell suffix
+   * @return the effective identifier with the cell suffix applied
+   */
+  public static String suffixed(String base, Optional<String> cellId) {
+    return cellId.map(c -> base + SEPARATOR + c).orElse(base);
+  }
+}

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorConfigChecks.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorConfigChecks.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.coordinator.common;
+
+/**
+ * Shared validation guards for the bundled coordinator configuration records.
+ *
+ * <p>Each guard throws {@link IllegalArgumentException} with the exact message the individual
+ * coordinator configs used before consolidation, so error wording and validation semantics are
+ * unchanged. The four coordinator configs (Hazelcast, Infinispan, JMS, PostgreSQL) all shared the
+ * same {@code > 0}, {@code >= 1}, and reconnect-backoff guard text verbatim.
+ */
+public final class CoordinatorConfigChecks {
+
+  private CoordinatorConfigChecks() {}
+
+  /**
+   * Requires {@code value > 0}, throwing {@link IllegalArgumentException} with the message {@code
+   * "<name> must be > 0"} otherwise.
+   *
+   * @param value the value to validate
+   * @param name the field name used in the error message
+   */
+  public static void requirePositive(long value, String name) {
+    if (value <= 0) {
+      throw new IllegalArgumentException(name + " must be > 0");
+    }
+  }
+
+  /**
+   * Requires {@code value >= 1}, throwing {@link IllegalArgumentException} with the message {@code
+   * "<name> must be >= 1"} otherwise.
+   *
+   * @param value the value to validate
+   * @param name the field name used in the error message
+   */
+  public static void requireAtLeastOne(int value, String name) {
+    if (value < 1) {
+      throw new IllegalArgumentException(name + " must be >= 1");
+    }
+  }
+
+  /**
+   * Validates the reconnect backoff pair: {@code initialMs} must be {@code > 0} and {@code maxMs}
+   * must be {@code >= initialMs}. Throws {@link IllegalArgumentException} with the original
+   * messages ({@code "reconnectBackoffInitialMs must be > 0"} or {@code "reconnectBackoffMaxMs must
+   * be >= reconnectBackoffInitialMs"}) otherwise.
+   *
+   * @param initialMs the initial reconnect delay in milliseconds
+   * @param maxMs the cap on the doubled reconnect delay in milliseconds
+   */
+  public static void requireBackoffPair(long initialMs, long maxMs) {
+    if (initialMs <= 0) {
+      throw new IllegalArgumentException("reconnectBackoffInitialMs must be > 0");
+    }
+    if (maxMs < initialMs) {
+      throw new IllegalArgumentException(
+          "reconnectBackoffMaxMs must be >= reconnectBackoffInitialMs");
+    }
+  }
+}

--- a/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorSupport.java
+++ b/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorSupport.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.coordinator.common;
+
+import jakarta.enterprise.inject.Instance;
+import java.util.function.Supplier;
+import org.jboss.logging.Logger;
+
+/** Shared CDI {@link Instance} resolution helpers for the bundled cluster coordinators. */
+public final class CoordinatorSupport {
+
+  private static final Logger log = Logger.getLogger(CoordinatorSupport.class);
+
+  private CoordinatorSupport() {}
+
+  /**
+   * Resolves a required dependency from a CDI {@link Instance}, throwing when unsatisfied and
+   * warning (then taking the first match) when ambiguous.
+   */
+  public static <T> T resolveRequired(
+      Instance<T> instance, String unsatisfiedMessage, String ambiguousMessage) {
+    if (instance == null || instance.isUnsatisfied()) {
+      throw new IllegalStateException(unsatisfiedMessage);
+    }
+    if (instance.isAmbiguous()) {
+      log.warn(ambiguousMessage);
+    }
+    return instance.get();
+  }
+
+  /**
+   * Resolves a coordinator config from its {@link Instance}, falling back to the supplied defaults
+   * when no producer is present.
+   */
+  public static <C> C resolveConfigOrDefault(Instance<C> configInstance, Supplier<C> defaults) {
+    return configInstance != null && configInstance.isResolvable()
+        ? configInstance.get()
+        : defaults.get();
+  }
+}

--- a/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
+++ b/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
@@ -31,22 +31,15 @@ import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.AbstractPushCoordinator;
+import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
-import run.ratchet.spi.JobWakeupHint;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.SchedulerLifecycleHook;
@@ -73,11 +66,10 @@ import run.ratchet.spi.SchedulerLifecycleHook;
 // Coordinator @Priority order: see PostgresqlListenNotifyCoordinator. Operators MUST pull in
 // exactly one coordinator module; distinct priorities only prevent CDI ambiguity errors on a
 // transitive double-pull.
-public class HazelcastClusterCoordinator implements ClusterCoordinator, SchedulerLifecycleHook {
+public class HazelcastClusterCoordinator extends AbstractPushCoordinator
+    implements ClusterCoordinator, SchedulerLifecycleHook {
 
   private static final Logger log = Logger.getLogger(HazelcastClusterCoordinator.class);
-
-  private static final int PRE_REGISTRATION_BUFFER_CAPACITY = 256;
 
   static final String COORDINATOR_KIND = "hazelcast";
 
@@ -96,18 +88,10 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
 
   private HazelcastCoordinatorConfig config;
 
-  private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
-  private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
-      new CopyOnWriteArrayList<>();
-  private final BlockingQueue<NotifyPayload> preRegistrationBuffer =
-      new ArrayBlockingQueue<>(PRE_REGISTRATION_BUFFER_CAPACITY);
-
   private HazelcastInstance directInstance;
   private ITopic<String> topic;
   private UUID listenerRegistrationId;
-  private ExecutorService listenerExecutor;
   private CoordinatorThreading threading;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   HazelcastClusterCoordinator() {
     // CDI proxy constructor — package-private to keep it out of the public API surface.
@@ -130,9 +114,8 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
   void init() {
     if (config == null) {
       config =
-          configInstance != null && configInstance.isResolvable()
-              ? configInstance.get()
-              : HazelcastCoordinatorConfig.defaults();
+          CoordinatorSupport.resolveConfigOrDefault(
+              configInstance, HazelcastCoordinatorConfig::defaults);
     }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
@@ -142,20 +125,34 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
       // factory. Standalone is an explicit opt-in via the test constructor.
       threading = CoordinatorThreading.managed("ratchet-coordinator-hazelcast");
     }
+    configureDispatch(
+        COORDINATOR_KIND,
+        "Hazelcast",
+        metrics,
+        identityProvider,
+        config.maxInboundPayloadChars(),
+        threading.newDispatchPool(
+            "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity()),
+        config.shutdownGraceMs());
     HazelcastInstance hz;
     if (directInstance != null) {
       hz = directInstance;
     } else {
-      HazelcastInstanceProvider provider = resolveProvider();
+      HazelcastInstanceProvider provider =
+          CoordinatorSupport.resolveRequired(
+              providerInstance,
+              "No HazelcastInstanceProvider available. Provide a @Produces"
+                  + " HazelcastInstanceProvider or use the Payara JNDI-bound default.",
+              "Multiple HazelcastInstanceProvider beans visible; first match wins. Use"
+                  + " @Alternative + @Priority for disambiguation.");
       hz = provider.hazelcastInstance();
     }
     topic = hz.getTopic(config.effectiveTopicName());
-    listenerExecutor = newListenerExecutor();
   }
 
   @Override
   public void afterStart() {
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     if (topic == null) {
@@ -168,7 +165,7 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
   public void notifyNewWork(JobPriority priority, NodeIdentity source, String executionTarget) {
     Objects.requireNonNull(priority, "priority");
     Objects.requireNonNull(source, "source");
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     try {
@@ -185,7 +182,7 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
                   throwable.getMessage());
             }
           },
-          listenerExecutor);
+          listenerExecutor());
     } catch (RuntimeException ex) {
       clusterWakeupPublished("failure");
       log.warnf(
@@ -193,16 +190,6 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
           "Hazelcast coordinator notifyNewWork transport/encode failure: %s — wakeup dropped",
           ex.getMessage());
     }
-  }
-
-  @Override
-  public void registerWakeupListener(Consumer<JobWakeupHint> listener) {
-    Objects.requireNonNull(listener, "listener");
-    if (closed.get()) {
-      return;
-    }
-    listeners.add(listener);
-    drainPreRegistrationBuffer();
   }
 
   /**
@@ -216,7 +203,7 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
 
   @Override
   public void close() {
-    if (!closed.compareAndSet(false, true)) {
+    if (!markClosed()) {
       return;
     }
     UUID regId = this.listenerRegistrationId;
@@ -227,28 +214,14 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
         // best-effort; Hazelcast may already be stopped (provider-driven)
       }
     }
-    ExecutorService executor = this.listenerExecutor;
-    if (executor != null) {
-      executor.shutdown();
-      try {
-        if (!executor.awaitTermination(config.shutdownGraceMs(), TimeUnit.MILLISECONDS)) {
-          executor.shutdownNow();
-        }
-      } catch (InterruptedException ignored) {
-        Thread.currentThread().interrupt();
-      }
-    }
+    shutdownListenerExecutor();
   }
 
   /** Dispatch path from the Hazelcast topic listener thread. */
   void onTopicMessage(String body) {
     NotifyPayload payload;
     try {
-      if (body != null && body.length() > config.maxInboundPayloadChars()) {
-        clusterWakeupReceived("parse_failure");
-        log.warnf(
-            "Hazelcast coordinator rejected oversized inbound payload (%d chars > cap %d)",
-            body.length(), config.maxInboundPayloadChars());
+      if (rejectIfOversized(body)) {
         return;
       }
       payload = codec.decode(body);
@@ -257,95 +230,7 @@ public class HazelcastClusterCoordinator implements ClusterCoordinator, Schedule
       log.debugf("Hazelcast coordinator dropped malformed payload: %s", parseEx.getMessage());
       return;
     }
-    NodeIdentity local;
-    try {
-      local = new NodeIdentity(identityProvider.getNodeId());
-    } catch (RuntimeException e) {
-      clusterWakeupReceived("ignored_provider_error");
-      return;
-    }
-    if (payload.node().equals(local)) {
-      clusterWakeupReceived("ignored_self");
-      return;
-    }
-    clusterWakeupReceived("delivered");
-    if (listeners.isEmpty()) {
-      bufferOrDropOldest(payload);
-      return;
-    }
-    dispatchToListeners(payload);
-  }
-
-  private void dispatchToListeners(NotifyPayload msg) {
-    JobWakeupHint hint = new JobWakeupHint(msg.priority(), msg.node(), msg.executionTarget());
-    for (Consumer<JobWakeupHint> listener : listeners) {
-      try {
-        listenerExecutor.execute(
-            () -> {
-              try {
-                listener.accept(hint);
-              } catch (RuntimeException listenerEx) {
-                clusterWakeupReceived("listener_failure");
-                log.warnf(
-                    listenerEx,
-                    "Hazelcast coordinator listener threw: %s — suppressing per SPI contract",
-                    listenerEx.getMessage());
-              }
-            });
-      } catch (RuntimeException submitEx) {
-        log.debugf(
-            submitEx,
-            "Hazelcast coordinator could not enqueue listener task: %s",
-            submitEx.getMessage());
-      }
-    }
-  }
-
-  // Counts as overflow regardless of the second offer's outcome — the boolean is irrelevant.
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  private void bufferOrDropOldest(NotifyPayload msg) {
-    if (preRegistrationBuffer.offer(msg)) {
-      return;
-    }
-    preRegistrationBuffer.poll();
-    preRegistrationBuffer.offer(msg);
-    clusterWakeupReceived("pre_registration_overflow");
-    log.warn("Hazelcast coordinator pre-registration buffer overflowed; oldest wakeup dropped");
-  }
-
-  private void drainPreRegistrationBuffer() {
-    NotifyPayload msg;
-    while ((msg = preRegistrationBuffer.poll()) != null) {
-      dispatchToListeners(msg);
-    }
-  }
-
-  private void clusterWakeupPublished(String outcome) {
-    metrics.clusterWakeupPublished(COORDINATOR_KIND, outcome);
-  }
-
-  private void clusterWakeupReceived(String outcome) {
-    metrics.clusterWakeupReceived(COORDINATOR_KIND, outcome);
-  }
-
-  private HazelcastInstanceProvider resolveProvider() {
-    Instance<HazelcastInstanceProvider> instance = this.providerInstance;
-    if (instance == null || instance.isUnsatisfied()) {
-      throw new IllegalStateException(
-          "No HazelcastInstanceProvider available. Provide a @Produces"
-              + " HazelcastInstanceProvider or use the Payara JNDI-bound default.");
-    }
-    if (instance.isAmbiguous()) {
-      log.warn(
-          "Multiple HazelcastInstanceProvider beans visible; first match wins. Use"
-              + " @Alternative + @Priority for disambiguation.");
-    }
-    return instance.get();
-  }
-
-  private ExecutorService newListenerExecutor() {
-    return threading.newDispatchPool(
-        "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity());
+    deliverDecodedPayload(payload);
   }
 
   /**

--- a/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastCoordinatorConfig.java
+++ b/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastCoordinatorConfig.java
@@ -17,6 +17,8 @@ package run.ratchet.coordinator.hazelcast;
 
 import java.util.Objects;
 import java.util.Optional;
+import run.ratchet.coordinator.common.CoordinatorCells;
+import run.ratchet.coordinator.common.CoordinatorConfigChecks;
 
 /**
  * Tunable configuration for {@link HazelcastClusterCoordinator}.
@@ -54,18 +56,11 @@ public record HazelcastCoordinatorConfig(
       throw new IllegalArgumentException("topicName must be non-blank");
     }
     Objects.requireNonNull(cellId, "cellId");
-    if (maxInboundPayloadChars <= 0) {
-      throw new IllegalArgumentException("maxInboundPayloadChars must be > 0");
-    }
-    if (listenerExecutorThreads < 1) {
-      throw new IllegalArgumentException("listenerExecutorThreads must be >= 1");
-    }
-    if (listenerExecutorQueueCapacity < 1) {
-      throw new IllegalArgumentException("listenerExecutorQueueCapacity must be >= 1");
-    }
-    if (shutdownGraceMs <= 0) {
-      throw new IllegalArgumentException("shutdownGraceMs must be > 0");
-    }
+    CoordinatorConfigChecks.requirePositive(maxInboundPayloadChars, "maxInboundPayloadChars");
+    CoordinatorConfigChecks.requireAtLeastOne(listenerExecutorThreads, "listenerExecutorThreads");
+    CoordinatorConfigChecks.requireAtLeastOne(
+        listenerExecutorQueueCapacity, "listenerExecutorQueueCapacity");
+    CoordinatorConfigChecks.requirePositive(shutdownGraceMs, "shutdownGraceMs");
   }
 
   public static HazelcastCoordinatorConfig defaults() {
@@ -75,6 +70,6 @@ public record HazelcastCoordinatorConfig(
 
   /** Effective topic name after applying the optional {@code cellId} suffix. */
   public String effectiveTopicName() {
-    return cellId.map(c -> topicName + "-" + c).orElse(topicName);
+    return CoordinatorCells.suffixed(topicName, cellId);
   }
 }

--- a/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/HazelcastCoordinatorConfigTest.java
+++ b/ratchet-coordinator-hazelcast/src/test/java/run/ratchet/coordinator/hazelcast/HazelcastCoordinatorConfigTest.java
@@ -39,7 +39,7 @@ class HazelcastCoordinatorConfigTest {
   void effectiveTopicNameAppliesCellId() {
     HazelcastCoordinatorConfig c =
         new HazelcastCoordinatorConfig("base", Optional.of("tenant42"), 16_384, 2, 1_024, 5_000L);
-    assertEquals("base-tenant42", c.effectiveTopicName());
+    assertEquals("base_tenant42", c.effectiveTopicName());
   }
 
   @Test

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
@@ -26,24 +26,17 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
 import java.util.Objects;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.AbstractPushCoordinator;
+import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
-import run.ratchet.spi.JobWakeupHint;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.SchedulerLifecycleHook;
@@ -70,11 +63,10 @@ import run.ratchet.spi.SchedulerLifecycleHook;
 // Coordinator @Priority order: see PostgresqlListenNotifyCoordinator. Operators MUST pull in
 // exactly one coordinator module; distinct priorities only prevent CDI ambiguity errors on a
 // transitive double-pull.
-public class InfinispanClusterCoordinator implements ClusterCoordinator, SchedulerLifecycleHook {
+public class InfinispanClusterCoordinator extends AbstractPushCoordinator
+    implements ClusterCoordinator, SchedulerLifecycleHook {
 
   private static final Logger log = Logger.getLogger(InfinispanClusterCoordinator.class);
-
-  private static final int PRE_REGISTRATION_BUFFER_CAPACITY = 256;
 
   static final String COORDINATOR_KIND = "infinispan";
 
@@ -93,18 +85,11 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
 
   private InfinispanCoordinatorConfig config;
 
-  private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
   private final AtomicLong sendSequence = new AtomicLong();
-  private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
-      new CopyOnWriteArrayList<>();
-  private final BlockingQueue<NotifyPayload> preRegistrationBuffer =
-      new ArrayBlockingQueue<>(PRE_REGISTRATION_BUFFER_CAPACITY);
 
   private InfinispanCacheLifecycle cacheLifecycle;
   private Cache<String, String> directCache;
-  private ExecutorService listenerExecutor;
   private CoordinatorThreading threading;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   protected InfinispanClusterCoordinator() {
     // CDI proxy constructor.
@@ -127,9 +112,8 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
   void init() {
     if (config == null) {
       config =
-          configInstance != null && configInstance.isResolvable()
-              ? configInstance.get()
-              : InfinispanCoordinatorConfig.defaults();
+          CoordinatorSupport.resolveConfigOrDefault(
+              configInstance, InfinispanCoordinatorConfig::defaults);
     }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
@@ -139,23 +123,37 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
       // factory. Standalone is an explicit opt-in via the test constructor.
       threading = CoordinatorThreading.managed("ratchet-coordinator-infinispan");
     }
+    configureDispatch(
+        COORDINATOR_KIND,
+        "Infinispan",
+        metrics,
+        identityProvider,
+        config.maxInboundPayloadChars(),
+        threading.newDispatchPool(
+            "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity()),
+        config.shutdownGraceMs());
     Cache<String, String> cache;
     if (directCache != null) {
       cache = directCache;
     } else {
-      InfinispanCacheManagerProvider provider = resolveProvider();
+      InfinispanCacheManagerProvider provider =
+          CoordinatorSupport.resolveRequired(
+              providerInstance,
+              "No InfinispanCacheManagerProvider available. Provide a @Produces"
+                  + " InfinispanCacheManagerProvider or use the WildFly subsystem-bound default.",
+              "Multiple InfinispanCacheManagerProvider beans visible; first match wins. Use"
+                  + " @Alternative + @Priority for disambiguation.");
       EmbeddedCacheManager cacheManager = provider.cacheManager();
       cache = cacheManager.getCache(config.effectiveCacheName());
     }
     cacheLifecycle =
         new InfinispanCacheLifecycle(
             cache, config, codec, this::onInboundNotification, this::onParseFailure);
-    listenerExecutor = newListenerExecutor();
   }
 
   @Override
   public void afterStart() {
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     if (cacheLifecycle == null) {
@@ -168,7 +166,7 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
   public void notifyNewWork(JobPriority priority, NodeIdentity source, String executionTarget) {
     Objects.requireNonNull(priority, "priority");
     Objects.requireNonNull(source, "source");
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     try {
@@ -187,16 +185,6 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
     }
   }
 
-  @Override
-  public void registerWakeupListener(Consumer<JobWakeupHint> listener) {
-    Objects.requireNonNull(listener, "listener");
-    if (closed.get()) {
-      return;
-    }
-    listeners.add(listener);
-    drainPreRegistrationBuffer();
-  }
-
   /**
    * Hook chain entry point — runs during {@code RatchetLifecycle.onShutdown} after pollers and the
    * execution coordinator have stopped. Delegates to {@link #close()}, which is idempotent.
@@ -208,125 +196,27 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator, Schedul
 
   @Override
   public void close() {
-    if (!closed.compareAndSet(false, true)) {
+    if (!markClosed()) {
       return;
     }
     InfinispanCacheLifecycle lifecycle = this.cacheLifecycle;
     if (lifecycle != null) {
       lifecycle.close();
     }
-    ExecutorService executor = this.listenerExecutor;
-    if (executor != null) {
-      executor.shutdown();
-      try {
-        if (!executor.awaitTermination(config.shutdownGraceMs(), TimeUnit.MILLISECONDS)) {
-          executor.shutdownNow();
-        }
-      } catch (InterruptedException ignored) {
-        Thread.currentThread().interrupt();
-      }
-    }
+    shutdownListenerExecutor();
   }
 
   /** Dispatch path from the cache listener. Self-suppresses then routes to listeners. */
   void onInboundNotification(NotifyPayload msg) {
-    NodeIdentity local;
-    try {
-      local = new NodeIdentity(identityProvider.getNodeId());
-    } catch (RuntimeException e) {
-      clusterWakeupReceived("ignored_provider_error");
-      return;
-    }
-    if (msg.node().equals(local)) {
-      clusterWakeupReceived("ignored_self");
-      return;
-    }
-    clusterWakeupReceived("delivered");
-    if (listeners.isEmpty()) {
-      bufferOrDropOldest(msg);
-      return;
-    }
-    dispatchToListeners(msg);
-  }
-
-  private void dispatchToListeners(NotifyPayload msg) {
-    JobWakeupHint hint = new JobWakeupHint(msg.priority(), msg.node(), msg.executionTarget());
-    for (Consumer<JobWakeupHint> listener : listeners) {
-      try {
-        listenerExecutor.execute(
-            () -> {
-              try {
-                listener.accept(hint);
-              } catch (RuntimeException listenerEx) {
-                clusterWakeupReceived("listener_failure");
-                log.warnf(
-                    listenerEx,
-                    "Infinispan coordinator listener threw: %s — suppressing per SPI contract",
-                    listenerEx.getMessage());
-              }
-            });
-      } catch (RuntimeException submitEx) {
-        log.debugf(
-            submitEx,
-            "Infinispan coordinator could not enqueue listener task: %s",
-            submitEx.getMessage());
-      }
-    }
-  }
-
-  // Counts as overflow regardless of the second offer's outcome — the boolean is irrelevant.
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  private void bufferOrDropOldest(NotifyPayload msg) {
-    if (preRegistrationBuffer.offer(msg)) {
-      return;
-    }
-    preRegistrationBuffer.poll();
-    preRegistrationBuffer.offer(msg);
-    clusterWakeupReceived("pre_registration_overflow");
-    log.warn("Infinispan coordinator pre-registration buffer overflowed; oldest wakeup dropped");
-  }
-
-  private void drainPreRegistrationBuffer() {
-    NotifyPayload msg;
-    while ((msg = preRegistrationBuffer.poll()) != null) {
-      dispatchToListeners(msg);
-    }
+    deliverDecodedPayload(msg);
   }
 
   private void onParseFailure() {
     clusterWakeupReceived("parse_failure");
   }
 
-  private void clusterWakeupPublished(String outcome) {
-    metrics.clusterWakeupPublished(COORDINATOR_KIND, outcome);
-  }
-
-  private void clusterWakeupReceived(String outcome) {
-    metrics.clusterWakeupReceived(COORDINATOR_KIND, outcome);
-  }
-
-  private InfinispanCacheManagerProvider resolveProvider() {
-    Instance<InfinispanCacheManagerProvider> instance = this.providerInstance;
-    if (instance == null || instance.isUnsatisfied()) {
-      throw new IllegalStateException(
-          "No InfinispanCacheManagerProvider available. Provide a @Produces"
-              + " InfinispanCacheManagerProvider or use the WildFly subsystem-bound default.");
-    }
-    if (instance.isAmbiguous()) {
-      log.warn(
-          "Multiple InfinispanCacheManagerProvider beans visible; first match wins. Use"
-              + " @Alternative + @Priority for disambiguation.");
-    }
-    return instance.get();
-  }
-
   /** Test accessor for the harness — exposes the lifecycle so readiness can be polled. */
   InfinispanCacheLifecycle lifecycle() {
     return cacheLifecycle;
-  }
-
-  private ExecutorService newListenerExecutor() {
-    return threading.newDispatchPool(
-        "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity());
   }
 }

--- a/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanCoordinatorConfig.java
+++ b/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanCoordinatorConfig.java
@@ -17,6 +17,8 @@ package run.ratchet.coordinator.infinispan;
 
 import java.util.Objects;
 import java.util.Optional;
+import run.ratchet.coordinator.common.CoordinatorCells;
+import run.ratchet.coordinator.common.CoordinatorConfigChecks;
 
 /**
  * Tunable configuration for {@link InfinispanClusterCoordinator}.
@@ -63,21 +65,12 @@ public record InfinispanCoordinatorConfig(
       throw new IllegalArgumentException("cacheName must be non-blank");
     }
     Objects.requireNonNull(cellId, "cellId");
-    if (wakeupTtlSeconds <= 0) {
-      throw new IllegalArgumentException("wakeupTtlSeconds must be > 0");
-    }
-    if (maxInboundPayloadChars <= 0) {
-      throw new IllegalArgumentException("maxInboundPayloadChars must be > 0");
-    }
-    if (listenerExecutorThreads < 1) {
-      throw new IllegalArgumentException("listenerExecutorThreads must be >= 1");
-    }
-    if (listenerExecutorQueueCapacity < 1) {
-      throw new IllegalArgumentException("listenerExecutorQueueCapacity must be >= 1");
-    }
-    if (shutdownGraceMs <= 0) {
-      throw new IllegalArgumentException("shutdownGraceMs must be > 0");
-    }
+    CoordinatorConfigChecks.requirePositive(wakeupTtlSeconds, "wakeupTtlSeconds");
+    CoordinatorConfigChecks.requirePositive(maxInboundPayloadChars, "maxInboundPayloadChars");
+    CoordinatorConfigChecks.requireAtLeastOne(listenerExecutorThreads, "listenerExecutorThreads");
+    CoordinatorConfigChecks.requireAtLeastOne(
+        listenerExecutorQueueCapacity, "listenerExecutorQueueCapacity");
+    CoordinatorConfigChecks.requirePositive(shutdownGraceMs, "shutdownGraceMs");
   }
 
   /** Default tuning suitable for WildFly + standalone Infinispan deployments. */
@@ -88,6 +81,6 @@ public record InfinispanCoordinatorConfig(
 
   /** The fully-qualified cache name after applying the optional {@code cellId} suffix. */
   public String effectiveCacheName() {
-    return cellId.map(c -> cacheName + "_" + c).orElse(cacheName);
+    return CoordinatorCells.suffixed(cacheName, cellId);
   }
 }

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
@@ -32,22 +32,15 @@ import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
 import jakarta.jms.Topic;
 import java.util.Objects;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.AbstractPushCoordinator;
+import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
 import run.ratchet.coordinator.common.DecodeException;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
-import run.ratchet.spi.JobWakeupHint;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.SchedulerLifecycleHook;
@@ -83,11 +76,10 @@ import run.ratchet.spi.SchedulerLifecycleHook;
 // Coordinator @Priority order: see PostgresqlListenNotifyCoordinator. Operators MUST pull in
 // exactly one coordinator module; distinct priorities only prevent CDI ambiguity errors on a
 // transitive double-pull.
-public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifecycleHook {
+public class JmsClusterCoordinator extends AbstractPushCoordinator
+    implements ClusterCoordinator, SchedulerLifecycleHook {
 
   private static final Logger log = Logger.getLogger(JmsClusterCoordinator.class);
-
-  private static final int PRE_REGISTRATION_BUFFER_CAPACITY = 256;
 
   static final String COORDINATOR_KIND = "jms";
 
@@ -106,19 +98,11 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
 
   private JmsCoordinatorConfig config;
 
-  private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
-  private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
-      new CopyOnWriteArrayList<>();
-  private final BlockingQueue<NotifyPayload> preRegistrationBuffer =
-      new ArrayBlockingQueue<>(PRE_REGISTRATION_BUFFER_CAPACITY);
-
   private JmsConnectionLifecycle connectionLifecycle;
   private ConnectionFactory directConnectionFactory;
   private Topic topic;
   private NodeIdentity localIdentity;
-  private ExecutorService listenerExecutor;
   private CoordinatorThreading threading;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   protected JmsClusterCoordinator() {
     // CDI proxy constructor.
@@ -165,9 +149,7 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
   void init() {
     if (config == null) {
       config =
-          configInstance != null && configInstance.isResolvable()
-              ? configInstance.get()
-              : JmsCoordinatorConfig.defaults();
+          CoordinatorSupport.resolveConfigOrDefault(configInstance, JmsCoordinatorConfig::defaults);
     }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
@@ -177,12 +159,27 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
       // managed thread factory. Standalone is an explicit opt-in via the test constructors.
       threading = CoordinatorThreading.managed("ratchet-coordinator-jms");
     }
+    configureDispatch(
+        COORDINATOR_KIND,
+        "JMS",
+        metrics,
+        identityProvider,
+        config.maxInboundPayloadChars(),
+        threading.newDispatchPool(
+            "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity()),
+        config.shutdownGraceMs());
     if (connectionLifecycle == null) {
       ConnectionFactory cf;
       if (directConnectionFactory != null) {
         cf = directConnectionFactory;
       } else {
-        JmsConnectionFactoryProvider provider = resolveProvider();
+        JmsConnectionFactoryProvider provider =
+            CoordinatorSupport.resolveRequired(
+                providerInstance,
+                "No JmsConnectionFactoryProvider available for JmsClusterCoordinator. Provide a"
+                    + " @Produces JmsConnectionFactoryProvider or use the default JNDI lookup bean.",
+                "Multiple JmsConnectionFactoryProvider beans visible; first match wins. Use"
+                    + " @Alternative + @Priority for disambiguation.");
         cf = provider.connectionFactory();
         if (topic == null) {
           this.topic = provider.topic();
@@ -192,13 +189,12 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
           new JmsConnectionLifecycle(
               cf, topic, config, this::onJmsMessage, this::onConnectionTransportFailure, threading);
     }
-    listenerExecutor = newListenerExecutor();
     localIdentity = new NodeIdentity(identityProvider.getNodeId());
   }
 
   @Override
   public void afterStart() {
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     if (connectionLifecycle == null || localIdentity == null) {
@@ -211,7 +207,7 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
   public void notifyNewWork(JobPriority priority, NodeIdentity source, String executionTarget) {
     Objects.requireNonNull(priority, "priority");
     Objects.requireNonNull(source, "source");
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     try {
@@ -252,16 +248,6 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
     }
   }
 
-  @Override
-  public void registerWakeupListener(Consumer<JobWakeupHint> listener) {
-    Objects.requireNonNull(listener, "listener");
-    if (closed.get()) {
-      return;
-    }
-    listeners.add(listener);
-    drainPreRegistrationBuffer();
-  }
-
   /**
    * Hook chain entry point — runs during {@code RatchetLifecycle.onShutdown} after pollers and the
    * execution coordinator have stopped. Delegates to {@link #close()}, which is idempotent.
@@ -273,24 +259,14 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
 
   @Override
   public void close() {
-    if (!closed.compareAndSet(false, true)) {
+    if (!markClosed()) {
       return;
     }
     JmsConnectionLifecycle lifecycle = this.connectionLifecycle;
     if (lifecycle != null) {
       lifecycle.close();
     }
-    ExecutorService executor = this.listenerExecutor;
-    if (executor != null) {
-      executor.shutdown();
-      try {
-        if (!executor.awaitTermination(config.shutdownGraceMs(), TimeUnit.MILLISECONDS)) {
-          executor.shutdownNow();
-        }
-      } catch (InterruptedException ignored) {
-        Thread.currentThread().interrupt();
-      }
-    }
+    shutdownListenerExecutor();
   }
 
   /** Dispatch path from the JMS provider's listener thread. */
@@ -302,13 +278,9 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
         return;
       }
       String body = tm.getText();
-      if (body != null && body.length() > config.maxInboundPayloadChars()) {
+      if (rejectIfOversized(body)) {
         // Hard cap on listener-thread allocation: a hostile or buggy producer can otherwise
         // attach a multi-MB body that the codec would happily decode into memory.
-        clusterWakeupReceived("parse_failure");
-        log.warnf(
-            "JMS coordinator rejected oversized inbound payload (%d chars > cap %d)",
-            body.length(), config.maxInboundPayloadChars());
         return;
       }
       payload = codec.decode(body);
@@ -321,93 +293,11 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
       log.warnf("JMS coordinator dropped inbound message due to JMS error: %s", ex.getMessage());
       return;
     }
-    NodeIdentity local;
-    try {
-      local = new NodeIdentity(identityProvider.getNodeId());
-    } catch (RuntimeException e) {
-      clusterWakeupReceived("ignored_provider_error");
-      return;
-    }
-    if (payload.node().equals(local)) {
-      clusterWakeupReceived("ignored_self");
-      return;
-    }
-    clusterWakeupReceived("delivered");
-    if (listeners.isEmpty()) {
-      bufferOrDropOldest(payload);
-      return;
-    }
-    dispatchToListeners(payload);
-  }
-
-  private void dispatchToListeners(NotifyPayload msg) {
-    JobWakeupHint hint = new JobWakeupHint(msg.priority(), msg.node(), msg.executionTarget());
-    for (Consumer<JobWakeupHint> listener : listeners) {
-      try {
-        listenerExecutor.execute(
-            () -> {
-              try {
-                listener.accept(hint);
-              } catch (RuntimeException listenerEx) {
-                clusterWakeupReceived("listener_failure");
-                log.warnf(
-                    listenerEx,
-                    "JMS coordinator listener threw: %s — suppressing per SPI contract",
-                    listenerEx.getMessage());
-              }
-            });
-      } catch (RuntimeException submitEx) {
-        // Executor refused — log only; the local poller floor is unaffected.
-        log.debugf(
-            submitEx, "JMS coordinator could not enqueue listener task: %s", submitEx.getMessage());
-      }
-    }
-  }
-
-  // Counts as overflow regardless of the second offer's outcome — the boolean is irrelevant.
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  private void bufferOrDropOldest(NotifyPayload msg) {
-    if (preRegistrationBuffer.offer(msg)) {
-      return;
-    }
-    preRegistrationBuffer.poll();
-    preRegistrationBuffer.offer(msg);
-    clusterWakeupReceived("pre_registration_overflow");
-    log.warn("JMS coordinator pre-registration buffer overflowed; oldest wakeup dropped");
-  }
-
-  private void drainPreRegistrationBuffer() {
-    NotifyPayload msg;
-    while ((msg = preRegistrationBuffer.poll()) != null) {
-      dispatchToListeners(msg);
-    }
+    deliverDecodedPayload(payload);
   }
 
   private void onConnectionTransportFailure() {
     clusterWakeupReceived("transport_failure");
-  }
-
-  private void clusterWakeupPublished(String outcome) {
-    metrics.clusterWakeupPublished(COORDINATOR_KIND, outcome);
-  }
-
-  private void clusterWakeupReceived(String outcome) {
-    metrics.clusterWakeupReceived(COORDINATOR_KIND, outcome);
-  }
-
-  private JmsConnectionFactoryProvider resolveProvider() {
-    Instance<JmsConnectionFactoryProvider> instance = this.providerInstance;
-    if (instance == null || instance.isUnsatisfied()) {
-      throw new IllegalStateException(
-          "No JmsConnectionFactoryProvider available for JmsClusterCoordinator. Provide a"
-              + " @Produces JmsConnectionFactoryProvider or use the default JNDI lookup bean.");
-    }
-    if (instance.isAmbiguous()) {
-      log.warn(
-          "Multiple JmsConnectionFactoryProvider beans visible; first match wins. Use"
-              + " @Alternative + @Priority for disambiguation.");
-    }
-    return instance.get();
   }
 
   /**
@@ -415,10 +305,5 @@ public class JmsClusterCoordinator implements ClusterCoordinator, SchedulerLifec
    */
   JmsConnectionLifecycle lifecycle() {
     return connectionLifecycle;
-  }
-
-  private ExecutorService newListenerExecutor() {
-    return threading.newDispatchPool(
-        "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity());
   }
 }

--- a/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsCoordinatorConfig.java
+++ b/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsCoordinatorConfig.java
@@ -17,6 +17,7 @@ package run.ratchet.coordinator.jms;
 
 import java.util.Objects;
 import java.util.Optional;
+import run.ratchet.coordinator.common.CoordinatorConfigChecks;
 
 /**
  * Tunable configuration for {@link JmsClusterCoordinator}.
@@ -73,25 +74,12 @@ public record JmsCoordinatorConfig(
     Objects.requireNonNull(connectionFactoryJndi, "connectionFactoryJndi");
     Objects.requireNonNull(topicJndi, "topicJndi");
     Objects.requireNonNull(cellId, "cellId");
-    if (reconnectBackoffInitialMs <= 0) {
-      throw new IllegalArgumentException("reconnectBackoffInitialMs must be > 0");
-    }
-    if (reconnectBackoffMaxMs < reconnectBackoffInitialMs) {
-      throw new IllegalArgumentException(
-          "reconnectBackoffMaxMs must be >= reconnectBackoffInitialMs");
-    }
-    if (maxInboundPayloadChars <= 0) {
-      throw new IllegalArgumentException("maxInboundPayloadChars must be > 0");
-    }
-    if (listenerExecutorThreads < 1) {
-      throw new IllegalArgumentException("listenerExecutorThreads must be >= 1");
-    }
-    if (listenerExecutorQueueCapacity < 1) {
-      throw new IllegalArgumentException("listenerExecutorQueueCapacity must be >= 1");
-    }
-    if (shutdownGraceMs <= 0) {
-      throw new IllegalArgumentException("shutdownGraceMs must be > 0");
-    }
+    CoordinatorConfigChecks.requireBackoffPair(reconnectBackoffInitialMs, reconnectBackoffMaxMs);
+    CoordinatorConfigChecks.requirePositive(maxInboundPayloadChars, "maxInboundPayloadChars");
+    CoordinatorConfigChecks.requireAtLeastOne(listenerExecutorThreads, "listenerExecutorThreads");
+    CoordinatorConfigChecks.requireAtLeastOne(
+        listenerExecutorQueueCapacity, "listenerExecutorQueueCapacity");
+    CoordinatorConfigChecks.requirePositive(shutdownGraceMs, "shutdownGraceMs");
   }
 
   /** Default tuning suitable for typical Jakarta EE deployments. */

--- a/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlCoordinatorConfig.java
+++ b/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlCoordinatorConfig.java
@@ -19,6 +19,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import run.ratchet.coordinator.common.CoordinatorCells;
+import run.ratchet.coordinator.common.CoordinatorConfigChecks;
 
 /**
  * Tunable configuration for {@link PostgresqlListenNotifyCoordinator}.
@@ -95,7 +97,7 @@ public record PostgresqlCoordinatorConfig(
                 "cellId '" + c + "' must match " + IDENTIFIER_PATTERN.pattern());
           }
         });
-    String effective = cellId.map(c -> channel + "_" + c).orElse(channel);
+    String effective = CoordinatorCells.suffixed(channel, cellId);
     int effectiveBytes = effective.getBytes(StandardCharsets.UTF_8).length;
     if (effectiveBytes > MAX_CHANNEL_BYTES) {
       throw new IllegalArgumentException(
@@ -107,28 +109,13 @@ public record PostgresqlCoordinatorConfig(
               + MAX_CHANNEL_BYTES
               + " bytes which would silently merge wakeup traffic across deployments");
     }
-    if (receiveTimeoutMs <= 0) {
-      throw new IllegalArgumentException("receiveTimeoutMs must be > 0");
-    }
-    if (reconnectBackoffInitialMs <= 0) {
-      throw new IllegalArgumentException("reconnectBackoffInitialMs must be > 0");
-    }
-    if (reconnectBackoffMaxMs < reconnectBackoffInitialMs) {
-      throw new IllegalArgumentException(
-          "reconnectBackoffMaxMs must be >= reconnectBackoffInitialMs");
-    }
-    if (maxInboundPayloadChars <= 0) {
-      throw new IllegalArgumentException("maxInboundPayloadChars must be > 0");
-    }
-    if (listenerExecutorThreads < 1) {
-      throw new IllegalArgumentException("listenerExecutorThreads must be >= 1");
-    }
-    if (listenerExecutorQueueCapacity < 1) {
-      throw new IllegalArgumentException("listenerExecutorQueueCapacity must be >= 1");
-    }
-    if (shutdownGraceMs <= 0) {
-      throw new IllegalArgumentException("shutdownGraceMs must be > 0");
-    }
+    CoordinatorConfigChecks.requirePositive(receiveTimeoutMs, "receiveTimeoutMs");
+    CoordinatorConfigChecks.requireBackoffPair(reconnectBackoffInitialMs, reconnectBackoffMaxMs);
+    CoordinatorConfigChecks.requirePositive(maxInboundPayloadChars, "maxInboundPayloadChars");
+    CoordinatorConfigChecks.requireAtLeastOne(listenerExecutorThreads, "listenerExecutorThreads");
+    CoordinatorConfigChecks.requireAtLeastOne(
+        listenerExecutorQueueCapacity, "listenerExecutorQueueCapacity");
+    CoordinatorConfigChecks.requirePositive(shutdownGraceMs, "shutdownGraceMs");
   }
 
   /** Default tuning suitable for typical deployments. */
@@ -139,6 +126,6 @@ public record PostgresqlCoordinatorConfig(
 
   /** The fully-qualified channel name after applying the optional {@code cellId} suffix. */
   public String effectiveChannel() {
-    return cellId.map(c -> channel + "_" + c).orElse(channel);
+    return CoordinatorCells.suffixed(channel, cellId);
   }
 }

--- a/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
+++ b/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
@@ -29,22 +29,16 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.Objects;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import javax.sql.DataSource;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.coordinator.common.AbstractPushCoordinator;
+import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
 import run.ratchet.coordinator.common.NotifyPayload;
-import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
-import run.ratchet.spi.JobWakeupHint;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.SchedulerLifecycleHook;
@@ -74,13 +68,10 @@ import run.ratchet.spi.SchedulerLifecycleHook;
 //   PG = PLATFORM_BEFORE + 400, JMS = +300, Hazelcast = +200, Infinispan = +100.
 // Operators MUST pull in exactly one coordinator module; distinct priorities only mean a
 // transitive double-pull picks PG over the others — it does not legitimize the configuration.
-public class PostgresqlListenNotifyCoordinator
+public class PostgresqlListenNotifyCoordinator extends AbstractPushCoordinator
     implements ClusterCoordinator, SchedulerLifecycleHook {
 
   private static final Logger log = Logger.getLogger(PostgresqlListenNotifyCoordinator.class);
-
-  /** Bounded buffer holding inbound messages that arrive before any listener registers. */
-  private static final int PRE_REGISTRATION_BUFFER_CAPACITY = 256;
 
   private static final String COORDINATOR_KIND = "postgresql";
 
@@ -100,19 +91,11 @@ public class PostgresqlListenNotifyCoordinator
 
   private PostgresqlCoordinatorConfig config;
 
-  private final NotifyPayloadCodec codec = new NotifyPayloadCodec();
-  private final CopyOnWriteArrayList<Consumer<JobWakeupHint>> listeners =
-      new CopyOnWriteArrayList<>();
-  private final BlockingQueue<NotifyPayload> preRegistrationBuffer =
-      new ArrayBlockingQueue<>(PRE_REGISTRATION_BUFFER_CAPACITY);
-
   private PostgresqlConnectionLifecycle connectionLifecycle;
   private PostgresqlConnectionLifecycle.ConnectionAcquirer publishConnectionAcquirer;
   private PostgresqlListenThread listenThread;
   private Thread listenThreadHandle;
-  private ExecutorService listenerExecutor;
   private CoordinatorThreading threading;
-  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   /** CDI proxy constructor — not for direct use. */
   @SuppressWarnings("unused")
@@ -152,9 +135,8 @@ public class PostgresqlListenNotifyCoordinator
   void init() {
     if (config == null) {
       config =
-          configInstance != null && configInstance.isResolvable()
-              ? configInstance.get()
-              : PostgresqlCoordinatorConfig.defaults();
+          CoordinatorSupport.resolveConfigOrDefault(
+              configInstance, PostgresqlCoordinatorConfig::defaults);
     }
     Objects.requireNonNull(config, "config");
     Objects.requireNonNull(identityProvider, "identityProvider");
@@ -164,9 +146,25 @@ public class PostgresqlListenNotifyCoordinator
       // managed thread factory. Standalone is an explicit opt-in via the test constructors.
       threading = CoordinatorThreading.managed("ratchet-coordinator-postgresql");
     }
+    configureDispatch(
+        COORDINATOR_KIND,
+        "PostgreSQL",
+        metrics,
+        identityProvider,
+        config.maxInboundPayloadChars(),
+        threading.newDispatchPool(
+            "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity()),
+        config.shutdownGraceMs());
     DataSource ds = null;
     if (connectionLifecycle == null || publishConnectionAcquirer == null) {
-      ds = resolveDataSource();
+      ds =
+          CoordinatorSupport.resolveRequired(
+              dataSourceInstance,
+              "No DataSource available for PostgresqlListenNotifyCoordinator. Provide a @Produces"
+                  + " DataSource or wire one via container-managed JNDI.",
+              "Multiple DataSource beans visible to PostgresqlListenNotifyCoordinator; first match"
+                  + " wins. Provide a @CoordinatorDataSource qualifier in a future revision for"
+                  + " disambiguation.");
     }
     if (connectionLifecycle == null) {
       connectionLifecycle = new PostgresqlConnectionLifecycle(ds, config);
@@ -175,7 +173,6 @@ public class PostgresqlListenNotifyCoordinator
       DataSource publishDataSource = ds;
       publishConnectionAcquirer = publishDataSource::getConnection;
     }
-    listenerExecutor = newListenerExecutor();
     listenThread =
         new PostgresqlListenThread(
             connectionLifecycle,
@@ -189,7 +186,7 @@ public class PostgresqlListenNotifyCoordinator
   /** {@inheritDoc} */
   @Override
   public void afterStart() {
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     if (listenThread == null) {
@@ -205,7 +202,7 @@ public class PostgresqlListenNotifyCoordinator
   public void notifyNewWork(JobPriority priority, NodeIdentity source, String executionTarget) {
     Objects.requireNonNull(priority, "priority");
     Objects.requireNonNull(source, "source");
-    if (closed.get()) {
+    if (isClosed()) {
       return;
     }
     try {
@@ -234,16 +231,6 @@ public class PostgresqlListenNotifyCoordinator
     }
   }
 
-  @Override
-  public void registerWakeupListener(Consumer<JobWakeupHint> listener) {
-    Objects.requireNonNull(listener, "listener");
-    if (closed.get()) {
-      return;
-    }
-    listeners.add(listener);
-    drainPreRegistrationBuffer();
-  }
-
   /**
    * Hook chain entry point — runs during {@code RatchetLifecycle.onShutdown} after pollers and the
    * execution coordinator have stopped. Delegates to {@link #close()}, which is idempotent.
@@ -255,7 +242,7 @@ public class PostgresqlListenNotifyCoordinator
 
   @Override
   public void close() {
-    if (!closed.compareAndSet(false, true)) {
+    if (!markClosed()) {
       return;
     }
     PostgresqlListenThread thread = this.listenThread;
@@ -277,17 +264,7 @@ public class PostgresqlListenNotifyCoordinator
         Thread.currentThread().interrupt();
       }
     }
-    ExecutorService executor = this.listenerExecutor;
-    if (executor != null) {
-      executor.shutdown();
-      try {
-        if (!executor.awaitTermination(config.shutdownGraceMs(), TimeUnit.MILLISECONDS)) {
-          executor.shutdownNow();
-        }
-      } catch (InterruptedException ignored) {
-        Thread.currentThread().interrupt();
-      }
-    }
+    shutdownListenerExecutor();
   }
 
   /**
@@ -303,73 +280,12 @@ public class PostgresqlListenNotifyCoordinator
 
   /** Dispatch path from the listen thread. Self-suppresses then routes to listeners. */
   private void onInboundNotification(NotifyPayload msg) {
-    NodeIdentity local;
-    try {
-      local = new NodeIdentity(identityProvider.getNodeId());
-    } catch (RuntimeException e) {
-      log.warnf("PostgreSQL coordinator: NodeIdentityProvider error: %s", e.getMessage());
-      clusterWakeupReceived("ignored_provider_error");
-      return;
-    }
-    if (msg.node().equals(local)) {
-      clusterWakeupReceived("ignored_self");
-      return;
-    }
-    clusterWakeupReceived("delivered");
-    if (listeners.isEmpty()) {
-      bufferOrDropOldest(msg);
-      return;
-    }
-    dispatchToListeners(msg);
+    deliverDecodedPayload(msg);
   }
 
-  private void dispatchToListeners(NotifyPayload msg) {
-    JobWakeupHint hint = new JobWakeupHint(msg.priority(), msg.node(), msg.executionTarget());
-    for (Consumer<JobWakeupHint> listener : listeners) {
-      try {
-        listenerExecutor.execute(
-            () -> {
-              try {
-                listener.accept(hint);
-              } catch (RuntimeException listenerEx) {
-                clusterWakeupReceived("listener_failure");
-                log.warnf(
-                    listenerEx,
-                    "PostgreSQL coordinator listener threw: %s — suppressing per SPI contract",
-                    listenerEx.getMessage());
-              }
-            });
-      } catch (RuntimeException submitEx) {
-        // Executor refused (shutdown or saturated). Skip; the local poller floor is unaffected.
-        log.debugf(
-            submitEx,
-            "PostgreSQL coordinator could not enqueue listener task: %s",
-            submitEx.getMessage());
-      }
-    }
-  }
-
-  // Drop oldest and try once more. Counts as overflow regardless of the second offer's outcome.
-  @SuppressWarnings("ResultOfMethodCallIgnored")
-  private void bufferOrDropOldest(NotifyPayload msg) {
-    if (preRegistrationBuffer.offer(msg)) {
-      return;
-    }
-    preRegistrationBuffer.poll();
-    preRegistrationBuffer.offer(msg);
-    clusterWakeupReceived("pre_registration_overflow");
-    log.warn("PostgreSQL coordinator pre-registration buffer overflowed; oldest wakeup dropped");
-  }
-
-  private void drainPreRegistrationBuffer() {
-    // Drain after the listener is visible so buffered wakeups reach the first subscriber.
-    // A notify can still arrive during concurrent listener registration and get buffered
-    // for the next registration cycle. The local poll loop is the correctness floor; the
-    // SPI wakeup signal is best-effort.
-    NotifyPayload msg;
-    while ((msg = preRegistrationBuffer.poll()) != null) {
-      dispatchToListeners(msg);
-    }
+  @Override
+  protected void onNodeIdentityProviderError(RuntimeException e) {
+    log.warnf("PostgreSQL coordinator: NodeIdentityProvider error: %s", e.getMessage());
   }
 
   private void onParseFailure() {
@@ -378,34 +294,5 @@ public class PostgresqlListenNotifyCoordinator
 
   private void onTransportFailure() {
     clusterWakeupReceived("transport_failure");
-  }
-
-  private void clusterWakeupPublished(String outcome) {
-    metrics.clusterWakeupPublished(COORDINATOR_KIND, outcome);
-  }
-
-  private void clusterWakeupReceived(String outcome) {
-    metrics.clusterWakeupReceived(COORDINATOR_KIND, outcome);
-  }
-
-  private DataSource resolveDataSource() {
-    Instance<DataSource> instance = this.dataSourceInstance;
-    if (instance == null || instance.isUnsatisfied()) {
-      throw new IllegalStateException(
-          "No DataSource available for PostgresqlListenNotifyCoordinator. Provide a @Produces"
-              + " DataSource or wire one via container-managed JNDI.");
-    }
-    if (instance.isAmbiguous()) {
-      log.warn(
-          "Multiple DataSource beans visible to PostgresqlListenNotifyCoordinator; first match"
-              + " wins. Provide a @CoordinatorDataSource qualifier in a future revision for"
-              + " disambiguation.");
-    }
-    return instance.get();
-  }
-
-  private ExecutorService newListenerExecutor() {
-    return threading.newDispatchPool(
-        "dispatch", config.listenerExecutorThreads(), config.listenerExecutorQueueCapacity());
   }
 }

--- a/ratchet-store-core/src/main/java/module-info.java
+++ b/ratchet-store-core/src/main/java/module-info.java
@@ -36,6 +36,13 @@ module run.ratchet.store.core {
   exports run.ratchet.store.query;
   exports run.ratchet.store.util;
 
+  // Store-implementor scaffolding (abstract context bases). Internal to the bundled store modules,
+  // not a public extension point; keep the visibility qualified so it can change without a break.
+  exports run.ratchet.store.context to
+      run.ratchet.store.mysql,
+      run.ratchet.store.postgresql,
+      run.ratchet.store.mongodb;
+
   opens run.ratchet.store.converter;
   opens run.ratchet.store.entity;
   opens run.ratchet.store.id;

--- a/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractJobRowMapper.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractJobRowMapper.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.context;
+
+import java.time.Instant;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.converter.JobPayloadConverter;
+import run.ratchet.store.converter.JsonMapConverter;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.util.JobHydrationSupport;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * Shared row-to-{@link JobEntity} hydration for the JDBC dialects.
+ *
+ * <p>Holds the 52 positional column indexes and the full {@link #hydrateRow(Object[])} setter body
+ * that both SQL stores share. Each dialect supplies only its own SELECT projection (PostgreSQL adds
+ * {@code ::text} casts on JSON columns) and a dialect label for hydration error messages.
+ *
+ * <p>The column order encoded by the {@code IDX_*} constants must match every dialect's projection.
+ */
+public abstract class AbstractJobRowMapper {
+
+  public static final int HYDRATION_COL_COUNT = 52;
+  public static final int IDX_Q_STATUS = 34;
+
+  protected static final int IDX_JOB_ID = 0;
+  protected static final int IDX_JOB_TYPE = 1;
+  protected static final int IDX_PRIORITY = 2;
+  protected static final int IDX_MAX_RETRIES = 3;
+  protected static final int IDX_BACKOFF_POLICY = 4;
+  protected static final int IDX_BACKOFF_PARAM_MS = 5;
+  protected static final int IDX_TIMEOUT_SEC = 6;
+  protected static final int IDX_CRON_EXPR = 7;
+  protected static final int IDX_ZONE_ID = 8;
+  protected static final int IDX_PAYLOAD = 9;
+  protected static final int IDX_PARAMS = 10;
+  protected static final int IDX_TARGET_CLASS = 11;
+  protected static final int IDX_METHOD_NAME = 12;
+  protected static final int IDX_IDEMPOTENCY_KEY = 13;
+  protected static final int IDX_BUSINESS_KEY = 14;
+  protected static final int IDX_RESOURCE_NAME = 15;
+  protected static final int IDX_ON_SUCCESS = 16;
+  protected static final int IDX_ON_FAILURE = 17;
+  protected static final int IDX_DEPENDS_ON = 18;
+  protected static final int IDX_SUPERSEDED_BY = 19;
+  protected static final int IDX_CREATED_AT = 20;
+  protected static final int IDX_CALLER_PRINCIPAL = 21;
+  protected static final int IDX_TERMINAL_STATUS = 22;
+  protected static final int IDX_TERMINAL_ERROR = 23;
+  protected static final int IDX_TOTAL_ATTEMPTS = 24;
+  protected static final int IDX_TERMINATED_AT = 25;
+  protected static final int IDX_EXEC_START = 26;
+  protected static final int IDX_EXEC_END = 27;
+  protected static final int IDX_EXEC_DURATION = 28;
+  protected static final int IDX_QUEUE_WAIT = 29;
+  protected static final int IDX_JOB_RESULT = 30;
+  protected static final int IDX_RESULT_TYPE = 31;
+  protected static final int IDX_TRACE_CONTEXT = 32;
+  protected static final int IDX_RECURRING_MASTER_ID = 33;
+  protected static final int IDX_Q_SCHEDULED_TIME = 35;
+  protected static final int IDX_Q_ATTEMPTS = 36;
+  protected static final int IDX_Q_PICKED_BY = 37;
+  protected static final int IDX_Q_PICKED_AT = 38;
+  protected static final int IDX_Q_PAUSED = 39;
+  protected static final int IDX_Q_LAST_ERROR = 40;
+  protected static final int IDX_Q_VERSION = 41;
+  protected static final int IDX_Q_UPDATED_AT = 42;
+  protected static final int IDX_Q_SIGNAL_KEY = 43;
+  protected static final int IDX_Q_SIGNAL_TIMEOUT = 44;
+  protected static final int IDX_Q_SIGNAL_PAYLOAD = 45;
+  protected static final int IDX_Q_SIGNAL_PAYLOAD_TYPE = 46;
+  protected static final int IDX_Q_SIGNAL_OUTCOME = 47;
+  protected static final int IDX_Q_SIGNAL_REJECTION_REASON = 48;
+  protected static final int IDX_Q_SIGNAL_DELIVERED_AT = 49;
+  protected static final int IDX_Q_SIGNAL_DELIVERED_BY = 50;
+  protected static final int IDX_Q_SIGNAL_DELIVERY_ID = 51;
+
+  private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
+  private static final JsonMapConverter JSON_MAP_CONVERTER = new JsonMapConverter();
+
+  private final JobHydrationSupport hydration;
+
+  protected AbstractJobRowMapper(String dialectLabel) {
+    this.hydration = new JobHydrationSupport(dialectLabel);
+  }
+
+  /**
+   * Reconstructs a {@link JobEntity} from one row of the shared hydration projection.
+   *
+   * <p>Throws {@link IllegalStateException} when a row carries neither a live {@code q.status} nor
+   * a terminal status: the terminal transition writes {@code terminal_status} before deleting the
+   * queue row in a single transaction, so a committed row always has one or the other. Neither is a
+   * corrupt row, surfaced rather than hydrated into an entity with a null status.
+   */
+  protected JobEntity hydrateRow(Object[] row) {
+    if (row == null) {
+      return null;
+    }
+    if (row.length != HYDRATION_COL_COUNT) {
+      throw new IllegalStateException(
+          "Hydration projection length mismatch: expected "
+              + HYDRATION_COL_COUNT
+              + " columns, got "
+              + row.length);
+    }
+    JobEntity j = new JobEntity();
+    j.setId(RowValues.uuidOrNull(row[IDX_JOB_ID]));
+    j.setJobType(enumValue(row, IDX_JOB_TYPE, "job_type", JobExecutionType.class));
+    j.setPriority(
+        RowValues.safeJobPriority(requiredNumber(row, IDX_PRIORITY, "priority").intValue()));
+    j.setMaxRetries(requiredNumber(row, IDX_MAX_RETRIES, "max_retries").intValue());
+    j.setBackoffPolicy(enumValue(row, IDX_BACKOFF_POLICY, "backoff_policy", BackoffPolicy.class));
+    j.setBackoffParamMs(requiredNumber(row, IDX_BACKOFF_PARAM_MS, "backoff_param_ms").intValue());
+    j.setTimeoutSec(requiredNumber(row, IDX_TIMEOUT_SEC, "timeout_sec").intValue());
+    j.setCronExpr((String) row[IDX_CRON_EXPR]);
+    j.setZoneId((String) row[IDX_ZONE_ID]);
+    j.setPayload(
+        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(RowValues.stringOrNull(row[IDX_PAYLOAD])));
+    j.setParams(
+        JSON_MAP_CONVERTER.convertToEntityAttribute(RowValues.stringOrNull(row[IDX_PARAMS])));
+    j.setTargetClass((String) row[IDX_TARGET_CLASS]);
+    j.setMethodName((String) row[IDX_METHOD_NAME]);
+    j.setIdempotencyKey((String) row[IDX_IDEMPOTENCY_KEY]);
+    j.setBusinessKey((String) row[IDX_BUSINESS_KEY]);
+    j.setResourceName((String) row[IDX_RESOURCE_NAME]);
+    j.setOnSuccessPayload(
+        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(
+            RowValues.stringOrNull(row[IDX_ON_SUCCESS])));
+    j.setOnFailurePayload(
+        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(
+            RowValues.stringOrNull(row[IDX_ON_FAILURE])));
+    j.setDependsOn(RowValues.uuidOrNull(row[IDX_DEPENDS_ON]));
+    j.setSupersededBy(RowValues.uuidOrNull(row[IDX_SUPERSEDED_BY]));
+    j.setCreatedAt(RowValues.instantOrNull(row[IDX_CREATED_AT]));
+    j.setCallerPrincipal((String) row[IDX_CALLER_PRINCIPAL]);
+
+    JobStatus terminal =
+        enumValueOrNull(row, IDX_TERMINAL_STATUS, "terminal_status", JobStatus.class);
+    j.setTerminalStatus(terminal);
+
+    j.setExecutionStartTime(RowValues.instantOrNull(row[IDX_EXEC_START]));
+    j.setExecutionEndTime(RowValues.instantOrNull(row[IDX_EXEC_END]));
+    j.setExecutionDurationMs(RowValues.longOrNull(row[IDX_EXEC_DURATION]));
+    j.setQueueWaitMs(RowValues.longOrNull(row[IDX_QUEUE_WAIT]));
+    j.setJobResult(RowValues.stringOrNull(row[IDX_JOB_RESULT]));
+    j.setResultType((String) row[IDX_RESULT_TYPE]);
+    j.setTraceContext(
+        JSON_MAP_CONVERTER.convertToEntityAttribute(
+            RowValues.stringOrNull(row[IDX_TRACE_CONTEXT])));
+    j.setRecurringMasterId(RowValues.uuidOrNull(row[IDX_RECURRING_MASTER_ID]));
+    j.setSignalKey((String) row[IDX_Q_SIGNAL_KEY]);
+    j.setSignalTimeout(RowValues.instantOrNull(row[IDX_Q_SIGNAL_TIMEOUT]));
+    j.setSignalPayload(RowValues.stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD]));
+    j.setSignalPayloadType(RowValues.stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD_TYPE]));
+    j.setSignalOutcome(RowValues.stringOrNull(row[IDX_Q_SIGNAL_OUTCOME]));
+    j.setSignalRejectionReason(RowValues.stringOrNull(row[IDX_Q_SIGNAL_REJECTION_REASON]));
+    j.setSignalDeliveredAt(RowValues.instantOrNull(row[IDX_Q_SIGNAL_DELIVERED_AT]));
+    j.setSignalDeliveredBy((String) row[IDX_Q_SIGNAL_DELIVERED_BY]);
+    j.setSignalDeliveryId(RowValues.stringOrNull(row[IDX_Q_SIGNAL_DELIVERY_ID]));
+
+    JobStatus live = enumValueOrNull(row, IDX_Q_STATUS, "q.status", JobStatus.class);
+
+    JobStatus resolved;
+    if (live != null) {
+      resolved = live;
+    } else if (terminal != null) {
+      resolved = terminal;
+    } else {
+      throw new IllegalStateException("Job " + j.getId() + " has no live or terminal status");
+    }
+    j.setStatus(resolved);
+
+    if (live != null) {
+      j.setScheduledTime(RowValues.instantOrNull(row[IDX_Q_SCHEDULED_TIME]));
+      j.setAttempts(requiredNumber(row, IDX_Q_ATTEMPTS, "q.attempts").intValue());
+      j.setPickedBy((String) row[IDX_Q_PICKED_BY]);
+      j.setPickedAt(RowValues.instantOrNull(row[IDX_Q_PICKED_AT]));
+      j.setPausedFromStatus(
+          enumValueOrNull(row, IDX_Q_PAUSED, "q.paused_from_status", JobStatus.class));
+      j.setLastError(RowValues.stringOrNull(row[IDX_Q_LAST_ERROR]));
+      j.setVersion(requiredNumber(row, IDX_Q_VERSION, "q.version").intValue());
+      // A live row's terminated_at is always null, so the updatedAt fallback resolves to createdAt.
+      Instant updatedAt = RowValues.instantOrNull(row[IDX_Q_UPDATED_AT]);
+      j.setUpdatedAt(updatedAt != null ? updatedAt : j.getCreatedAt());
+    } else {
+      Number ta = numberOrNull(row, IDX_TOTAL_ATTEMPTS, "total_attempts");
+      j.setAttempts(ta != null ? ta.intValue() : 0);
+      j.setLastError(RowValues.stringOrNull(row[IDX_TERMINAL_ERROR]));
+      j.setVersion(0);
+      Instant fallbackSched = RowValues.instantOrNull(row[IDX_EXEC_START]);
+      if (fallbackSched == null) {
+        fallbackSched = RowValues.instantOrNull(row[IDX_CREATED_AT]);
+      }
+      j.setScheduledTime(fallbackSched);
+      Instant updatedAt = RowValues.instantOrNull(row[IDX_TERMINATED_AT]);
+      j.setUpdatedAt(updatedAt != null ? updatedAt : j.getCreatedAt());
+    }
+    return j;
+  }
+
+  private <E extends Enum<E>> E enumValue(
+      Object[] row, int index, String column, Class<E> enumType) {
+    return hydration.enumValue(row, index, column, enumType);
+  }
+
+  private <E extends Enum<E>> E enumValueOrNull(
+      Object[] row, int index, String column, Class<E> enumType) {
+    return hydration.enumValueOrNull(row, index, column, enumType);
+  }
+
+  private Number requiredNumber(Object[] row, int index, String column) {
+    return hydration.requiredNumber(row, index, column);
+  }
+
+  private Number numberOrNull(Object[] row, int index, String column) {
+    return hydration.numberOrNull(row, index, column);
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractSqlStoreContext.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractSqlStoreContext.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.context;
+
+import jakarta.persistence.EntityManager;
+import run.ratchet.spi.MetricsCollector;
+
+/**
+ * Shared scaffolding for the JDBC/JPA store dialects (MySQL, PostgreSQL).
+ *
+ * <p>Adds the {@link EntityManager} handle and the trusted native-query scalar helpers on top of
+ * {@link AbstractStoreContext}. Both helpers translate transient faults so a deadlock or dropped
+ * connection during a scalar query surfaces as a retryable {@code RatchetTransientStoreException}.
+ */
+public abstract class AbstractSqlStoreContext extends AbstractStoreContext {
+
+  private final EntityManager em;
+
+  protected AbstractSqlStoreContext(
+      EntityManager em, MetricsCollector metricsCollector, int priorityBoostIntervalMinutes) {
+    super(metricsCollector, priorityBoostIntervalMinutes);
+    this.em = em;
+  }
+
+  public EntityManager em() {
+    return em;
+  }
+
+  /**
+   * Executes a trusted, package-local SQL count query. Callers must pass hard-coded SQL templates
+   * only; runtime values belong in {@code params}.
+   */
+  // Trusted compile-time SQL template; runtime values are bound via setParameter.
+  @SuppressWarnings("SqlSourceToSinkFlow")
+  public long countByNative(String sql, Object... params) {
+    try {
+      var query = em.createNativeQuery(sql);
+      for (int i = 0; i < params.length; i++) {
+        query.setParameter(i + 1, params[i]);
+      }
+      return ((Number) query.getSingleResult()).longValue();
+    } catch (RuntimeException e) {
+      throw translateTransientStoreException("count by native SQL", e);
+    }
+  }
+
+  /**
+   * Executes a trusted, package-local SQL scalar query, returning {@code 0.0} for a SQL NULL.
+   * Callers must pass hard-coded SQL templates only; runtime values belong in {@code params}.
+   */
+  // Trusted compile-time SQL template; runtime values are bound via setParameter.
+  @SuppressWarnings("SqlSourceToSinkFlow")
+  public double doubleByNativeOrZero(String sql, Object... params) {
+    try {
+      var query = em.createNativeQuery(sql);
+      for (int i = 0; i < params.length; i++) {
+        query.setParameter(i + 1, params[i]);
+      }
+      Object result = query.getSingleResult();
+      return result == null ? 0.0 : ((Number) result).doubleValue();
+    } catch (RuntimeException e) {
+      throw translateTransientStoreException("scalar by native SQL", e);
+    }
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractStoreContext.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractStoreContext.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.context;
+
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobType;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.ConstraintDetector;
+import run.ratchet.store.util.TransientStoreExceptions;
+
+/**
+ * Shared scaffolding for a store module's per-operation context.
+ *
+ * <p>Holds the metrics collector, the priority-boost window, transient-fault translation, and the
+ * timed-operation wrapper that every store dialect needs. Concrete contexts supply only the dialect
+ * labels and their {@link ConstraintDetector}; SQL dialects extend {@link AbstractSqlStoreContext}
+ * for the native-query helpers.
+ *
+ * <p>This is store-implementor scaffolding, not application API. The qualified export in {@code
+ * module-info} limits it to the bundled store modules.
+ */
+public abstract class AbstractStoreContext {
+
+  private static final MetricsCollector NOOP_METRICS_COLLECTOR = new NoopMetricsCollector();
+
+  private final MetricsCollector metricsCollector;
+  private final int priorityBoostIntervalMinutes;
+
+  protected AbstractStoreContext(
+      MetricsCollector metricsCollector, int priorityBoostIntervalMinutes) {
+    this.metricsCollector = metricsCollector == null ? NOOP_METRICS_COLLECTOR : metricsCollector;
+    this.priorityBoostIntervalMinutes = priorityBoostIntervalMinutes;
+  }
+
+  /** Returns the shared no-op metrics collector, for callers that must pass one explicitly. */
+  public static MetricsCollector noopMetricsCollector() {
+    return NOOP_METRICS_COLLECTOR;
+  }
+
+  public int priorityBoostIntervalMinutes() {
+    return priorityBoostIntervalMinutes;
+  }
+
+  /** Lowercase dialect token used as the metric {@code store} dimension (for example, "mysql"). */
+  protected abstract String dialectMetric();
+
+  /** Human-readable dialect label used in exception messages (for example, "MySQL"). */
+  protected abstract String dialectLabel();
+
+  public abstract ConstraintDetector constraintDetector();
+
+  public RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
+    RatchetTransientStoreException wrapped =
+        TransientStoreExceptions.translateOrNull(
+            dialectLabel(), constraintDetector(), operation, e);
+    if (wrapped != null) {
+      return wrapped;
+    }
+    return additionalTranslation(operation, e);
+  }
+
+  /**
+   * Hook for dialect-specific translation applied after the shared transient check. The default
+   * returns {@code e} unchanged; stores override to recognize their own non-transient failures.
+   */
+  protected RuntimeException additionalTranslation(String operation, RuntimeException e) {
+    return e;
+  }
+
+  public <T> T timedStoreOperation(
+      String operation, Supplier<T> action, Function<T, String> outcomeFunction) {
+    long startNanos = System.nanoTime();
+    try {
+      T result = action.get();
+      recordStoreOperation(operation, outcomeFunction.apply(result), startNanos);
+      return result;
+    } catch (RatchetTransientStoreException e) {
+      recordStoreOperation(operation, "transient_failure", startNanos);
+      throw e;
+    } catch (RuntimeException e) {
+      RuntimeException translated = translateTransientStoreException(operation, e);
+      recordStoreOperation(
+          operation,
+          translated instanceof RatchetTransientStoreException ? "transient_failure" : "failure",
+          startNanos);
+      throw translated;
+    }
+  }
+
+  private void recordStoreOperation(String operation, String outcome, long startNanos) {
+    metricsCollector.storeOperation(
+        dialectMetric(), operation, outcome, System.nanoTime() - startNanos);
+  }
+
+  private static final class NoopMetricsCollector implements MetricsCollector {
+    @Override
+    public void jobStarted(UUID jobId, JobType type, JobPriority priority) {}
+
+    @Override
+    public void jobCompleted(UUID jobId, JobType type, long executionTimeMs) {}
+
+    @Override
+    public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {}
+
+    @Override
+    public void successFinalizationRetried(UUID jobId, JobType type) {}
+
+    @Override
+    public void successFinalizationMinimal(UUID jobId, JobType type) {}
+
+    @Override
+    public void successFinalizationStuck(UUID jobId, JobType type) {}
+
+    @Override
+    public void claimTransientFailure(String executionType) {}
+
+    @Override
+    public void jobsClaimed(String executionType, int claimedCount) {}
+
+    @Override
+    public void gateRejected(String executionType, String gateStatus) {}
+
+    @Override
+    public void localWakeup(String source) {}
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractStoreContext.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/context/AbstractStoreContext.java
@@ -67,6 +67,12 @@ public abstract class AbstractStoreContext {
   public abstract ConstraintDetector constraintDetector();
 
   public RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
+    if (e instanceof RatchetTransientStoreException) {
+      // A nested operation already translated this. Re-running the detector would walk its cause
+      // chain, re-detect the underlying fault, and wrap it a second time — losing the inner
+      // operation label. Return the original transient unchanged, matching timedStoreOperation.
+      return e;
+    }
     RatchetTransientStoreException wrapped =
         TransientStoreExceptions.translateOrNull(
             dialectLabel(), constraintDetector(), operation, e);

--- a/ratchet-store-core/src/main/java/run/ratchet/store/converter/JsonListConverter.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/converter/JsonListConverter.java
@@ -15,8 +15,6 @@
  */
 package run.ratchet.store.converter;
 
-import jakarta.json.bind.JsonbBuilder;
-import jakarta.json.bind.JsonbException;
 import jakarta.persistence.Converter;
 import java.util.List;
 
@@ -27,6 +25,11 @@ import java.util.List;
  * <p>Deserialization intentionally targets raw {@link List} because JSON-B cannot recover erased
  * element types for {@code List<Object>}. Scalar values and nested JSON structures are restored as
  * JSON-B's standard runtime types, not application-specific POJOs.
+ *
+ * <p>Routes through {@link PayloadSerializerHolder} so the framework's {@link
+ * run.ratchet.spi.PayloadSerializer} SPI is the single JSON boundary. JPA converters are not
+ * CDI-managed beans, so the holder's static registration pattern is used instead of field
+ * injection.
  */
 @Converter
 public class JsonListConverter extends AbstractJsonAttributeConverter<List<Object>> {
@@ -37,30 +40,18 @@ public class JsonListConverter extends AbstractJsonAttributeConverter<List<Objec
 
   @Override
   protected String serialize(List<Object> attribute) {
-    try (var jsonb = JsonbBuilder.create()) {
-      return jsonb.toJson(attribute);
-    } catch (JsonbException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new JsonbException("JSON-B list serializer close failed", e);
-    }
+    return PayloadSerializerHolder.get().serialize(attribute);
   }
 
   @SuppressWarnings("unchecked")
   @Override
   protected List<Object> deserialize(String dbData) {
-    try (var jsonb = JsonbBuilder.create()) {
-      return (List<Object>) jsonb.fromJson(dbData, List.class);
-    } catch (JsonbException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new JsonbException("JSON-B list deserializer close failed", e);
-    }
+    return (List<Object>) PayloadSerializerHolder.get().deserialize(dbData, List.class);
   }
 
   @Override
   protected Class<? extends RuntimeException> conversionExceptionType() {
-    return JsonbException.class;
+    return IllegalArgumentException.class;
   }
 
   @Override

--- a/ratchet-store-core/src/main/java/run/ratchet/store/converter/JsonObjectMapConverter.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/converter/JsonObjectMapConverter.java
@@ -15,9 +15,6 @@
  */
 package run.ratchet.store.converter;
 
-import jakarta.json.bind.Jsonb;
-import jakarta.json.bind.JsonbBuilder;
-import jakarta.json.bind.JsonbException;
 import jakarta.persistence.Converter;
 import java.util.Map;
 
@@ -25,17 +22,13 @@ import java.util.Map;
  * JPA {@link AttributeConverter} that converts {@code Map<String, Object>} to/from JSON for
  * database storage.
  *
- * <p>A single {@link Jsonb} instance is reused across all calls. Holding one shared instance avoids
- * the per-call {@code JsonbBuilder.create()} overhead (which involves ServiceLoader resolution)
- * without attaching per-thread state to pooled/virtual execution threads, matching the shared
- * fallback instance maintained by {@link PayloadSerializerHolder}.
+ * <p>Routes through {@link PayloadSerializerHolder} so the framework's {@link
+ * run.ratchet.spi.PayloadSerializer} SPI is the single JSON boundary. JPA converters are not
+ * CDI-managed beans, so the holder's static registration pattern is used instead of field
+ * injection.
  */
 @Converter
 public class JsonObjectMapConverter extends AbstractJsonAttributeConverter<Map<String, Object>> {
-
-  // Single shared instance: avoids per-call JsonbBuilder.create() (ServiceLoader + config) without
-  // pinning a never-cleaned Jsonb to each pooled/virtual thread. Held for the JVM lifetime.
-  private static final Jsonb JSONB = JsonbBuilder.create();
 
   public String convertToDatabaseColumn(Map<String, Object> attribute) {
     return super.convertToDatabaseColumn(attribute);
@@ -43,18 +36,18 @@ public class JsonObjectMapConverter extends AbstractJsonAttributeConverter<Map<S
 
   @Override
   protected String serialize(Map<String, Object> attribute) {
-    return JSONB.toJson(attribute);
+    return PayloadSerializerHolder.get().serialize(attribute);
   }
 
   @SuppressWarnings("unchecked")
   @Override
   protected Map<String, Object> deserialize(String dbData) {
-    return (Map<String, Object>) JSONB.fromJson(dbData, Map.class);
+    return (Map<String, Object>) PayloadSerializerHolder.get().deserialize(dbData, Map.class);
   }
 
   @Override
   protected Class<? extends RuntimeException> conversionExceptionType() {
-    return JsonbException.class;
+    return IllegalArgumentException.class;
   }
 
   @Override

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveParameterBinder.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveParameterBinder.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Function;
+import run.ratchet.store.entity.ArchivedJobEntity;
+
+/**
+ * Shared archive-insert column list and positional parameter binder for the SQL stores.
+ *
+ * <p>The column list, the value placeholders, and the 31-parameter binding order are identical
+ * across dialects; only the four UUID columns differ in encoding (MySQL stores {@code BINARY(16)},
+ * PostgreSQL stores native {@code uuid}). Callers pass an {@code idEncoder} that maps a {@link
+ * UUID} to its stored form.
+ */
+public final class ArchiveParameterBinder {
+
+  public static final String ARCHIVE_COLUMNS =
+      """
+      archive_id, original_job_id, final_status, job_type, priority, total_attempts,
+      max_retries, backoff_policy, backoff_param_ms, timeout_sec, target_class,
+      method_name, business_key, cron_expr, zone_id, original_scheduled_time,
+      original_created_at, first_execution_time, completion_time,
+      total_execution_time_ms, queue_wait_ms, archived_at, archived_by, archive_reason,
+      job_result, result_type, final_error, payload_summary, depended_on, superseded_by,
+      tags
+      """;
+
+  public static final String ARCHIVE_VALUE_PLACEHOLDERS =
+      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+  private ArchiveParameterBinder() {}
+
+  /**
+   * Binds the 31 archive columns in schema order onto {@code query}, starting at positional index
+   * {@code parameter}. The four UUID columns ({@code archive_id}, {@code original_job_id}, {@code
+   * depended_on}, {@code superseded_by}) are passed through {@code idEncoder}.
+   *
+   * @return the next free positional parameter index
+   */
+  public static int bind(
+      Query query, ArchivedJobEntity archive, int parameter, Function<UUID, Object> idEncoder) {
+    query.setParameter(parameter++, idEncoder.apply(archive.getId()));
+    query.setParameter(parameter++, idEncoder.apply(archive.getOriginalJobId()));
+    query.setParameter(parameter++, archive.getFinalStatus().name());
+    query.setParameter(parameter++, archive.getJobType().name());
+    query.setParameter(parameter++, archive.getPriority().ordinal());
+    query.setParameter(parameter++, archive.getTotalAttempts());
+    query.setParameter(parameter++, archive.getMaxRetries());
+    query.setParameter(parameter++, archive.getBackoffPolicy().name());
+    query.setParameter(parameter++, archive.getBackoffParamMs());
+    query.setParameter(parameter++, archive.getTimeoutSec());
+    query.setParameter(parameter++, archive.getTargetClass());
+    query.setParameter(parameter++, archive.getMethodName());
+    query.setParameter(parameter++, archive.getBusinessKey());
+    query.setParameter(parameter++, archive.getCronExpr());
+    query.setParameter(parameter++, archive.getZoneId());
+    query.setParameter(parameter++, timestampOrNull(archive.getOriginalScheduledTime()));
+    query.setParameter(parameter++, timestampOrNull(archive.getOriginalCreatedAt()));
+    query.setParameter(parameter++, timestampOrNull(archive.getFirstExecutionTime()));
+    query.setParameter(parameter++, timestampOrNull(archive.getCompletionTime()));
+    query.setParameter(parameter++, archive.getTotalExecutionTimeMs());
+    query.setParameter(parameter++, archive.getQueueWaitMs());
+    query.setParameter(parameter++, timestampOrNull(archive.getArchivedAt()));
+    query.setParameter(parameter++, archive.getArchivedBy());
+    query.setParameter(parameter++, archive.getArchiveReason());
+    query.setParameter(parameter++, archive.getJobResult());
+    query.setParameter(parameter++, archive.getResultType());
+    query.setParameter(parameter++, archive.getFinalError());
+    query.setParameter(parameter++, archive.getPayloadSummary());
+    query.setParameter(parameter++, idEncoder.apply(archive.getDependedOn()));
+    query.setParameter(parameter++, idEncoder.apply(archive.getSupersededBy()));
+    query.setParameter(parameter++, archive.getTags());
+    return parameter;
+  }
+
+  private static Timestamp timestampOrNull(Instant instant) {
+    return instant == null ? null : Timestamp.from(instant);
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/JobClaimSqlSupport.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/JobClaimSqlSupport.java
@@ -29,6 +29,7 @@ import run.ratchet.store.spi.ExecutionTargetFilter;
 public final class JobClaimSqlSupport {
 
   private static final String SAFE_SQL_EXPRESSION_PATTERN = "[A-Za-z0-9_().,\\s+\\-*/]+";
+  private static final String SAFE_COLUMN_PREFIX_PATTERN = "|[A-Za-z_][A-Za-z0-9_]*\\.";
 
   private JobClaimSqlSupport() {}
 
@@ -150,20 +151,41 @@ public final class JobClaimSqlSupport {
 
   public static String buildBoostedOrderBy(
       String timeColumn, String overdueMinutesExpression, int boostInterval) {
+    return buildBoostedOrderBy(timeColumn, overdueMinutesExpression, boostInterval, "");
+  }
+
+  /**
+   * Builds the effective-priority ORDER BY, qualifying the {@code priority} and {@code job_id}
+   * columns with {@code columnPrefix} (for example {@code "q."} when the query joins the queue
+   * table under an alias, or {@code ""} for an unqualified single-table select).
+   */
+  public static String buildBoostedOrderBy(
+      String timeColumn, String overdueMinutesExpression, int boostInterval, String columnPrefix) {
     requireSafeSqlFragment(timeColumn, "timeColumn");
     requireSafeSqlFragment(overdueMinutesExpression, "overdueMinutesExpression");
+    requireSafeColumnPrefix(columnPrefix);
     return boostInterval > 0
-        ? "(priority + FLOOR(GREATEST(0, "
+        ? "("
+            + columnPrefix
+            + "priority + FLOOR(GREATEST(0, "
             + overdueMinutesExpression
             + ") / ?)) DESC, "
             + timeColumn
-            + " ASC, job_id ASC"
-        : "priority DESC, " + timeColumn + " ASC, job_id ASC";
+            + " ASC, "
+            + columnPrefix
+            + "job_id ASC"
+        : columnPrefix + "priority DESC, " + timeColumn + " ASC, " + columnPrefix + "job_id ASC";
   }
 
   private static void requireSafeSqlFragment(String value, String name) {
     if (value == null || !value.matches(SAFE_SQL_EXPRESSION_PATTERN)) {
       throw new IllegalArgumentException(name + " must be a store-defined SQL fragment");
+    }
+  }
+
+  private static void requireSafeColumnPrefix(String value) {
+    if (value == null || !value.matches(SAFE_COLUMN_PREFIX_PATTERN)) {
+      throw new IllegalArgumentException("columnPrefix must be empty or a store-defined alias");
     }
   }
 

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/JobWriteSupport.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/JobWriteSupport.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import java.util.Objects;
+import java.util.UUID;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.id.UuidV7Factory;
+
+/** Shared save-path helpers used by SQL store write operations. */
+public final class JobWriteSupport {
+
+  private JobWriteSupport() {}
+
+  public static void checkHotField(UUID jobId, String fieldName, Object incoming, Object stored) {
+    if (Objects.equals(incoming, stored)) {
+      return;
+    }
+    throw new IllegalStateException(
+        "save() rejected: hot-field mutation detected for id="
+            + jobId
+            + " field="
+            + fieldName
+            + " incoming="
+            + incoming
+            + " stored="
+            + stored
+            + ". Use an explicit transition method.");
+  }
+
+  public static void assignIdIfMissing(JobEntity job) {
+    if (job.getId() == null) {
+      job.setId(UuidV7Factory.create());
+    }
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/LockValidation.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/LockValidation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/** Shared lock-argument validation and duration conversion used by store lock implementations. */
+public final class LockValidation {
+
+  private LockValidation() {}
+
+  public static void requireLockName(String name) {
+    Objects.requireNonNull(name, "name");
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("name must be non-empty");
+    }
+  }
+
+  public static void requirePositiveDuration(Duration duration, String parameterName) {
+    Objects.requireNonNull(duration, parameterName);
+    if (duration.isZero() || duration.isNegative()) {
+      throw new IllegalArgumentException(parameterName + " must be positive");
+    }
+  }
+
+  public static long durationMicros(Duration duration) {
+    long seconds = duration.getSeconds();
+    long microsFromNanos = (duration.getNano() + 999L) / 1_000L;
+    if (seconds > (Long.MAX_VALUE - microsFromNanos) / 1_000_000L) {
+      return Long.MAX_VALUE;
+    }
+    return Math.max(1L, seconds * 1_000_000L + microsFromNanos);
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/TransientStoreExceptions.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/TransientStoreExceptions.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.store.ConstraintDetector;
+
+/**
+ * Shared transient-fault translation for store operation classes.
+ *
+ * <p>Each store's {@code StoreContext} delegates here so the deadlock / transient-connection
+ * classification lives in one place instead of being copy-pasted per dialect.
+ */
+public final class TransientStoreExceptions {
+
+  private TransientStoreExceptions() {}
+
+  /**
+   * Wraps {@code e} as a {@link RatchetTransientStoreException} when {@code detector} classifies it
+   * as a deadlock or a transient connection failure; otherwise returns {@code null} so the caller
+   * can rethrow the original exception (or apply its own additional translation).
+   *
+   * @param dialectLabel human-readable store label used in the exception message (for example,
+   *     {@code "MySQL"})
+   * @param detector the store's constraint detector; implementations walk the cause chain
+   * @param operation short description of the failing operation, for the message
+   * @param e the runtime exception thrown by the JDBC / JPA layer
+   * @return a wrapping {@link RatchetTransientStoreException}, or {@code null} when {@code e} is
+   *     not a recognized transient fault
+   */
+  public static RatchetTransientStoreException translateOrNull(
+      String dialectLabel, ConstraintDetector detector, String operation, RuntimeException e) {
+    if (detector.isDeadlock(e) || detector.isTransientConnectionFailure(e)) {
+      return new RatchetTransientStoreException(
+          "Transient " + dialectLabel + " store concurrency failure during " + operation, e);
+    }
+    return null;
+  }
+}

--- a/ratchet-store-core/src/test/java/run/ratchet/store/converter/JsonListConverterTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/converter/JsonListConverterTest.java
@@ -19,9 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.spi.PayloadSerializer;
@@ -79,25 +82,38 @@ class JsonListConverterTest {
   }
 
   @Test
-  void ignoresInstalledPayloadSerializer() {
-    PayloadSerializerHolder.set(new ThrowingSerializer());
+  void routesThroughInstalledPayloadSerializer() {
+    RecordingSerializer recorder = new RecordingSerializer();
+    PayloadSerializerHolder.set(recorder);
 
     String json = converter.convertToDatabaseColumn(List.of("alpha"));
     List<Object> restored = converter.convertToEntityAttribute(json);
 
     assertEquals(List.of("alpha"), restored);
+    assertEquals(1, recorder.serializeCount.get());
+    assertEquals(1, recorder.deserializeCount.get());
   }
 
-  static final class ThrowingSerializer implements PayloadSerializer {
+  /** Records framework invocations while delegating JSON via a nested JSON-B call. */
+  static final class RecordingSerializer implements PayloadSerializer {
+
+    final AtomicInteger serializeCount = new AtomicInteger();
+    final AtomicInteger deserializeCount = new AtomicInteger();
+    private final Jsonb jsonb = JsonbBuilder.create();
 
     @Override
     public String serialize(Object payload) {
-      throw new IllegalArgumentException("holder should not be used");
+      serializeCount.incrementAndGet();
+      return payload == null ? null : jsonb.toJson(payload);
     }
 
     @Override
     public <T> T deserialize(String json, Class<T> type) {
-      throw new IllegalArgumentException("holder should not be used");
+      deserializeCount.incrementAndGet();
+      if (json == null || json.isEmpty()) {
+        return null;
+      }
+      return jsonb.fromJson(json, type);
     }
   }
 }

--- a/ratchet-store-core/src/test/java/run/ratchet/store/converter/JsonObjectMapConverterTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/converter/JsonObjectMapConverterTest.java
@@ -19,9 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.spi.PayloadSerializer;
@@ -89,25 +92,38 @@ class JsonObjectMapConverterTest {
   }
 
   @Test
-  void ignoresInstalledPayloadSerializer() {
-    PayloadSerializerHolder.set(new ThrowingSerializer());
+  void routesThroughInstalledPayloadSerializer() {
+    RecordingSerializer recorder = new RecordingSerializer();
+    PayloadSerializerHolder.set(recorder);
 
     String json = converter.convertToDatabaseColumn(Map.of("name", "Alice"));
     Map<String, Object> restored = converter.convertToEntityAttribute(json);
 
     assertEquals("Alice", restored.get("name"));
+    assertEquals(1, recorder.serializeCount.get());
+    assertEquals(1, recorder.deserializeCount.get());
   }
 
-  static final class ThrowingSerializer implements PayloadSerializer {
+  /** Records framework invocations while delegating JSON via a nested JSON-B call. */
+  static final class RecordingSerializer implements PayloadSerializer {
+
+    final AtomicInteger serializeCount = new AtomicInteger();
+    final AtomicInteger deserializeCount = new AtomicInteger();
+    private final Jsonb jsonb = JsonbBuilder.create();
 
     @Override
     public String serialize(Object payload) {
-      throw new IllegalArgumentException("holder should not be used");
+      serializeCount.incrementAndGet();
+      return payload == null ? null : jsonb.toJson(payload);
     }
 
     @Override
     public <T> T deserialize(String json, Class<T> type) {
-      throw new IllegalArgumentException("holder should not be used");
+      deserializeCount.incrementAndGet();
+      if (json == null || json.isEmpty()) {
+        return null;
+      }
+      return jsonb.fromJson(json, type);
     }
   }
 }

--- a/ratchet-store-core/src/test/java/run/ratchet/store/util/JobClaimSqlSupportTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/util/JobClaimSqlSupportTest.java
@@ -78,12 +78,31 @@ class JobClaimSqlSupportTest {
   }
 
   @Test
+  void buildBoostedOrderByQualifiesPriorityAndJobIdWithColumnPrefix() {
+    assertEquals(
+        "q.priority DESC, q.scheduled_time ASC, q.job_id ASC",
+        JobClaimSqlSupport.buildBoostedOrderBy("q.scheduled_time", "age_minutes", 0, "q."));
+
+    assertEquals(
+        "(q.priority + FLOOR(GREATEST(0, age_minutes) / ?)) DESC, q.scheduled_time ASC,"
+            + " q.job_id ASC",
+        JobClaimSqlSupport.buildBoostedOrderBy("q.scheduled_time", "age_minutes", 15, "q."));
+  }
+
+  @Test
   void buildBoostedOrderByRejectsUnsafeFragments() {
     assertThrows(
         IllegalArgumentException.class,
         () ->
             JobClaimSqlSupport.buildBoostedOrderBy(
                 "scheduled_time", "age_minutes); DELETE FROM scheduler_job_queue; --", 15));
+  }
+
+  @Test
+  void buildBoostedOrderByRejectsUnsafeColumnPrefix() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> JobClaimSqlSupport.buildBoostedOrderBy("scheduled_time", "age_minutes", 15, "q; --"));
   }
 
   @Test

--- a/ratchet-store-core/src/test/java/run/ratchet/store/util/RowValuesTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/util/RowValuesTest.java
@@ -20,11 +20,47 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.ByteBuffer;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.TimeZone;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobPriority;
 
 class RowValuesTest {
+
+  @Test
+  void instantOrNullCoercesEverySupportedTemporalType() {
+    Instant expected = Instant.parse("2026-05-12T12:00:00Z");
+
+    assertNull(RowValues.instantOrNull(null));
+    assertEquals(expected, RowValues.instantOrNull(expected));
+    assertEquals(expected, RowValues.instantOrNull(Timestamp.from(expected)));
+    assertEquals(expected, RowValues.instantOrNull(expected.atOffset(ZoneOffset.UTC)));
+    assertEquals(expected, RowValues.instantOrNull(Date.from(expected)));
+  }
+
+  @Test
+  void instantOrNullInterpretsLocalDateTimeAsUtcRegardlessOfDefaultZone() {
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+
+      assertEquals(
+          Instant.parse("2026-05-12T12:00:00Z"),
+          RowValues.instantOrNull(LocalDateTime.parse("2026-05-12T12:00:00")));
+    } finally {
+      TimeZone.setDefault(original);
+    }
+  }
+
+  @Test
+  void instantOrNullReturnsNullForUnsupportedType() {
+    assertNull(RowValues.instantOrNull("2026-05-12T12:00:00Z"));
+  }
 
   @Test
   void safeJobPriorityReturnsNormalForOutOfRangeOrdinals() {

--- a/ratchet-store-core/src/test/java/run/ratchet/store/util/TransientStoreExceptionsTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/util/TransientStoreExceptionsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.store.ConstraintDetector;
+
+class TransientStoreExceptionsTest {
+
+  @Test
+  void wrapsDeadlockWithDialectLabelAndOperation() {
+    RuntimeException cause = new RuntimeException("deadlock");
+
+    RatchetTransientStoreException wrapped =
+        TransientStoreExceptions.translateOrNull("MySQL", detector(true, false), "save job", cause);
+
+    assertSame(cause, wrapped.getCause());
+    assertTrue(wrapped.getMessage().contains("MySQL"));
+    assertTrue(wrapped.getMessage().contains("save job"));
+  }
+
+  @Test
+  void wrapsTransientConnectionFailure() {
+    RuntimeException cause = new RuntimeException("connection reset");
+
+    RatchetTransientStoreException wrapped =
+        TransientStoreExceptions.translateOrNull(
+            "PostgreSQL", detector(false, true), "find job", cause);
+
+    assertSame(cause, wrapped.getCause());
+  }
+
+  @Test
+  void returnsNullForNonTransientFailure() {
+    assertNull(
+        TransientStoreExceptions.translateOrNull(
+            "MongoDB", detector(false, false), "op", new RuntimeException("boom")));
+  }
+
+  private static ConstraintDetector detector(boolean deadlock, boolean transientConnection) {
+    return new ConstraintDetector() {
+      @Override
+      public String constraintName(Exception e) {
+        return null;
+      }
+
+      @Override
+      public boolean isDuplicateKey(Exception e) {
+        return false;
+      }
+
+      @Override
+      public boolean isDeadlock(Exception e) {
+        return deadlock;
+      }
+
+      @Override
+      public boolean isTransientConnectionFailure(Exception e) {
+        return transientConnection;
+      }
+    };
+  }
+}

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobClaimOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobClaimOperations.java
@@ -56,6 +56,7 @@ import run.ratchet.store.dto.JobClaimDto;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.ExecutionTargetFilter;
+import run.ratchet.store.util.StatusClassifier;
 
 /**
  * Claim pipeline: candidate planning via {@code $match → $project → $sort → $limit} with index
@@ -89,7 +90,7 @@ final class MongoJobClaimOperations {
       String nodeId,
       NodeTagFilter tagFilter,
       ExecutionTargetFilter executionTargetFilter) {
-    if (limit <= 0 || !MongoStoreContext.isPollerExecutable(jobType)) {
+    if (limit <= 0 || !StatusClassifier.isPollerExecutable(jobType)) {
       return List.of();
     }
     List<UUID> candidateIds =

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoNodeLockOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoNodeLockOperations.java
@@ -29,6 +29,8 @@ import static run.ratchet.store.mongodb.MongoFieldNames.ID;
 import static run.ratchet.store.mongodb.MongoFieldNames.LOCKED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.OWNER_NODE;
 import static run.ratchet.store.mongodb.MongoFieldNames.STARTED_AT;
+import static run.ratchet.store.util.LockValidation.requireLockName;
+import static run.ratchet.store.util.LockValidation.requirePositiveDuration;
 
 import com.mongodb.MongoCommandException;
 import com.mongodb.client.model.FindOneAndUpdateOptions;
@@ -115,20 +117,6 @@ final class MongoNodeLockOperations implements LockStore, NodeStore {
         ctx.locks()
             .updateOne(and(eq(ID, name), eq(OWNER_NODE, nodeId)), set(EXPIRES_AT, newExpiry));
     return result.getModifiedCount() > 0;
-  }
-
-  private static void requireLockName(String name) {
-    Objects.requireNonNull(name, "name");
-    if (name.isBlank()) {
-      throw new IllegalArgumentException("name must be non-empty");
-    }
-  }
-
-  private static void requirePositiveDuration(Duration duration, String parameterName) {
-    Objects.requireNonNull(duration, parameterName);
-    if (duration.isZero() || duration.isNegative()) {
-      throw new IllegalArgumentException(parameterName + " must be positive");
-    }
   }
 
   @Override

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
@@ -32,6 +32,7 @@ import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.util.StatusClassifier;
+import run.ratchet.store.util.TransientStoreExceptions;
 
 /**
  * Shared context passed into every Mongo operation class.
@@ -115,9 +116,10 @@ final class MongoStoreContext {
   }
 
   RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
-    if (constraintDetector.isDeadlock(e) || constraintDetector.isTransientConnectionFailure(e)) {
-      return new RatchetTransientStoreException(
-          "Transient MongoDB store concurrency failure during " + operation, e);
+    RatchetTransientStoreException wrapped =
+        TransientStoreExceptions.translateOrNull("MongoDB", constraintDetector, operation, e);
+    if (wrapped != null) {
+      return wrapped;
     }
     if (containsMongoException(e)) {
       return new IllegalStateException("MongoDB store failure during " + operation, e);

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
@@ -21,29 +21,22 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import java.util.List;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Supplier;
 import org.bson.Document;
-import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
-import run.ratchet.api.JobType;
-import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.ConstraintDetector;
+import run.ratchet.store.context.AbstractStoreContext;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.util.StatusClassifier;
-import run.ratchet.store.util.TransientStoreExceptions;
 
 /**
  * Shared context passed into every Mongo operation class.
  *
- * <p>Owns the {@link MongoDatabase} handle, collection accessors, status classification helpers,
- * and transient-exception translation.
+ * <p>Owns the {@link MongoDatabase} handle, collection accessors, and status classification helpers
+ * on top of the shared {@link AbstractStoreContext} scaffolding. Mongo adds a translation branch
+ * for non-transient {@link MongoException}s via {@link #additionalTranslation}.
  */
-final class MongoStoreContext {
-
-  private static final String DIALECT = "mongodb";
-  private static final MetricsCollector NOOP_METRICS_COLLECTOR = new NoopMetricsCollector();
+final class MongoStoreContext extends AbstractStoreContext {
 
   static final List<String> EXECUTABLE_JOB_TYPES =
       List.of("SINGLE", "BATCH_CHILD", "CHAIN_STEP", "WORKFLOW_BRANCH");
@@ -52,16 +45,14 @@ final class MongoStoreContext {
 
   private final MongoClient client;
   private final MongoDatabase database;
-  private final MetricsCollector metricsCollector;
-  private final int priorityBoostIntervalMinutes;
   private final MongoConstraintDetector constraintDetector = new MongoConstraintDetector();
 
   MongoStoreContext(MongoClient client, MongoDatabase database) {
-    this(client, database, NOOP_METRICS_COLLECTOR, 15);
+    this(client, database, noopMetricsCollector(), 15);
   }
 
   MongoStoreContext(MongoClient client, MongoDatabase database, int priorityBoostIntervalMinutes) {
-    this(client, database, NOOP_METRICS_COLLECTOR, priorityBoostIntervalMinutes);
+    this(client, database, noopMetricsCollector(), priorityBoostIntervalMinutes);
   }
 
   MongoStoreContext(
@@ -69,14 +60,9 @@ final class MongoStoreContext {
       MongoDatabase database,
       MetricsCollector metricsCollector,
       int priorityBoostIntervalMinutes) {
+    super(metricsCollector, priorityBoostIntervalMinutes);
     this.client = client;
     this.database = database;
-    this.metricsCollector = metricsCollector;
-    this.priorityBoostIntervalMinutes = priorityBoostIntervalMinutes;
-  }
-
-  static MetricsCollector noopMetricsCollector() {
-    return NOOP_METRICS_COLLECTOR;
   }
 
   static boolean isPollerExecutable(JobExecutionType jobType) {
@@ -107,48 +93,27 @@ final class MongoStoreContext {
     return database;
   }
 
-  int priorityBoostIntervalMinutes() {
-    return priorityBoostIntervalMinutes;
+  @Override
+  protected String dialectMetric() {
+    return "mongodb";
   }
 
-  MongoConstraintDetector constraintDetector() {
+  @Override
+  protected String dialectLabel() {
+    return "MongoDB";
+  }
+
+  @Override
+  public ConstraintDetector constraintDetector() {
     return constraintDetector;
   }
 
-  RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
-    RatchetTransientStoreException wrapped =
-        TransientStoreExceptions.translateOrNull("MongoDB", constraintDetector, operation, e);
-    if (wrapped != null) {
-      return wrapped;
-    }
+  @Override
+  protected RuntimeException additionalTranslation(String operation, RuntimeException e) {
     if (containsMongoException(e)) {
       return new IllegalStateException("MongoDB store failure during " + operation, e);
     }
     return e;
-  }
-
-  <T> T timedStoreOperation(
-      String operation, Supplier<T> action, Function<T, String> outcomeFunction) {
-    long startNanos = System.nanoTime();
-    try {
-      T result = action.get();
-      recordStoreOperation(operation, outcomeFunction.apply(result), startNanos);
-      return result;
-    } catch (RatchetTransientStoreException e) {
-      recordStoreOperation(operation, "transient_failure", startNanos);
-      throw e;
-    } catch (RuntimeException e) {
-      RuntimeException translated = translateTransientStoreException(operation, e);
-      recordStoreOperation(
-          operation,
-          translated instanceof RatchetTransientStoreException ? "transient_failure" : "failure",
-          startNanos);
-      throw translated;
-    }
-  }
-
-  private void recordStoreOperation(String operation, String outcome, long startNanos) {
-    metricsCollector.storeOperation(DIALECT, operation, outcome, System.nanoTime() - startNanos);
   }
 
   private static boolean containsMongoException(Throwable throwable) {
@@ -216,43 +181,5 @@ final class MongoStoreContext {
 
   MongoCollection<Document> recurringJobArchive() {
     return database.getCollection("scheduler_recurring_job_archive");
-  }
-
-  private static final class NoopMetricsCollector implements MetricsCollector {
-    @Override
-    public void jobStarted(UUID jobId, JobType type, JobPriority priority) {}
-
-    @Override
-    public void jobCompleted(UUID jobId, JobType type, long executionTimeMs) {}
-
-    @Override
-    public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {}
-
-    @Override
-    public void successFinalizationRetried(UUID jobId, JobType type) {}
-
-    @Override
-    public void successFinalizationMinimal(UUID jobId, JobType type) {}
-
-    @Override
-    public void successFinalizationStuck(UUID jobId, JobType type) {}
-
-    @Override
-    public void claimTransientFailure(String executionType) {}
-
-    @Override
-    public void jobsClaimed(String executionType, int claimedCount) {}
-
-    @Override
-    public void gateRejected(String executionType, String gateStatus) {}
-
-    @Override
-    public void localWakeup(String source) {}
-
-    @Override
-    public void clusterWakeupPublished(String transport, String outcome) {}
-
-    @Override
-    public void clusterWakeupReceived(String transport, String outcome) {}
   }
 }

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
@@ -22,19 +22,16 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import java.util.List;
 import org.bson.Document;
-import run.ratchet.api.JobStatus;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.ConstraintDetector;
 import run.ratchet.store.context.AbstractStoreContext;
-import run.ratchet.store.entity.JobExecutionType;
-import run.ratchet.store.util.StatusClassifier;
 
 /**
  * Shared context passed into every Mongo operation class.
  *
- * <p>Owns the {@link MongoDatabase} handle, collection accessors, and status classification helpers
- * on top of the shared {@link AbstractStoreContext} scaffolding. Mongo adds a translation branch
- * for non-transient {@link MongoException}s via {@link #additionalTranslation}.
+ * <p>Owns the {@link MongoDatabase} handle and collection accessors on top of the shared {@link
+ * AbstractStoreContext} scaffolding. Mongo adds a translation branch for non-transient {@link
+ * MongoException}s via {@link #additionalTranslation}.
  */
 final class MongoStoreContext extends AbstractStoreContext {
 
@@ -63,18 +60,6 @@ final class MongoStoreContext extends AbstractStoreContext {
     super(metricsCollector, priorityBoostIntervalMinutes);
     this.client = client;
     this.database = database;
-  }
-
-  static boolean isPollerExecutable(JobExecutionType jobType) {
-    return StatusClassifier.isPollerExecutable(jobType);
-  }
-
-  static boolean isLiveStatus(JobStatus status) {
-    return StatusClassifier.isLiveStatus(status);
-  }
-
-  static boolean isTerminalStatus(JobStatus status) {
-    return StatusClassifier.isTerminalStatus(status);
   }
 
   /**

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
@@ -32,25 +32,12 @@ import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 import run.ratchet.store.spi.ArchiveStore;
 import run.ratchet.store.util.ArchiveHelper;
+import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
 import run.ratchet.store.util.RowValues;
 
 final class MysqlArchiveOperations implements ArchiveStore {
-
-  private static final String ARCHIVE_COLUMNS =
-      """
-      archive_id, original_job_id, final_status, job_type, priority, total_attempts,
-      max_retries, backoff_policy, backoff_param_ms, timeout_sec, target_class,
-      method_name, business_key, cron_expr, zone_id, original_scheduled_time,
-      original_created_at, first_execution_time, completion_time,
-      total_execution_time_ms, queue_wait_ms, archived_at, archived_by, archive_reason,
-      job_result, result_type, final_error, payload_summary, depended_on, superseded_by,
-      tags
-      """;
-
-  private static final String ARCHIVE_VALUE_PLACEHOLDERS =
-      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
   // language=MySQL
   private static final String INSERT_ARCHIVE_SQL =
@@ -58,7 +45,9 @@ final class MysqlArchiveOperations implements ArchiveStore {
       INSERT INTO scheduler_job_archive (%s)
       VALUES %s
       """
-          .formatted(ARCHIVE_COLUMNS, ARCHIVE_VALUE_PLACEHOLDERS);
+          .formatted(
+              ArchiveParameterBinder.ARCHIVE_COLUMNS,
+              ArchiveParameterBinder.ARCHIVE_VALUE_PLACEHOLDERS);
 
   private final MysqlStoreContext ctx;
   private final MysqlJobRowMapper mapper;
@@ -85,45 +74,6 @@ final class MysqlArchiveOperations implements ArchiveStore {
     }
   }
 
-  private static int setArchiveParameters(Query query, ArchivedJobEntity archive, int parameter) {
-    query.setParameter(parameter++, UuidByteArrayConverter.toBytes(archive.getId()));
-    query.setParameter(parameter++, UuidByteArrayConverter.toBytes(archive.getOriginalJobId()));
-    query.setParameter(parameter++, archive.getFinalStatus().name());
-    query.setParameter(parameter++, archive.getJobType().name());
-    query.setParameter(parameter++, archive.getPriority().ordinal());
-    query.setParameter(parameter++, archive.getTotalAttempts());
-    query.setParameter(parameter++, archive.getMaxRetries());
-    query.setParameter(parameter++, archive.getBackoffPolicy().name());
-    query.setParameter(parameter++, archive.getBackoffParamMs());
-    query.setParameter(parameter++, archive.getTimeoutSec());
-    query.setParameter(parameter++, archive.getTargetClass());
-    query.setParameter(parameter++, archive.getMethodName());
-    query.setParameter(parameter++, archive.getBusinessKey());
-    query.setParameter(parameter++, archive.getCronExpr());
-    query.setParameter(parameter++, archive.getZoneId());
-    query.setParameter(parameter++, timestampOrNull(archive.getOriginalScheduledTime()));
-    query.setParameter(parameter++, timestampOrNull(archive.getOriginalCreatedAt()));
-    query.setParameter(parameter++, timestampOrNull(archive.getFirstExecutionTime()));
-    query.setParameter(parameter++, timestampOrNull(archive.getCompletionTime()));
-    query.setParameter(parameter++, archive.getTotalExecutionTimeMs());
-    query.setParameter(parameter++, archive.getQueueWaitMs());
-    query.setParameter(parameter++, timestampOrNull(archive.getArchivedAt()));
-    query.setParameter(parameter++, archive.getArchivedBy());
-    query.setParameter(parameter++, archive.getArchiveReason());
-    query.setParameter(parameter++, archive.getJobResult());
-    query.setParameter(parameter++, archive.getResultType());
-    query.setParameter(parameter++, archive.getFinalError());
-    query.setParameter(parameter++, archive.getPayloadSummary());
-    query.setParameter(parameter++, UuidByteArrayConverter.toBytes(archive.getDependedOn()));
-    query.setParameter(parameter++, UuidByteArrayConverter.toBytes(archive.getSupersededBy()));
-    query.setParameter(parameter++, archive.getTags());
-    return parameter;
-  }
-
-  private static Timestamp timestampOrNull(Instant instant) {
-    return instant == null ? null : Timestamp.from(instant);
-  }
-
   /**
    * Archives one terminal job in the caller's store transaction.
    *
@@ -136,7 +86,7 @@ final class MysqlArchiveOperations implements ArchiveStore {
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
-      setArchiveParameters(query, archive, 1);
+      ArchiveParameterBinder.bind(query, archive, 1, UuidByteArrayConverter::toBytes);
       query.executeUpdate();
       return archive;
     } catch (RuntimeException e) {
@@ -173,7 +123,10 @@ final class MysqlArchiveOperations implements ArchiveStore {
       }
 
       String rows =
-          String.join(",", Collections.nCopies(archives.size(), ARCHIVE_VALUE_PLACEHOLDERS));
+          String.join(
+              ",",
+              Collections.nCopies(
+                  archives.size(), ArchiveParameterBinder.ARCHIVE_VALUE_PLACEHOLDERS));
       Query query =
           ctx.em()
               .createNativeQuery(
@@ -181,10 +134,11 @@ final class MysqlArchiveOperations implements ArchiveStore {
                   INSERT INTO scheduler_job_archive (%s)
                   VALUES %s
                   """
-                      .formatted(ARCHIVE_COLUMNS, rows));
+                      .formatted(ArchiveParameterBinder.ARCHIVE_COLUMNS, rows));
       int parameter = 1;
       for (ArchivedJobEntity archive : archives) {
-        parameter = setArchiveParameters(query, archive, parameter);
+        parameter =
+            ArchiveParameterBinder.bind(query, archive, parameter, UuidByteArrayConverter::toBytes);
       }
       query.executeUpdate();
       return archives.size();
@@ -256,7 +210,7 @@ final class MysqlArchiveOperations implements ArchiveStore {
     try {
       var searchQuery =
           ArchiveQuerySupport.buildFindArchivedJobsQuery(
-              ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
+              ArchiveParameterBinder.ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
       Query query = ctx.em().createNativeQuery(searchQuery.sql());
       ArchiveQuerySupport.bindParameters(query, searchQuery);
       @SuppressWarnings("unchecked")

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.ArchivedJobEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
@@ -218,6 +219,8 @@ final class MysqlArchiveOperations implements ArchiveStore {
       }
       tags.hydrateTagsBatch(jobs);
       return jobs;
+    } catch (RatchetTransientStoreException e) {
+      throw e;
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("find jobs for archiving", e);
     }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
@@ -34,6 +34,7 @@ import run.ratchet.store.spi.ArchiveStore;
 import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.RowValues;
 
 final class MysqlArchiveOperations implements ArchiveStore {
 
@@ -260,9 +261,7 @@ final class MysqlArchiveOperations implements ArchiveStore {
       ArchiveQuerySupport.bindParameters(query, searchQuery);
       @SuppressWarnings("unchecked")
       List<Object[]> rows = query.getResultList();
-      return rows.stream()
-          .map(row -> ArchiveRowMapper.map(row, MysqlJobRowMapper::toInstant))
-          .toList();
+      return rows.stream().map(row -> ArchiveRowMapper.map(row, RowValues::instantOrNull)).toList();
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("find archived jobs", e);
     }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlAuxiliaryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlAuxiliaryOperations.java
@@ -37,6 +37,7 @@ import run.ratchet.store.spi.ExecutionStore;
 import run.ratchet.store.spi.JobLogStore;
 import run.ratchet.store.spi.ResourcePermitStore;
 import run.ratchet.store.spi.WorkflowConditionStore;
+import run.ratchet.store.util.RowValues;
 
 final class MysqlAuxiliaryOperations
     implements ExecutionStore,
@@ -61,7 +62,7 @@ final class MysqlAuxiliaryOperations
     condition.setConditionType(WorkflowCondition.ConditionType.valueOf(row[3].toString()));
     condition.setConditionExpression(row[4] == null ? null : row[4].toString());
     condition.setConditionPriority(((Number) row[5]).intValue());
-    condition.setCreatedAt(MysqlJobRowMapper.toInstant(row[6]));
+    condition.setCreatedAt(RowValues.instantOrNull(row[6]));
     return condition;
   }
 

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
@@ -347,9 +347,11 @@ final class MysqlJobClaimOperations implements JobClaimStore {
       String placeholders = String.join(",", Collections.nCopies(jobIds.size(), "?"));
       /*
        * MySQL has no PostgreSQL-style UPDATE ... RETURNING for claiming and hydrating rows in one
-       * statement. The caller already holds candidate row locks from FOR UPDATE SKIP LOCKED, so this
-       * dialect keeps the portable MySQL pattern: UPDATE the locked PENDING rows, then reselect the
-       * ids owned by this node to report which candidates were actually claimed.
+       * statement. The caller already holds candidate row locks from FOR UPDATE SKIP LOCKED, so every
+       * locked candidate is still PENDING at UPDATE time and the affected-row count equals the
+       * candidate count: the whole candidate set is claimed. A read-back SELECT is kept only as a
+       * defensive fallback for the lock-impossible count mismatch, matching PostgreSQL's two
+       * round-trip claim instead of paying a third.
        */
       // language=MySQL
       String updateSql =
@@ -369,7 +371,12 @@ final class MysqlJobClaimOperations implements JobClaimStore {
       for (UUID id : jobIds) {
         updateQuery.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
       }
-      updateQuery.executeUpdate();
+      int affected = updateQuery.executeUpdate();
+      if (affected == jobIds.size()) {
+        boolean[] claimed = new boolean[jobIds.size()];
+        Arrays.fill(claimed, true);
+        return claimed;
+      }
 
       // language=MySQL
       String selectSql =

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
@@ -39,6 +39,7 @@ import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.JobClaimStore;
 import run.ratchet.store.util.JobClaimSqlSupport;
+import run.ratchet.store.util.RowValues;
 
 final class MysqlJobClaimOperations implements JobClaimStore {
 
@@ -304,7 +305,7 @@ final class MysqlJobClaimOperations implements JobClaimStore {
     }
 
     Instant scheduledTime() {
-      return MysqlJobRowMapper.toInstant(value(ClaimColumn.SCHEDULED_TIME));
+      return RowValues.instantOrNull(value(ClaimColumn.SCHEDULED_TIME));
     }
 
     int version() {

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobRowMapper.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobRowMapper.java
@@ -15,12 +15,8 @@
  */
 package run.ratchet.store.mysql;
 
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import org.jboss.logging.Logger;
@@ -141,25 +137,6 @@ final class MysqlJobRowMapper {
     return RowValues.uuidOrNull(val);
   }
 
-  static Instant toInstant(Object val) {
-    if (val == null) {
-      return null;
-    }
-    if (val instanceof Timestamp ts) {
-      return ts.toInstant();
-    }
-    if (val instanceof Instant inst) {
-      return inst;
-    }
-    if (val instanceof LocalDateTime ldt) {
-      return ldt.toInstant(ZoneOffset.UTC);
-    }
-    if (val instanceof Date date) {
-      return date.toInstant();
-    }
-    return null;
-  }
-
   JobEntity hydrateJobEntity(Object[] row) {
     if (row == null) {
       return null;
@@ -194,15 +171,15 @@ final class MysqlJobRowMapper {
         JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_ON_FAILURE])));
     j.setDependsOn(uuidOrNull(row[IDX_DEPENDS_ON]));
     j.setSupersededBy(uuidOrNull(row[IDX_SUPERSEDED_BY]));
-    j.setCreatedAt(toInstant(row[IDX_CREATED_AT]));
+    j.setCreatedAt(RowValues.instantOrNull(row[IDX_CREATED_AT]));
     j.setCallerPrincipal((String) row[IDX_CALLER_PRINCIPAL]);
 
     JobStatus terminal =
         enumValueOrNull(row, IDX_TERMINAL_STATUS, "terminal_status", JobStatus.class);
     j.setTerminalStatus(terminal);
 
-    j.setExecutionStartTime(toInstant(row[IDX_EXEC_START]));
-    j.setExecutionEndTime(toInstant(row[IDX_EXEC_END]));
+    j.setExecutionStartTime(RowValues.instantOrNull(row[IDX_EXEC_START]));
+    j.setExecutionEndTime(RowValues.instantOrNull(row[IDX_EXEC_END]));
     j.setExecutionDurationMs(longOrNull(row[IDX_EXEC_DURATION]));
     j.setQueueWaitMs(longOrNull(row[IDX_QUEUE_WAIT]));
     j.setJobResult(stringOrNull(row[IDX_JOB_RESULT]));
@@ -211,12 +188,12 @@ final class MysqlJobRowMapper {
         JSON_MAP_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_TRACE_CONTEXT])));
     j.setRecurringMasterId(uuidOrNull(row[IDX_RECURRING_MASTER_ID]));
     j.setSignalKey((String) row[IDX_Q_SIGNAL_KEY]);
-    j.setSignalTimeout(toInstant(row[IDX_Q_SIGNAL_TIMEOUT]));
+    j.setSignalTimeout(RowValues.instantOrNull(row[IDX_Q_SIGNAL_TIMEOUT]));
     j.setSignalPayload(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD]));
     j.setSignalPayloadType(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD_TYPE]));
     j.setSignalOutcome(stringOrNull(row[IDX_Q_SIGNAL_OUTCOME]));
     j.setSignalRejectionReason(stringOrNull(row[IDX_Q_SIGNAL_REJECTION_REASON]));
-    j.setSignalDeliveredAt(toInstant(row[IDX_Q_SIGNAL_DELIVERED_AT]));
+    j.setSignalDeliveredAt(RowValues.instantOrNull(row[IDX_Q_SIGNAL_DELIVERED_AT]));
     j.setSignalDeliveredBy((String) row[IDX_Q_SIGNAL_DELIVERED_BY]);
     j.setSignalDeliveryId(stringOrNull(row[IDX_Q_SIGNAL_DELIVERY_ID]));
 
@@ -234,15 +211,15 @@ final class MysqlJobRowMapper {
     j.setStatus(resolved);
 
     if (live != null) {
-      j.setScheduledTime(toInstant(row[IDX_Q_SCHEDULED_TIME]));
+      j.setScheduledTime(RowValues.instantOrNull(row[IDX_Q_SCHEDULED_TIME]));
       j.setAttempts(requiredNumber(row, IDX_Q_ATTEMPTS, "q.attempts").intValue());
       j.setPickedBy((String) row[IDX_Q_PICKED_BY]);
-      j.setPickedAt(toInstant(row[IDX_Q_PICKED_AT]));
+      j.setPickedAt(RowValues.instantOrNull(row[IDX_Q_PICKED_AT]));
       j.setPausedFromStatus(
           enumValueOrNull(row, IDX_Q_PAUSED, "q.paused_from_status", JobStatus.class));
       j.setLastError(stringOrNull(row[IDX_Q_LAST_ERROR]));
       j.setVersion(requiredNumber(row, IDX_Q_VERSION, "q.version").intValue());
-      Instant queueUpdatedAt = toInstant(row[IDX_Q_UPDATED_AT]);
+      Instant queueUpdatedAt = RowValues.instantOrNull(row[IDX_Q_UPDATED_AT]);
       if (queueUpdatedAt != null) {
         j.setUpdatedAt(queueUpdatedAt);
       }
@@ -251,15 +228,15 @@ final class MysqlJobRowMapper {
       j.setAttempts(ta != null ? ta.intValue() : 0);
       j.setLastError(stringOrNull(row[IDX_TERMINAL_ERROR]));
       j.setVersion(0);
-      Instant fallbackSched = toInstant(row[IDX_EXEC_START]);
+      Instant fallbackSched = RowValues.instantOrNull(row[IDX_EXEC_START]);
       if (fallbackSched == null) {
-        fallbackSched = toInstant(row[IDX_CREATED_AT]);
+        fallbackSched = RowValues.instantOrNull(row[IDX_CREATED_AT]);
       }
       j.setScheduledTime(fallbackSched);
     }
 
     if (j.getUpdatedAt() == null) {
-      Instant updatedAt = toInstant(row[IDX_TERMINATED_AT]);
+      Instant updatedAt = RowValues.instantOrNull(row[IDX_TERMINATED_AT]);
       if (updatedAt == null) {
         updatedAt = j.getCreatedAt();
       }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobRowMapper.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobRowMapper.java
@@ -15,24 +15,21 @@
  */
 package run.ratchet.store.mysql;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import org.jboss.logging.Logger;
-import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
+import run.ratchet.store.context.AbstractJobRowMapper;
 import run.ratchet.store.converter.JobPayloadConverter;
 import run.ratchet.store.converter.JsonMapConverter;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobPayload;
-import run.ratchet.store.util.JobHydrationSupport;
 import run.ratchet.store.util.RowValues;
 import run.ratchet.store.util.StatusClassifier;
 
-final class MysqlJobRowMapper {
+final class MysqlJobRowMapper extends AbstractJobRowMapper {
 
   // language=MySQL
   static final String HYDRATION_SELECT =
@@ -51,63 +48,14 @@ final class MysqlJobRowMapper {
       q.signal_outcome, q.signal_rejection_reason, q.signal_delivered_at,
       q.signal_delivered_by, q.signal_delivery_id\
       """;
-  static final int HYDRATION_COL_COUNT = 52;
-  static final int IDX_Q_STATUS = 34;
-  private static final Logger log = Logger.getLogger(MysqlJobRowMapper.class);
+  static final int HYDRATION_COL_COUNT = AbstractJobRowMapper.HYDRATION_COL_COUNT;
+  static final int IDX_Q_STATUS = AbstractJobRowMapper.IDX_Q_STATUS;
   private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
   private static final JsonMapConverter JSON_MAP_CONVERTER = new JsonMapConverter();
-  private static final JobHydrationSupport HYDRATION = new JobHydrationSupport("MySQL");
-  private static final int IDX_JOB_ID = 0;
-  private static final int IDX_JOB_TYPE = 1;
-  private static final int IDX_PRIORITY = 2;
-  private static final int IDX_MAX_RETRIES = 3;
-  private static final int IDX_BACKOFF_POLICY = 4;
-  private static final int IDX_BACKOFF_PARAM_MS = 5;
-  private static final int IDX_TIMEOUT_SEC = 6;
-  private static final int IDX_CRON_EXPR = 7;
-  private static final int IDX_ZONE_ID = 8;
-  private static final int IDX_PAYLOAD = 9;
-  private static final int IDX_PARAMS = 10;
-  private static final int IDX_TARGET_CLASS = 11;
-  private static final int IDX_METHOD_NAME = 12;
-  private static final int IDX_IDEMPOTENCY_KEY = 13;
-  private static final int IDX_BUSINESS_KEY = 14;
-  private static final int IDX_RESOURCE_NAME = 15;
-  private static final int IDX_ON_SUCCESS = 16;
-  private static final int IDX_ON_FAILURE = 17;
-  private static final int IDX_DEPENDS_ON = 18;
-  private static final int IDX_SUPERSEDED_BY = 19;
-  private static final int IDX_CREATED_AT = 20;
-  private static final int IDX_CALLER_PRINCIPAL = 21;
-  private static final int IDX_TERMINAL_STATUS = 22;
-  private static final int IDX_TERMINAL_ERROR = 23;
-  private static final int IDX_TOTAL_ATTEMPTS = 24;
-  private static final int IDX_TERMINATED_AT = 25;
-  private static final int IDX_EXEC_START = 26;
-  private static final int IDX_EXEC_END = 27;
-  private static final int IDX_EXEC_DURATION = 28;
-  private static final int IDX_QUEUE_WAIT = 29;
-  private static final int IDX_JOB_RESULT = 30;
-  private static final int IDX_RESULT_TYPE = 31;
-  private static final int IDX_TRACE_CONTEXT = 32;
-  private static final int IDX_RECURRING_MASTER_ID = 33;
-  private static final int IDX_Q_SCHEDULED_TIME = 35;
-  private static final int IDX_Q_ATTEMPTS = 36;
-  private static final int IDX_Q_PICKED_BY = 37;
-  private static final int IDX_Q_PICKED_AT = 38;
-  private static final int IDX_Q_PAUSED = 39;
-  private static final int IDX_Q_LAST_ERROR = 40;
-  private static final int IDX_Q_VERSION = 41;
-  private static final int IDX_Q_UPDATED_AT = 42;
-  private static final int IDX_Q_SIGNAL_KEY = 43;
-  private static final int IDX_Q_SIGNAL_TIMEOUT = 44;
-  private static final int IDX_Q_SIGNAL_PAYLOAD = 45;
-  private static final int IDX_Q_SIGNAL_PAYLOAD_TYPE = 46;
-  private static final int IDX_Q_SIGNAL_OUTCOME = 47;
-  private static final int IDX_Q_SIGNAL_REJECTION_REASON = 48;
-  private static final int IDX_Q_SIGNAL_DELIVERED_AT = 49;
-  private static final int IDX_Q_SIGNAL_DELIVERED_BY = 50;
-  private static final int IDX_Q_SIGNAL_DELIVERY_ID = 51;
+
+  MysqlJobRowMapper() {
+    super("MySQL");
+  }
 
   static boolean isTerminalStatus(JobStatus s) {
     return StatusClassifier.isTerminalStatus(s);
@@ -138,112 +86,7 @@ final class MysqlJobRowMapper {
   }
 
   JobEntity hydrateJobEntity(Object[] row) {
-    if (row == null) {
-      return null;
-    }
-    if (row.length != HYDRATION_COL_COUNT) {
-      throw new IllegalStateException(
-          "Hydration projection length mismatch: expected "
-              + HYDRATION_COL_COUNT
-              + " columns, got "
-              + row.length);
-    }
-    JobEntity j = new JobEntity();
-    j.setId(uuidOrNull(row[IDX_JOB_ID]));
-    j.setJobType(enumValue(row, IDX_JOB_TYPE, "job_type", JobExecutionType.class));
-    j.setPriority(safeJobPriority(requiredNumber(row, IDX_PRIORITY, "priority").intValue()));
-    j.setMaxRetries(requiredNumber(row, IDX_MAX_RETRIES, "max_retries").intValue());
-    j.setBackoffPolicy(enumValue(row, IDX_BACKOFF_POLICY, "backoff_policy", BackoffPolicy.class));
-    j.setBackoffParamMs(requiredNumber(row, IDX_BACKOFF_PARAM_MS, "backoff_param_ms").intValue());
-    j.setTimeoutSec(requiredNumber(row, IDX_TIMEOUT_SEC, "timeout_sec").intValue());
-    j.setCronExpr((String) row[IDX_CRON_EXPR]);
-    j.setZoneId((String) row[IDX_ZONE_ID]);
-    j.setPayload(JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_PAYLOAD])));
-    j.setParams(JSON_MAP_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_PARAMS])));
-    j.setTargetClass((String) row[IDX_TARGET_CLASS]);
-    j.setMethodName((String) row[IDX_METHOD_NAME]);
-    j.setIdempotencyKey((String) row[IDX_IDEMPOTENCY_KEY]);
-    j.setBusinessKey((String) row[IDX_BUSINESS_KEY]);
-    j.setResourceName((String) row[IDX_RESOURCE_NAME]);
-    j.setOnSuccessPayload(
-        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_ON_SUCCESS])));
-    j.setOnFailurePayload(
-        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_ON_FAILURE])));
-    j.setDependsOn(uuidOrNull(row[IDX_DEPENDS_ON]));
-    j.setSupersededBy(uuidOrNull(row[IDX_SUPERSEDED_BY]));
-    j.setCreatedAt(RowValues.instantOrNull(row[IDX_CREATED_AT]));
-    j.setCallerPrincipal((String) row[IDX_CALLER_PRINCIPAL]);
-
-    JobStatus terminal =
-        enumValueOrNull(row, IDX_TERMINAL_STATUS, "terminal_status", JobStatus.class);
-    j.setTerminalStatus(terminal);
-
-    j.setExecutionStartTime(RowValues.instantOrNull(row[IDX_EXEC_START]));
-    j.setExecutionEndTime(RowValues.instantOrNull(row[IDX_EXEC_END]));
-    j.setExecutionDurationMs(longOrNull(row[IDX_EXEC_DURATION]));
-    j.setQueueWaitMs(longOrNull(row[IDX_QUEUE_WAIT]));
-    j.setJobResult(stringOrNull(row[IDX_JOB_RESULT]));
-    j.setResultType((String) row[IDX_RESULT_TYPE]);
-    j.setTraceContext(
-        JSON_MAP_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_TRACE_CONTEXT])));
-    j.setRecurringMasterId(uuidOrNull(row[IDX_RECURRING_MASTER_ID]));
-    j.setSignalKey((String) row[IDX_Q_SIGNAL_KEY]);
-    j.setSignalTimeout(RowValues.instantOrNull(row[IDX_Q_SIGNAL_TIMEOUT]));
-    j.setSignalPayload(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD]));
-    j.setSignalPayloadType(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD_TYPE]));
-    j.setSignalOutcome(stringOrNull(row[IDX_Q_SIGNAL_OUTCOME]));
-    j.setSignalRejectionReason(stringOrNull(row[IDX_Q_SIGNAL_REJECTION_REASON]));
-    j.setSignalDeliveredAt(RowValues.instantOrNull(row[IDX_Q_SIGNAL_DELIVERED_AT]));
-    j.setSignalDeliveredBy((String) row[IDX_Q_SIGNAL_DELIVERED_BY]);
-    j.setSignalDeliveryId(stringOrNull(row[IDX_Q_SIGNAL_DELIVERY_ID]));
-
-    JobStatus live = enumValueOrNull(row, IDX_Q_STATUS, "q.status", JobStatus.class);
-
-    JobStatus resolved;
-    if (live != null) {
-      resolved = live;
-    } else if (terminal != null) {
-      resolved = terminal;
-    } else {
-      log.errorf("Job %s has no live or terminal status — possible invariant violation", j.getId());
-      resolved = null;
-    }
-    j.setStatus(resolved);
-
-    if (live != null) {
-      j.setScheduledTime(RowValues.instantOrNull(row[IDX_Q_SCHEDULED_TIME]));
-      j.setAttempts(requiredNumber(row, IDX_Q_ATTEMPTS, "q.attempts").intValue());
-      j.setPickedBy((String) row[IDX_Q_PICKED_BY]);
-      j.setPickedAt(RowValues.instantOrNull(row[IDX_Q_PICKED_AT]));
-      j.setPausedFromStatus(
-          enumValueOrNull(row, IDX_Q_PAUSED, "q.paused_from_status", JobStatus.class));
-      j.setLastError(stringOrNull(row[IDX_Q_LAST_ERROR]));
-      j.setVersion(requiredNumber(row, IDX_Q_VERSION, "q.version").intValue());
-      Instant queueUpdatedAt = RowValues.instantOrNull(row[IDX_Q_UPDATED_AT]);
-      if (queueUpdatedAt != null) {
-        j.setUpdatedAt(queueUpdatedAt);
-      }
-    } else {
-      Number ta = numberOrNull(row, IDX_TOTAL_ATTEMPTS, "total_attempts");
-      j.setAttempts(ta != null ? ta.intValue() : 0);
-      j.setLastError(stringOrNull(row[IDX_TERMINAL_ERROR]));
-      j.setVersion(0);
-      Instant fallbackSched = RowValues.instantOrNull(row[IDX_EXEC_START]);
-      if (fallbackSched == null) {
-        fallbackSched = RowValues.instantOrNull(row[IDX_CREATED_AT]);
-      }
-      j.setScheduledTime(fallbackSched);
-    }
-
-    if (j.getUpdatedAt() == null) {
-      Instant updatedAt = RowValues.instantOrNull(row[IDX_TERMINATED_AT]);
-      if (updatedAt == null) {
-        updatedAt = j.getCreatedAt();
-      }
-      j.setUpdatedAt(updatedAt);
-    }
-
-    return j;
+    return hydrateRow(row);
   }
 
   static List<JobEntity> hydrateRows(List<Object[]> rows) {
@@ -269,23 +112,5 @@ final class MysqlJobRowMapper {
 
   static String traceContextToJson(JobEntity job) {
     return JSON_MAP_CONVERTER.convertToDatabaseColumn(job.getTraceContext());
-  }
-
-  private static <E extends Enum<E>> E enumValue(
-      Object[] row, int index, String column, Class<E> enumType) {
-    return HYDRATION.enumValue(row, index, column, enumType);
-  }
-
-  private static <E extends Enum<E>> E enumValueOrNull(
-      Object[] row, int index, String column, Class<E> enumType) {
-    return HYDRATION.enumValueOrNull(row, index, column, enumType);
-  }
-
-  private static Number requiredNumber(Object[] row, int index, String column) {
-    return HYDRATION.requiredNumber(row, index, column);
-  }
-
-  private static Number numberOrNull(Object[] row, int index, String column) {
-    return HYDRATION.numberOrNull(row, index, column);
   }
 }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobWriteOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobWriteOperations.java
@@ -29,6 +29,7 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.RowValues;
 
 final class MysqlJobWriteOperations {
 
@@ -384,7 +385,7 @@ final class MysqlJobWriteOperations {
     if (!"PENDING".equals(storedStatus) && !"WAITING".equals(storedStatus)) {
       return false;
     }
-    Instant storedSched = MysqlJobRowMapper.toInstant(row[1]);
+    Instant storedSched = RowValues.instantOrNull(row[1]);
     Instant incomingSched = job.getScheduledTime();
     if (Objects.equals(storedSched, incomingSched)) {
       return false;
@@ -392,7 +393,7 @@ final class MysqlJobWriteOperations {
     if (!Objects.equals(JobStatus.valueOf(storedStatus), job.getStatus())
         || !Objects.equals(((Number) row[2]).intValue(), job.getAttempts())
         || !Objects.equals(row[3], job.getPickedBy())
-        || !Objects.equals(MysqlJobRowMapper.toInstant(row[4]), job.getPickedAt())
+        || !Objects.equals(RowValues.instantOrNull(row[4]), job.getPickedAt())
         || !Objects.equals(
             row[5] != null ? JobStatus.valueOf((String) row[5]) : null, job.getPausedFromStatus())
         || !Objects.equals(row[6], job.getLastError())
@@ -523,11 +524,11 @@ final class MysqlJobWriteOperations {
       JobStatus storedStatus = JobStatus.valueOf(qStatus);
       checkHotField(id, "status", incoming.getStatus(), storedStatus);
       checkHotField(
-          id, "scheduledTime", incoming.getScheduledTime(), MysqlJobRowMapper.toInstant(row[1]));
+          id, "scheduledTime", incoming.getScheduledTime(), RowValues.instantOrNull(row[1]));
       Integer storedAttempts = ((Number) row[2]).intValue();
       checkHotField(id, "attempts", incoming.getAttempts(), storedAttempts);
       checkHotField(id, "pickedBy", incoming.getPickedBy(), row[3]);
-      checkHotField(id, "pickedAt", incoming.getPickedAt(), MysqlJobRowMapper.toInstant(row[4]));
+      checkHotField(id, "pickedAt", incoming.getPickedAt(), RowValues.instantOrNull(row[4]));
       String pausedFrom = (String) row[5];
       JobStatus storedPausedFrom = pausedFrom != null ? JobStatus.valueOf(pausedFrom) : null;
       checkHotField(id, "pausedFromStatus", incoming.getPausedFromStatus(), storedPausedFrom);
@@ -569,10 +570,10 @@ final class MysqlJobWriteOperations {
     }
 
     JobStatus storedStatus = JobStatus.valueOf(hotStatusStr);
-    Instant storedSched = MysqlJobRowMapper.toInstant(row[1]);
+    Instant storedSched = RowValues.instantOrNull(row[1]);
     int storedAttempts = ((Number) row[2]).intValue();
     Object storedPickedBy = row[3];
-    Instant storedPickedAt = MysqlJobRowMapper.toInstant(row[4]);
+    Instant storedPickedAt = RowValues.instantOrNull(row[4]);
     String storedPausedFromStr = (String) row[5];
     JobStatus storedPausedFrom =
         storedPausedFromStr != null ? JobStatus.valueOf(storedPausedFromStr) : null;

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobWriteOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobWriteOperations.java
@@ -15,6 +15,9 @@
  */
 package run.ratchet.store.mysql;
 
+import static run.ratchet.store.util.JobWriteSupport.assignIdIfMissing;
+import static run.ratchet.store.util.JobWriteSupport.checkHotField;
+
 import jakarta.persistence.Query;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -27,7 +30,6 @@ import run.ratchet.api.exception.RatchetOptimisticLockException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
-import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 import run.ratchet.store.util.RowValues;
 
@@ -93,28 +95,6 @@ final class MysqlJobWriteOperations {
     this.tags = tags;
   }
 
-  private static void checkHotField(UUID jobId, String fieldName, Object incoming, Object stored) {
-    if (Objects.equals(incoming, stored)) {
-      return;
-    }
-    throw new IllegalStateException(
-        "save() rejected: hot-field mutation detected for id="
-            + jobId
-            + " field="
-            + fieldName
-            + " incoming="
-            + incoming
-            + " stored="
-            + stored
-            + ". Use an explicit transition method.");
-  }
-
-  private static void assignTsidIfMissing(JobEntity job) {
-    if (job.getId() == null) {
-      job.setId(UuidV7Factory.create());
-    }
-  }
-
   JobEntity save(JobEntity job) {
     if (job.getId() == null) {
       saveInsert(job);
@@ -132,7 +112,7 @@ final class MysqlJobWriteOperations {
     Timestamp nowTs = Timestamp.from(now);
 
     for (JobEntity job : jobs) {
-      assignTsidIfMissing(job);
+      assignIdIfMissing(job);
     }
 
     executeColdBulkInsert(jobs, nowTs);
@@ -143,7 +123,7 @@ final class MysqlJobWriteOperations {
   }
 
   void saveInsert(JobEntity job) {
-    assignTsidIfMissing(job);
+    assignIdIfMissing(job);
     Instant now = Instant.now();
     Timestamp nowTs = Timestamp.from(now);
     if (job.getCreatedAt() == null) {

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlNodeLockOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlNodeLockOperations.java
@@ -15,6 +15,10 @@
  */
 package run.ratchet.store.mysql;
 
+import static run.ratchet.store.util.LockValidation.durationMicros;
+import static run.ratchet.store.util.LockValidation.requireLockName;
+import static run.ratchet.store.util.LockValidation.requirePositiveDuration;
+
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
@@ -126,29 +130,6 @@ final class MysqlNodeLockOperations implements NodeStore, LockStore {
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("renew lock", e);
     }
-  }
-
-  private static void requireLockName(String name) {
-    Objects.requireNonNull(name, "name");
-    if (name.isBlank()) {
-      throw new IllegalArgumentException("name must be non-empty");
-    }
-  }
-
-  private static void requirePositiveDuration(Duration duration, String parameterName) {
-    Objects.requireNonNull(duration, parameterName);
-    if (duration.isZero() || duration.isNegative()) {
-      throw new IllegalArgumentException(parameterName + " must be positive");
-    }
-  }
-
-  private static long durationMicros(Duration duration) {
-    long seconds = duration.getSeconds();
-    long microsFromNanos = (duration.getNano() + 999L) / 1_000L;
-    if (seconds > (Long.MAX_VALUE - microsFromNanos) / 1_000_000L) {
-      return Long.MAX_VALUE;
-    }
-    return Math.max(1L, seconds * 1_000_000L + microsFromNanos);
   }
 
   @Override

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlRecurringJobOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlRecurringJobOperations.java
@@ -33,6 +33,7 @@ import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
 import run.ratchet.store.util.JobClaimSqlSupport;
 import run.ratchet.store.util.RecurringJobRows;
+import run.ratchet.store.util.RowValues;
 
 /**
  * MySQL implementation of {@link RecurringJobStore} against the dedicated {@code
@@ -113,7 +114,7 @@ final class MysqlRecurringJobOperations implements RecurringJobStore {
     if (rows.isEmpty() || rows.get(0) == null) {
       return Optional.empty();
     }
-    Instant nf = MysqlJobRowMapper.toInstant(rows.get(0));
+    Instant nf = RowValues.instantOrNull(rows.get(0));
     return Optional.ofNullable(nf);
   }
 

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSignalOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSignalOperations.java
@@ -17,8 +17,6 @@ package run.ratchet.store.mysql;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -30,6 +28,7 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 import run.ratchet.store.spi.SignalStore;
+import run.ratchet.store.util.RowValues;
 
 /**
  * MySQL implementation of {@link SignalStore}.
@@ -45,19 +44,6 @@ final class MysqlSignalOperations implements SignalStore {
 
   MysqlSignalOperations(MysqlStoreContext ctx) {
     this.ctx = ctx;
-  }
-
-  private static Instant toInstant(Object value) {
-    if (value == null) {
-      return null;
-    }
-    if (value instanceof Timestamp ts) {
-      return ts.toInstant();
-    }
-    if (value instanceof LocalDateTime ldt) {
-      return ldt.atZone(ZoneId.of("UTC")).toInstant();
-    }
-    return null;
   }
 
   @Override
@@ -93,7 +79,7 @@ final class MysqlSignalOperations implements SignalStore {
         JobEntity job = new JobEntity();
         job.setId(UuidByteArrayConverter.fromBytes((byte[]) row[0]));
         job.setSignalKey((String) row[1]);
-        job.setSignalTimeout(toInstant(row[2]));
+        job.setSignalTimeout(RowValues.instantOrNull(row[2]));
         job.setStatus(JobStatus.WAITING);
         job.setJobType(row[4] != null ? JobExecutionType.valueOf((String) row[4]) : null);
         job.setPriority(
@@ -109,7 +95,7 @@ final class MysqlSignalOperations implements SignalStore {
         job.setSignalPayloadType((String) row[11]);
         job.setSignalOutcome((String) row[12]);
         job.setSignalRejectionReason((String) row[13]);
-        job.setSignalDeliveredAt(toInstant(row[14]));
+        job.setSignalDeliveredAt(RowValues.instantOrNull(row[14]));
         job.setSignalDeliveredBy((String) row[15]);
         job.setSignalDeliveryId((String) row[16]);
         result.add(job);

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlStoreContext.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlStoreContext.java
@@ -16,23 +16,12 @@
 package run.ratchet.store.mysql;
 
 import jakarta.persistence.EntityManager;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import run.ratchet.api.JobPriority;
-import run.ratchet.api.JobType;
-import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
-import run.ratchet.store.util.TransientStoreExceptions;
+import run.ratchet.store.ConstraintDetector;
+import run.ratchet.store.context.AbstractSqlStoreContext;
 
-final class MysqlStoreContext {
+final class MysqlStoreContext extends AbstractSqlStoreContext {
 
-  private static final String DIALECT = "mysql";
-  private static final MetricsCollector NOOP_METRICS_COLLECTOR = new NoopMetricsCollector();
-
-  private final EntityManager em;
-  private final MetricsCollector metricsCollector;
-  private final int priorityBoostIntervalMinutes;
   private final MysqlConstraintDetector constraintDetector = new MysqlConstraintDetector();
 
   MysqlStoreContext(EntityManager em, MetricsCollector metricsCollector) {
@@ -41,123 +30,21 @@ final class MysqlStoreContext {
 
   MysqlStoreContext(
       EntityManager em, MetricsCollector metricsCollector, int priorityBoostIntervalMinutes) {
-    this.em = em;
-    this.metricsCollector = metricsCollector == null ? NOOP_METRICS_COLLECTOR : metricsCollector;
-    this.priorityBoostIntervalMinutes = priorityBoostIntervalMinutes;
+    super(em, metricsCollector, priorityBoostIntervalMinutes);
   }
 
-  EntityManager em() {
-    return em;
+  @Override
+  protected String dialectMetric() {
+    return "mysql";
   }
 
-  MysqlConstraintDetector constraintDetector() {
+  @Override
+  protected String dialectLabel() {
+    return "MySQL";
+  }
+
+  @Override
+  public ConstraintDetector constraintDetector() {
     return constraintDetector;
-  }
-
-  int priorityBoostIntervalMinutes() {
-    return priorityBoostIntervalMinutes;
-  }
-
-  RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
-    RatchetTransientStoreException wrapped =
-        TransientStoreExceptions.translateOrNull("MySQL", constraintDetector, operation, e);
-    return wrapped != null ? wrapped : e;
-  }
-
-  /**
-   * Executes a trusted, package-local SQL count query. Callers must pass hard-coded SQL templates
-   * only; runtime values belong in {@code params}.
-   */
-  // SQL template is a compile-time constant defined in this package; runtime values are bound as
-  // JDBC parameters via setParameter.
-  @SuppressWarnings("SqlSourceToSinkFlow")
-  long countByNative(String sql, Object... params) {
-    var query = em.createNativeQuery(sql);
-    for (int i = 0; i < params.length; i++) {
-      query.setParameter(i + 1, params[i]);
-    }
-    return ((Number) query.getSingleResult()).longValue();
-  }
-
-  /**
-   * Executes a trusted, package-local SQL scalar query. Callers must pass hard-coded SQL templates
-   * only; runtime values belong in {@code params}.
-   */
-  // SQL template is a compile-time constant defined in this package; runtime values are bound as
-  // JDBC parameters via setParameter.
-  @SuppressWarnings("SqlSourceToSinkFlow")
-  double doubleByNativeOrZero(String sql, Object... params) {
-    var query = em.createNativeQuery(sql);
-    for (int i = 0; i < params.length; i++) {
-      query.setParameter(i + 1, params[i]);
-    }
-    Object result = query.getSingleResult();
-    return result == null ? 0.0 : ((Number) result).doubleValue();
-  }
-
-  <T> T timedStoreOperation(
-      String operation, Supplier<T> action, Function<T, String> outcomeFunction) {
-    long startNanos = System.nanoTime();
-    try {
-      T result = action.get();
-      recordStoreOperation(operation, outcomeFunction.apply(result), startNanos);
-      return result;
-    } catch (RatchetTransientStoreException e) {
-      recordStoreOperation(operation, "transient_failure", startNanos);
-      throw e;
-    } catch (RuntimeException e) {
-      RuntimeException translated = translateTransientStoreException(operation, e);
-      recordStoreOperation(
-          operation,
-          translated instanceof RatchetTransientStoreException ? "transient_failure" : "failure",
-          startNanos);
-      throw translated;
-    }
-  }
-
-  private void recordStoreOperation(String operation, String outcome, long startNanos) {
-    metricsCollector.storeOperation(DIALECT, operation, outcome, System.nanoTime() - startNanos);
-  }
-
-  private static final class NoopMetricsCollector implements MetricsCollector {
-    @Override
-    public void jobStarted(UUID jobId, JobType type, JobPriority priority) {}
-
-    @Override
-    public void jobCompleted(UUID jobId, JobType type, long executionTimeMs) {}
-
-    @Override
-    public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {}
-
-    @Override
-    public void successFinalizationRetried(UUID jobId, JobType type) {}
-
-    @Override
-    public void successFinalizationMinimal(UUID jobId, JobType type) {}
-
-    @Override
-    public void successFinalizationStuck(UUID jobId, JobType type) {}
-
-    @Override
-    public void claimTransientFailure(String executionType) {}
-
-    @Override
-    public void jobsClaimed(String executionType, int claimedCount) {}
-
-    @Override
-    public void gateRejected(String executionType, String gateStatus) {}
-
-    @Override
-    public void localWakeup(String source) {}
-
-    @Override
-    public void clusterWakeupPublished(String transport, String outcome) {}
-
-    @Override
-    public void clusterWakeupReceived(String transport, String outcome) {}
-
-    @Override
-    public void storeOperation(
-        String store, String operation, String outcome, long durationNanos) {}
   }
 }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlStoreContext.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlStoreContext.java
@@ -23,6 +23,7 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.util.TransientStoreExceptions;
 
 final class MysqlStoreContext {
 
@@ -58,11 +59,9 @@ final class MysqlStoreContext {
   }
 
   RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
-    if (constraintDetector.isDeadlock(e) || constraintDetector.isTransientConnectionFailure(e)) {
-      return new RatchetTransientStoreException(
-          "Transient MySQL store concurrency failure during " + operation, e);
-    }
-    return e;
+    RatchetTransientStoreException wrapped =
+        TransientStoreExceptions.translateOrNull("MySQL", constraintDetector, operation, e);
+    return wrapped != null ? wrapped : e;
   }
 
   /**

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobRowMapperTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobRowMapperTest.java
@@ -15,14 +15,11 @@
  */
 package run.ratchet.store.mysql;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.util.TimeZone;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.BackoffPolicy;
@@ -46,20 +43,6 @@ class MysqlJobRowMapperTest {
     assertTrue(thrown.getMessage().contains("job_type"));
     assertTrue(thrown.getMessage().contains("UNKNOWN_TYPE"));
     assertInstanceOf(IllegalArgumentException.class, thrown.getCause());
-  }
-
-  @Test
-  void toInstantInterpretsLocalDateTimeAsUtc() {
-    TimeZone original = TimeZone.getDefault();
-    try {
-      TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
-
-      assertEquals(
-          Instant.parse("2026-05-12T12:00:00Z"),
-          MysqlJobRowMapper.toInstant(LocalDateTime.parse("2026-05-12T12:00:00")));
-    } finally {
-      TimeZone.setDefault(original);
-    }
   }
 
   private static Object[] liveRow() {

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobRowMapperTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobRowMapperTest.java
@@ -45,6 +45,18 @@ class MysqlJobRowMapperTest {
     assertInstanceOf(IllegalArgumentException.class, thrown.getCause());
   }
 
+  @Test
+  void hydrateRejectsRowsWithNoEffectiveStatus() {
+    Object[] row = liveRow();
+    row[MysqlJobRowMapper.IDX_Q_STATUS] = null;
+
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class, () -> new MysqlJobRowMapper().hydrateJobEntity(row));
+
+    assertTrue(thrown.getMessage().contains("no live or terminal status"));
+  }
+
   private static Object[] liveRow() {
     Object[] row = new Object[MysqlJobRowMapper.HYDRATION_COL_COUNT];
     Instant now = Instant.parse("2026-05-12T14:30:00Z");

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTransientExceptionTranslationTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTransientExceptionTranslationTest.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.store.mysql;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.persistence.EntityManager;
@@ -47,6 +48,22 @@ class MysqlTransientExceptionTranslationTest {
 
     assertThrows(
         RatchetTransientStoreException.class, () -> archives.archiveJob(job, "ttl", "node-1"));
+  }
+
+  @Test
+  void translateLeavesAnAlreadyTranslatedTransientUnwrapped() {
+    // The EM proxy is never touched here; only dialectLabel()/constraintDetector() run.
+    MysqlStoreContext ctx = throwingContext("executeUpdate");
+    RatchetTransientStoreException alreadyTranslated =
+        new RatchetTransientStoreException(
+            "inner operation", new SQLTransientException("connection lost"));
+
+    RuntimeException result =
+        ctx.translateTransientStoreException("outer operation", alreadyTranslated);
+
+    // A nested operation already translated this; re-translating must not double-wrap. The
+    // detector would otherwise walk the cause chain, re-detect the transient, and re-wrap.
+    assertSame(alreadyTranslated, result);
   }
 
   @Test

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTransientExceptionTranslationTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTransientExceptionTranslationTest.java
@@ -136,6 +136,14 @@ class MysqlTransientExceptionTranslationTest {
         RatchetTransientStoreException.class, () -> auxiliary.releasePermit("api", JOB_ID));
   }
 
+  @Test
+  void countByNativeTranslatesTransientReadFailure() {
+    MysqlJobCountOperations counts =
+        new MysqlJobCountOperations(throwingContext("getSingleResult"));
+
+    assertThrows(RatchetTransientStoreException.class, counts::countActiveNodes);
+  }
+
   private static MysqlStoreContext throwingContext(String throwingQueryMethod) {
     EntityManager em =
         (EntityManager)

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
@@ -31,25 +31,12 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.ArchiveStore;
 import run.ratchet.store.util.ArchiveHelper;
+import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
 import run.ratchet.store.util.RowValues;
 
 final class PostgresqlArchiveOperations implements ArchiveStore {
-
-  private static final String ARCHIVE_COLUMNS =
-      """
-      archive_id, original_job_id, final_status, job_type, priority, total_attempts,
-      max_retries, backoff_policy, backoff_param_ms, timeout_sec, target_class,
-      method_name, business_key, cron_expr, zone_id, original_scheduled_time,
-      original_created_at, first_execution_time, completion_time,
-      total_execution_time_ms, queue_wait_ms, archived_at, archived_by, archive_reason,
-      job_result, result_type, final_error, payload_summary, depended_on, superseded_by,
-      tags
-      """;
-
-  private static final String ARCHIVE_VALUE_PLACEHOLDERS =
-      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
   private static final String MISSING_ARCHIVE_JOB_MESSAGE = "Job not found for archival: ";
 
@@ -59,7 +46,9 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
       INSERT INTO scheduler_job_archive (%s)
       VALUES %s
       """
-          .formatted(ARCHIVE_COLUMNS, ARCHIVE_VALUE_PLACEHOLDERS);
+          .formatted(
+              ArchiveParameterBinder.ARCHIVE_COLUMNS,
+              ArchiveParameterBinder.ARCHIVE_VALUE_PLACEHOLDERS);
 
   private final PostgresqlStoreContext ctx;
   private final PostgresqlJobReadOperations reads;
@@ -78,45 +67,6 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
     }
   }
 
-  private static int setArchiveParameters(Query query, ArchivedJobEntity archive, int parameter) {
-    query.setParameter(parameter++, archive.getId());
-    query.setParameter(parameter++, archive.getOriginalJobId());
-    query.setParameter(parameter++, archive.getFinalStatus().name());
-    query.setParameter(parameter++, archive.getJobType().name());
-    query.setParameter(parameter++, archive.getPriority().ordinal());
-    query.setParameter(parameter++, archive.getTotalAttempts());
-    query.setParameter(parameter++, archive.getMaxRetries());
-    query.setParameter(parameter++, archive.getBackoffPolicy().name());
-    query.setParameter(parameter++, archive.getBackoffParamMs());
-    query.setParameter(parameter++, archive.getTimeoutSec());
-    query.setParameter(parameter++, archive.getTargetClass());
-    query.setParameter(parameter++, archive.getMethodName());
-    query.setParameter(parameter++, archive.getBusinessKey());
-    query.setParameter(parameter++, archive.getCronExpr());
-    query.setParameter(parameter++, archive.getZoneId());
-    query.setParameter(parameter++, timestampOrNull(archive.getOriginalScheduledTime()));
-    query.setParameter(parameter++, timestampOrNull(archive.getOriginalCreatedAt()));
-    query.setParameter(parameter++, timestampOrNull(archive.getFirstExecutionTime()));
-    query.setParameter(parameter++, timestampOrNull(archive.getCompletionTime()));
-    query.setParameter(parameter++, archive.getTotalExecutionTimeMs());
-    query.setParameter(parameter++, archive.getQueueWaitMs());
-    query.setParameter(parameter++, timestampOrNull(archive.getArchivedAt()));
-    query.setParameter(parameter++, archive.getArchivedBy());
-    query.setParameter(parameter++, archive.getArchiveReason());
-    query.setParameter(parameter++, archive.getJobResult());
-    query.setParameter(parameter++, archive.getResultType());
-    query.setParameter(parameter++, archive.getFinalError());
-    query.setParameter(parameter++, archive.getPayloadSummary());
-    query.setParameter(parameter++, archive.getDependedOn());
-    query.setParameter(parameter++, archive.getSupersededBy());
-    query.setParameter(parameter++, archive.getTags());
-    return parameter;
-  }
-
-  private static Timestamp timestampOrNull(Instant instant) {
-    return instant == null ? null : Timestamp.from(instant);
-  }
-
   /**
    * Archives one terminal job in the caller's store transaction.
    *
@@ -130,7 +80,7 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
-      setArchiveParameters(query, archive, 1);
+      ArchiveParameterBinder.bind(query, archive, 1, id -> id);
       query.executeUpdate();
       return archive;
     } catch (RuntimeException e) {
@@ -168,7 +118,10 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
       }
 
       String rows =
-          String.join(",", Collections.nCopies(archives.size(), ARCHIVE_VALUE_PLACEHOLDERS));
+          String.join(
+              ",",
+              Collections.nCopies(
+                  archives.size(), ArchiveParameterBinder.ARCHIVE_VALUE_PLACEHOLDERS));
       Query query =
           ctx.em()
               .createNativeQuery(
@@ -176,10 +129,10 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
                   INSERT INTO scheduler_job_archive (%s)
                   VALUES %s
                   """
-                      .formatted(ARCHIVE_COLUMNS, rows));
+                      .formatted(ArchiveParameterBinder.ARCHIVE_COLUMNS, rows));
       int parameter = 1;
       for (ArchivedJobEntity archive : archives) {
-        parameter = setArchiveParameters(query, archive, parameter);
+        parameter = ArchiveParameterBinder.bind(query, archive, parameter, id -> id);
       }
       query.executeUpdate();
       return archives.size();
@@ -238,7 +191,7 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
     try {
       var searchQuery =
           ArchiveQuerySupport.buildFindArchivedJobsQuery(
-              ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
+              ArchiveParameterBinder.ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
       Query query = ctx.em().createNativeQuery(searchQuery.sql());
       ArchiveQuerySupport.bindParameters(query, searchQuery);
       @SuppressWarnings("unchecked")

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.ArchivedJobEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
@@ -189,25 +190,31 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
   @Override
   @SuppressWarnings("unchecked")
   public List<JobEntity> findJobsForArchiving(Instant olderThan, int limit) {
-    // language=PostgreSQL
-    String sql =
-        """
-        SELECT %s
-        FROM scheduler_job c
-        LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
-        WHERE c.terminal_status IS NOT NULL
-          AND c.terminated_at < ?
-        ORDER BY c.terminated_at ASC
-        LIMIT ?
-        """
-            .formatted(PostgresqlJobRowMapper.hydrationSelect());
-    List<Object[]> rows =
-        ctx.em()
-            .createNativeQuery(sql)
-            .setParameter(1, Timestamp.from(olderThan))
-            .setParameter(2, limit)
-            .getResultList();
-    return reads.hydrateRowsWithTags(rows);
+    try {
+      // language=PostgreSQL
+      String sql =
+          """
+          SELECT %s
+          FROM scheduler_job c
+          LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+          WHERE c.terminal_status IS NOT NULL
+            AND c.terminated_at < ?
+          ORDER BY c.terminated_at ASC
+          LIMIT ?
+          """
+              .formatted(PostgresqlJobRowMapper.hydrationSelect());
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, Timestamp.from(olderThan))
+              .setParameter(2, limit)
+              .getResultList();
+      return reads.hydrateRowsWithTags(rows);
+    } catch (RatchetTransientStoreException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find jobs for archiving", e);
+    }
   }
 
   @Override
@@ -227,25 +234,33 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
   @SuppressWarnings("SqlSourceToSinkFlow")
   public List<ArchivedJobEntity> findArchivedJobs(
       String targetClass, String businessKey, Instant from, Instant to, int limit) {
-    var searchQuery =
-        ArchiveQuerySupport.buildFindArchivedJobsQuery(
-            ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
-    Query query = ctx.em().createNativeQuery(searchQuery.sql());
-    ArchiveQuerySupport.bindParameters(query, searchQuery);
-    @SuppressWarnings("unchecked")
-    List<Object[]> rows = query.getResultList();
-    return rows.stream()
-        .map(row -> ArchiveRowMapper.map(row, PostgresqlJobRowMapper::toInstant))
-        .toList();
+    try {
+      var searchQuery =
+          ArchiveQuerySupport.buildFindArchivedJobsQuery(
+              ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
+      Query query = ctx.em().createNativeQuery(searchQuery.sql());
+      ArchiveQuerySupport.bindParameters(query, searchQuery);
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows = query.getResultList();
+      return rows.stream()
+          .map(row -> ArchiveRowMapper.map(row, PostgresqlJobRowMapper::toInstant))
+          .toList();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find archived jobs", e);
+    }
   }
 
   @Override
   public int purgeArchivedJobs(Instant olderThan) {
-    // language=PostgreSQL
-    String sql = "DELETE FROM scheduler_job_archive WHERE archived_at < ?";
-    return ctx.em()
-        .createNativeQuery(sql)
-        .setParameter(1, Timestamp.from(olderThan))
-        .executeUpdate();
+    try {
+      // language=PostgreSQL
+      String sql = "DELETE FROM scheduler_job_archive WHERE archived_at < ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, Timestamp.from(olderThan))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("purge archived jobs", e);
+    }
   }
 }

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
@@ -33,6 +33,7 @@ import run.ratchet.store.spi.ArchiveStore;
 import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.RowValues;
 
 final class PostgresqlArchiveOperations implements ArchiveStore {
 
@@ -242,9 +243,7 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
       ArchiveQuerySupport.bindParameters(query, searchQuery);
       @SuppressWarnings("unchecked")
       List<Object[]> rows = query.getResultList();
-      return rows.stream()
-          .map(row -> ArchiveRowMapper.map(row, PostgresqlJobRowMapper::toInstant))
-          .toList();
+      return rows.stream().map(row -> ArchiveRowMapper.map(row, RowValues::instantOrNull)).toList();
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("find archived jobs", e);
     }

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
@@ -35,6 +35,7 @@ import run.ratchet.store.spi.ExecutionStore;
 import run.ratchet.store.spi.JobLogStore;
 import run.ratchet.store.spi.ResourcePermitStore;
 import run.ratchet.store.spi.WorkflowConditionStore;
+import run.ratchet.store.util.RowValues;
 
 final class PostgresqlAuxiliaryOperations
     implements ExecutionStore,
@@ -57,7 +58,7 @@ final class PostgresqlAuxiliaryOperations
     condition.setConditionType(WorkflowCondition.ConditionType.valueOf(row[3].toString()));
     condition.setConditionExpression(row[4] == null ? null : row[4].toString());
     condition.setConditionPriority(((Number) row[5]).intValue());
-    condition.setCreatedAt(PostgresqlJobRowMapper.toInstant(row[6]));
+    condition.setCreatedAt(RowValues.instantOrNull(row[6]));
     return condition;
   }
 

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlBusinessKeyReservations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlBusinessKeyReservations.java
@@ -23,6 +23,7 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.util.BusinessKeyReservations;
+import run.ratchet.store.util.StatusClassifier;
 
 final class PostgresqlBusinessKeyReservations {
 
@@ -107,8 +108,8 @@ final class PostgresqlBusinessKeyReservations {
   void syncForJob(JobEntity job) {
     try {
       deleteReservationByOwner(job.getId());
-      JobStatus status = PostgresqlStoreContext.effectiveStatus(job.getStatus());
-      if (PostgresqlStoreContext.isLiveStatus(status) && job.getBusinessKey() != null) {
+      JobStatus status = StatusClassifier.effectiveStatus(job.getStatus());
+      if (StatusClassifier.isLiveStatus(status) && job.getBusinessKey() != null) {
         insertReservation(job.getBusinessKey(), job.getId(), ownerTableFor(job.getJobType()));
       }
     } catch (RuntimeException e) {
@@ -126,7 +127,7 @@ final class PostgresqlBusinessKeyReservations {
   void syncForJob(UUID ownerJobId, JobStatus status) {
     try {
       deleteReservationByOwner(ownerJobId);
-      if (!PostgresqlStoreContext.isLiveStatus(status)) {
+      if (!StatusClassifier.isLiveStatus(status)) {
         return;
       }
       // language=PostgreSQL

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
@@ -34,6 +34,7 @@ import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.JobClaimStore;
 import run.ratchet.store.util.JobClaimSqlSupport;
+import run.ratchet.store.util.RowValues;
 
 final class PostgresqlJobClaimOperations implements JobClaimStore {
 
@@ -345,7 +346,7 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
     }
 
     Instant scheduledTime() {
-      return PostgresqlJobRowMapper.toInstant(value(ClaimColumn.SCHEDULED_TIME));
+      return RowValues.instantOrNull(value(ClaimColumn.SCHEDULED_TIME));
     }
 
     int version() {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
@@ -51,14 +51,9 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
     this.reads = reads;
   }
 
-  static String buildBoostOrderBy(String timeColumn, int boostInterval) {
-    return boostInterval > 0
-        ? "(priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - "
-            + timeColumn
-            + "))) / (60.0 * ?))) DESC, "
-            + timeColumn
-            + " ASC, job_id ASC"
-        : "priority DESC, " + timeColumn + " ASC, job_id ASC";
+  // Overdue minutes since the row was due: EXTRACT(EPOCH ...) is seconds, /60 converts to minutes.
+  private static String pgOverdueMinutes(String timeColumn) {
+    return "EXTRACT(EPOCH FROM (statement_timestamp() - " + timeColumn + "))/60";
   }
 
   /**
@@ -94,7 +89,8 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
             typeFilter,
             executionTargetFilterSql,
             tagFilterSql,
-            buildBoostOrderBy(timeColumn, boostInterval));
+            JobClaimSqlSupport.buildBoostedOrderBy(
+                timeColumn, pgOverdueMinutes(timeColumn), boostInterval));
   }
 
   // language=PostgreSQL
@@ -120,17 +116,8 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
             timeColumn,
             typeFilter,
             tagFilterSql,
-            buildHydratedBoostOrderBy(timeColumn, boostInterval));
-  }
-
-  private static String buildHydratedBoostOrderBy(String timeColumn, int boostInterval) {
-    return boostInterval > 0
-        ? "(q.priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - "
-            + timeColumn
-            + "))) / (60.0 * ?))) DESC, "
-            + timeColumn
-            + " ASC, q.job_id ASC"
-        : "q.priority DESC, " + timeColumn + " ASC, q.job_id ASC";
+            JobClaimSqlSupport.buildBoostedOrderBy(
+                timeColumn, pgOverdueMinutes(timeColumn), boostInterval, "q."));
   }
 
   // SQL template is a compile-time constant defined in this package; runtime values are bound as

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobClaimOperations.java
@@ -35,6 +35,7 @@ import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.JobClaimStore;
 import run.ratchet.store.util.JobClaimSqlSupport;
 import run.ratchet.store.util.RowValues;
+import run.ratchet.store.util.StatusClassifier;
 
 final class PostgresqlJobClaimOperations implements JobClaimStore {
 
@@ -183,7 +184,7 @@ final class PostgresqlJobClaimOperations implements JobClaimStore {
       String nodeId,
       NodeTagFilter tagFilter,
       ExecutionTargetFilter executionTargetFilter) {
-    if (limit <= 0 || !PostgresqlStoreContext.isPollerExecutable(jobType)) {
+    if (limit <= 0 || !StatusClassifier.isPollerExecutable(jobType)) {
       return List.of();
     }
     try {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobCountOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobCountOperations.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.util.RowValues;
 
 final class PostgresqlJobCountOperations {
 
@@ -272,7 +273,7 @@ final class PostgresqlJobCountOperations {
     if (results.isEmpty() || results.get(0) == null) {
       return Optional.empty();
     }
-    return Optional.ofNullable(PostgresqlJobRowMapper.toInstant(results.get(0)));
+    return Optional.ofNullable(RowValues.instantOrNull(results.get(0)));
   }
 
   long getQueueWaitTimePercentile(double percentile) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRowMapper.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRowMapper.java
@@ -15,9 +15,7 @@
  */
 package run.ratchet.store.postgresql;
 
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -165,15 +163,15 @@ final class PostgresqlJobRowMapper {
         JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_ON_FAILURE])));
     j.setDependsOn(uuidOrNull(row[IDX_DEPENDS_ON]));
     j.setSupersededBy(uuidOrNull(row[IDX_SUPERSEDED_BY]));
-    j.setCreatedAt(toInstant(row[IDX_CREATED_AT]));
+    j.setCreatedAt(RowValues.instantOrNull(row[IDX_CREATED_AT]));
     j.setCallerPrincipal((String) row[IDX_CALLER_PRINCIPAL]);
 
     JobStatus terminal =
         enumValueOrNull(row, IDX_TERMINAL_STATUS, "terminal_status", JobStatus.class);
     j.setTerminalStatus(terminal);
 
-    j.setExecutionStartTime(toInstant(row[IDX_EXEC_START]));
-    j.setExecutionEndTime(toInstant(row[IDX_EXEC_END]));
+    j.setExecutionStartTime(RowValues.instantOrNull(row[IDX_EXEC_START]));
+    j.setExecutionEndTime(RowValues.instantOrNull(row[IDX_EXEC_END]));
     j.setExecutionDurationMs(longOrNull(row[IDX_EXEC_DURATION]));
     j.setQueueWaitMs(longOrNull(row[IDX_QUEUE_WAIT]));
     j.setJobResult(stringOrNull(row[IDX_JOB_RESULT]));
@@ -182,12 +180,12 @@ final class PostgresqlJobRowMapper {
         JSON_MAP_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_TRACE_CONTEXT])));
     j.setRecurringMasterId(uuidOrNull(row[IDX_RECURRING_MASTER_ID]));
     j.setSignalKey((String) row[IDX_Q_SIGNAL_KEY]);
-    j.setSignalTimeout(toInstant(row[IDX_Q_SIGNAL_TIMEOUT]));
+    j.setSignalTimeout(RowValues.instantOrNull(row[IDX_Q_SIGNAL_TIMEOUT]));
     j.setSignalPayload(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD]));
     j.setSignalPayloadType(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD_TYPE]));
     j.setSignalOutcome(stringOrNull(row[IDX_Q_SIGNAL_OUTCOME]));
     j.setSignalRejectionReason(stringOrNull(row[IDX_Q_SIGNAL_REJECTION_REASON]));
-    j.setSignalDeliveredAt(toInstant(row[IDX_Q_SIGNAL_DELIVERED_AT]));
+    j.setSignalDeliveredAt(RowValues.instantOrNull(row[IDX_Q_SIGNAL_DELIVERED_AT]));
     j.setSignalDeliveredBy((String) row[IDX_Q_SIGNAL_DELIVERED_BY]);
     j.setSignalDeliveryId(stringOrNull(row[IDX_Q_SIGNAL_DELIVERY_ID]));
 
@@ -204,27 +202,27 @@ final class PostgresqlJobRowMapper {
     j.setStatus(resolved);
 
     if (live != null) {
-      j.setScheduledTime(toInstant(row[IDX_Q_SCHEDULED_TIME]));
+      j.setScheduledTime(RowValues.instantOrNull(row[IDX_Q_SCHEDULED_TIME]));
       j.setAttempts(requiredNumber(row, IDX_Q_ATTEMPTS, "q.attempts").intValue());
       j.setPickedBy((String) row[IDX_Q_PICKED_BY]);
-      j.setPickedAt(toInstant(row[IDX_Q_PICKED_AT]));
+      j.setPickedAt(RowValues.instantOrNull(row[IDX_Q_PICKED_AT]));
       j.setPausedFromStatus(
           enumValueOrNull(row, IDX_Q_PAUSED, "q.paused_from_status", JobStatus.class));
       j.setLastError(stringOrNull(row[IDX_Q_LAST_ERROR]));
       j.setVersion(requiredNumber(row, IDX_Q_VERSION, "q.version").intValue());
-      Instant updatedAt = toInstant(row[IDX_Q_UPDATED_AT]);
+      Instant updatedAt = RowValues.instantOrNull(row[IDX_Q_UPDATED_AT]);
       j.setUpdatedAt(updatedAt != null ? updatedAt : j.getCreatedAt());
     } else {
       Number ta = numberOrNull(row, IDX_TOTAL_ATTEMPTS, "total_attempts");
       j.setAttempts(ta != null ? ta.intValue() : 0);
       j.setLastError(stringOrNull(row[IDX_TERMINAL_ERROR]));
       j.setVersion(0);
-      Instant fallbackSched = toInstant(row[IDX_EXEC_START]);
+      Instant fallbackSched = RowValues.instantOrNull(row[IDX_EXEC_START]);
       if (fallbackSched == null) {
-        fallbackSched = toInstant(row[IDX_CREATED_AT]);
+        fallbackSched = RowValues.instantOrNull(row[IDX_CREATED_AT]);
       }
       j.setScheduledTime(fallbackSched);
-      Instant updatedAt = toInstant(row[IDX_TERMINATED_AT]);
+      Instant updatedAt = RowValues.instantOrNull(row[IDX_TERMINATED_AT]);
       j.setUpdatedAt(updatedAt != null ? updatedAt : j.getCreatedAt());
     }
     return j;
@@ -244,19 +242,6 @@ final class PostgresqlJobRowMapper {
 
   static boolean isTerminalStatus(JobStatus s) {
     return StatusClassifier.isTerminalStatus(s);
-  }
-
-  static Instant toInstant(Object value) {
-    if (value instanceof Instant i) {
-      return i;
-    }
-    if (value instanceof Timestamp t) {
-      return t.toInstant();
-    }
-    if (value instanceof OffsetDateTime odt) {
-      return odt.toInstant();
-    }
-    return null;
   }
 
   static String stringOrNull(Object value) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRowMapper.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRowMapper.java
@@ -15,19 +15,16 @@
  */
 package run.ratchet.store.postgresql;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
+import run.ratchet.store.context.AbstractJobRowMapper;
 import run.ratchet.store.converter.JobPayloadConverter;
 import run.ratchet.store.converter.JsonMapConverter;
 import run.ratchet.store.entity.JobEntity;
-import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobPayload;
-import run.ratchet.store.util.JobHydrationSupport;
 import run.ratchet.store.util.RowValues;
 import run.ratchet.store.util.StatusClassifier;
 
@@ -39,75 +36,26 @@ import run.ratchet.store.util.StatusClassifier;
  *   <li>Live state from {@code scheduler_job_queue} (alias {@code q}) when present.
  * </ul>
  *
- * <p>Status priority on hydration: {@code q.status} (live) → {@code c.rec_status} (recurring shim)
- * → {@code c.terminal_status} (terminal).
+ * <p>Shares the column indexes and hydration body with {@link AbstractJobRowMapper}; only the
+ * projection differs (PostgreSQL casts JSON columns to {@code ::text}).
  */
-final class PostgresqlJobRowMapper {
+final class PostgresqlJobRowMapper extends AbstractJobRowMapper {
 
-  static final int HYDRATION_COL_COUNT = 52;
-  static final int IDX_Q_STATUS = 34;
+  static final int HYDRATION_COL_COUNT = AbstractJobRowMapper.HYDRATION_COL_COUNT;
+  static final int IDX_Q_STATUS = AbstractJobRowMapper.IDX_Q_STATUS;
   private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
   private static final JsonMapConverter JSON_MAP_CONVERTER = new JsonMapConverter();
-  private static final JobHydrationSupport HYDRATION = new JobHydrationSupport("PostgreSQL");
-  private static final int IDX_JOB_ID = 0;
-  private static final int IDX_JOB_TYPE = 1;
-  private static final int IDX_PRIORITY = 2;
-  private static final int IDX_MAX_RETRIES = 3;
-  private static final int IDX_BACKOFF_POLICY = 4;
-  private static final int IDX_BACKOFF_PARAM_MS = 5;
-  private static final int IDX_TIMEOUT_SEC = 6;
-  private static final int IDX_CRON_EXPR = 7;
-  private static final int IDX_ZONE_ID = 8;
-  private static final int IDX_PAYLOAD = 9;
-  private static final int IDX_PARAMS = 10;
-  private static final int IDX_TARGET_CLASS = 11;
-  private static final int IDX_METHOD_NAME = 12;
-  private static final int IDX_IDEMPOTENCY_KEY = 13;
-  private static final int IDX_BUSINESS_KEY = 14;
-  private static final int IDX_RESOURCE_NAME = 15;
-  private static final int IDX_ON_SUCCESS = 16;
-  private static final int IDX_ON_FAILURE = 17;
-  private static final int IDX_DEPENDS_ON = 18;
-  private static final int IDX_SUPERSEDED_BY = 19;
-  private static final int IDX_CREATED_AT = 20;
-  private static final int IDX_CALLER_PRINCIPAL = 21;
-  private static final int IDX_TERMINAL_STATUS = 22;
-  private static final int IDX_TERMINAL_ERROR = 23;
-  private static final int IDX_TOTAL_ATTEMPTS = 24;
-  private static final int IDX_TERMINATED_AT = 25;
-  private static final int IDX_EXEC_START = 26;
-  private static final int IDX_EXEC_END = 27;
-  private static final int IDX_EXEC_DURATION = 28;
-  private static final int IDX_QUEUE_WAIT = 29;
-  private static final int IDX_JOB_RESULT = 30;
-  private static final int IDX_RESULT_TYPE = 31;
-  private static final int IDX_TRACE_CONTEXT = 32;
-  private static final int IDX_RECURRING_MASTER_ID = 33;
-  private static final int IDX_Q_SCHEDULED_TIME = 35;
-  private static final int IDX_Q_ATTEMPTS = 36;
-  private static final int IDX_Q_PICKED_BY = 37;
-  private static final int IDX_Q_PICKED_AT = 38;
-  private static final int IDX_Q_PAUSED = 39;
-  private static final int IDX_Q_LAST_ERROR = 40;
-  private static final int IDX_Q_VERSION = 41;
-  private static final int IDX_Q_UPDATED_AT = 42;
-  private static final int IDX_Q_SIGNAL_KEY = 43;
-  private static final int IDX_Q_SIGNAL_TIMEOUT = 44;
-  private static final int IDX_Q_SIGNAL_PAYLOAD = 45;
-  private static final int IDX_Q_SIGNAL_PAYLOAD_TYPE = 46;
-  private static final int IDX_Q_SIGNAL_OUTCOME = 47;
-  private static final int IDX_Q_SIGNAL_REJECTION_REASON = 48;
-  private static final int IDX_Q_SIGNAL_DELIVERED_AT = 49;
-  private static final int IDX_Q_SIGNAL_DELIVERED_BY = 50;
-  private static final int IDX_Q_SIGNAL_DELIVERY_ID = 51;
+  private static final PostgresqlJobRowMapper SHARED = new PostgresqlJobRowMapper();
 
-  private PostgresqlJobRowMapper() {}
+  private PostgresqlJobRowMapper() {
+    super("PostgreSQL");
+  }
 
   /**
    * Returns a SELECT projection joining the cold metadata table {@code scheduler_job} (alias {@code
    * c}) with the hot queue table {@code scheduler_job_queue} (alias {@code q}). Callers must
    * include {@code FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id} in
-   * their query. The column order matches {@link #hydrate(Object[])}.
+   * their query. The column order matches {@link AbstractJobRowMapper}'s index constants.
    */
   static String hydrationSelect() {
     // language=PostgreSQL
@@ -130,102 +78,7 @@ final class PostgresqlJobRowMapper {
   }
 
   static JobEntity hydrate(Object[] row) {
-    if (row == null) {
-      return null;
-    }
-    if (row.length != HYDRATION_COL_COUNT) {
-      throw new IllegalStateException(
-          "Hydration projection length mismatch: expected "
-              + HYDRATION_COL_COUNT
-              + " columns, got "
-              + row.length);
-    }
-    JobEntity j = new JobEntity();
-    j.setId(uuidOrNull(row[IDX_JOB_ID]));
-    j.setJobType(enumValue(row, IDX_JOB_TYPE, "job_type", JobExecutionType.class));
-    j.setPriority(safeJobPriority(requiredNumber(row, IDX_PRIORITY, "priority").intValue()));
-    j.setMaxRetries(requiredNumber(row, IDX_MAX_RETRIES, "max_retries").intValue());
-    j.setBackoffPolicy(enumValue(row, IDX_BACKOFF_POLICY, "backoff_policy", BackoffPolicy.class));
-    j.setBackoffParamMs(requiredNumber(row, IDX_BACKOFF_PARAM_MS, "backoff_param_ms").intValue());
-    j.setTimeoutSec(requiredNumber(row, IDX_TIMEOUT_SEC, "timeout_sec").intValue());
-    j.setCronExpr((String) row[IDX_CRON_EXPR]);
-    j.setZoneId((String) row[IDX_ZONE_ID]);
-    j.setPayload(JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_PAYLOAD])));
-    j.setParams(JSON_MAP_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_PARAMS])));
-    j.setTargetClass((String) row[IDX_TARGET_CLASS]);
-    j.setMethodName((String) row[IDX_METHOD_NAME]);
-    j.setIdempotencyKey((String) row[IDX_IDEMPOTENCY_KEY]);
-    j.setBusinessKey((String) row[IDX_BUSINESS_KEY]);
-    j.setResourceName((String) row[IDX_RESOURCE_NAME]);
-    j.setOnSuccessPayload(
-        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_ON_SUCCESS])));
-    j.setOnFailurePayload(
-        JOB_PAYLOAD_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_ON_FAILURE])));
-    j.setDependsOn(uuidOrNull(row[IDX_DEPENDS_ON]));
-    j.setSupersededBy(uuidOrNull(row[IDX_SUPERSEDED_BY]));
-    j.setCreatedAt(RowValues.instantOrNull(row[IDX_CREATED_AT]));
-    j.setCallerPrincipal((String) row[IDX_CALLER_PRINCIPAL]);
-
-    JobStatus terminal =
-        enumValueOrNull(row, IDX_TERMINAL_STATUS, "terminal_status", JobStatus.class);
-    j.setTerminalStatus(terminal);
-
-    j.setExecutionStartTime(RowValues.instantOrNull(row[IDX_EXEC_START]));
-    j.setExecutionEndTime(RowValues.instantOrNull(row[IDX_EXEC_END]));
-    j.setExecutionDurationMs(longOrNull(row[IDX_EXEC_DURATION]));
-    j.setQueueWaitMs(longOrNull(row[IDX_QUEUE_WAIT]));
-    j.setJobResult(stringOrNull(row[IDX_JOB_RESULT]));
-    j.setResultType((String) row[IDX_RESULT_TYPE]);
-    j.setTraceContext(
-        JSON_MAP_CONVERTER.convertToEntityAttribute(stringOrNull(row[IDX_TRACE_CONTEXT])));
-    j.setRecurringMasterId(uuidOrNull(row[IDX_RECURRING_MASTER_ID]));
-    j.setSignalKey((String) row[IDX_Q_SIGNAL_KEY]);
-    j.setSignalTimeout(RowValues.instantOrNull(row[IDX_Q_SIGNAL_TIMEOUT]));
-    j.setSignalPayload(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD]));
-    j.setSignalPayloadType(stringOrNull(row[IDX_Q_SIGNAL_PAYLOAD_TYPE]));
-    j.setSignalOutcome(stringOrNull(row[IDX_Q_SIGNAL_OUTCOME]));
-    j.setSignalRejectionReason(stringOrNull(row[IDX_Q_SIGNAL_REJECTION_REASON]));
-    j.setSignalDeliveredAt(RowValues.instantOrNull(row[IDX_Q_SIGNAL_DELIVERED_AT]));
-    j.setSignalDeliveredBy((String) row[IDX_Q_SIGNAL_DELIVERED_BY]);
-    j.setSignalDeliveryId(stringOrNull(row[IDX_Q_SIGNAL_DELIVERY_ID]));
-
-    JobStatus live = enumValueOrNull(row, IDX_Q_STATUS, "q.status", JobStatus.class);
-
-    JobStatus resolved;
-    if (live != null) {
-      resolved = live;
-    } else if (terminal != null) {
-      resolved = terminal;
-    } else {
-      throw new IllegalStateException("Job " + j.getId() + " has no live or terminal status");
-    }
-    j.setStatus(resolved);
-
-    if (live != null) {
-      j.setScheduledTime(RowValues.instantOrNull(row[IDX_Q_SCHEDULED_TIME]));
-      j.setAttempts(requiredNumber(row, IDX_Q_ATTEMPTS, "q.attempts").intValue());
-      j.setPickedBy((String) row[IDX_Q_PICKED_BY]);
-      j.setPickedAt(RowValues.instantOrNull(row[IDX_Q_PICKED_AT]));
-      j.setPausedFromStatus(
-          enumValueOrNull(row, IDX_Q_PAUSED, "q.paused_from_status", JobStatus.class));
-      j.setLastError(stringOrNull(row[IDX_Q_LAST_ERROR]));
-      j.setVersion(requiredNumber(row, IDX_Q_VERSION, "q.version").intValue());
-      Instant updatedAt = RowValues.instantOrNull(row[IDX_Q_UPDATED_AT]);
-      j.setUpdatedAt(updatedAt != null ? updatedAt : j.getCreatedAt());
-    } else {
-      Number ta = numberOrNull(row, IDX_TOTAL_ATTEMPTS, "total_attempts");
-      j.setAttempts(ta != null ? ta.intValue() : 0);
-      j.setLastError(stringOrNull(row[IDX_TERMINAL_ERROR]));
-      j.setVersion(0);
-      Instant fallbackSched = RowValues.instantOrNull(row[IDX_EXEC_START]);
-      if (fallbackSched == null) {
-        fallbackSched = RowValues.instantOrNull(row[IDX_CREATED_AT]);
-      }
-      j.setScheduledTime(fallbackSched);
-      Instant updatedAt = RowValues.instantOrNull(row[IDX_TERMINATED_AT]);
-      j.setUpdatedAt(updatedAt != null ? updatedAt : j.getCreatedAt());
-    }
-    return j;
+    return SHARED.hydrateRow(row);
   }
 
   static List<JobEntity> hydrateRows(List<Object[]> rows) {
@@ -258,24 +111,6 @@ final class PostgresqlJobRowMapper {
 
   static JobPriority safeJobPriority(int ordinal) {
     return RowValues.safeJobPriority(ordinal);
-  }
-
-  private static <E extends Enum<E>> E enumValue(
-      Object[] row, int index, String column, Class<E> enumType) {
-    return HYDRATION.enumValue(row, index, column, enumType);
-  }
-
-  private static <E extends Enum<E>> E enumValueOrNull(
-      Object[] row, int index, String column, Class<E> enumType) {
-    return HYDRATION.enumValueOrNull(row, index, column, enumType);
-  }
-
-  private static Number requiredNumber(Object[] row, int index, String column) {
-    return HYDRATION.requiredNumber(row, index, column);
-  }
-
-  private static Number numberOrNull(Object[] row, int index, String column) {
-    return HYDRATION.numberOrNull(row, index, column);
   }
 
   static String payloadToJson(JobEntity job) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobWriteOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobWriteOperations.java
@@ -28,6 +28,7 @@ import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.id.UuidV7Factory;
+import run.ratchet.store.util.RowValues;
 
 final class PostgresqlJobWriteOperations {
 
@@ -470,7 +471,7 @@ final class PostgresqlJobWriteOperations {
     if (!"PENDING".equals(storedStatus) && !"WAITING".equals(storedStatus)) {
       return false;
     }
-    Instant storedSched = PostgresqlJobRowMapper.toInstant(row[IDX_HOT_SCHEDULED_TIME]);
+    Instant storedSched = RowValues.instantOrNull(row[IDX_HOT_SCHEDULED_TIME]);
     Instant incomingSched = job.getScheduledTime();
     if (Objects.equals(storedSched, incomingSched)) {
       return false;
@@ -478,8 +479,7 @@ final class PostgresqlJobWriteOperations {
     if (!Objects.equals(JobStatus.valueOf(storedStatus), job.getStatus())
         || !Objects.equals(((Number) row[IDX_HOT_ATTEMPTS]).intValue(), job.getAttempts())
         || !Objects.equals(row[IDX_HOT_PICKED_BY], job.getPickedBy())
-        || !Objects.equals(
-            PostgresqlJobRowMapper.toInstant(row[IDX_HOT_PICKED_AT]), job.getPickedAt())
+        || !Objects.equals(RowValues.instantOrNull(row[IDX_HOT_PICKED_AT]), job.getPickedAt())
         || !Objects.equals(
             row[IDX_HOT_PAUSED_FROM_STATUS] != null
                 ? JobStatus.valueOf((String) row[IDX_HOT_PAUSED_FROM_STATUS])
@@ -607,15 +607,12 @@ final class PostgresqlJobWriteOperations {
           id,
           "scheduledTime",
           incoming.getScheduledTime(),
-          PostgresqlJobRowMapper.toInstant(row[IDX_HOT_SCHEDULED_TIME]));
+          RowValues.instantOrNull(row[IDX_HOT_SCHEDULED_TIME]));
       Integer storedAttempts = ((Number) row[IDX_HOT_ATTEMPTS]).intValue();
       checkHotField(id, "attempts", incoming.getAttempts(), storedAttempts);
       checkHotField(id, "pickedBy", incoming.getPickedBy(), row[IDX_HOT_PICKED_BY]);
       checkHotField(
-          id,
-          "pickedAt",
-          incoming.getPickedAt(),
-          PostgresqlJobRowMapper.toInstant(row[IDX_HOT_PICKED_AT]));
+          id, "pickedAt", incoming.getPickedAt(), RowValues.instantOrNull(row[IDX_HOT_PICKED_AT]));
       String pausedFrom = (String) row[IDX_HOT_PAUSED_FROM_STATUS];
       JobStatus storedPausedFrom = pausedFrom != null ? JobStatus.valueOf(pausedFrom) : null;
       checkHotField(id, "pausedFromStatus", incoming.getPausedFromStatus(), storedPausedFrom);
@@ -657,10 +654,10 @@ final class PostgresqlJobWriteOperations {
     }
 
     JobStatus storedStatus = JobStatus.valueOf(hotStatusStr);
-    Instant storedSched = PostgresqlJobRowMapper.toInstant(row[IDX_HOT_SCHEDULED_TIME]);
+    Instant storedSched = RowValues.instantOrNull(row[IDX_HOT_SCHEDULED_TIME]);
     int storedAttempts = ((Number) row[IDX_HOT_ATTEMPTS]).intValue();
     Object storedPickedBy = row[IDX_HOT_PICKED_BY];
-    Instant storedPickedAt = PostgresqlJobRowMapper.toInstant(row[IDX_HOT_PICKED_AT]);
+    Instant storedPickedAt = RowValues.instantOrNull(row[IDX_HOT_PICKED_AT]);
     String storedPausedFromStr = (String) row[IDX_HOT_PAUSED_FROM_STATUS];
     JobStatus storedPausedFrom =
         storedPausedFromStr != null ? JobStatus.valueOf(storedPausedFromStr) : null;

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobWriteOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobWriteOperations.java
@@ -15,6 +15,9 @@
  */
 package run.ratchet.store.postgresql;
 
+import static run.ratchet.store.util.JobWriteSupport.assignIdIfMissing;
+import static run.ratchet.store.util.JobWriteSupport.checkHotField;
+
 import jakarta.persistence.Query;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -27,7 +30,6 @@ import run.ratchet.api.exception.RatchetOptimisticLockException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
-import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.util.RowValues;
 
 final class PostgresqlJobWriteOperations {
@@ -104,28 +106,6 @@ final class PostgresqlJobWriteOperations {
     this.tags = tags;
   }
 
-  private static void checkHotField(UUID jobId, String fieldName, Object incoming, Object stored) {
-    if (Objects.equals(incoming, stored)) {
-      return;
-    }
-    throw new IllegalStateException(
-        "save() rejected: hot-field mutation detected for id="
-            + jobId
-            + " field="
-            + fieldName
-            + " incoming="
-            + incoming
-            + " stored="
-            + stored
-            + ". Use an explicit transition method.");
-  }
-
-  private static void assignTsidIfMissing(JobEntity job) {
-    if (job.getId() == null) {
-      job.setId(UuidV7Factory.create());
-    }
-  }
-
   JobEntity save(JobEntity job) {
     if (job.getId() == null) {
       saveInsert(job);
@@ -143,7 +123,7 @@ final class PostgresqlJobWriteOperations {
     Timestamp nowTs = Timestamp.from(now);
 
     for (JobEntity job : jobs) {
-      assignTsidIfMissing(job);
+      assignIdIfMissing(job);
       if (job.getCreatedAt() == null) {
         job.setCreatedAt(now);
       }
@@ -168,7 +148,7 @@ final class PostgresqlJobWriteOperations {
   }
 
   void saveInsert(JobEntity job) {
-    assignTsidIfMissing(job);
+    assignIdIfMissing(job);
     Instant now = Instant.now();
     Timestamp nowTs = Timestamp.from(now);
     if (job.getCreatedAt() == null) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlNodeLockOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlNodeLockOperations.java
@@ -15,6 +15,10 @@
  */
 package run.ratchet.store.postgresql;
 
+import static run.ratchet.store.util.LockValidation.durationMicros;
+import static run.ratchet.store.util.LockValidation.requireLockName;
+import static run.ratchet.store.util.LockValidation.requirePositiveDuration;
+
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
@@ -110,29 +114,6 @@ final class PostgresqlNodeLockOperations implements LockStore, NodeStore {
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("renew lock", e);
     }
-  }
-
-  private static void requireLockName(String name) {
-    Objects.requireNonNull(name, "name");
-    if (name.isBlank()) {
-      throw new IllegalArgumentException("name must be non-empty");
-    }
-  }
-
-  private static void requirePositiveDuration(Duration duration, String parameterName) {
-    Objects.requireNonNull(duration, parameterName);
-    if (duration.isZero() || duration.isNegative()) {
-      throw new IllegalArgumentException(parameterName + " must be positive");
-    }
-  }
-
-  private static long durationMicros(Duration duration) {
-    long seconds = duration.getSeconds();
-    long microsFromNanos = (duration.getNano() + 999L) / 1_000L;
-    if (seconds > (Long.MAX_VALUE - microsFromNanos) / 1_000_000L) {
-      return Long.MAX_VALUE;
-    }
-    return Math.max(1L, seconds * 1_000_000L + microsFromNanos);
   }
 
   @Override

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSignalOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSignalOperations.java
@@ -27,6 +27,7 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.SignalStore;
+import run.ratchet.store.util.RowValues;
 
 /**
  * PostgreSQL implementation of {@link SignalStore}.
@@ -52,10 +53,6 @@ final class PostgresqlSignalOperations implements SignalStore {
       return uuid;
     }
     return UUID.fromString(value.toString());
-  }
-
-  private static Instant toInstant(Object value) {
-    return PostgresqlJobRowMapper.toInstant(value);
   }
 
   @Override
@@ -91,7 +88,7 @@ final class PostgresqlSignalOperations implements SignalStore {
         JobEntity job = new JobEntity();
         job.setId(toUuid(row[0]));
         job.setSignalKey((String) row[1]);
-        job.setSignalTimeout(toInstant(row[2]));
+        job.setSignalTimeout(RowValues.instantOrNull(row[2]));
         job.setStatus(JobStatus.WAITING);
         job.setJobType(row[4] != null ? JobExecutionType.valueOf((String) row[4]) : null);
         job.setPriority(
@@ -107,7 +104,7 @@ final class PostgresqlSignalOperations implements SignalStore {
         job.setSignalPayloadType((String) row[11]);
         job.setSignalOutcome((String) row[12]);
         job.setSignalRejectionReason((String) row[13]);
-        job.setSignalDeliveredAt(toInstant(row[14]));
+        job.setSignalDeliveredAt(RowValues.instantOrNull(row[14]));
         job.setSignalDeliveredBy((String) row[15]);
         job.setSignalDeliveryId((String) row[16]);
         result.add(job);

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
@@ -16,12 +16,9 @@
 package run.ratchet.store.postgresql;
 
 import jakarta.persistence.EntityManager;
-import run.ratchet.api.JobStatus;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.ConstraintDetector;
 import run.ratchet.store.context.AbstractSqlStoreContext;
-import run.ratchet.store.entity.JobExecutionType;
-import run.ratchet.store.util.StatusClassifier;
 
 final class PostgresqlStoreContext extends AbstractSqlStoreContext {
 
@@ -39,22 +36,6 @@ final class PostgresqlStoreContext extends AbstractSqlStoreContext {
   PostgresqlStoreContext(
       EntityManager em, MetricsCollector metricsCollector, int priorityBoostIntervalMinutes) {
     super(em, metricsCollector, priorityBoostIntervalMinutes);
-  }
-
-  static boolean isPollerExecutable(JobExecutionType jobType) {
-    return StatusClassifier.isPollerExecutable(jobType);
-  }
-
-  static boolean isLiveStatus(JobStatus status) {
-    return StatusClassifier.isLiveStatus(status);
-  }
-
-  static boolean isTerminalStatus(JobStatus status) {
-    return StatusClassifier.isTerminalStatus(status);
-  }
-
-  static JobStatus effectiveStatus(JobStatus status) {
-    return StatusClassifier.effectiveStatus(status);
   }
 
   @Override

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
@@ -26,6 +26,7 @@ import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.util.StatusClassifier;
+import run.ratchet.store.util.TransientStoreExceptions;
 
 final class PostgresqlStoreContext {
 
@@ -82,11 +83,9 @@ final class PostgresqlStoreContext {
   }
 
   RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
-    if (constraintDetector.isDeadlock(e) || constraintDetector.isTransientConnectionFailure(e)) {
-      return new RatchetTransientStoreException(
-          "Transient PostgreSQL store concurrency failure during " + operation, e);
-    }
-    return e;
+    RatchetTransientStoreException wrapped =
+        TransientStoreExceptions.translateOrNull("PostgreSQL", constraintDetector, operation, e);
+    return wrapped != null ? wrapped : e;
   }
 
   /**

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
@@ -16,42 +16,29 @@
 package run.ratchet.store.postgresql;
 
 import jakarta.persistence.EntityManager;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
-import run.ratchet.api.JobType;
-import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.ConstraintDetector;
+import run.ratchet.store.context.AbstractSqlStoreContext;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.util.StatusClassifier;
-import run.ratchet.store.util.TransientStoreExceptions;
 
-final class PostgresqlStoreContext {
+final class PostgresqlStoreContext extends AbstractSqlStoreContext {
 
-  private static final String DIALECT = "postgresql";
-  private static final MetricsCollector NOOP_METRICS_COLLECTOR = new NoopMetricsCollector();
-
-  private final EntityManager em;
-  private final MetricsCollector metricsCollector;
-  private final int priorityBoostIntervalMinutes;
   private final PostgresqlConstraintDetector constraintDetector =
       new PostgresqlConstraintDetector();
 
   PostgresqlStoreContext(EntityManager em) {
-    this(em, NOOP_METRICS_COLLECTOR, 15);
+    this(em, noopMetricsCollector(), 15);
   }
 
   PostgresqlStoreContext(EntityManager em, int priorityBoostIntervalMinutes) {
-    this(em, NOOP_METRICS_COLLECTOR, priorityBoostIntervalMinutes);
+    this(em, noopMetricsCollector(), priorityBoostIntervalMinutes);
   }
 
   PostgresqlStoreContext(
       EntityManager em, MetricsCollector metricsCollector, int priorityBoostIntervalMinutes) {
-    this.em = em;
-    this.metricsCollector = metricsCollector;
-    this.priorityBoostIntervalMinutes = priorityBoostIntervalMinutes;
+    super(em, metricsCollector, priorityBoostIntervalMinutes);
   }
 
   static boolean isPollerExecutable(JobExecutionType jobType) {
@@ -70,101 +57,18 @@ final class PostgresqlStoreContext {
     return StatusClassifier.effectiveStatus(status);
   }
 
-  EntityManager em() {
-    return em;
+  @Override
+  protected String dialectMetric() {
+    return "postgresql";
   }
 
-  PostgresqlConstraintDetector constraintDetector() {
+  @Override
+  protected String dialectLabel() {
+    return "PostgreSQL";
+  }
+
+  @Override
+  public ConstraintDetector constraintDetector() {
     return constraintDetector;
-  }
-
-  int priorityBoostIntervalMinutes() {
-    return priorityBoostIntervalMinutes;
-  }
-
-  RuntimeException translateTransientStoreException(String operation, RuntimeException e) {
-    RatchetTransientStoreException wrapped =
-        TransientStoreExceptions.translateOrNull("PostgreSQL", constraintDetector, operation, e);
-    return wrapped != null ? wrapped : e;
-  }
-
-  /**
-   * Runs a compile-time SQL count query with positional parameters.
-   *
-   * <p>The {@code sql} argument must be a package-owned constant. Never pass user-controlled SQL
-   * fragments; bind user values through {@code params}.
-   */
-  long countByNative(String sql, Object... params) {
-    try {
-      var query = em.createNativeQuery(sql);
-      for (int i = 0; i < params.length; i++) {
-        query.setParameter(i + 1, params[i]);
-      }
-      return ((Number) query.getSingleResult()).longValue();
-    } catch (RuntimeException e) {
-      throw translateTransientStoreException("count by native SQL", e);
-    }
-  }
-
-  <T> T timedStoreOperation(
-      String operation, Supplier<T> action, Function<T, String> outcomeFunction) {
-    long startNanos = System.nanoTime();
-    try {
-      T result = action.get();
-      recordStoreOperation(operation, outcomeFunction.apply(result), startNanos);
-      return result;
-    } catch (RatchetTransientStoreException e) {
-      recordStoreOperation(operation, "transient_failure", startNanos);
-      throw e;
-    } catch (RuntimeException e) {
-      RuntimeException translated = translateTransientStoreException(operation, e);
-      recordStoreOperation(
-          operation,
-          translated instanceof RatchetTransientStoreException ? "transient_failure" : "failure",
-          startNanos);
-      throw translated;
-    }
-  }
-
-  private void recordStoreOperation(String operation, String outcome, long startNanos) {
-    metricsCollector.storeOperation(DIALECT, operation, outcome, System.nanoTime() - startNanos);
-  }
-
-  private static final class NoopMetricsCollector implements MetricsCollector {
-    @Override
-    public void jobStarted(UUID jobId, JobType type, JobPriority priority) {}
-
-    @Override
-    public void jobCompleted(UUID jobId, JobType type, long executionTimeMs) {}
-
-    @Override
-    public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {}
-
-    @Override
-    public void successFinalizationRetried(UUID jobId, JobType type) {}
-
-    @Override
-    public void successFinalizationMinimal(UUID jobId, JobType type) {}
-
-    @Override
-    public void successFinalizationStuck(UUID jobId, JobType type) {}
-
-    @Override
-    public void claimTransientFailure(String executionType) {}
-
-    @Override
-    public void jobsClaimed(String executionType, int claimedCount) {}
-
-    @Override
-    public void gateRejected(String executionType, String gateStatus) {}
-
-    @Override
-    public void localWakeup(String source) {}
-
-    @Override
-    public void clusterWakeupPublished(String transport, String outcome) {}
-
-    @Override
-    public void clusterWakeupReceived(String transport, String outcome) {}
   }
 }

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlExceptionTranslationTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlExceptionTranslationTest.java
@@ -16,6 +16,7 @@
 package run.ratchet.store.postgresql;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceException;
@@ -57,6 +58,55 @@ class PostgresqlExceptionTranslationTest {
     assertThrows(
         RatchetTransientStoreException.class,
         () -> archives.archiveJob(input, "retention", "test"));
+  }
+
+  @Test
+  void findJobsForArchivingTranslatesDeadlock() {
+    var archives = archiveOperations(entityManager(queryThrowingOnResults()));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> archives.findJobsForArchiving(Instant.now(), 10));
+  }
+
+  @Test
+  void findJobsForArchivingDoesNotRewrapInnerTagFailure() {
+    var archives =
+        archiveOperations(
+            entityManager(
+                queryReturning(Collections.singletonList(terminalRow())),
+                queryThrowingOnResults()));
+
+    RatchetTransientStoreException thrown =
+        assertThrows(
+            RatchetTransientStoreException.class,
+            () -> archives.findJobsForArchiving(Instant.now(), 10));
+    // The guard rethrows the inner transient as-is; it is not re-translated to the outer op label.
+    assertTrue(thrown.getMessage().contains("hydrate job tags batch"));
+  }
+
+  @Test
+  void findArchivedJobsTranslatesDeadlock() {
+    var archives = archiveOperations(entityManager(queryThrowingOnResults()));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> archives.findArchivedJobs("Job", null, null, null, 10));
+  }
+
+  @Test
+  void purgeArchivedJobsTranslatesDeadlock() {
+    var archives = archiveOperations(entityManager(queryThrowingOnExecute()));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> archives.purgeArchivedJobs(Instant.now()));
+  }
+
+  private static PostgresqlArchiveOperations archiveOperations(EntityManager em) {
+    var ctx = new PostgresqlStoreContext(em);
+    var tags = new PostgresqlTagOperations(ctx);
+    var reads = new PostgresqlJobReadOperations(ctx, tags);
+    return new PostgresqlArchiveOperations(ctx, reads);
   }
 
   @Test


### PR DESCRIPTION
# Consolidate duplicated store and coordinator code

Correctness fixes in this codebase have been landing in two-to-four places at once,
because the SQL stores and the cluster coordinators each carried their own copy of
machinery that is identical apart from a dialect or transport name. This branch pulls
those copies into shared helpers so the next fix lands once.

It is behavior-preserving except for the three changes called out at the bottom. Each
hoist is its own commit; the affected module tests run green before and after.

## Store core

- **Transient fault translation** → `TransientStoreExceptions.translateOrNull`. Also fixes
  a latent double-wrap in the PostgreSQL archive path.
- **Timestamp coercion** → `RowValues.instantOrNull`. The four per-store copies each handled
  a different subset of the temporal types a driver can return; the shared one handles all of
  them.
- **Store-context scaffolding** → `AbstractStoreContext` / `AbstractSqlStoreContext`
  (translate, timed, metrics, native count/scalar helpers). Mongo overrides only its extra
  exception branch.
- **Row-mapper hydration** → `AbstractJobRowMapper` (the 52 column indexes and the hydrate
  body).
- **Claim ordering** → the priority-boost expression now comes from
  `JobClaimSqlSupport.buildBoostedOrderBy`. It had been copied into three places.
- **Archive insert** → `ArchiveParameterBinder` (the column list and the parameter binder),
  with each store supplying only its id encoding.
- **JSON converters** now all route through the `PayloadSerializer` boundary. Two of them had
  been serializing directly and bypassing the configured serializer.
- **Lows**: lock-argument validation → `LockValidation`; the save-path hot-field guard and id
  assignment → `JobWriteSupport`; redundant `StatusClassifier` pass-throughs removed.

## Coordinators

- **Push-dispatch machinery** → `AbstractPushCoordinator` in coordinator-common: the listener
  registry, the pre-registration buffer, the dispatch executor's lifecycle, and the
  self-suppression and metric tail that every transport shared. Each coordinator now supplies
  only its publish path, its listener registration, its inbound extraction, and its teardown.
  The base adopts a dispatch pool built by the coordinator from `CoordinatorThreading`, so
  thread creation still routes through the managed thread factory.
- **Config validation** → `CoordinatorConfigChecks`; cell-id suffixing → `CoordinatorCells`.

## Performance

- **MySQL claim** dropped a round-trip. The claim ran three statements per cycle — select
  candidates `FOR UPDATE SKIP LOCKED`, update them to `RUNNING`, then read back which rows the
  update changed. The read-back is redundant: the select already holds the row locks, so every
  locked candidate is still `PENDING` when the update runs and the update claims all of them.
  The update's affected-row count is now the signal, matching PostgreSQL's two round-trips. The
  read-back stays as a fallback for a count mismatch the locks make impossible.

## Three behavior changes worth a look

- **MySQL hydration on a row with no status now fails loud.** It used to log and return null
  while PostgreSQL threw. A hydrated row with no status is corruption either way, so both
  stores now throw. The previously-divergent path is covered by a test.
- **Hazelcast cell separator changed from `-` to `_`.** Multi-cell deployments append a
  `cellId` to the topic / cache / channel name to isolate traffic. The separator had drifted —
  Hazelcast used `-`, the others `_`. It is pinned to `_` because a hyphen is not a legal
  character in an unquoted PostgreSQL `NOTIFY` channel, while an underscore is valid for all
  three. **This renames the effective Hazelcast topic for anyone already using `cellId`**
  (`base-cell` becomes `base_cell`); plan a restart window if that applies to you.
- A `listenerExecutorQueueCapacity` lower bound (`>= 1`) is now enforced on every coordinator
  config through the shared validator, with the same message the configs used before.

## Testing

Full reactor `mvn test` green, including the store contract tests against MySQL, PostgreSQL,
and MongoDB and the architecture tests. The MySQL claim change was checked against the claim
contract and concurrency tests. The cross-server portability matrix has not been run on this
branch yet.
