### PR TITLE
Cover four untested behavioral guards across signal, lock, timeout, and post-execution paths

### DIFF
--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractLockStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractLockStoreContract.java
@@ -116,6 +116,25 @@ public abstract class AbstractLockStoreContract implements JobStoreContractFixtu
   }
 
   @Test
+  void renewLock_extensionKeepsCompetingNodeLockedOutPastOriginalTtl() throws InterruptedException {
+    assertTrue(
+        lockStore().tryLock("renew-observable-lock", Duration.ofMillis(500), "node-A"),
+        "First tryLock should succeed");
+
+    assertTrue(
+        lockStore().renewLock("renew-observable-lock", Duration.ofMinutes(5), "node-A"),
+        "renewLock should succeed for the lock owner");
+
+    // Sleep past the ORIGINAL 500ms ttl. If renewLock were a silent no-op that returned true
+    // without moving the expiry forward, the lease would now be expired and node-B could claim it.
+    Thread.sleep(800);
+
+    assertFalse(
+        lockStore().tryLock("renew-observable-lock", Duration.ofMinutes(5), "node-B"),
+        "Competing node must stay locked out — renewLock must extend the lease, not just return true");
+  }
+
+  @Test
   void unlock_releasesForOtherNode() {
     lockStore().tryLock("lock1", Duration.ofMinutes(5), "node-A");
     lockStore().unlock("lock1", "node-A");

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/transaction/PostExecutionRequiresNewIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/transaction/PostExecutionRequiresNewIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.ri.core.internal.PostExecutionHandler;
+import run.ratchet.ri.payload.JobPayloadFactory;
+import run.ratchet.store.entity.BatchEntity;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.util.BaseRatchetIT;
+import run.ratchet.testsuite.util.RatchetArchiveBuilder;
+
+/**
+ * Proves the runtime effect of {@code @Transactional(REQUIRES_NEW)} on {@link
+ * PostExecutionHandler}: the batch-child completion ack commits in its own transaction and survives
+ * a rollback of the caller's JTA context. The annotation is pinned by reflection in the store TCK,
+ * but only a live container proves that the container actually suspends the caller transaction
+ * rather than silently treating the attribute as REQUIRED and re-executing completed work.
+ *
+ * <p>JPA-only: exercises JTA suspension semantics not applicable to document stores.
+ */
+@EnabledIfSystemProperty(named = "ratchet.test.db.type", matches = "mysql|postgresql")
+class PostExecutionRequiresNewIT extends BaseRatchetIT {
+
+  @Inject private PostExecutionHandler postExecutionHandler;
+
+  @Inject private BatchStore batchStore;
+
+  @Inject private JobCrudStore jobCrudStore;
+
+  @Inject private UserTransaction utx;
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    String dbType = System.getProperty("ratchet.test.db.type", "mysql");
+    String profile = System.getProperty("testsuite.profile", "wildfly-managed");
+
+    return RatchetArchiveBuilder.create()
+        .addRatchetDependencies(profile, dbType)
+        .addStoreInfrastructure()
+        .addBeansXml()
+        .build();
+  }
+
+  @Test
+  void batchChildAck_commitsInOwnTransaction_andSurvivesCallerRollback() throws Exception {
+    // A three-item batch so neither the ack nor the probe below completes it: the only observable
+    // effect is the completed-child counter moving, with no completion cascade.
+    JobEntity parent = jobCrudStore.save(batchParentJob());
+    BatchEntity batch = new BatchEntity();
+    batch.setId(parent.getId());
+    batch.setTotalItems(3);
+    batch.setCompletedItems(0);
+    batch.setFailedItems(0);
+    batch.setCompletionProcessed(false);
+    batchStore.saveBatch(batch);
+
+    // update() reads only getDependsOn() off the child, so an in-memory entity is enough and the
+    // poller has no claimable row to touch.
+    JobEntity child = new JobEntity();
+    child.setJobType(JobExecutionType.BATCH_CHILD);
+    child.setDependsOn(parent.getId());
+
+    utx.begin();
+    postExecutionHandler.handleJobSuccess(child); // REQUIRES_NEW commits completed 0 -> 1
+    utx.rollback(); // rolls back the empty caller transaction
+
+    // Read the committed counter without going through the JPA first/second-level cache: a fresh
+    // atomic increment locks and reads the live row, then returns the post-update value. If the
+    // REQUIRES_NEW ack committed, the row is already 1 and this returns 2; if the ack had instead
+    // joined and rolled back with the caller, the row would be 0 and this would return 1.
+    int afterProbeIncrement = batchStore.incrementCompletedAtomic(parent.getId()).completedItems();
+    assertEquals(
+        2,
+        afterProbeIncrement,
+        "REQUIRES_NEW ack must commit independently of the rolled-back caller transaction");
+  }
+
+  private static JobEntity batchParentJob() {
+    JobEntity job = new JobEntity();
+    job.setJobType(JobExecutionType.BATCH_PARENT);
+    job.setStatus(JobStatus.PENDING);
+    job.setPriority(JobPriority.NORMAL);
+    job.setBackoffPolicy(BackoffPolicy.NONE);
+    // Future-dated so the running poller never claims the parent anchor mid-test.
+    job.setScheduledTime(Instant.now().plus(Duration.ofHours(1)));
+    job.setPayload(JobPayloadFactory.noop());
+    job.setIdempotencyKey(UUID.randomUUID().toString());
+    return job;
+  }
+}

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceSignalTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceSignalTest.java
@@ -398,6 +398,49 @@ class DefaultJobSchedulerServiceSignalTest {
   }
 
   @Test
