### PR TITLE
Stabilize the flaky WorkerTagAffinityIT (quiesce the background poller)

### DIFF
--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/core/WorkerTagAffinityIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/core/WorkerTagAffinityIT.java
@@ -27,6 +27,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.NodeTagFilter;
+import run.ratchet.ri.core.PollerScheduler;
 import run.ratchet.ri.payload.JobPayloadFactory;
 import run.ratchet.store.dto.JobClaimDto;
 import run.ratchet.store.entity.JobEntity;
@@ -35,6 +36,7 @@ import run.ratchet.store.spi.JobClaimStore;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.TagStore;
 import run.ratchet.testsuite.util.BaseRatchetIT;
+import run.ratchet.testsuite.util.PollerControl;
 import run.ratchet.testsuite.util.RatchetArchiveBuilder;
 
 /**
@@ -46,6 +48,7 @@ class WorkerTagAffinityIT extends BaseRatchetIT {
   @Inject private JobCrudStore jobCrudStore;
   @Inject private JobClaimStore jobClaimStore;
   @Inject private TagStore tagStore;
+  @Inject private PollerScheduler pollerScheduler;
 
   @Deployment
   public static WebArchive createDeployment() {
@@ -56,6 +59,16 @@ class WorkerTagAffinityIT extends BaseRatchetIT {
         .addStoreInfrastructure()
         .addBeansXml()
         .build();
+  }
+
+  // This IT drives the claim store directly, so the engine's auto-started poller must not race it
+  // for the same PENDING rows (a poll tick between persistJob and claim consumes the job, and the
+  // direct claim then sees nothing). Stop the poller before each truncate; nothing restarts it, so
+  // it stays quiescent for the test body. This also keeps TRUNCATE from deadlocking a live cycle.
+  @Override
+  protected void truncateAll() throws Exception {
+    PollerControl.stopAndAwait(pollerScheduler);
+    super.truncateAll();
   }
 
   @Test

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/performance/BasePerformanceIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/performance/BasePerformanceIT.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.inject.Inject;
-import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,7 +28,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Future;
 import java.util.function.LongSupplier;
 import org.awaitility.core.ConditionTimeoutException;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -40,7 +38,6 @@ import run.ratchet.api.JobHandle;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.SerializableCheckedRunnable;
 import run.ratchet.ri.core.PollerScheduler;
-import run.ratchet.ri.core.internal.DefaultPollerScheduler;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobClaimStore;
 import run.ratchet.store.spi.JobStore;
@@ -53,6 +50,7 @@ import run.ratchet.testsuite.util.BaseRatchetIT;
 import run.ratchet.testsuite.util.PerformanceBaseline;
 import run.ratchet.testsuite.util.PerformanceReport;
 import run.ratchet.testsuite.util.PerformanceReportWriter;
+import run.ratchet.testsuite.util.PollerControl;
 import run.ratchet.testsuite.util.RatchetArchiveBuilder;
 
 /** Shared setup for performance ITs. */
