### PR TITLE
Gate CI on a single aggregating job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,26 @@ jobs:
         with:
           name: tck-conformance-reports-${{ matrix.server }}-${{ matrix.database }}
           path: ratchet-testsuite/target/tck-*-conformance-report.md
+
+  # Single aggregating gate. Branch protection requires only this context (plus
+  # CodeQL's "Analyze (Java)" and DCO), so the volatile set of CI jobs lives
+  # here in the workflow instead of being re-enumerated in repo settings. Adding
+  # or dropping an integration-test matrix cell is gated automatically: needs
+  # waits on the whole matrix and reports its aggregate result.
+  #
+  # if: always() is required — without it a skipped upstream skips this job too,
+  # and a skipped required check sits "pending" forever and hard-blocks the PR.
+  # The step keys on failure/cancelled (not "all success") so a legitimately
+  # skipped upstream still passes the gate.
+  ci-required:
+    name: CI required
+    if: ${{ always() }}
+    needs: [build, spotbugs, ee11-verify, integration-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required jobs passed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "A required upstream job failed or was cancelled:"
+          echo '${{ toJSON(needs) }}'
+          exit 1


### PR DESCRIPTION
## What

Replace the hand-maintained list of required status checks with a single aggregating `CI required` job. It `needs:` the four jobs that run on a PR (`build`, `spotbugs`, `ee11-verify`, `integration-test`) and fails if any of them fail or are cancelled.

## Why

The required-checks list in branch protection drifted from `ci.yml`. The matrix lists five server bases (the `wildfly-ee11-managed` trio included), but only twelve `integration-test (...)` contexts were ever marked required — so a PR could merge with all three `wildfly-ee11` cells red. `spotbugs` and `ee11-verify` ran but couldn't block a merge either.

`needs: integration-test` waits on the whole matrix and reports its aggregate, so the volatile set of gated jobs lives in the workflow instead of being re-listed in repo settings. Adding or dropping a matrix cell is gated automatically from now on. This also promotes `spotbugs` and `ee11-verify` to gating — intended, since they already run on every PR.

`if: always()` is required: without it a skipped upstream skips the gate too, and a skipped required check sits pending and hard-blocks the PR. The step keys on `failure`/`cancelled` so a legitimately skipped job still passes.

## Rollout (order matters)

Required checks are enforced against each PR's head SHA, so the branch-protection change must come last or open PRs jam permanently:

1. Merge this PR. `CI required` runs but is not yet required.
2. Re-run open PRs so `CI required` reports on their head SHA; let the merge queue drain.
3. Flip branch protection: add `CI required`, drop the twelve `integration-test (...)` contexts and the now-redundant `build`. End state requires just `CI required` + `Analyze (Java)` (CodeQL stays separate — different workflow, no matrix, no drift). `DCO` is unaffected.