+  void deliverSignalDecisionByIdReturnsZeroWithoutEventOrMetricsWhenNoRowsUnblocked() {
+    SignalDecision decision = SignalDecision.approved("approved-payload");
+    when(payloadSerializer.serialize("approved-payload")).thenReturn("serialized-payload");
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(job(JOB_ID, "approval-key")));
+    when(signalStore.deliverSignalById(
+            eq(JOB_ID),
+            eq("serialized-payload"),
+            eq(DefaultJobSchedulerService.SIGNAL_PAYLOAD_TYPE_DECISION),
+            eq("APPROVED"),
+            isNull(),
+            eq("bob"),
+            eq(FIXED_NOW),
+            anyString()))
+        .thenReturn(0);
+
+    assertEquals(0, service.deliverSignal(JOB_ID, decision));
+
+    verify(eventPublisher, never()).publish(any());
+    verify(metricsCollector, never()).signalDelivered(any(), any(), anyString(), any());
+  }
+
+  @Test
+  void deliverSignalDecisionByKeyReturnsZeroWithoutEventWhenNoRowsUnblocked() {
+    SignalDecision decision = SignalDecision.rejected("needs-review", "nope");
+    when(payloadSerializer.serialize("needs-review")).thenReturn("serialized-payload");
+    when(signalStore.deliverSignalByKey(
+            eq("approval-key"),
+            eq("serialized-payload"),
+            eq(DefaultJobSchedulerService.SIGNAL_PAYLOAD_TYPE_DECISION),
+            eq("REJECTED"),
+            eq("nope"),
+            eq("bob"),
+            eq(FIXED_NOW),
+            anyString()))
+        .thenReturn(0);
+
+    assertEquals(0, service.deliverSignal("approval-key", decision));
+
+    verify(eventPublisher, never()).publish(any());
+    verify(metricsCollector, never()).signalDelivered(any(), any(), anyString(), any());
+  }
+
+  @Test
   void cancelJobsByTagPublishesBulkEventUsingInjectedClock() {
     when(jobBatchStatusStore.cancelJobsByTag("stale")).thenReturn(3);
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTimeoutHandlerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTimeoutHandlerTest.java
@@ -357,6 +357,31 @@ class JobTimeoutHandlerTest {
   }
 
   @Test
+  void scanSignalTimeoutsIsolatesPerJobFailuresAndProcessesRemainingJobs() {
+    JobTimeoutHandler scanHandler =
+        newHandler(
+            signalStore, metricsCollector, JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE);
+    UUID poisonedId = new UUID(0L, 1L);
+    UUID survivorId = new UUID(0L, 2L);
+    JobEntity survivor = waitingJob(survivorId, 0);
+    when(signalStore.findTimedOutSignalJobs(any(Instant.class), anyInt()))
+        .thenReturn(List.of(waitingJob(poisonedId, 0), survivor));
+    when(jobRetryStore.incrementRetryAttempt(poisonedId))
+        .thenThrow(new IllegalStateException("store down"));
+    when(jobRetryStore.incrementRetryAttempt(survivorId)).thenReturn(1);
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(survivorId), eq(JobStatus.WAITING), eq(JobStatus.FAILED), anyString()))
+        .thenReturn(true);
+
+    scanHandler.scanSignalTimeouts();
+
+    verify(jobBatchStatusStore)
+        .compareAndSwapStatus(
+            eq(survivorId), eq(JobStatus.WAITING), eq(JobStatus.FAILED), anyString());
+    verify(lifecycleFacade).handlePermanentFailure(eq(survivor), any());
+  }
+
+  @Test
   void signalTimeoutPublishesTimedOutMetricWhenFailureIsApplied() {
     JobTimeoutHandler metricsHandler =
         newHandler(null, metricsCollector, JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE);
@@ -446,6 +471,19 @@ class JobTimeoutHandlerTest {
   private JobEntity waitingJobWithMaxRetries(int maxRetries) {
     JobEntity job = new JobEntity();
     job.setId(JOB_ID);
+    job.setMaxRetries(maxRetries);
+    job.setStatus(JobStatus.WAITING);
+    job.setJobType(JobExecutionType.SINGLE);
+    job.setPriority(JobPriority.NORMAL);
+    job.setSignalKey("approval");
+    job.setSignalTimeout(Instant.now().minusSeconds(1));
+    job.setBackoffPolicy(BackoffPolicy.NONE);
+    return job;
+  }
+
+  private JobEntity waitingJob(UUID id, int maxRetries) {
+    JobEntity job = new JobEntity();
+    job.setId(id);
     job.setMaxRetries(maxRetries);
     job.setStatus(JobStatus.WAITING);
     job.setJobType(JobExecutionType.SINGLE);


### PR DESCRIPTION
Follow-up to the test-layer hardening in #63, closing the remaining behavioral gaps the audit flagged but left uncovered. Each is a guard that already exists in production code and was never exercised by a test, so a regression would pass the suite silently.

**deliverSignal idempotency (zero-row path)**
deliverSignal is documented as idempotent: a delivery that unblocks zero rows must not publish an event or record a metric. The RI guards this with `if (unblocked > 0)`, but every existing test stubbed a positive count. Adds by-id and by-key cases that return 0 and assert nothing is published or recorded.

**renewLock observable extension (store TCK, runs on MySQL/PostgreSQL/MongoDB)**
The only renewLock success test checked the boolean return. Adds a contract that renews a short lease, sleeps past the original ttl, and asserts a competing node still cannot acquire the lock, so a no-op renew that returns true can no longer pass.

**scanSignalTimeouts per-job isolation**
The scan wraps each job in its own try/catch so one poisoned row cannot strand the rest of the batch. Adds a case with two timed-out jobs where the first throws and the second still transitions to FAILED.

**PostExecutionHandler REQUIRES_NEW runtime (container IT, MySQL/PostgreSQL)**
The REQUIRES_NEW attribute is pinned by reflection in the TCK, but only a live container proves the caller transaction is actually suspended rather than silently treated as REQUIRED. Begins a UserTransaction, acks a batch-child completion, rolls the outer transaction back, and asserts the completed-child increment survived.

Verified locally: the unit and TCK additions pass, with the lock contract green on MySQL, PostgreSQL, and MongoDB; the container IT passes on the wildfly-managed + mysql cell.
