### PR TITLE
Add multi-cell deployment guide, fix doc drift, and harden the Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,10 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: true
+  # Let an in-flight deploy finish instead of cancelling it. A failed CI run still
+  # fires the workflow_run trigger, and cancelling here would kill a good push-triggered
+  # deploy before its skipped build no-ops. Matches GitHub's recommended Pages config.
+  cancel-in-progress: false
 
 jobs:
   build:

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -137,6 +137,7 @@ export default defineConfig({
             { text: 'Docker', link: '/deployment/docker' },
             { text: 'Kubernetes', link: '/deployment/kubernetes' },
             { text: 'Cluster Configuration', link: '/deployment/cluster-configuration' },
+            { text: 'Multi-Cell Deployment', link: '/deployment/multi-cell' },
             { text: 'Performance Tuning', link: '/deployment/performance-tuning' },
             { text: 'Monitoring', link: '/deployment/monitoring' },
             { text: 'Troubleshooting', link: '/deployment/troubleshooting' },

--- a/website/docs/advanced/custom-logging.md
+++ b/website/docs/advanced/custom-logging.md
@@ -39,7 +39,7 @@ Each job execution receives its own `JobLogger` instance, bound to that job's ID
 
 ## Reference Pattern: JBoss Logging Implementation
 
-The default `JBossLoggingJobLogger` bridges job logs to JBoss Logging (which auto-detects the runtime backend — JBoss LogManager, SLF4J, Log4j 2, or JDK JUL) and publishes each log line as an internal `JobLogLine` event. The event is delivered to programmatic listeners and CDI observers; database persistence is not automatic unless your application observes the event and calls `JobLogStore.appendLog(...)` or installs an equivalent integration.
+The default `JBossLoggingJobLogger` bridges job logs to JBoss Logging (which auto-detects the runtime backend — JBoss LogManager, SLF4J, Log4j 2, or JDK JUL) and publishes each log line as an internal `JobLogLine` event. The event is delivered to programmatic listeners and CDI observers; database persistence is not automatic unless your application observes the event and calls `JobAuditStore.appendLog(...)` or installs an equivalent integration.
 
 ```java
 public class JBossLoggingJobLogger implements JobLogger {
@@ -97,7 +97,7 @@ public class JBossLoggingJobLogger implements JobLogger {
 If you wire a logger like this, the dual routing means:
 
 1. **Backend log output** -- Log messages appear in the container's standard log output (console, log files), prefixed with `[Job <id>]`. The actual backend depends on what JBoss Logging detects at startup: JBoss LogManager on WildFly, Logback when `ch.qos.logback.classic.Logger` is on the classpath, Log4j 2 when its API is present, and JDK `java.util.logging` as the final fallback.
-2. **Event publishing** -- Log lines are published as `JobLogLine` events through the `InternalEventPublisher`, which delivers them to registered programmatic listeners and CDI observers. Persist them to `JobLogStore` only if your application wants database-backed job traces.
+2. **Event publishing** -- Log lines are published as `JobLogLine` events through the `InternalEventPublisher`, which delivers them to registered programmatic listeners and CDI observers. Persist them to `JobAuditStore` only if your application wants database-backed job traces.
 
 ### Level Mapping
 
@@ -277,52 +277,51 @@ If you only need log persistence without console output:
 
 ```java
 import run.ratchet.spi.JobLogger;
-import run.ratchet.ri.core.InternalEventPublisher;
-import run.ratchet.ri.core.JobLogLine;
+import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.JobLogEntity.LogLevel;
 import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.UUID;
 
 public class SilentJobLogger implements JobLogger {
 
     private final UUID jobId;
-    private final InternalEventPublisher eventPublisher;
+    private final JobAuditStore auditStore;
 
-    public SilentJobLogger(UUID jobId, InternalEventPublisher eventPublisher) {
+    public SilentJobLogger(UUID jobId, JobAuditStore auditStore) {
         this.jobId = jobId;
-        this.eventPublisher = eventPublisher;
+        this.auditStore = auditStore;
     }
 
     @Override
     public void info(String message) {
-        publish(LogLevel.INFO, message);
+        persist(LogLevel.INFO, message);
     }
 
     @Override
     public void debug(String message) {
-        publish(LogLevel.DEBUG, message);
+        persist(LogLevel.DEBUG, message);
     }
 
     @Override
     public void warn(String message) {
-        publish(LogLevel.WARN, message);
+        persist(LogLevel.WARN, message);
     }
 
     @Override
     public void error(String message) {
-        publish(LogLevel.ERROR, message);
+        persist(LogLevel.ERROR, message);
     }
 
     @Override
     public void trace(String message) {
-        publish(LogLevel.TRACE, message);
+        persist(LogLevel.TRACE, message);
     }
 
-    private void publish(LogLevel level, String message) {
-        if (eventPublisher != null) {
-            eventPublisher.publish(
-                new JobLogLine(jobId, Instant.now(), level, message, new HashMap<>()));
+    private void persist(LogLevel level, String message) {
+        if (auditStore != null) {
+            auditStore.appendLog(
+                new JobLogEntity(jobId, Instant.now(), level, message));
         }
     }
 }
@@ -370,7 +369,7 @@ A worked example showing the SLF4J + Logback + JBoss Logging triangle is in [`ex
 
 ## Log Persistence
 
-If your application observes `JobLogLine` events and persists them through the `JobLogStore` SPI, you get a queryable `scheduler_job_log` table or collection:
+If your application observes `JobLogLine` events and persists them through the `JobAuditStore` SPI, you get a queryable `scheduler_job_log` table or collection:
 
 ```sql
 -- Find recent error logs for a specific job
@@ -393,7 +392,7 @@ When log persistence is wired, the `LogPurgeTimer` in the RI cleans up old log e
 
 **Leverage the event system carefully.** If your logger publishes through `InternalEventPublisher`, that dispatch is synchronous. If your custom logger does expensive work (network calls, file I/O), consider queuing log entries and flushing asynchronously to avoid blocking job execution.
 
-**Configure logger levels per category.** Ratchet's framework loggers use the fully-qualified class name as the logger category (e.g. `run.ratchet.ri.core.JobTask`). Configure levels through your backend of choice. Examples:
+**Configure logger levels per category.** Ratchet's framework loggers use the fully-qualified class name as the logger category (e.g. `run.ratchet.ri.core.internal.JobTask`). Configure levels through your backend of choice. Examples:
 
 WildFly (`standalone.xml`):
 ```xml

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -609,7 +609,7 @@ The default implementation already handles JDBC URLs with embedded credentials, 
 
 ---
 
-### 13. LambdaDescriptor
+### 14. LambdaDescriptor
 
 **Module:** `ratchet-api`
 **Package:** `run.ratchet.spi`
@@ -854,11 +854,10 @@ The TCK includes abstract contracts for each store sub-interface:
 | `AbstractLockStoreContract` | Lock acquire, release, expiry |
 | `AbstractNodeStoreContract` | Node registration, heartbeat, dead node detection |
 | `AbstractArchiveStoreContract` | Job archiving and retrieval |
-| `AbstractExecutionStoreContract` | Execution history persistence |
-| `AbstractJobLogStoreContract` | Log persistence and retrieval |
+| `AbstractJobAuditStoreContract` | Execution history + per-job log persistence |
+| `AbstractJobAnalyticsStoreContract` | Analytics/aggregation queries |
 | `AbstractTagStoreContract` | Tag-based job queries |
 | `AbstractWorkflowConditionStoreContract` | Workflow condition evaluation |
-| `AbstractBatchMetricsStoreContract` | Batch-level metrics |
 | `AbstractDlqAlertStoreContract` | DLQ alert lifecycle |
 | `AbstractResourcePermitStoreContract` | Permit acquire and release |
 | `AbstractDualWriteInvariantContract` | Cross-store invariants for dual hot/cold write paths |

--- a/website/docs/api-reference/overview.md
+++ b/website/docs/api-reference/overview.md
@@ -37,7 +37,7 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`JobPriority`](./job-options#jobpriority) | Enum | Priority levels: LOWEST, LOW, NORMAL, HIGH, CRITICAL |
 | [`BackoffPolicy`](./job-options#backoffpolicy) | Enum | Retry delay strategies: NONE, FIXED, EXPONENTIAL |
 | [`JobType`](./job-options#jobtype) | Enum | Job categories: SINGLE, RECURRING, BATCH, CHAIN, WORKFLOW, SYSTEM |
-| [`CircuitBreakerProfile`](./annotations#circuitbreakerprotected) | Enum | Pre-configured circuit breaker profiles: DEFAULT, FAST, CRITICAL, EXTERNAL_API |
+| [`CircuitBreakerProfile`](./annotations#circuitbreakerprotected) | Enum | Pre-configured circuit breaker profiles: DEFAULT, FAST, CRITICAL, EXTERNAL_API, CLAIM_PATH |
 
 ### `run.ratchet.api` — Annotations
 

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -527,7 +527,7 @@ public class MicrometerMetricsCollector implements MetricsCollector {
 
 ## JobLogger
 
-Custom logging backend for job execution. The default RI bridges to `java.util.logging`.
+Custom logging backend for job execution. The default RI bridges to JBoss Logging.
 
 :::info
 This interface is marked `@Incubating` and may change.

--- a/website/docs/comparison/vs-db-scheduler.md
+++ b/website/docs/comparison/vs-db-scheduler.md
@@ -57,7 +57,7 @@ It is clean, it is minimal, and it works.
 
 ## What Ratchet is
 
-Ratchet is bigger. It assumes CDI, ships multiple stores including MongoDB, has workflow primitives, captures `CallerPrincipal`, has a circuit breaker, a `RetryPolicy` SPI, a dead letter queue, and worker tag affinity. The reference implementation is around 60 files of source code in the `ratchet` module alone.
+Ratchet is bigger. It assumes CDI, ships multiple stores including MongoDB, has workflow primitives, captures `CallerPrincipal`, has a circuit breaker, a `RetryPolicy` SPI, a dead letter queue, and worker tag affinity. The reference implementation is around 112 files of source code in the `ratchet` module alone.
 
 Where db-scheduler asks "what's the smallest correct way to schedule a task?", Ratchet asks "what do Jakarta EE apps actually need from a scheduler, including the things you do not realize you need until you are in production?"
 

--- a/website/docs/concepts/batches.md
+++ b/website/docs/concepts/batches.md
@@ -157,13 +157,13 @@ scheduler.<User>streamingBatch("Process All Users")
 
 ### How Streaming Works
 
-1. The stream is consumed in chunks of `chunkSize` items (default: 500)
+1. The stream is consumed in chunks of `chunkSize` items (default: 100)
 2. Each chunk creates a batch of child jobs via a bulk insert
 3. The parent BATCH_PARENT job is created to track overall progress
 4. Streaming continues until the stream is exhausted
 5. Child jobs execute in parallel as they're created (no need to wait for streaming to finish)
 
-This means a million-row result set never needs to be held in memory -- it's processed in 500-item chunks.
+This means a million-row result set never needs to be held in memory -- it's processed in 100-item chunks.
 
 ### Streaming Progress
 
@@ -211,7 +211,7 @@ scheduler.<Record>streamingBatch("ETL Pipeline")
 |--------|-------------|
 | `fromStream(stream)` | Set the input stream |
 | `process(action)` | Define per-item processing logic |
-| `withChunkSize(size)` | Items per bulk insert (default: 500) |
+| `withChunkSize(size)` | Items per bulk insert (default: 100) |
 | `onProgress(hook)` | Track streaming progress |
 | `onBatchProgress(hook)` | Track batch execution progress |
 | `thenOnBatchSuccess(task)` | Execute on 100% success |

--- a/website/docs/concepts/clustering.md
+++ b/website/docs/concepts/clustering.md
@@ -168,7 +168,7 @@ public interface NodeIdentityProvider {
 
 ### Default: DefaultNodeIdentityProvider
 
-The default implementation constructs the node ID from `hostname + PID`, providing uniqueness across machines and across multiple instances on the same machine.
+The default implementation constructs the node ID as `hostname-PID-<8-char UUID>` (falling back to a bare random UUID when hostname resolution fails), providing uniqueness across machines and across multiple instances on the same machine.
 
 ### Custom Implementation
 

--- a/website/docs/concepts/error-handling.md
+++ b/website/docs/concepts/error-handling.md
@@ -160,7 +160,7 @@ When a job permanently fails (exhausts retries, `@DoNotRetry`, or `RetryPolicy` 
 ```java
 public void onDlq(@Observes JobDlqEvent event) {
     slackService.alert(String.format(
-        "Job %d moved to DLQ after %d attempts: %s",
+        "Job %s moved to DLQ after %d attempts: %s",
         event.getJobId(), event.getRetryAttempt(), event.getErrorMessage()));
 }
 ```
@@ -203,8 +203,8 @@ The failure callback is invoked **only on permanent failure** (DLQ entry), not o
 
 | Event | When | Key Fields |
 |-------|------|------------|
-| `JobRetryingEvent` | Each retry attempt | `jobId`, `errorMessage`, `attemptCount`, `nextScheduledTime` |
-| `JobDlqEvent` | Permanent failure (DLQ entry) | `jobId`, `errorMessage`, `attemptCount` |
+| `JobRetryingEvent` | Each retry attempt | `jobId`, `errorMessage`, `retryAttempt`, `scheduledTime` |
+| `JobDlqEvent` | Permanent failure (DLQ entry) | `jobId`, `errorMessage`, `retryAttempt` |
 | `JobFailedEvent` | Terminal failure only (job reaches FAILED state) -- not fired on retryable attempts | `jobId`, `errorMessage`, `retryAttempt` |
 
 ## Circuit Breaker Integration

--- a/website/docs/concepts/overview.md
+++ b/website/docs/concepts/overview.md
@@ -308,7 +308,7 @@ SPIs marked `@Incubating` may change before 1.0:
 
 | SPI | Purpose | Default |
 |-----|---------|---------|
-| `NodeIdentityProvider` | Cluster node identity | Hostname + PID |
+| `NodeIdentityProvider` | Cluster node identity | Hostname-PID-UUID suffix |
 | `ExecutorProvider` | Thread pool management | Container-managed executors |
 | `JobLoggerFactory` | Structured job logging | JBoss Logging-backed logger |
 | `ErrorSanitizer` | Exception message sanitization | Truncate + strip PII |

--- a/website/docs/concepts/persistence.md
+++ b/website/docs/concepts/persistence.md
@@ -167,7 +167,7 @@ indexes for traversal/search. MongoDB defines analogous collection indexes in
 | `idx_job_depends_on` | `scheduler_job(depends_on)` | Chain/workflow traversal |
 | `idx_job_superseded_by` | `scheduler_job(superseded_by)` | Replacement lookup |
 | `idx_job_created_at` | `scheduler_job(created_at)` | Operational search and retention |
-| `idx_job_recurring_pending` | recurring state (`job_type`, `rec_status`, `next_fire`) | Transitional recurring-master scheduling |
+| `idx_rec_claim` | `scheduler_recurring_job(next_fire) WHERE is_paused = FALSE` (PostgreSQL) / `scheduler_recurring_job(is_paused, next_fire)` (MySQL) | Recurring-master claim scheduling |
 | `idx_signal_key_status` | `scheduler_job_queue(signal_key, status)` | Atomic signal delivery by key |
 | `idx_signal_timeout_status` | `scheduler_job_queue(status, signal_timeout)` | Signal timeout scans |
 | `idx_signal_delivery_id` | `scheduler_job_queue(signal_delivery_id)` | Signal delivery event lookup |
@@ -305,15 +305,18 @@ Different databases report constraint violations differently. The `ConstraintDet
 
 ```java
 public interface ConstraintDetector {
-    boolean isUniqueConstraintViolation(Exception e);
-    boolean isForeignKeyViolation(Exception e);
+    @Nullable String constraintName(Exception e);
+    boolean isDuplicateKey(Exception e);
+    default boolean isDuplicateBusinessKey(Exception e);
+    boolean isDeadlock(Exception e);
+    boolean isTransientConnectionFailure(Exception e);
 }
 ```
 
 Each SQL store module provides a dialect-specific implementation:
 
 - **MySQL:** Parses for "Duplicate entry" in the error message
-- **PostgreSQL:** Checks SQL state codes (23505 for unique violation, 23503 for FK violation)
+- **PostgreSQL:** Checks SQL state codes (23505 for unique violation, plus deadlock/serialization and connection-failure states)
 
 This is used primarily for idempotency key enforcement -- when a duplicate key is detected, the submission is silently rejected rather than throwing an error to the caller.
 

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -316,7 +316,7 @@ A reasonable starting point:
 
 | Executor Threads | Recommended Pool Size |
 |-----------------|----------------------|
-| 8 (default) | 15-20 |
+| 20 (default) | 15-20 |
 | 16 | 25-30 |
 | 32 | 40-50 |
 | 64+ | executor threads * 1.5 |
@@ -350,7 +350,7 @@ max_connections = 200
 
 ## Schema Upgrades
 
-Ratchet uses `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` in its DDL. This means you can safely re-run the schema file against an existing database — it will create any missing tables or indexes without modifying existing ones.
+Ratchet uses `CREATE TABLE IF NOT EXISTS` in its DDL on both MySQL and PostgreSQL. On PostgreSQL it also uses `CREATE INDEX IF NOT EXISTS`; on MySQL indexes are declared inline within `CREATE TABLE IF NOT EXISTS` (MySQL has no partial indexes), so MySQL re-run safety relies on `CREATE TABLE IF NOT EXISTS` across the 18 tables. This means you can safely re-run the schema file against an existing database — it will create any missing tables or indexes without modifying existing ones.
 
 For schema changes between Ratchet versions:
 

--- a/website/docs/deployment/installation.md
+++ b/website/docs/deployment/installation.md
@@ -173,8 +173,8 @@ Start your application and verify Ratchet initialized:
 
 ```
 INFO [run.ratchet.ri.cdi.RatchetLifecycle] Ratchet starting
-INFO [run.ratchet.ri.core.DefaultNodeIdentityProvider] Scheduler nodeId=...
-INFO [run.ratchet.ri.core.Poller] Poller initialized (batch=50)
+INFO [run.ratchet.ri.core.internal.DefaultNodeIdentityProvider] Scheduler nodeId=...
+INFO [run.ratchet.ri.core.internal.Poller] Poller initialized (batch=50)
 INFO [run.ratchet.ri.cdi.RatchetLifecycle] Ratchet started
 ```
 

--- a/website/docs/deployment/multi-cell.md
+++ b/website/docs/deployment/multi-cell.md
@@ -1,0 +1,186 @@
+---
+sidebar_position: 12
+title: Multi-Cell Deployment
+description: Running several independent Ratchet cells side by side — one store per cell — for tenant isolation or throughput beyond a single shared store.
+---
+
+# Multi-Cell Deployment
+
+A **cell** is one self-contained Ratchet deployment: its own application
+instances, its own datasource, and its own schema. Running several cells
+side by side gives you isolation or aggregate throughput that a single
+shared store cannot, and it needs no special code. Ratchet already scopes
+every uniqueness guarantee — job IDs, idempotency keys, business keys — to a
+single store, so N stores are N independent schedulers that happen to run the
+same engine.
+
+This is a deployment topology, not a feature. There is no cross-cell API, no
+cell registry, and no shared coordination layer. Your application decides
+which cell a submission belongs to and talks to that cell's
+`JobSchedulerService`.
+
+## Cell vs. Cluster
+
+These are different axes and they compose. A cluster scales one store
+horizontally; a cell adds another store.
+
+| | Shared-store cluster | Multi-cell |
+|---|---|---|
+| **Stores** | One store, many nodes | One store *per cell* |
+| **Coordination** | Database claim (`SKIP LOCKED`) + optional `ClusterCoordinator` | None between cells |
+| **Scales** | Worker capacity against one store | Aggregate store throughput and isolation |
+| **Job visibility** | All nodes see all jobs | Each cell sees only its own jobs |
+| **Failure blast radius** | One store is a shared fate | Each cell fails independently |
+
+A single cell is almost always itself a cluster: multiple nodes sharing that
+cell's store. "Multi-cell" describes the relationship *between* stores.
+
+## When You Actually Need Cells
+
+Reach for cells only when a shared-store cluster cannot give you what you
+need. Most deployments never do.
+
+**A shared-store cluster (optionally with worker tag affinity) is enough when:**
+
+- One database can hold and serve your whole job population.
+- You want different node groups to handle different work. Worker tag
+  affinity routes jobs to eligible nodes *within one store* — tag a job with
+  `withTags(...)` and constrain a node's claims with a
+  [`NodeTagAffinityProvider`](/advanced/spi-implementation). No second store
+  is required for workload routing.
+- Tenants can coexist in one schema with application-level scoping.
+
+**Move to cells when:**
+
+- **You need a hard isolation boundary.** Separate schemas mean a tenant's
+  data, retention policy, and schema evolution are physically independent,
+  and one tenant's load cannot starve another's claims.
+- **You have outgrown one store's write throughput.** A single store has a
+  commit-throughput ceiling — under sustained enqueue load the bottleneck is
+  transaction commit, not worker count, so adding nodes does not help past a
+  point. Splitting the workload across cells multiplies the number of
+  independent commit pipelines. See [Performance
+  Tuning](/deployment/performance-tuning) for the single-store analysis.
+
+Worker tag affinity and cells answer different questions. Tag affinity asks
+*which node runs this job* inside one store. Cells ask *which store the job
+lives in at all*. Use affinity first; reach for cells when a single store is
+the wrong unit of isolation or throughput.
+
+## Pattern 1: Cell per Tenant
+
+Each tenant gets its own cell — its own schema, and usually its own
+connection pool.
+
+```
+Tenant A  ->  Ratchet cell A  ->  schema_a
+Tenant B  ->  Ratchet cell B  ->  schema_b
+Tenant C  ->  Ratchet cell C  ->  schema_c
+```
+
+Use it for:
+
+- **Compliance and data residency** — a tenant's jobs, payloads, and history
+  never share a table with another tenant's.
+- **A billing or quota boundary** — per-cell metrics attribute load directly
+  to a tenant.
+- **Independent schema evolution** — migrate or pause one tenant's cell
+  without touching the others.
+
+The cost is operational: more schemas to provision, migrate, and monitor.
+Below a few dozen tenants this is usually worth it for the isolation; far
+beyond that, a shared schema with application-level tenant scoping is the
+more practical choice unless regulation forces separation.
+
+## Pattern 2: Cell per Workload Domain
+
+Each cell owns a class of work whose throughput and latency profile differs
+from the others.
+
+```
+High-frequency reconciliation  ->  cell "reconcile"
+Low-frequency reporting         ->  cell "reports"
+User-facing notifications       ->  cell "notify"
+```
+
+Use it for:
+
+- **Protecting latency-sensitive work from bulk work** — a reporting batch
+  that saturates its own store's commit pipeline cannot slow down
+  notification jobs in a different cell.
+- **Tuning each store independently** — poll interval, batch size, retention,
+  and pool sizing per domain.
+- **Independent scaling** — grow the reconciliation cell's node count without
+  touching the reporting cell.
+
+This is the throughput-and-isolation pattern. When one shared store would
+mix a heavy, commit-bound workload with a light, latency-sensitive one,
+separate cells keep their commit pipelines apart.
+
+## Cross-Cell Non-Guarantees
+
+Cells are independent stores. Every Ratchet guarantee that is scoped to a
+store stops at the cell boundary. Read these before adopting the model.
+
+- **Job chains and cascades do not cross cells.** A `thenOnSuccess` /
+  `thenOnFailure` chain, a workflow, a batch parent and its children, and a
+  recurring master and its instances all live in one store. A step cannot
+  depend on, trigger, or wait for a job in another cell.
+- **Idempotency keys are per-cell.** The `idempotency_key` uniqueness
+  constraint exists within one schema. The same key submitted to two cells
+  produces two jobs.
+- **Business-key deduplication is per-cell.** The active-unique business-key
+  guard is a per-schema index. Two cells can each hold an active job with the
+  same business key.
+- **Tag-scoped queries and cancellation see one cell.** `JobQueryService`,
+  `cancelJobsByTag`, and `cancelRecurringJobsByTag` operate against the cell
+  whose store you queried. There is no fan-out across cells.
+- **Signals are per-cell.** `deliverSignal` reaches only waiting jobs in the
+  cell it is delivered to.
+
+The application owns anything that must span cells. If you need a workflow
+to cross a boundary, model it with an explicit cross-cell handoff in your own
+code, not with a Ratchet chain.
+
+## Routing Submissions
+
+Because there is no cross-cell layer, routing is the application's
+responsibility: choose the cell, then submit to that cell's
+`JobSchedulerService`. The job never moves between cells afterward — it is
+claimed, executed, retried, and archived entirely within the cell it was
+created in.
+
+Keep the routing key stable and outside the job payload. For cell-per-tenant
+the key is the tenant ID; for cell-per-domain it is the workload class. A job
+submitted to the wrong cell is not an error Ratchet can detect — it will run
+in that cell against that cell's data.
+
+## Sizing Reference
+
+Pick the smallest model that satisfies your strongest requirement. Isolation
+and throughput pull toward cells; everything else favors a single store.
+
+| Isolation need | Throughput need | Recommended model |
+|---|---|---|
+| None (shared schema is fine) | Within one store's commit ceiling | **Single shared-store cluster** |
+| Route work to specific nodes | Within one store's commit ceiling | **Shared-store cluster + worker tag affinity** |
+| Physical per-tenant separation | Per tenant, modest | **Cell per tenant** |
+| Keep workload classes apart | One workload is commit-bound | **Cell per workload domain** |
+| Per-tenant separation *and* high aggregate volume | Exceeds one store | **Cells, sized per tenant or domain** |
+
+Throughput planning starts with a single cell, because the ceiling is a
+property of one store. Establish what one cell sustains for your workload and
+hardware (the limiting factor is transaction commit, not worker count — see
+[Performance Tuning](/deployment/performance-tuning)), then add cells when
+your aggregate target or isolation requirement exceeds it. Each cell is
+sized like any single deployment: see [Cluster
+Configuration](/deployment/cluster-configuration) for per-cell node, pool,
+and polling tuning.
+
+## See Also
+
+- [Deployment Overview](/deployment/overview) — application server, database, and module requirements
+- [Clustering](/deployment/clustering) — scaling one store across nodes with `SKIP LOCKED`
+- [Cluster Configuration](/deployment/cluster-configuration) — per-cell node, pool, and polling tuning
+- [Performance Tuning](/deployment/performance-tuning) — the single-store commit-throughput ceiling
+- [SPI Implementation](/advanced/spi-implementation) — `NodeTagAffinityProvider` for in-store workload routing

--- a/website/docs/deployment/mysql.md
+++ b/website/docs/deployment/mysql.md
@@ -180,7 +180,7 @@ INDEX idx_claim_executable (status, job_type, scheduled_time, priority, job_id)
 INDEX idx_queue_orphan (status, picked_at, picked_by)
 
 -- recurring-master scheduling
-INDEX idx_job_recurring_pending (job_type, rec_status, next_fire)
+INDEX idx_rec_claim (is_paused, next_fire)
 ```
 
 ## Performance Tuning

--- a/website/docs/deployment/overview.md
+++ b/website/docs/deployment/overview.md
@@ -14,7 +14,7 @@ Ratchet is a portable, CDI-based job scheduler for Jakarta EE 10/11. It deploys 
 |-----------|-------------|-------|
 | **Java** | 17 or later | Virtual threads available on 21+ |
 | **Jakarta EE Runtime** | 10/11 with CDI, JPA, Interceptors, and Jakarta Concurrency | WildFly, Payara, Open Liberty, GlassFish 8, etc. |
-| **CDI** | 4.0+ | `beans.xml` with `bean-discovery-mode="all"` |
+| **CDI** | 4.0+ | `beans.xml` with `bean-discovery-mode="annotated"` |
 | **Database** | MySQL 8+, PostgreSQL 14+, or MongoDB 6+ | One store module per database |
 | **Build Tool** | Maven 3.8+ | BOM import for version management |
 

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -289,7 +289,7 @@ LIMIT 100
 FOR UPDATE SKIP LOCKED;
 ```
 
-The query should use `idx_claim_executable` on `scheduler_job_queue` on both PostgreSQL and MySQL — it is the hot-path claim index, partial on `status = 'PENDING'`. A sort on computed effective priority is expected; a full scan of the pending queue is not. If you see a sequential scan, check that statistics are up to date:
+The query should use `idx_claim_executable` on `scheduler_job_queue` on both PostgreSQL and MySQL — it is the hot-path claim index. On PostgreSQL it is partial on `status = 'PENDING'`; on MySQL it is a plain index with `status` as the leading column (MySQL has no partial indexes). A sort on computed effective priority is expected; a full scan of the pending queue is not. If you see a sequential scan, check that statistics are up to date:
 
 ```sql
 -- PostgreSQL

--- a/website/docs/deployment/troubleshooting.md
+++ b/website/docs/deployment/troubleshooting.md
@@ -165,7 +165,7 @@ Only reset jobs if you're certain the claiming node is truly dead. Resetting a j
 
 ### Poll cycle taking too long
 
-**Symptom:** `PerformanceMetricsEvent` shows poll cycles > 1 second.
+**Symptom:** Poller logs or claim-query latency show poll cycles taking longer than 1 second.
 
 **Diagnosis:** Check if the polling query is using indexes:
 

--- a/website/docs/getting-started/basic-concepts.md
+++ b/website/docs/getting-started/basic-concepts.md
@@ -75,7 +75,7 @@ scheduler.enqueue(() -> processInvoice(invoiceId))
     .submit();                         // Persists and returns a JobHandle
 ```
 
-The builder is not submitted until you call `.submit()` (or `.immediate()` for cluster-wide wakeup). See the [JobBuilder API](../api-reference/job-builder.md) for all options.
+The builder is not submitted until you call `.submit()`. Use `.immediate()` beforehand to flag the job for an immediate cross-node wakeup hint. See the [JobBuilder API](../api-reference/job-builder.md) for all options.
 
 ## JobHandle
 
@@ -132,8 +132,7 @@ A **store** is the persistence backend that holds jobs, execution history, locks
 |-----------|---------------|
 | `JobCrudStore` | CRUD operations on jobs |
 | `JobClaimStore` | Claiming due jobs for execution (`SKIP LOCKED` on SQL stores, atomic updates on MongoDB) |
-| `ExecutionStore` | Recording execution history |
-| `JobLogStore` | Optional structured storage for persisted `JobLogLine` events |
+| `JobAuditStore` | Execution history and per-job log persistence (optional capability) |
 | `ArchiveStore` | Moving completed jobs to archive |
 | `NodeStore` | Cluster node heartbeats |
 | `LockStore` | Distributed advisory locks |

--- a/website/docs/getting-started/first-job.md
+++ b/website/docs/getting-started/first-job.md
@@ -270,7 +270,6 @@ Ratchet fires events for every job lifecycle transition. The full set of event t
 | `JobCompletedEvent` | Job finishes successfully |
 | `JobFailedEvent` | Job fails after exhausting retries |
 | `JobRetryingEvent` | Job failed but will be retried |
-| `JobCancellingEvent` | Job cancellation requested |
 | `JobCancelledEvent` | Job successfully cancelled |
 | `JobPausedEvent` | Job paused via `pauseJob()` |
 | `JobResumedEvent` | Job resumed via `resumeJob()` |
@@ -281,7 +280,6 @@ Ratchet fires events for every job lifecycle transition. The full set of event t
 | `ChainCompletedEvent` | Final step in a chain completes |
 | `ChainFailedEvent` | A chain step failed |
 | `WorkflowBranchTriggeredEvent` | A conditional workflow branch was triggered |
-| `PerformanceMetricsEvent` | Periodic performance metrics snapshot |
 
 All events extend `AbstractJobSchedulerEvent`, which provides common fields: `jobId`, `businessKey`, `jobType`, `priority`, `nodeId`, and `timestamp`.
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -156,7 +156,7 @@ Ratchet keeps its dependency footprint small. Here's what each module brings in:
 | Module | Key Dependencies |
 |--------|-----------------|
 | `ratchet-api` | `jakarta.enterprise.cdi-api` (for `@InterceptorBinding` on `@CircuitBreakerProtected`) |
-| `ratchet` | ASM 9.7.1 (lambda bytecode analysis), cron-utils 9.2.1 (cron expression parsing), JBoss Logging; Jakarta EE APIs are provided by the runtime |
+| `ratchet` | ASM 9.8 (lambda bytecode analysis), cron-utils 9.2.1 (cron expression parsing), JBoss Logging; Jakarta EE APIs are provided by the runtime |
 | `ratchet-store-core` | Jakarta Persistence / JSON APIs, ASM, JBoss Logging |
 | `ratchet-store-mysql` / `ratchet-store-postgresql` | SQL store logic; JDBC drivers are supplied by the application server or your deployment |
 | `ratchet-store-mongodb` | MongoDB sync driver |

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -152,8 +152,8 @@ When the application starts, you should see:
 
 ```
 INFO [run.ratchet.ri.cdi.RatchetLifecycle] Ratchet starting
-INFO [run.ratchet.ri.core.DefaultNodeIdentityProvider] Scheduler nodeId=...
-INFO [run.ratchet.ri.core.Poller] Poller initialized (batch=50)
+INFO [run.ratchet.ri.core.internal.DefaultNodeIdentityProvider] Scheduler nodeId=...
+INFO [run.ratchet.ri.core.internal.Poller] Poller initialized (batch=50)
 INFO [run.ratchet.ri.cdi.RatchetLifecycle] Ratchet started
 ```
 

--- a/website/docs/troubleshooting/common-issues.md
+++ b/website/docs/troubleshooting/common-issues.md
@@ -54,8 +54,8 @@ The most common cause of a broken fresh deployment is an empty `ClassPolicy` all
 ```
 ERROR: ClassPolicy allowedPackages is empty — refusing to start. Provide an
 @Alternative @Priority(APPLICATION) ClassPolicy bean with your application's package
-prefixes, or opt out (ONLY for demos/tests) with
-RatchetOptions.builder().security(s -> s.allowEmptyClassPolicy(true)).build()
+prefixes, or set RatchetOptions.security(...allowEmptyClassPolicy(true)) ONLY for
+demos/tests.
 ```
 
 You must provide a `ClassPolicy` bean that allows your application packages:
@@ -129,7 +129,7 @@ SEVERE: Job 12345 target method not found: processData with descriptor (Ljava/la
 Ratchet requires the target method to be `public`. If the method is `private`, `protected`, or package-private, you will see:
 
 ```
-SecurityException: Method processData in class com.myapp.MyService is private
+Method processData in class com.myapp.MyService is private
     — only public methods can be scheduled as jobs. Change the method visibility to public.
 ```
 
@@ -321,7 +321,7 @@ Ratchet uses type-isolated thread pools with semaphore-based concurrency limits.
 When a pool is at capacity, the poller skips claiming jobs of that type. Look for:
 
 ```
-ThreadPoolManager initialized with managed executors with semaphore-based limiting
+Thread pool 'ratchet' initialized with semaphore-based accounting
 ```
 
 **Diagnosis:**

--- a/website/docs/troubleshooting/debugging.md
+++ b/website/docs/troubleshooting/debugging.md
@@ -313,14 +313,14 @@ Set fine-grained log levels to focus on the subsystem you are debugging:
 
 | What you are debugging | Logger to set to FINE/DEBUG |
 |---|---|
-| Job not being picked up | `run.ratchet.ri.core.Poller` |
-| Job execution failures | `run.ratchet.ri.core.JobTask` |
-| Retry/backoff decisions | `run.ratchet.ri.core.JobTask` |
+| Job not being picked up | `run.ratchet.ri.core.internal.Poller` |
+| Job execution failures | `run.ratchet.ri.core.internal.JobTask` |
+| Retry/backoff decisions | `run.ratchet.ri.core.internal.JobTask` |
 | Security/ClassPolicy rejections | `run.ratchet.ri.security` |
 | Circuit breaker behavior | `run.ratchet.ri.resilience` |
-| Thread pool saturation | `run.ratchet.ri.core.ThreadPoolManager` |
-| Orphan recovery | `run.ratchet.ri.core.OrphanRecoveryTimer` |
-| Timeout enforcement | `run.ratchet.ri.core.JobTimeoutHandler` |
+| Thread pool saturation | `run.ratchet.ri.core.internal.ThreadPoolManager` |
+| Orphan recovery | `run.ratchet.ri.core.internal.OrphanRecoveryTimer` |
+| Timeout enforcement | `run.ratchet.ri.core.internal.JobTimeoutHandler` |
 | CDI bean resolution | `run.ratchet.ri.cdi` |
 | Recurring job scheduling | `run.ratchet.ri.core.RecurringScheduler` |
 | Batch orchestration | `run.ratchet.ri.core.BatchService` |

--- a/website/docs/troubleshooting/faq.md
+++ b/website/docs/troubleshooting/faq.md
@@ -39,7 +39,7 @@ The SQL modules provide DDL scripts (`src/main/resources/ddl/`) as plain SQL fil
 
 When a job fails, Ratchet follows this decision path:
 
-1. **Check for `@DoNotRetry`:** If the exception class (or any class in its hierarchy) is annotated with `@DoNotRetry`, the job skips all retry logic and moves directly to the DLQ.
+1. **Check for `@DoNotRetry`:** If the exception class (or any exception in its cause chain) is annotated with `@DoNotRetry`, the job skips all retry logic and moves directly to the DLQ.
 
 2. **Consult the RetryPolicy SPI:** The `RetryPolicy.shouldRetry(attempt, cause)` method is called. The default implementation (`DefaultRetryPolicy`) always returns `true`, deferring to the attempt limit.
 
@@ -79,7 +79,7 @@ Yes. Ratchet is designed for multi-node deployment. Each node runs its own polle
 - **Automatic failover:** If a node crashes, the `OrphanRecoveryTimer` on surviving nodes detects stale heartbeats and resets orphaned RUNNING jobs back to PENDING.
 - **Node identity:** Each node registers in `scheduler_node` with a unique ID and periodic heartbeat (default every 10 seconds).
 
-There is no built-in job routing or affinity -- any node can execute any job. If you need affinity (e.g., "only node X should run this type of job"), implement a custom `ClusterCoordinator` SPI.
+Ratchet supports worker tag affinity: tag jobs with `withTags(...)` and constrain which jobs a node claims by providing a `NodeTagAffinityProvider` (default `DefaultNodeTagAffinityProvider`, consumed by the poller). For fully custom routing or cross-node wakeups, implement the `ClusterCoordinator` SPI.
 
 **Key multi-node settings:**
 

--- a/website/docs/troubleshooting/overview.md
+++ b/website/docs/troubleshooting/overview.md
@@ -13,7 +13,7 @@ When something goes wrong with your Ratchet jobs, there are several layers of ob
 Follow this general strategy when troubleshooting Ratchet issues:
 
 1. **Check the job status in the database** -- live state (`PENDING`/`RUNNING`/`PAUSED`/`WAITING`) is on the `scheduler_job_queue` table; terminal outcome lives on `scheduler_job`
-2. **Review the logs** -- Ratchet uses `java.util.logging` (JUL) with detailed lifecycle messages
+2. **Review the logs** -- Ratchet logs through JBoss Logging (most Jakarta EE runtimes route this to their own logging subsystem; it falls back to `java.util.logging` if no other backend is present) with detailed lifecycle messages
 3. **Listen to events** -- the event system provides real-time visibility into job state transitions
 4. **Inspect execution history** -- the `scheduler_job_execution` table records every attempt
 
@@ -100,7 +100,6 @@ public class JobDiagnosticObserver {
 | `JobCompletedEvent` | Job finishes successfully |
 | `JobRetryingEvent` | Job failed but will be retried (includes next scheduled time) |
 | `JobDlqEvent` | Job exhausted retries and moved to dead letter queue |
-| `JobCancellingEvent` | Cancel request received for a job |
 | `JobCancelledEvent` | Job successfully canceled |
 | `JobPausedEvent` | Job paused via `pauseJob()` |
 | `JobResumedEvent` | Job resumed via `resumeJob()` |
@@ -110,11 +109,10 @@ public class JobDiagnosticObserver {
 | `ChainCompletedEvent` | All chain steps completed successfully |
 | `ChainFailedEvent` | A chain step failed permanently |
 | `WorkflowBranchTriggeredEvent` | A conditional workflow branch was activated |
-| `PerformanceMetricsEvent` | Periodic metrics snapshot |
 
 ## Logging Configuration
 
-Ratchet uses `java.util.logging` (JUL) under the package `run.ratchet`. Most Jakarta EE runtimes bridge JUL to their logging subsystem.
+Ratchet logs through JBoss Logging (most Jakarta EE runtimes route this to their own logging subsystem; it falls back to `java.util.logging` if no other backend is present) under the package `run.ratchet`. Most Jakarta EE runtimes bridge it to their logging subsystem.
 
 ### WildFly / JBoss EAP
 
@@ -126,10 +124,10 @@ Add a logger category in your `standalone.xml`:
         <level name="DEBUG"/>
     </logger>
     <!-- For detailed poller and thread pool diagnostics -->
-    <logger category="run.ratchet.ri.core.Poller">
+    <logger category="run.ratchet.ri.core.internal.Poller">
         <level name="FINE"/>
     </logger>
-    <logger category="run.ratchet.ri.core.ThreadPoolManager">
+    <logger category="run.ratchet.ri.core.internal.ThreadPoolManager">
         <level name="FINE"/>
     </logger>
 </subsystem>
@@ -155,10 +153,10 @@ Add to `server.xml`:
 
 | Logger | What It Logs |
 |---|---|
-| `run.ratchet.ri.core.JobTask` | Job execution lifecycle, payload resolution, retry decisions |
-| `run.ratchet.ri.core.Poller` | Poll cycle results, claim counts, adaptive delay changes |
-| `run.ratchet.ri.core.OrphanRecoveryTimer` | Orphan detection and recovery actions |
-| `run.ratchet.ri.core.JobTimeoutHandler` | Soft and hard timeout warnings |
+| `run.ratchet.ri.core.internal.JobTask` | Job execution lifecycle, payload resolution, retry decisions |
+| `run.ratchet.ri.core.internal.Poller` | Poll cycle results, claim counts, adaptive delay changes |
+| `run.ratchet.ri.core.internal.OrphanRecoveryTimer` | Orphan detection and recovery actions |
+| `run.ratchet.ri.core.internal.JobTimeoutHandler` | Soft and hard timeout warnings |
 | `run.ratchet.ri.resilience.CircuitBreaker` | Circuit breaker state transitions |
 | `run.ratchet.ri.security.JobSecurityValidator` | Security validation results and rejections |
 | `run.ratchet.ri.security.PackagePrefixClassPolicy` | Class policy allow/deny decisions |
@@ -168,14 +166,15 @@ Add to `server.xml`:
 Ratchet automatically sets MDC (Mapped Diagnostic Context) values during job execution:
 
 - `jobId` -- the job's unique identifier
-- `nodeId` -- the cluster node executing the job
+- `node` -- the cluster node executing the job
+- `jobType` -- the job's execution type
 - `jobCreator` -- the user who created the job (if set)
 
 These MDC values are available in your log format patterns for correlation:
 
 ```
 # Example log4j2 pattern
-%d{ISO8601} [%X{jobId}] [%X{nodeId}] %-5p %c - %m%n
+%d{ISO8601} [%X{jobId}] [%X{node}] %-5p %c - %m%n
 ```
 
 ## Configuration Reference


### PR DESCRIPTION
## Summary

Three docs-facing changes:

1. **New multi-cell deployment guide** (`website/docs/deployment/multi-cell.md`, wired into the deployment sidebar). Documents running several independent Ratchet cells side by side, one store and schema per cell, for tenant isolation or throughput past a single shared store. Covers the cell-per-tenant and cell-per-workload-domain patterns, the per-cell uniqueness boundary (chains, idempotency keys, business keys, tag-scoped queries, and signals all stop at the cell edge), when a shared-store cluster with worker tag affinity is enough instead, and a sizing reference.

2. **Documentation accuracy sweep.** Checked the published docs against the current source and fixed roughly 30 references that had drifted. Highlights:
   - `JobLogStore`/`ExecutionStore` (removed SPIs) replaced with `JobAuditStore`; three non-existent TCK contract classes dropped.
   - The custom-logging example imported a package-private record and the wrong package for `InternalEventPublisher`; rewritten to compile against the real `JobLogger` interface.
   - "uses java.util.logging" corrected to JBoss Logging; framework logger categories given their real `.internal` package.
   - `idx_job_recurring_pending`/`rec_status` (gone with the dedicated recurring-master table) replaced with `idx_rec_claim`.
   - Removed `JobCancellingEvent` and `PerformanceMetricsEvent` (not real events); corrected the FAQ claim that worker tag affinity does not exist.
   - Smaller fixes: streaming chunk default of 100, ASM 9.8, the MDC `node` key, the `ConstraintDetector` method set, `CircuitBreakerProfile.CLAIM_PATH`, and a UUID format-string bug.

3. **Docs deploy workflow fix.** The Pages workflow shared one concurrency group across its push and post-CI triggers with `cancel-in-progress: true`. When CI fails, the post-CI run could cancel an in-flight push deploy and then skip its own build, leaving the site un-updated. Set `cancel-in-progress: false` so in-flight deploys finish, matching the recommended Pages setup.

Every accuracy fix was verified against the source before the doc was changed.

## Testing

- [x] `cd website && npm run build` — VitePress build clean, no dead links
- [ ] Maven targets not applicable; no Java sources changed

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

Docs-only change plus a one-line workflow tweak; no Java touched.

Unrelated heads-up: `main` CI is currently red on a flaky `WorkerTagAffinityIT` claim-timing test in the GlassFish+MySQL cell (182 run, 1 failure). While CI stays red, the post-CI deploy path that regenerates conformance reports from CI artifacts stays skipped, so those pages serve their committed versions until CI goes green. Neither is caused by or fixable here.
