### PR TITLE
Document the signal payload round-trip contract and add TCK coverage

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobContext.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobContext.java
@@ -138,10 +138,14 @@ public final class JobContext {
    * Returns the signal payload delivered to this job, cast to the requested type, or {@code null}
    * if this job was not a signal-waiting job or no payload was included with the signal.
    *
-   * <p>A {@link SignalDecision} payload is returned as delivered. A raw payload delivered via
-   * {@code deliverSignal(..., Serializable)} is observed as its JSON-native form ({@code String},
-   * boxed number, boolean, {@code List}, or {@code Map}); request that type rather than the
-   * original concrete class.
+   * <p>A payload delivered via {@code deliverSignal(..., Serializable)} is observed as its
+   * JSON-native form — a {@code String}, a {@link Number} (typically a {@code java.math.BigDecimal}
+   * under the default JSON-B serializer), a {@code Boolean}, a {@code List}, or a {@code Map} — so
+   * request that type rather than the original concrete class. A {@link SignalDecision} delivered
+   * via {@code deliverSignal(..., SignalDecision)} is obtained by requesting {@code
+   * SignalDecision.class}; its {@code outcome} and {@code rejectionReason} are typed as declared,
+   * but its inner {@link SignalDecision#payload(Class) payload} carries the same JSON-native-only
+   * limitation.
    *
    * @throws ClassCastException if the payload cannot be cast to {@code type}
    */

--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -274,12 +274,24 @@ public interface JobSchedulerService {
    * <p>Idempotent: if the job is already in a non-WAITING state (including terminal states), this
    * method returns {@code 0} without modifying the job.
    *
-   * <p>The signal payload is serialized to JSON via the configured {@code PayloadSerializer} and
-   * stored on the job entity. The executing task reads it back through {@link
-   * JobContext#signalPayload(Class)} as its JSON-native form — a {@code String}, boxed number,
-   * boolean, {@code List}, or {@code Map} — so request the type the value maps to. A concrete bean
-   * class is not reconstructed to its original type; deliver a {@link SignalDecision} or a
-   * JSON-native value when the executing code needs typed access.
+   * <p><b>Payload round-trip contract.</b> The payload is serialized to JSON via the configured
+   * {@code PayloadSerializer} and stored on the job entity. Any {@link Serializable} is accepted
+   * here without validation, but only its JSON structure is retained — its concrete Java type is
+   * not. The executing task therefore observes the payload through {@link
+   * JobContext#signalPayload(Class)} in its JSON-native form: a {@code String}, a {@link Number}
+   * (typically a {@code java.math.BigDecimal} under the default JSON-B serializer), a {@code
+   * Boolean}, a {@code List}, or a {@code Map}. Request one of those types, not the original
+   * concrete class.
+   *
+   * <p>Delivering a value whose JSON does not map back to the type the job requests — a custom
+   * bean, for example — is accepted at write time and fails only later, as a {@link
+   * ClassCastException} thrown from {@code signalPayload(Class)} inside the running job. This
+   * deferred, read-side failure is a deliberate choice: it mirrors how JSON-B serializes an
+   * arbitrary {@code Object}, and the producer and consumer of a durable signal are decoupled in
+   * time. When the executing code needs structured typed access, deliver a {@link SignalDecision} —
+   * whose {@code outcome} and {@code rejectionReason} round-trip as declared — or shape the payload
+   * as JSON-native values up front. (A {@code SignalDecision}'s own inner payload carries the same
+   * JSON-native-only limitation; see {@link SignalDecision#payload(Class)}.)
    *
    * <p>Subject to {@link run.ratchet.spi.JobAuthorizationPolicy#checkDeliverSignal(UUID, String,
    * String)}.
@@ -323,6 +335,10 @@ public interface JobSchedulerService {
    *
    * <p>Idempotent: jobs already past WAITING are not affected and do not count toward the return
    * value.
+   *
+   * <p>The payload round-trip contract is identical to {@link #deliverSignal(UUID, Serializable)}:
+   * the value is retained as its JSON structure only and observed by each unblocked job in its
+   * JSON-native form.
    *
    * <p>Subject to {@link run.ratchet.spi.JobAuthorizationPolicy#checkDeliverSignal(String,
    * String)}. Because this is an atomic bulk operation, the policy receives the signal key rather

--- a/ratchet-api/src/main/java/run/ratchet/api/SignalDecision.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/SignalDecision.java
@@ -80,7 +80,14 @@ public record SignalDecision(Outcome outcome, Serializable payload, String rejec
   }
 
   /**
-   * Returns the optional payload cast to the requested type.
+   * Returns the optional inner payload cast to the requested type.
+   *
+   * <p>This is the inner value attached to the decision, not the decision itself. Like a raw signal
+   * payload, it survives delivery only as its JSON structure: after a round-trip it is observed in
+   * its JSON-native form — a {@code String}, a {@link Number}, a {@code Boolean}, a {@code List},
+   * or a {@code Map} — so request that type rather than the original concrete class. The decision's
+   * own {@link #outcome()} and {@link #rejectionReason()} are unaffected and remain typed as
+   * declared.
    *
    * @param type expected payload type
    * @param <T> expected payload type

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/SignalStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/SignalStore.java
@@ -51,6 +51,12 @@ public interface SignalStore {
    * metadata write must be atomic. Implementations must throw if the update cannot be completed; a
    * normal return value means the delivery transaction committed for that many rows.
    *
+   * <p>{@code payloadType} is a short marker classifying the stored payload. Exactly two values are
+   * defined: {@code "RAW"} for a payload delivered through {@code deliverSignal(.., Serializable)},
+   * and {@code "DECISION"} for a {@link run.ratchet.api.SignalDecision}. Stores persist it verbatim
+   * in a {@code VARCHAR(16)} column and do not interpret it; the runtime switches on {@code
+   * "DECISION"} when hydrating the executing job.
+   *
    * @throws RuntimeException when the store cannot complete the delivery atomically
    */
   int deliverSignalById(
@@ -70,6 +76,9 @@ public interface SignalStore {
    * update, or the store's closest equivalent, so concurrent deliveries cannot unblock the same
    * jobs twice. Implementations must throw if the update cannot be completed; a normal return value
    * means the delivery transaction committed for that many rows.
+   *
+   * <p>{@code payloadType} carries the same {@code "RAW"}/{@code "DECISION"} marker contract
+   * described on {@link #deliverSignalById}.
    *
    * @throws RuntimeException when the store cannot complete the delivery atomically
    */

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractSignalPayloadContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractSignalPayloadContract.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+
+/**
+ * Base contract for the raw payload delivered through {@code deliverSignal(.., Serializable)}.
+ *
+ * <p>A raw signal payload is retained as its JSON structure only; the executing job observes it in
+ * its JSON-native form through {@code JobContext.signalPayload(Class)} — a {@code String}, a {@code
+ * Number}, a {@code Boolean}, a {@code List}, or a {@code Map} — never the original concrete class.
+ * Each contract delivers one of the five documented shapes and asserts the shape the job observes,
+ * locking the round-trip across every conformant store.
+ *
+ * <p>The numeric case asserts a {@code Number} by value rather than a concrete type: a JSON number
+ * maps back to {@code java.math.BigDecimal} under the default JSON-B serializer, and the portable
+ * guarantee is "a {@code Number}", not "the same boxed type that was delivered". Likewise the list
+ * and map cases assert the collection interface, not a provider-specific implementation class.
+ *
+ * @see TckJobs#recordRawSignalPayload()
+ */
+public abstract class AbstractSignalPayloadContract {
+
+  @AfterEach
+  void clearAfterEach() {
+    runtime().clear();
+    TckJobs.resetAll();
+  }
+
+  @Test
+  void rawStringPayloadRoundTripsAsJsonNativeString() {
+    assertRawSignalRoundTrips("raw-string-tck", "hello-raw", "String:hello-raw");
+  }
+
+  @Test
+  void rawNumberPayloadRoundTripsAsJsonNativeNumber() {
+    assertRawSignalRoundTrips("raw-number-tck", 42, "Number:42");
+  }
+
+  @Test
+  void rawBooleanPayloadRoundTripsAsJsonNativeBoolean() {
+    assertRawSignalRoundTrips("raw-boolean-tck", true, "Boolean:true");
+  }
+
+  @Test
+  void rawListPayloadRoundTripsAsJsonNativeList() {
+    // A concrete Serializable list: the bare List.of(..) type does not satisfy the Serializable
+    // parameter bound at compile time, mirroring how callers must shape a list payload.
+    assertRawSignalRoundTrips("raw-list-tck", new ArrayList<>(List.of("x", "y")), "List:[x, y]");
+  }
+
+  @Test
+  void rawMapPayloadRoundTripsAsJsonNativeMap() {
+    assertRawSignalRoundTrips(
+        "raw-map-tck", new LinkedHashMap<>(Map.of("a", "1", "b", "2")), "Map:{a=1, b=2}");
+  }
+
+  /**
+   * Submits a signal-waiting job, delivers {@code payload} as a raw signal, and asserts the running
+   * job observed it as {@code expectedToken} (see {@link TckJobs#recordRawSignalPayload()}).
+   */
+  private void assertRawSignalRoundTrips(
+      String signalKey, Serializable payload, String expectedToken) {
+    JobHandle handle =
+        runtime()
+            .scheduler()
+            .enqueue(TckJobs::recordRawSignalPayload)
+            .awaitSignal(signalKey, defaultTimeout())
+            .submit();
+    runtime().probe().track(handle);
+
+    assertEquals(
+        1,
+        runtime().scheduler().deliverSignal(handle.id(), payload),
+        "delivering a raw payload should unblock exactly the waiting job");
+
+    assertTrue(
+        runtime().probe().awaitCompleted(handle, defaultTimeout()),
+        "raw signal should unblock and complete the job");
+    assertEquals(List.of(expectedToken), TckJobs.rawSignalPayloads());
+  }
+
+  protected abstract RatchetTckRuntime runtime();
+
+  protected Duration defaultTimeout() {
+    return Duration.ofSeconds(10);
+  }
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -49,7 +49,8 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractSimpleWorkflowContract",
                   "AbstractResilienceStrategyContract",
                   "AbstractJobAuthorizationContract",
-                  "AbstractSignalDecisionContract")));
+                  "AbstractSignalDecisionContract",
+                  "AbstractSignalPayloadContract")));
 
   @Override
   protected String tierTitle() {

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/TckJobs.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/TckJobs.java
@@ -15,7 +15,10 @@
  */
 package run.ratchet.tck.api;
 
+import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,6 +61,8 @@ public final class TckJobs {
   private static final AtomicReference<CountDownLatch> RELEASE_LATCH = new AtomicReference<>();
   private static final ConcurrentLinkedQueue<String> CHAIN_EVENTS = new ConcurrentLinkedQueue<>();
   private static final ConcurrentLinkedQueue<String> SIGNAL_DECISIONS =
+      new ConcurrentLinkedQueue<>();
+  private static final ConcurrentLinkedQueue<String> RAW_SIGNAL_PAYLOADS =
       new ConcurrentLinkedQueue<>();
 
   private TckJobs() {}
@@ -134,6 +139,52 @@ public final class TckJobs {
                 + decision.rejectionReason());
   }
 
+  /**
+   * Signal-waiting task body that records the delivered <em>raw</em> payload's observed runtime
+   * category and value through {@link JobContext}. Used by {@link AbstractSignalPayloadContract} to
+   * pin the JSON-native round-trip of a {@code deliverSignal(.., Serializable)} payload across
+   * stores. The recorded token is {@code "<category>:<value>"} where category is the JSON-native
+   * shape ({@code String}, {@code Boolean}, {@code Number}, {@code List}, {@code Map}) rather than
+   * the original concrete class, which is intentionally not reconstructed.
+   */
+  public static void recordRawSignalPayload() {
+    RAW_SIGNAL_PAYLOADS.add(
+        describeRawPayload(JobContext.current().signalPayload(Serializable.class)));
+  }
+
+  private static String describeRawPayload(Serializable payload) {
+    if (payload == null) {
+      return "null";
+    }
+    if (payload instanceof String s) {
+      return "String:" + s;
+    }
+    if (payload instanceof Boolean b) {
+      return "Boolean:" + b;
+    }
+    // JSON-B maps a bare JSON number to a Number (commonly a BigDecimal), so the contract
+    // compares by value, not by concrete type.
+    if (payload instanceof Number n) {
+      return "Number:" + n;
+    }
+    // Sort entries/elements so the rendering is deterministic regardless of the deserialized
+    // collection impl's iteration order.
+    if (payload instanceof Map<?, ?> m) {
+      TreeMap<String, String> sorted = new TreeMap<>();
+      m.forEach((k, v) -> sorted.put(String.valueOf(k), String.valueOf(v)));
+      return "Map:" + sorted;
+    }
+    if (payload instanceof List<?> l) {
+      return "List:" + l;
+    }
+    return "Other(" + payload.getClass().getName() + "):" + payload;
+  }
+
+  /** Snapshot of recorded raw signal payload tokens in observation order. */
+  public static List<String> rawSignalPayloads() {
+    return List.copyOf(RAW_SIGNAL_PAYLOADS);
+  }
+
   /** Snapshot of recorded chain events in observation order. */
   public static List<String> chainEvents() {
     return List.copyOf(CHAIN_EVENTS);
@@ -150,5 +201,6 @@ public final class TckJobs {
     RELEASE_LATCH.set(null);
     CHAIN_EVENTS.clear();
     SIGNAL_DECISIONS.clear();
+    RAW_SIGNAL_PAYLOADS.clear();
   }
 }

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiSignalPayloadIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiSignalPayloadIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.tck.api.AbstractSignalPayloadContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+
+/** RI subclass of {@link AbstractSignalPayloadContract}. */
+@ExtendWith(ArquillianExtension.class)
+class RiSignalPayloadIT extends AbstractSignalPayloadContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+
+  @Override
+  protected RatchetTckRuntime runtime() {
+    return runtime;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.create();
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -76,6 +76,9 @@ import run.ratchet.store.spi.WorkflowConditionStore;
 public class DefaultJobSchedulerService
     implements JobSchedulerService, RecurringAnnotationMaintenanceService {
 
+  // signal_payload_type markers persisted in the VARCHAR(16) column. These two values are the only
+  // ones defined: RAW for a payload delivered via deliverSignal(.., Serializable), DECISION for a
+  // SignalDecision. JobTask switches on DECISION to rebuild the wrapper; everything else is RAW.
   public static final String SIGNAL_PAYLOAD_TYPE_DECISION = "DECISION";
   static final String SIGNAL_PAYLOAD_TYPE_RAW = "RAW";
   // Used when the caller principal can't be resolved (e.g. no Elytron context in tests).


### PR DESCRIPTION
## Summary

`deliverSignal(.., Serializable)` accepts any `Serializable`, but only the payload's JSON structure survives delivery. Its concrete Java type does not, so the executing job observes the payload in its JSON-native form (`String`, `Number`, `Boolean`, `List`, or `Map`). A custom bean delivered this way comes back as a `Map` and throws `ClassCastException` inside the running job rather than at the call site.

That contract was documented only on the read side, and the raw-payload path was pinned only by an RI unit test against a mock store, while `SignalDecision` already had a full cross-store contract. This PR closes both gaps. No behavior or method signatures change.

**Commit 1 (docs):** makes the write-side behavior explicit on both `deliverSignal` overloads, states that the deferred read-side failure is a deliberate choice consistent with how JSON-B serializes an arbitrary `Object`, and corrects wording that implied a `SignalDecision` gives typed access to its inner payload. It does not: only `outcome` and `rejectionReason` round-trip as declared, and the inner payload carries the same JSON-native limitation. The two `signal_payload_type` markers (`RAW`, `DECISION`) are now documented on the `SignalStore` SPI and the constants that set them.

**Commit 2 (TCK):** adds `AbstractSignalPayloadContract` covering all five JSON-native shapes (`String`, `Number`, `Boolean`, `List`, `Map`) across every conformant store, registered in the API conformance catalog so it counts toward the report, with `RiSignalPayloadIT` running it on the RI via the existing profile switch. The numeric case asserts a `Number` by value rather than a concrete type, since JSON-B maps a JSON number back to `BigDecimal`, and the list/map cases assert the interface rather than a provider-specific implementation class.

## Testing

- [ ] `mvn clean test -B`
- [x] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

What I actually ran:

- `mvn -DskipTests test-compile` on the full reactor: clean.
- `mvn test -pl ratchet-tck/api -am`: passes, including `allApiContractsAreCataloged`, which fails the build if the new contract is left out of the conformance catalog.
- `mvn spotless:apply`: only the changed files were reformatted.

`RiSignalPayloadIT` (the cross-store end-to-end run) has not been driven through the server/database matrix yet. The JSON-native round-trip behavior was reasoned through rather than executed.

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

Behavior is unchanged; the Javadoc clarifications are the change itself, and nothing in the website references this readback nuance.

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

The public API/SPI change is documentation only (no signatures or behavior change), plus the new `AbstractSignalPayloadContract` class in the TCK API module.

Follow-up, deliberately out of scope: the `Serializable` parameter bound on `deliverSignal` rejects a bare `List.of(..)` or `Map.of(..)` at compile time even though those values are serializable, so callers must wrap them in a concrete type (the contract does the same). Worth revisiting if the ergonomics matter.

## Additional Context

The deferred, read-side `ClassCastException` for a non-JSON-native payload is intentional rather than a bug to fix at write time: it matches JSON-B's `serialize(Object)` behavior, and a durable signal's producer and consumer are decoupled in time. Failing at the consumer was chosen over rejecting at the producer.
