### PR TITLE
Advance linear chains after workflow branch evaluation

### DIFF
--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
@@ -85,6 +85,10 @@ public class ChainScheduler {
   }
 
   public void cancelChain(JobEntity failed) {
+    cancelChain(failed, Set.of());
+  }
+
+  protected void cancelChain(JobEntity failed, Set<UUID> skippedDirectChildren) {
     Deque<UUID> stack = new ArrayDeque<>();
     stack.push(failed.getId());
     boolean canceled = false;
@@ -93,6 +97,9 @@ public class ChainScheduler {
       UUID parentId = stack.pop();
       List<JobEntity> children = findAllDependants(parentId);
       for (JobEntity child : children) {
+        if (parentId.equals(failed.getId()) && skippedDirectChildren.contains(child.getId())) {
+          continue;
+        }
         JobStatus status = child.getStatus();
         if (status == JobStatus.PENDING || status == JobStatus.WAITING) {
           // Terminal CANCELED transition: cancelJob runs DELETE hot + UPDATE cold +
@@ -111,8 +118,19 @@ public class ChainScheduler {
   }
 
   public boolean scheduleNext(JobEntity finished) {
+    return scheduleNext(finished, Set.of());
+  }
+
+  protected boolean scheduleNext(JobEntity finished, Set<UUID> skippedDirectChildren) {
     List<JobEntity> children = findAllDependants(finished.getId());
-    if (children.isEmpty()) {
+    boolean hasEligibleChild = false;
+    for (JobEntity child : children) {
+      if (!skippedDirectChildren.contains(child.getId())) {
+        hasEligibleChild = true;
+        break;
+      }
+    }
+    if (!hasEligibleChild) {
       if (finished.getJobType() == JobExecutionType.CHAIN_STEP) {
         publishChainCompleted(finished);
       }
@@ -121,6 +139,9 @@ public class ChainScheduler {
 
     boolean scheduled = false;
     for (JobEntity c : children) {
+      if (skippedDirectChildren.contains(c.getId())) {
+        continue;
+      }
       if (c.getStatus() == JobStatus.PENDING && CHAIN_LOCK_TIME.equals(c.getScheduledTime())) {
         c.setScheduledTime(effective().instant());
         jobCrudStore.save(c);
@@ -147,7 +168,7 @@ public class ChainScheduler {
     return clock != null ? clock : Clock.systemUTC();
   }
 
-  private List<JobEntity> findAllDependants(UUID parentId) {
+  protected List<JobEntity> findAllDependants(UUID parentId) {
     List<JobEntity> dependants = new ArrayList<>();
     int offset = 0;
     while (true) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/WorkflowScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/WorkflowScheduler.java
@@ -22,6 +22,7 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -180,6 +181,8 @@ public class WorkflowScheduler extends ChainScheduler {
     log.infof("Evaluating %s workflow conditions for job %s", conditions.size(), parentJob.getId());
 
     Map<UUID, JobEntity> childJobs = loadChildJobs(conditions);
+    Set<UUID> conditionalChildIds =
+        conditions.stream().map(WorkflowConditionEntity::getChildJobId).collect(Collectors.toSet());
     WorkflowConditionEntity scheduledCondition = null;
     for (WorkflowConditionEntity condition : conditions) {
       try {
@@ -207,6 +210,7 @@ public class WorkflowScheduler extends ChainScheduler {
     }
 
     cancelUnscheduledBranches(conditions, scheduledCondition, childJobs);
+    boolean linearChainAdvanced = handleLinearChain(parentJob, conditionalChildIds);
 
     if (scheduledCondition != null) {
       publishWorkflowBranchTriggered(parentJob, scheduledCondition);
@@ -217,10 +221,15 @@ public class WorkflowScheduler extends ChainScheduler {
     }
 
     log.infof("No workflow conditions met for job %s", parentJob.getId());
+    return linearChainAdvanced;
+  }
+
+  private boolean handleLinearChain(JobEntity parentJob, Set<UUID> conditionalChildIds) {
     if (parentJob.getStatus() == JobStatus.FAILED) {
-      super.cancelChain(parentJob);
+      super.cancelChain(parentJob, conditionalChildIds);
+      return false;
     }
-    return false;
+    return super.scheduleNext(parentJob, conditionalChildIds);
   }
 
   private IllegalStateException failWorkflowCondition(JobEntity parentJob, Exception cause) {

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/WorkflowSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/WorkflowSchedulerTest.java
@@ -232,6 +232,55 @@ class WorkflowSchedulerTest {
   }
 
   @Test
+  void scheduleNext_unmatchedFailureBranchDoesNotBlockSuccessfulLinearChain() {
+    JobEntity parent = job(new UUID(0L, 300L), JobStatus.SUCCEEDED);
+    JobEntity failureBranch = job(new UUID(0L, 301L), JobStatus.PENDING);
+    JobEntity linearChild = job(new UUID(0L, 302L), JobStatus.PENDING);
+    failureBranch.setScheduledTime(ChainScheduler.CHAIN_LOCK_TIME);
+    linearChild.setScheduledTime(ChainScheduler.CHAIN_LOCK_TIME);
+    WorkflowConditionEntity condition = condition(parent.getId(), failureBranch.getId(), 0);
+    condition.setConditionType(WorkflowCondition.ConditionType.FAILURE);
+    when(conditionStore.findConditionsByParentJobId(parent.getId())).thenReturn(List.of(condition));
+    when(conditionEvaluator.evaluate(condition, parent)).thenReturn(false);
+    when(jobCrudStore.findById(failureBranch.getId())).thenReturn(Optional.of(failureBranch));
+    when(jobTerminalStore.cancelJob(failureBranch.getId())).thenReturn(true);
+    when(jobCrudStore.findDependants(eq(parent.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of(failureBranch, linearChild));
+
+    assertTrue(scheduler.scheduleNext(parent));
+
+    verify(jobTerminalStore).cancelJob(failureBranch.getId());
+    verify(jobCrudStore).save(linearChild);
+    assertEquals(FIXED_NOW, linearChild.getScheduledTime());
+  }
+
+  @Test
+  void scheduleNext_matchedFailureBranchCancelsLinearChainWithoutCancelingBranch() {
+    JobEntity parent = job(new UUID(0L, 310L), JobStatus.FAILED);
+    JobEntity failureBranch = job(new UUID(0L, 311L), JobStatus.PENDING);
+    JobEntity linearChild = job(new UUID(0L, 312L), JobStatus.PENDING);
+    failureBranch.setScheduledTime(ChainScheduler.CHAIN_LOCK_TIME);
+    linearChild.setScheduledTime(ChainScheduler.CHAIN_LOCK_TIME);
+    WorkflowConditionEntity condition = condition(parent.getId(), failureBranch.getId(), 0);
+    condition.setConditionType(WorkflowCondition.ConditionType.FAILURE);
+    when(conditionStore.findConditionsByParentJobId(parent.getId())).thenReturn(List.of(condition));
+    when(conditionEvaluator.evaluate(condition, parent)).thenReturn(true);
+    when(jobCrudStore.findById(failureBranch.getId())).thenReturn(Optional.of(failureBranch));
+    when(jobCrudStore.findDependants(eq(parent.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of(failureBranch, linearChild));
+    when(jobCrudStore.findDependants(eq(linearChild.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of());
+    when(jobTerminalStore.cancelJob(linearChild.getId())).thenReturn(true);
+
+    assertTrue(scheduler.scheduleNext(parent));
+
+    verify(jobCrudStore).save(failureBranch);
+    verify(jobTerminalStore).cancelJob(linearChild.getId());
+    verify(jobTerminalStore, never()).cancelJob(failureBranch.getId());
+    assertEquals(FIXED_NOW, failureBranch.getScheduledTime());
+  }
+
+  @Test
   void scheduleNext_failedParentWithNoConditionsFallsBackToCancelChain() {
     JobEntity parent = job(new UUID(0L, 32L), JobStatus.FAILED);
     JobEntity child = job(new UUID(0L, 33L), JobStatus.PENDING);


### PR DESCRIPTION
## Summary

Fix workflow scheduling when a completed job has both conditional workflow branches and a normal linear child.

- advance non-conditional linear children after workflow branch evaluation
- avoid canceling the selected conditional branch when a failed parent cancels the remaining linear chain
- cover the successful-parent/unmatched-failure-branch and failed-parent/matched-failure-branch cases

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [x] `mvn -pl ratchet -am -Dtest=WorkflowSchedulerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `mvn -pl ratchet -am spotless:check`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

This was split out from the Ratchet showcase branch so the core workflow behavior can review and merge independently.
