### PR TITLE
Make store implementations behaviorally interchangeable on edge cases

### DIFF
--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobBatchStatusStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobBatchStatusStore.java
@@ -50,6 +50,9 @@ public interface JobBatchStatusStore {
    *     column untouched
    * @return {@code true} when the row was at {@code expected} and was updated to {@code newStatus},
    *     {@code false} otherwise (lost race or row missing)
+   * @throws IllegalArgumentException if {@code expected} is a terminal status. CAS targets only
+   *     live rows; every store rejects a terminal {@code expected} rather than returning {@code
+   *     false}, which a caller could not distinguish from a lost race.
    */
   boolean compareAndSwapStatus(UUID id, JobStatus expected, JobStatus newStatus, String error);
 

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobCrudStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobCrudStore.java
@@ -74,6 +74,9 @@ public interface JobCrudStore {
    *     the {@link Nullable} annotation reflects this contract for static analysers.
    * @param id job id to inspect
    * @return current status, or {@code null} when no job exists for {@code id}
+   * @throws IllegalStateException if a job row exists but carries neither a live nor a terminal
+   *     status. This is a store invariant violation; every store fails loud here rather than
+   *     returning {@code null} (which a caller could not distinguish from "no such job").
    */
   @Nullable JobStatus getJobStatus(UUID id);
 
@@ -88,6 +91,10 @@ public interface JobCrudStore {
    * Finds the active job currently associated with a business key, if any.
    *
    * <p>Transaction attribute: {@code SUPPORTS}.
+   *
+   * @throws IllegalStateException if a reservation claims a live-queue owner but no hot row exists.
+   *     This is a store invariant violation; every store fails loud here rather than returning an
+   *     empty {@link Optional}.
    */
   Optional<JobEntity> findActiveByBusinessKey(String businessKey);
 

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobCrudStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobCrudStore.java
@@ -248,10 +248,17 @@ public interface JobCrudStore {
   /**
    * Returns the queue wait time at the given percentile for succeeded jobs.
    *
+   * <p>The value is computed with <b>discrete nearest-rank</b> semantics (equivalent to SQL {@code
+   * PERCENTILE_DISC}): the result is always an actually-observed {@code queueWaitMs} value, never
+   * an interpolation between two observations. All stores return the same value for the same data.
+   *
    * <p>Transaction attribute: {@code SUPPORTS}.
    *
    * @param percentile a fraction in the range [0.0, 1.0], e.g. 0.95 for p95
    * @return queue wait time in milliseconds at the requested percentile, or 0 if no data
+   * @throws IllegalArgumentException if {@code percentile} is {@code NaN} or outside [0.0, 1.0].
+   *     All stores reject an out-of-range percentile rather than clamping or passing it to the
+   *     backend.
    */
   long getQueueWaitTimePercentile(double percentile);
 }

--- a/ratchet-store-core/src/main/java/run/ratchet/store/spi/SignalStore.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/spi/SignalStore.java
@@ -40,6 +40,8 @@ public interface SignalStore {
    * @param limit maximum number of jobs to return; must be positive
    * @return expired WAITING jobs, never null
    *     <p>Transaction attribute: {@code SUPPORTS}.
+   * @throws IllegalArgumentException if {@code limit} is not positive ({@code limit <= 0}). All
+   *     stores reject a non-positive limit rather than clamping, so callers see identical behavior.
    * @throws RuntimeException when the store cannot read timed-out signal jobs
    */
   List<JobEntity> findTimedOutSignalJobs(Instant now, int limit);

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoAuxiliaryOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoAuxiliaryOperations.java
@@ -241,6 +241,14 @@ final class MongoAuxiliaryOperations {
     try (ClientSession session = ctx.startSession()) {
       return session.withTransaction(
           () -> {
+            // Validate the resource is configured before any fast-path so an unconfigured
+            // resource fails hard even when a stray permit row already exists for
+            // (resource, jobId). The SQL stores take the resource-limit row lock first, so this
+            // keeps the IllegalArgumentException contract identical across stores.
+            if (ctx.resourceLimits().find(session, eq(ID, resource)).first() == null) {
+              throw new IllegalArgumentException("Resource is not configured: " + resource);
+            }
+
             if (ctx.resourcePermits()
                     .find(session, and(eq(RESOURCE_NAME, resource), eq(JOB_ID, jobId)))
                     .first()
@@ -264,9 +272,7 @@ final class MongoAuxiliaryOperations {
                         new FindOneAndUpdateOptions().returnDocument(ReturnDocument.AFTER));
 
             if (result == null) {
-              if (ctx.resourceLimits().find(session, eq(ID, resource)).first() == null) {
-                throw new IllegalArgumentException("Resource is not configured: " + resource);
-              }
+              // Resource exists (validated above) but is at capacity.
               return false;
             }
 

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
@@ -414,37 +414,21 @@ final class MongoJobCrudOperations {
   }
 
   long getQueueWaitTimePercentile(double percentile) {
-    // Prefer MongoDB 7.0+ $percentile; fall back to sort+skip for older servers.
-    List<Document> pipeline =
-        List.of(
-            new Document(
-                "$match",
-                new Document(QUEUE_WAIT_MS, new Document("$ne", null))
-                    .append(STATUS, STATUS_SUCCEEDED)),
-            new Document(
-                "$group",
-                new Document(ID, null)
-                    .append(
-                        "p",
-                        new Document(
-                            "$percentile",
-                            new Document("input", "$" + QUEUE_WAIT_MS)
-                                .append("p", List.of(percentile))
-                                .append("method", "approximate")))));
-    try {
-      Optional<Long> percentileValue = aggregateFirstNumberListValue(ctx.jobs(), pipeline, "p");
-      if (percentileValue.isPresent()) {
-        return percentileValue.get();
-      }
-    } catch (Exception e) {
-      log.debug("$percentile aggregation not available, using sort+skip approximation", e);
+    if (Double.isNaN(percentile) || percentile < 0.0 || percentile > 1.0) {
+      throw new IllegalArgumentException("percentile must be in [0.0, 1.0], got: " + percentile);
     }
+    // Exact discrete nearest-rank over SUCCEEDED jobs, matching PostgreSQL PERCENTILE_DISC and the
+    // MySQL CUME_DIST path. We deliberately avoid $percentile: its only mode is "approximate"
+    // (t-digest), which would diverge from the SQL stores on the same data. Percentile reads are an
+    // admin/metrics path, not the hot path, so the full ordering cost is acceptable.
     long total =
         ctx.jobs().countDocuments(and(ne(QUEUE_WAIT_MS, null), eq(STATUS, STATUS_SUCCEEDED)));
     if (total == 0) {
       return 0;
     }
-    long skipCount = (long) (total * percentile);
+    // Smallest 1-based rank k with k/total >= percentile, clamped to [1, total]; skip = k - 1.
+    long rank = (long) Math.ceil(percentile * total);
+    long skipCount = Math.max(1, Math.min(rank, total)) - 1;
     Document doc =
         ctx.jobs()
             .find(and(ne(QUEUE_WAIT_MS, null), eq(STATUS, STATUS_SUCCEEDED)))
@@ -460,17 +444,6 @@ final class MongoJobCrudOperations {
       MongoCollection<Document> collection, List<? extends Bson> pipeline, String field) {
     Number value = numberField(collection.aggregate(pipeline).first(), field);
     return value == null ? 0.0 : value.doubleValue();
-  }
-
-  private static Optional<Long> aggregateFirstNumberListValue(
-      MongoCollection<Document> collection, List<? extends Bson> pipeline, String field) {
-    Object value = fieldValue(collection.aggregate(pipeline).first(), field);
-    if (!(value instanceof List<?> values)
-        || values.isEmpty()
-        || !(values.get(0) instanceof Number number)) {
-      return Optional.empty();
-    }
-    return Optional.of(number.longValue());
   }
 
   private static double ratioFromAggregate(

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
@@ -61,6 +61,7 @@ import run.ratchet.store.spi.JobBatchStatusStore;
 import run.ratchet.store.spi.JobPauseStore;
 import run.ratchet.store.spi.JobRetryStore;
 import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.util.StatusClassifier;
 
 /**
  * Job state-transition operations. Every method targets a specific {@code (id, status)}
@@ -83,6 +84,18 @@ final class MongoJobLifecycleOperations
 
   @Override
   public void updateJobStatus(UUID id, JobStatus status, String errorMessage) {
+    // A live target is a plain status set. Terminal targets route through the guarded terminal
+    // methods so the picked-by/terminated-at cleanup matches the SQL stores, which never let
+    // updateJobStatus flip a row straight to a terminal status without that bookkeeping.
+    if (!StatusClassifier.isLiveStatus(status)) {
+      switch (status) {
+        case CANCELED -> cancelJob(id);
+        case FAILED -> markJobFailedTerminal(id, errorMessage, 0);
+        case SUCCEEDED -> markJobSucceededMinimal(id, null, null, null, null);
+        default -> throw new IllegalArgumentException("Unsupported status target: " + status);
+      }
+      return;
+    }
     runMutation(
         "update_status",
         () -> {

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobLifecycleOperations.java
@@ -115,6 +115,10 @@ final class MongoJobLifecycleOperations
   @Override
   public boolean compareAndSwapStatus(
       UUID id, JobStatus expected, JobStatus newStatus, String error) {
+    if (!StatusClassifier.isLiveStatus(expected)) {
+      throw new IllegalArgumentException(
+          "compareAndSwapStatus expected must be a live status; got " + expected);
+    }
     return ctx.timedStoreOperation(
         "compare_and_swap_status",
         () -> {

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoSignalOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoSignalOperations.java
@@ -69,6 +69,9 @@ final class MongoSignalOperations implements SignalStore {
 
   @Override
   public List<JobEntity> findTimedOutSignalJobs(Instant now, int limit) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive: " + limit);
+    }
     Bson filter =
         and(
             eq(STATUS, JobStatus.WAITING.name()),
@@ -77,7 +80,7 @@ final class MongoSignalOperations implements SignalStore {
 
     List<JobEntity> result = new ArrayList<>();
     for (Document doc :
-        ctx.jobs().find(filter).sort(ascending(SIGNAL_TIMEOUT, "_id")).limit(Math.max(1, limit))) {
+        ctx.jobs().find(filter).sort(ascending(SIGNAL_TIMEOUT, "_id")).limit(limit)) {
       result.add(DocumentMapper.toJobEntity(doc));
     }
     return result;

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/JobLifecycleIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/JobLifecycleIT.java
@@ -81,9 +81,11 @@ class JobLifecycleIT extends BaseDocumentStoreIT {
     job = store().save(job);
 
     store().claimNextBatch(1, "node-1");
-    store().incrementRetryAttempt(job.getId());
-    store().compareAndSwapStatus(job.getId(), JobStatus.RUNNING, JobStatus.FAILED, "first attempt");
-    store().compareAndSwapStatus(job.getId(), JobStatus.FAILED, JobStatus.PENDING, null);
+    int attempts = store().incrementRetryAttempt(job.getId());
+    // Reschedule via scheduleJobRetry (RUNNING -> PENDING) to retry while preserving the attempt
+    // count. compareAndSwapStatus rejects a terminal expected on every store, and
+    // resetFailedToPending would zero attempts, so neither fits this flow.
+    store().scheduleJobRetry(job.getId(), "first attempt", Instant.now().minusSeconds(1), attempts);
 
     List<JobEntity> reclaimed = store().claimNextBatch(1, "node-1");
     assertEquals(1, reclaimed.size());

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoResourcePermitConfigCheckOrderingTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoResourcePermitConfigCheckOrderingTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.ResourcePermitEntity;
+import run.ratchet.store.id.UuidV7Factory;
+
+/**
+ * Mongo-specific regression for the {@code tryAcquirePermit} config-check ordering. A stray permit
+ * row for an <em>unconfigured</em> resource must still fail hard with {@link
+ * IllegalArgumentException}, matching the SQL stores which lock the resource-limit row first.
+ *
+ * <p>This corrupt state — a permit that references a resource with no limit row — cannot be reached
+ * through the cross-store {@code ResourcePermitStore} SPI (there is no un-configure operation), so
+ * the regression lives here as a store-specific test rather than in the shared TCK contract. The
+ * Mongo store previously short-circuited on the existing-permit fast path and returned {@code
+ * true}, silently bypassing the documented {@code @throws IllegalArgumentException}.
+ */
+class MongoResourcePermitConfigCheckOrderingTest {
+
+  private static final MongoTestFixture fixture = new MongoTestFixture();
+
+  @AfterAll
+  static void closeFixture() {
+    fixture.close();
+  }
+
+  @BeforeEach
+  @AfterEach
+  void cleanup() {
+    fixture.cleanupStore();
+  }
+
+  @Test
+  void tryAcquirePermit_strayPermitForUnconfiguredResource_stillFailsHard() {
+    JobEntity job = fixture.store().save(fixture.newPendingJob());
+    String resource = "never-configured";
+
+    // Insert a stray permit directly: no SPI call can create a permit for an unconfigured resource.
+    ResourcePermitEntity stray = ResourcePermitEntity.create(resource, job.getId(), "node-1");
+    stray.setId(UuidV7Factory.create());
+    fixture
+        .database()
+        .getCollection("scheduler_resource_permit")
+        .insertOne(DocumentMapper.toDocument(stray));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> fixture.store().tryAcquirePermit(resource, job.getId(), "node-1"),
+        "an unconfigured resource must fail hard even when a stray permit row already exists");
+  }
+}

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobClaimOperations.java
@@ -89,6 +89,9 @@ final class MysqlJobClaimOperations implements JobClaimStore {
   @Override
   @SuppressWarnings("unchecked")
   public List<JobEntity> claimNextBatch(int limit, String nodeId, NodeTagFilter tagFilter) {
+    if (limit <= 0) {
+      return List.of();
+    }
     List<Object[]> candidateRows;
     try {
       candidateRows = selectClaimCandidates(limit, tagFilter);

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
@@ -18,6 +18,7 @@ package run.ratchet.store.mysql;
 import jakarta.persistence.Query;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -279,68 +280,77 @@ final class MysqlJobQueryOperations {
 
   @SuppressWarnings("unchecked")
   List<JobEntity> searchJobs(JobFilter filter, int limit, int offset) {
-    boolean archive = useArchive(filter);
-    int safeLimit = Math.min(limit, MAX_IN_CLAUSE);
-    int effectiveOffset = (filter != null && filter.cursor() != null) ? 0 : offset;
+    try {
+      boolean archive = useArchive(filter);
+      int safeLimit = Math.min(limit, MAX_IN_CLAUSE);
+      int effectiveOffset = (filter != null && filter.cursor() != null) ? 0 : offset;
 
-    List<Object> params = new ArrayList<>();
-    String sql;
-    if (archive) {
-      sql = buildUnionSearchSql(filter, params, safeLimit, effectiveOffset);
-    } else {
-      sql =
-          "SELECT "
-              + MysqlJobRowMapper.HYDRATION_SELECT
-              + " "
-              + HYDRATION_FROM
-              + buildWhere(filter, params)
-              + buildOrderBy(filter)
-              + " LIMIT "
-              + safeLimit
-              + " OFFSET "
-              + effectiveOffset;
-    }
-
-    Query q = ctx.em().createNativeQuery(sql);
-    bindParams(q, params);
-    List<Object[]> rows = q.getResultList();
-    List<JobEntity> result = new ArrayList<>(rows.size());
-    List<JobEntity> jobsToHydrate = new ArrayList<>(rows.size());
-    for (Object[] row : rows) {
-      JobEntity job = mapper.hydrateJobEntity(row);
-      if (job != null) {
-        // Skip tag hydration for archive rows (null q.status marks terminal-only rows from archive)
-        if (!archive || row[MysqlJobRowMapper.IDX_Q_STATUS] != null) {
-          jobsToHydrate.add(job);
-        }
-        result.add(job);
+      List<Object> params = new ArrayList<>();
+      String sql;
+      if (archive) {
+        sql = buildUnionSearchSql(filter, params, safeLimit, effectiveOffset);
+      } else {
+        sql =
+            "SELECT "
+                + MysqlJobRowMapper.HYDRATION_SELECT
+                + " "
+                + HYDRATION_FROM
+                + buildWhere(filter, params)
+                + buildOrderBy(filter)
+                + " LIMIT "
+                + safeLimit
+                + " OFFSET "
+                + effectiveOffset;
       }
+
+      Query q = ctx.em().createNativeQuery(sql);
+      bindParams(q, params);
+      List<Object[]> rows = q.getResultList();
+      List<JobEntity> result = new ArrayList<>(rows.size());
+      List<JobEntity> jobsToHydrate = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        JobEntity job = mapper.hydrateJobEntity(row);
+        if (job != null) {
+          // Skip tag hydration for archive rows (null q.status marks terminal-only rows from
+          // archive)
+          if (!archive || row[MysqlJobRowMapper.IDX_Q_STATUS] != null) {
+            jobsToHydrate.add(job);
+          }
+          result.add(job);
+        }
+      }
+      tags.hydrateTagsBatch(jobsToHydrate);
+      return result;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("search jobs", e);
     }
-    tags.hydrateTagsBatch(jobsToHydrate);
-    return result;
   }
 
   long countJobs(JobFilter filter) {
-    boolean archive = useArchive(filter);
-    List<Object> params = new ArrayList<>();
-    String sql;
-    if (archive) {
-      sql =
-          "SELECT COUNT(*) FROM ("
-              + "SELECT 1 "
-              + HYDRATION_FROM
-              + buildWhere(filter, params)
-              + " UNION ALL "
-              + "SELECT 1 FROM scheduler_job_archive a"
-              + buildArchiveWhere(filter, params)
-              + ") AS combined";
-    } else {
-      // language=MySQL
-      sql = "SELECT COUNT(*) " + HYDRATION_FROM + buildWhere(filter, params);
+    try {
+      boolean archive = useArchive(filter);
+      List<Object> params = new ArrayList<>();
+      String sql;
+      if (archive) {
+        sql =
+            "SELECT COUNT(*) FROM ("
+                + "SELECT 1 "
+                + HYDRATION_FROM
+                + buildWhere(filter, params)
+                + " UNION ALL "
+                + "SELECT 1 FROM scheduler_job_archive a"
+                + buildArchiveWhere(filter, params)
+                + ") AS combined";
+      } else {
+        // language=MySQL
+        sql = "SELECT COUNT(*) " + HYDRATION_FROM + buildWhere(filter, params);
+      }
+      Query q = ctx.em().createNativeQuery(sql);
+      bindParams(q, params);
+      return ((Number) q.getSingleResult()).longValue();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs", e);
     }
-    Query q = ctx.em().createNativeQuery(sql);
-    bindParams(q, params);
-    return ((Number) q.getSingleResult()).longValue();
   }
 
   private String buildWhere(JobFilter filter, List<Object> params) {
@@ -617,7 +627,7 @@ final class MysqlJobQueryOperations {
       params.add(sortVal);
       params.add(sortVal);
       params.add(UuidByteArrayConverter.toBytes(c.jobId()));
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | DateTimeParseException e) {
       log.warnf(e, "Ignoring malformed job-query cursor; falling back to offset pagination");
     }
   }
@@ -643,7 +653,7 @@ final class MysqlJobQueryOperations {
       params.add(sortVal);
       params.add(sortVal);
       params.add(UuidByteArrayConverter.toBytes(c.jobId()));
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalArgumentException | DateTimeParseException e) {
       log.warnf(
           e, "Ignoring malformed archive job-query cursor; falling back to offset pagination");
     }

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobReadOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobReadOperations.java
@@ -107,8 +107,7 @@ final class MysqlJobReadOperations {
       if (terminal != null) {
         return JobStatus.valueOf(terminal);
       }
-      log.errorf("Job %s has no live or terminal status — invariant violation", id);
-      return null;
+      throw new IllegalStateException("Job " + id + " has no live or terminal status");
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("get job status", e);
     }
@@ -183,7 +182,12 @@ final class MysqlJobReadOperations {
         log.errorf(
             "bkres invariant violation: business_key=%s claims QUEUE owner job=%s but no hot row",
             businessKey, job.getId());
-        return Optional.empty();
+        throw new IllegalStateException(
+            "Business key reservation "
+                + businessKey
+                + " claims QUEUE owner job "
+                + job.getId()
+                + " but no hot row exists");
       }
       tags.hydrateTagsSingle(job);
       return Optional.of(job);

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlNodeLockOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlNodeLockOperations.java
@@ -156,7 +156,11 @@ final class MysqlNodeLockOperations implements NodeStore, LockStore {
 
   @Override
   public Optional<NodeEntity> findNodeById(String nodeId) {
-    return Optional.ofNullable(ctx.em().find(NodeEntity.class, nodeId));
+    try {
+      return Optional.ofNullable(ctx.em().find(NodeEntity.class, nodeId));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find node by id", e);
+    }
   }
 
   @Override

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSignalOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSignalOperations.java
@@ -215,7 +215,7 @@ final class MysqlSignalOperations implements SignalStore {
           "SELECT "
               + MysqlJobRowMapper.HYDRATION_SELECT
               + " FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id"
-              + " WHERE q.signal_delivery_id = ? LIMIT 1000";
+              + " WHERE q.signal_delivery_id = ?";
       List<Object[]> rows =
           ctx.em().createNativeQuery(sql).setParameter(1, deliveryId).getResultList();
       return MysqlJobRowMapper.hydrateRows(rows);

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlTagOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlTagOperations.java
@@ -95,8 +95,11 @@ final class MysqlTagOperations implements TagStore {
   @Override
   public List<UUID> findJobIdsByTag(String tag, int limit, int offset) {
     try {
+      // ORDER BY job_id makes the "ordered" contract explicit in the query rather than relying on
+      // the (tag, job_id) index returning rows in id order, which a plan change could break.
       // language=MySQL
-      String sql = "SELECT job_id FROM scheduler_job_tag WHERE tag = ? LIMIT ? OFFSET ?";
+      String sql =
+          "SELECT job_id FROM scheduler_job_tag WHERE tag = ? ORDER BY job_id LIMIT ? OFFSET ?";
       List<?> rows =
           ctx.em()
               .createNativeQuery(sql)

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlTagOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlTagOperations.java
@@ -191,8 +191,10 @@ final class MysqlTagOperations implements TagStore {
               JOIN scheduler_job_tag t ON t.job_id = c2.job_id
               JOIN scheduler_job_execution e ON e.job_id = c2.job_id
               WHERE t.tag = ? AND c2.terminal_status IS NOT NULL
-                AND e.id = (SELECT MAX(e2.id) FROM scheduler_job_execution e2
-                            WHERE e2.job_id = c2.job_id)
+                AND e.id = (SELECT e2.id FROM scheduler_job_execution e2
+                            WHERE e2.job_id = c2.job_id
+                            ORDER BY e2.attempt DESC, e2.started_at DESC, e2.id DESC
+                            LIMIT 1)
                 AND e.node_id IS NOT NULL AND e.node_id <> ''
               GROUP BY e.node_id
           ) u GROUP BY node ORDER BY node

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlBatchOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlBatchOperations.java
@@ -316,8 +316,8 @@ final class PostgresqlBatchOperations implements BatchStore, BatchMetricsStore {
     try {
       return PayloadSerializerHolder.get().deserialize(jsonValue.toString(), JobPayload.class);
     } catch (IllegalArgumentException e) {
-      log.warn("Bad progress_hook JSON", e);
-      return null;
+      log.warn("Failed to deserialize stored batch progress hook payload", e);
+      throw new IllegalArgumentException("JobPayload deserialization error", e);
     }
   }
 

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobCountOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobCountOperations.java
@@ -277,13 +277,16 @@ final class PostgresqlJobCountOperations {
   }
 
   long getQueueWaitTimePercentile(double percentile) {
-    if (percentile < 0.0 || percentile > 1.0) {
+    if (Double.isNaN(percentile) || percentile < 0.0 || percentile > 1.0) {
       throw new IllegalArgumentException("percentile must be in [0.0, 1.0], got: " + percentile);
     }
+    // PERCENTILE_DISC (discrete) returns an actually-observed value by nearest-rank, matching the
+    // MySQL CUME_DIST path and the Mongo sort+skip path. PERCENTILE_CONT would interpolate between
+    // observed values and diverge from the other stores.
     // language=PostgreSQL
     String sql =
         """
-        SELECT COALESCE(PERCENTILE_CONT(?) WITHIN GROUP (ORDER BY queue_wait_ms), 0)
+        SELECT COALESCE(PERCENTILE_DISC(?) WITHIN GROUP (ORDER BY queue_wait_ms), 0)
         FROM scheduler_job WHERE queue_wait_ms IS NOT NULL
           AND terminal_status = 'SUCCEEDED'
         """;

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSignalOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSignalOperations.java
@@ -58,8 +58,10 @@ final class PostgresqlSignalOperations implements SignalStore {
   @Override
   @SuppressWarnings("unchecked")
   public List<JobEntity> findTimedOutSignalJobs(Instant now, int limit) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive: " + limit);
+    }
     try {
-      int safeLimit = Math.max(1, limit);
       // language=PostgreSQL
       String sql =
           """
@@ -80,7 +82,7 @@ final class PostgresqlSignalOperations implements SignalStore {
           ctx.em()
               .createNativeQuery(sql)
               .setParameter(1, Timestamp.from(now))
-              .setMaxResults(safeLimit)
+              .setMaxResults(limit)
               .getResultList();
 
       List<JobEntity> result = new ArrayList<>(rows.size());

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBatchStatusStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBatchStatusStoreContract.java
@@ -128,6 +128,34 @@ public abstract class AbstractJobBatchStatusStoreContract implements JobStoreCon
   }
 
   @Test
+  void updateJobStatus_terminalTarget_terminalizesRunningJob() {
+    // A terminal target routes through the guarded terminal transition on every store, so a RUNNING
+    // job becomes SUCCEEDED. Mongo must route here too rather than blindly setting the status
+    // field.
+    var running = runningJob("node-1");
+
+    store().updateJobStatus(running.getId(), JobStatus.SUCCEEDED, null);
+
+    assertEquals(JobStatus.SUCCEEDED, store().getJobStatus(running.getId()));
+  }
+
+  @Test
+  void updateJobStatus_terminalTarget_nonRunningJob_isNoOp() {
+    // Because terminal targets route through the RUNNING-guarded terminal methods, a non-RUNNING
+    // job
+    // is left untouched on every store. The Mongo bug flipped a PENDING job straight to SUCCEEDED;
+    // the SQL stores leave it PENDING. All three must agree.
+    var pending = persist(newPendingJob());
+
+    store().updateJobStatus(pending.getId(), JobStatus.SUCCEEDED, null);
+
+    assertEquals(
+        JobStatus.PENDING,
+        store().getJobStatus(pending.getId()),
+        "a non-RUNNING job must not be flipped straight to a terminal status");
+  }
+
+  @Test
   void resetRunningJob_reclaimsMatchingNodeOnly() {
     var matching = runningJob("node-1");
     var wrongNode = runningJob("node-2");

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBatchStatusStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBatchStatusStoreContract.java
@@ -18,6 +18,7 @@ package run.ratchet.tck.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -62,6 +63,19 @@ public abstract class AbstractJobBatchStatusStoreContract implements JobStoreCon
         JobStatus.PENDING,
         store().getJobStatus(saved.getId()),
         "Status should remain PENDING after failed CAS");
+  }
+
+  @Test
+  void compareAndSwapStatus_terminalExpected_throws() {
+    // A terminal `expected` is caller misuse. Every store rejects it with IllegalArgumentException
+    // rather than silently returning false, which a caller could not distinguish from a lost race.
+    var saved = persist(newPendingJob());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            store()
+                .compareAndSwapStatus(saved.getId(), JobStatus.SUCCEEDED, JobStatus.PENDING, null));
   }
 
   @Test

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobCrudStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobCrudStoreContract.java
@@ -407,4 +407,44 @@ public abstract class AbstractJobCrudStoreContract implements JobStoreContractFi
         updated.getCreatedAt(),
         "save() must not overwrite the createdAt set by create()");
   }
+
+  @Test
+  void getQueueWaitTimePercentile_outOfRange_throws() {
+    // Every store rejects NaN and out-of-[0,1] percentiles identically rather than clamping or
+    // forwarding the value to the backend.
+    assertThrows(
+        IllegalArgumentException.class, () -> store().getQueueWaitTimePercentile(Double.NaN));
+    assertThrows(IllegalArgumentException.class, () -> store().getQueueWaitTimePercentile(-0.1));
+    assertThrows(IllegalArgumentException.class, () -> store().getQueueWaitTimePercentile(1.5));
+  }
+
+  @Test
+  void getQueueWaitTimePercentile_noData_returnsZero() {
+    assertEquals(0L, store().getQueueWaitTimePercentile(0.95), "no succeeded jobs yields 0");
+  }
+
+  @Test
+  void getQueueWaitTimePercentile_discreteNearestRank_returnsObservedValue() {
+    // Four SUCCEEDED jobs with queue_wait_ms 10, 20, 30, 40. Discrete nearest-rank
+    // (PERCENTILE_DISC)
+    // returns an actually-observed value, identical on every store. The p50 assertion is the
+    // discriminator: discrete returns 20, an interpolated percentile would return 25.
+    for (long queueWaitMs : new long[] {10L, 20L, 30L, 40L}) {
+      persistSucceededJobWithQueueWait(queueWaitMs);
+    }
+
+    assertEquals(10L, store().getQueueWaitTimePercentile(0.0), "p0 is the minimum observation");
+    assertEquals(
+        20L,
+        store().getQueueWaitTimePercentile(0.5),
+        "discrete p50 returns an observed value (20), not the interpolated 25");
+    assertEquals(40L, store().getQueueWaitTimePercentile(1.0), "p100 is the maximum observation");
+  }
+
+  private void persistSucceededJobWithQueueWait(long queueWaitMs) {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store()
+        .markJobSucceeded(saved.getId(), null, null, Instant.now(), Instant.now(), 0L, queueWaitMs);
+  }
 }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSignalStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSignalStoreContract.java
@@ -18,6 +18,7 @@ package run.ratchet.tck.store;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -217,6 +218,20 @@ public abstract class AbstractSignalStoreContract implements JobStoreContractFix
     List<JobEntity> timedOut = store().findTimedOutSignalJobs(Instant.now(), 2);
 
     assertEquals(2, timedOut.size(), "timeout scan must honor the requested batch limit");
+  }
+
+  @Test
+  void findTimedOutSignalJobs_nonPositiveLimit_throws() {
+    // Every store rejects a non-positive limit identically (no silent clamp to 1), so callers see
+    // the same IllegalArgumentException regardless of backend.
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store().findTimedOutSignalJobs(Instant.now(), 0),
+        "limit == 0 must be rejected, not clamped");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> store().findTimedOutSignalJobs(Instant.now(), -5),
+        "negative limit must be rejected");
   }
 
   @Test


### PR DESCRIPTION
The MySQL, PostgreSQL, and MongoDB stores implement one `JobStore` SPI and are meant to be drop-in interchangeable, but their behavior had drifted on the unhappy paths — not-found invariants, out-of-range arguments, and value semantics that the SPI Javadoc never pinned down. The same call could throw on one backend and silently return null, a clamped value, or a different number on another. This tightens the SPI contracts, converges the implementations, and locks the behavior with cross-store TCK tests.

## What changed

Convergence (all verified green on MySQL + PostgreSQL + MongoDB):

- **Resource permits:** MongoDB validated the resource was configured *after* a fast-path that returned `true` for an existing permit, so an unconfigured resource could skip the documented `IllegalArgumentException`. It now checks configuration first, like the SQL stores.
- **Signal timeout scan:** `findTimedOutSignalJobs` threw on a non-positive limit on MySQL but silently clamped to 1 on PostgreSQL/MongoDB. All stores now reject it, as the SPI already required.
- **Status updates:** MongoDB `updateJobStatus` flipped a job straight to a terminal status regardless of its current state, skipping the reservation/terminated-at cleanup the SQL stores perform. Terminal targets now route through the guarded terminal methods on every store.
- **Queue-wait percentile:** PostgreSQL interpolated (`PERCENTILE_CONT`) while MySQL returned an observed value, and the MongoDB fallback returned 0 for p=1.0 and never validated its input. All stores now compute a discrete nearest-rank value (`PERCENTILE_DISC`), reject NaN/out-of-range input, and agree on the same result.
- **Tag scans:** the MySQL `findJobIdsByTag` query had no `ORDER BY` and only returned ordered rows by accident of an index; the per-node tag tiebreaker also differed from PostgreSQL. Both now match PostgreSQL.
- **Corrupt-data invariants:** MySQL returned null/empty where PostgreSQL threw (a job row with no live or terminal status; a reservation claiming a queue owner with no hot row); PostgreSQL swallowed a corrupt batch progress-hook payload where MySQL rethrew. These now fail loud consistently.
- **Fault translation:** MySQL `searchJobs`, `countJobs`, and `findNodeById` let raw provider exceptions escape where PostgreSQL translated them; they now translate uniformly.
- **Other edges:** MySQL dropped an undocumented 1000-row cap on signal-delivery lookups; `compareAndSwapStatus` rejects a terminal `expected` status on MongoDB as it already did on the SQL stores; a non-positive claim limit returns an empty list on MySQL like the rest of the claim API; a malformed pagination cursor falls back to offset pagination on MySQL like PostgreSQL.

## Contract + tests

SPI Javadoc now specifies the previously-unwritten behavior (non-positive limits, percentile semantics and range, terminal-status guards, corrupt-invariant failures). New negative/edge tests were added to the shared store contracts, so they run against all three stores, plus a MongoDB-specific regression for the permit ordering (a corrupt state the cross-store SPI cannot reach).

Two divergences are intentionally left as documented variance rather than forced: nullable cron/zone coercion (better fixed by validating in the API layer, a separate write-path change) and a recurring-master no-op update returning `false` on MongoDB vs `true` on SQL.