@@ -69,8 +67,6 @@ public abstract class BasePerformanceIT extends BaseRatchetIT {
   protected static final Duration PERF_POLL_INTERVAL =
       Duration.ofMillis(Long.getLong("perf.poll.interval.ms", 200));
 
-  private static final Duration POLLER_STOP_TIMEOUT = Duration.ofSeconds(5);
-  private static final Duration POLLER_STOP_POLL_INTERVAL = Duration.ofMillis(10);
   private static final ConcurrentMap<Class<?>, PerformanceBaseline> BASELINES =
       new ConcurrentHashMap<>();
   private static final ConcurrentMap<Class<?>, PerformanceReportWriter> REPORT_WRITERS =
@@ -191,31 +187,12 @@ public abstract class BasePerformanceIT extends BaseRatchetIT {
   /** Stop poller to avoid TRUNCATE deadlock. */
   @Override
   protected void truncateAll() throws Exception {
-    pollerScheduler.stop();
-    await()
-        .atMost(POLLER_STOP_TIMEOUT)
-        .pollInterval(POLLER_STOP_POLL_INTERVAL)
-        .until(() -> pollerSchedulerStopped(pollerScheduler));
+    PollerControl.stopAndAwait(pollerScheduler);
     super.truncateAll();
   }
 
   static boolean pollerSchedulerStopped(PollerScheduler scheduler) {
-    Object lock = readField(scheduler, "scheduleLock", Object.class);
-    synchronized (lock) {
-      Future<?> handle = readField(scheduler, "handle", Future.class);
-      return !readField(scheduler, "cycleRunning", Boolean.class)
-          && (handle == null || handle.isDone() || handle.isCancelled());
-    }
-  }
-
-  private static <T> T readField(Object target, String name, Class<T> type) {
-    try {
-      Field field = DefaultPollerScheduler.class.getDeclaredField(name);
-      field.setAccessible(true);
-      return type.cast(field.get(target));
-    } catch (ReflectiveOperationException e) {
-      throw new IllegalStateException("Unable to read " + name + " from " + target.getClass(), e);
-    }
+    return PollerControl.isStopped(scheduler);
   }
 
   protected List<JobHandle> enqueueN(int count, SerializableCheckedRunnable task) {

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/PollerControl.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/PollerControl.java
@@ -43,8 +43,9 @@ public final class PollerControl {
 
   /** Stops the poller and blocks until no cycle is running and no future cycle is scheduled. */
   public static void stopAndAwait(PollerScheduler scheduler) {
-    scheduler.stop();
-    await().atMost(STOP_TIMEOUT).pollInterval(STOP_POLL_INTERVAL).until(() -> isStopped(scheduler));
+    DefaultPollerScheduler poller = asDefault(scheduler);
+    poller.stop();
+    await().atMost(STOP_TIMEOUT).pollInterval(STOP_POLL_INTERVAL).until(() -> isStopped(poller));
   }
 
   /**
@@ -53,20 +54,37 @@ public final class PollerControl {
    * idle-state query.
    */
   public static boolean isStopped(PollerScheduler scheduler) {
-    Object lock = readField(scheduler, "scheduleLock", Object.class);
+    DefaultPollerScheduler poller = asDefault(scheduler);
+    Object lock = readField(poller, "scheduleLock", Object.class);
     synchronized (lock) {
-      Future<?> handle = readField(scheduler, "handle", Future.class);
-      return !readField(scheduler, "cycleRunning", Boolean.class)
+      Future<?> handle = readField(poller, "handle", Future.class);
+      return !readField(poller, "cycleRunning", Boolean.class)
           && (handle == null || handle.isDone() || handle.isCancelled());
     }
   }
 
-  private static <T> T readField(Object target, String name, Class<T> type) {
+  /**
+   * Narrows to the concrete poller whose internals this helper reflects over, failing fast with an
+   * actionable message if a different {@link PollerScheduler} implementation is ever wired in. (A
+   * normal-scoped CDI client proxy still passes, since it subclasses the bean type.)
+   */
+  private static DefaultPollerScheduler asDefault(PollerScheduler scheduler) {
+    if (scheduler instanceof DefaultPollerScheduler poller) {
+      return poller;
+    }
+    throw new IllegalStateException(
+        "PollerControl requires a "
+            + DefaultPollerScheduler.class.getName()
+            + " but was given "
+            + (scheduler == null ? "null" : scheduler.getClass().getName()));
+  }
+
+  private static <T> T readField(DefaultPollerScheduler target, String name, Class<T> type) {
     try {
       Field field = DefaultPollerScheduler.class.getDeclaredField(name);
       field.setAccessible(true);
       return type.cast(field.get(target));
-    } catch (ReflectiveOperationException e) {
+    } catch (ReflectiveOperationException | RuntimeException e) {
       throw new IllegalStateException("Unable to read " + name + " from " + target.getClass(), e);
     }
   }

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/PollerControl.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/PollerControl.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.util;
+
+import static org.awaitility.Awaitility.await;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import run.ratchet.ri.core.PollerScheduler;
+import run.ratchet.ri.core.internal.DefaultPollerScheduler;
+
+/**
+ * Quiesces the engine's background poller for integration tests that drive the store directly.
+ *
+ * <p>The full reference implementation deploys into the Arquillian container, and {@code
+ * RatchetLifecycle} auto-starts the poller. A test that calls {@code claimNextBatchOptimized}
+ * itself is then racing that poller for the same PENDING rows: when a poll tick lands between
+ * inserting a job and the test's own claim, the poller consumes the job and the direct claim sees
+ * nothing. Stopping the poller (and waiting for any in-flight cycle to finish) removes the race so
+ * the store sees only the test's own claims. It also avoids a {@code TRUNCATE} deadlocking against
+ * a live poll cycle's row locks.
+ */
+public final class PollerControl {
+
+  private static final Duration STOP_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration STOP_POLL_INTERVAL = Duration.ofMillis(10);
+
+  private PollerControl() {}
+
+  /** Stops the poller and blocks until no cycle is running and no future cycle is scheduled. */
+  public static void stopAndAwait(PollerScheduler scheduler) {
+    scheduler.stop();
+    await().atMost(STOP_TIMEOUT).pollInterval(STOP_POLL_INTERVAL).until(() -> isStopped(scheduler));
+  }
+
+  /**
+   * Returns {@code true} when the poller has no cycle currently running and no scheduled handle
+   * pending. Reads {@link DefaultPollerScheduler} internals reflectively because the SPI exposes no
+   * idle-state query.
+   */
+  public static boolean isStopped(PollerScheduler scheduler) {
+    Object lock = readField(scheduler, "scheduleLock", Object.class);
+    synchronized (lock) {
+      Future<?> handle = readField(scheduler, "handle", Future.class);
+      return !readField(scheduler, "cycleRunning", Boolean.class)
+          && (handle == null || handle.isDone() || handle.isCancelled());
+    }
+  }
+
+  private static <T> T readField(Object target, String name, Class<T> type) {
+    try {
+      Field field = DefaultPollerScheduler.class.getDeclaredField(name);
+      field.setAccessible(true);
+      return type.cast(field.get(target));
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException("Unable to read " + name + " from " + target.getClass(), e);
+    }
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -165,6 +165,7 @@ public class RatchetArchiveBuilder {
     archive.addClasses(
         BaseRatchetIT.class,
         JobAssertions.class,
+        PollerControl.class,
         TestClassPolicy.class,
         TestCleanupStrategy.class,
         TestDataManipulator.class,


### PR DESCRIPTION
## Summary

`WorkerTagAffinityIT` was intermittently failing (`expected 1 but got 0`) on the GlassFish+MySQL cell. It calls `claimNextBatchOptimized` directly, but the full engine deploys into the Arquillian container and `RatchetLifecycle` auto-starts the Poller. The background poller (default node filter, ~2s interval) races the test for the same PENDING rows: when a poll tick lands between persisting a tagged job and the test's own claim, the poller consumes the job and the direct claim returns nothing. Rare on fast WildFly, more likely on the slower GlassFish/EclipseLink cell.

The fix quiesces the poller for this test, the same way the performance ITs already do:

- New `PollerControl` test helper with `stopAndAwait()` / `isStopped()`, extracting the private-field reflection that previously lived only in `BasePerformanceIT` so there is one copy.
- `WorkerTagAffinityIT` injects `PollerScheduler` and overrides `truncateAll()` to stop the poller before each truncate, so it stays idle for the test body. This also removes a latent TRUNCATE-versus-poller deadlock.
- `BasePerformanceIT` now delegates to `PollerControl` (behavior- and signature-preserving).

The fix is deterministic by construction: with no background claimer, there is no competitor for the PENDING rows. Test-only change; no production code touched.

Decoys ruled out first: timezone skew is already mitigated end-to-end (`connectionTimeZone=UTC` + `TZ=UTC`, both covering GlassFish; CI runs UTC), and a flush/visibility race is impossible since WildFly/Hibernate passes deterministically.

## Testing

- [x] `WorkerTagAffinityIT` on WildFly+MySQL: 4/4
- [x] `WorkerTagAffinityIT` on GlassFish+MySQL (the flaky cell): 4/4
- [x] `BasePerformanceITTest` (covers the extracted reflection): 3/3
- [x] Full reactor `test-compile` + `spotless:apply`

## Docs

- [ ] Docs updated where behavior, configuration, logs, or examples changed
- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

Test-infrastructure only. The `PollerControl` helper reads `DefaultPollerScheduler` private fields reflectively (no public idle-state query exists) — same approach `BasePerformanceIT` already used, now shared.
