### PR TITLE
Close the remaining structural TCK coverage gaps

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobBuilder.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobBuilder.java
@@ -197,6 +197,11 @@ public interface JobBuilder {
    * instead of merging, but the key still binds to exactly one job: the task executes exactly once,
    * and a subsequent re-submit with the same key returns the original job's handle.
    *
+   * <p>The key is persisted in a UUID-sized {@code VARCHAR(36)} column, so it must be at most 36
+   * characters. A longer key is rejected when the job is submitted. {@link
+   * #withBusinessKey(String)} carries no such limit. The auto-generated default is a 36-character
+   * UUID.
+   *
    * @param key if null or blank, the auto-generated UUID is kept
    * @return this builder
    */

--- a/ratchet-api/src/main/java/run/ratchet/spi/RetryPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/RetryPolicy.java
@@ -25,6 +25,13 @@ public interface RetryPolicy {
   /**
    * Returns whether a failed job attempt should be retried.
    *
+   * <p>The result is combined with the job's configured {@code maxRetries} using logical AND: the
+   * engine schedules another attempt only when this method returns {@code true} <em>and</em> the
+   * attempt is still within {@code maxRetries}. A policy MAY therefore terminate retries earlier
+   * than {@code maxRetries}, but MUST NOT extend them beyond it — once {@code maxRetries} is
+   * reached the job moves to terminal failure regardless of what this method returns. Use {@code
+   * maxRetries} as the ceiling and this method to stop sooner.
+   *
    * @param attempt 1-based attempt number
    * @param cause failure that ended the attempt; never {@code null}
    * @return {@code true} to schedule another attempt, {@code false} to move toward terminal failure

--- a/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsCoordinatorTestHarness.java
+++ b/ratchet-coordinator-jms/src/test/java/run/ratchet/coordinator/jms/JmsCoordinatorTestHarness.java
@@ -33,6 +33,8 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.api.SignalDecision;
+import run.ratchet.coordinator.common.NotifyPayload;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
@@ -124,6 +126,16 @@ public final class JmsCoordinatorTestHarness implements CoordinatorTestHarness {
     } catch (Exception e) {
       throw new IllegalStateException("raw-wire injection failed", e);
     }
+  }
+
+  @Override
+  public String futureVersionRawMessage(NodeIdentity source) {
+    // Encode through the production codec with a version well clear of CURRENT_VERSION, so the
+    // payload stays unsupported even after a future wire bump.
+    return new NotifyPayloadCodec()
+        .encode(
+            new NotifyPayload(
+                NotifyPayloadCodec.CURRENT_VERSION + 1000, source, JobPriority.HIGH, null));
   }
 
   @Override

--- a/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlCoordinatorTestHarness.java
+++ b/ratchet-coordinator-postgresql/src/test/java/run/ratchet/coordinator/postgresql/PostgresqlCoordinatorTestHarness.java
@@ -33,6 +33,8 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.api.SignalDecision;
+import run.ratchet.coordinator.common.NotifyPayload;
+import run.ratchet.coordinator.common.internal.NotifyPayloadCodec;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
@@ -128,6 +130,16 @@ public final class PostgresqlCoordinatorTestHarness implements CoordinatorTestHa
       // Use NOTIFY with a parameter-escaped string payload.
       s.execute("NOTIFY " + channel + ", " + quote(rawPayload));
     }
+  }
+
+  @Override
+  public String futureVersionRawMessage(NodeIdentity source) {
+    // Encode through the production codec with a version well clear of CURRENT_VERSION, so the
+    // payload stays unsupported even after a future wire bump.
+    return new NotifyPayloadCodec()
+        .encode(
+            new NotifyPayload(
+                NotifyPayloadCodec.CURRENT_VERSION + 1000, source, JobPriority.HIGH, null));
   }
 
   @Override

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRecurringJobStoreContractTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRecurringJobStoreContractTest.java
@@ -37,6 +37,7 @@ import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.TagStore;
 import run.ratchet.tck.store.AbstractRecurringJobStoreContract;
+import run.ratchet.tck.store.JobStoreContractFixture;
 
 class MongoRecurringJobStoreContractTest extends AbstractRecurringJobStoreContract {
 
@@ -50,6 +51,11 @@ class MongoRecurringJobStoreContractTest extends AbstractRecurringJobStoreContra
   @Override
   protected RecurringJobStore recurringStore() {
     return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobStoreContractFixture jobFixture() {
+    return fixture;
   }
 
   @Override

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlRecurringJobStoreContractTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlRecurringJobStoreContractTest.java
@@ -20,6 +20,7 @@ import run.ratchet.store.entity.JobPayload;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.TagStore;
 import run.ratchet.tck.store.AbstractRecurringJobStoreContract;
+import run.ratchet.tck.store.JobStoreContractFixture;
 
 class MysqlRecurringJobStoreContractTest extends AbstractRecurringJobStoreContract {
 
@@ -28,6 +29,11 @@ class MysqlRecurringJobStoreContractTest extends AbstractRecurringJobStoreContra
   @Override
   protected RecurringJobStore recurringStore() {
     return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobStoreContractFixture jobFixture() {
+    return fixture;
   }
 
   @Override

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlRecurringJobStoreContractTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlRecurringJobStoreContractTest.java
@@ -20,6 +20,7 @@ import run.ratchet.store.entity.JobPayload;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.TagStore;
 import run.ratchet.tck.store.AbstractRecurringJobStoreContract;
+import run.ratchet.tck.store.JobStoreContractFixture;
 
 class PostgresqlRecurringJobStoreContractTest extends AbstractRecurringJobStoreContract {
 
@@ -28,6 +29,11 @@ class PostgresqlRecurringJobStoreContractTest extends AbstractRecurringJobStoreC
   @Override
   protected RecurringJobStore recurringStore() {
     return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobStoreContractFixture jobFixture() {
+    return fixture;
   }
 
   @Override

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractBroadcastSignalContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractBroadcastSignalContract.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+
+/**
+ * Base contract for the broadcast {@code deliverSignal(signalKey, payload)} overload.
+ *
+ * <p>A broadcast atomically moves every WAITING job sharing the {@code signalKey} to PENDING,
+ * returns the number of jobs it transitioned, and leaves waiters on any other key untouched. The
+ * single-job overload is exercised by {@link AbstractSignalDecisionContract}; this contract pins
+ * the fan-out semantics of the keyed overload.
+ */
+public abstract class AbstractBroadcastSignalContract {
+
+  @AfterEach
+  void clearAfterEach() {
+    runtime().clear();
+    TckJobs.resetAll();
+  }
+
+  @Test
+  void broadcastUnblocksEveryMatchingWaiterAndCountsThem() {
+    String key = "broadcast-tck-match";
+    JobHandle a = waitingJob(key);
+    JobHandle b = waitingJob(key);
+    JobHandle c = waitingJob(key);
+    JobHandle other = waitingJob("broadcast-tck-other");
+
+    int unblocked = runtime().scheduler().deliverSignal(key, "go");
+
+    assertEquals(
+        3, unblocked, "broadcast must return the count of WAITING jobs it moved to PENDING");
+    assertTrue(runtime().probe().awaitCompleted(a, defaultTimeout()), "matching waiter a must run");
+    assertTrue(runtime().probe().awaitCompleted(b, defaultTimeout()), "matching waiter b must run");
+    assertTrue(runtime().probe().awaitCompleted(c, defaultTimeout()), "matching waiter c must run");
+    assertFalse(
+        runtime().probe().awaitExecuted(other, quietWindow()),
+        "a waiter on a different signalKey must stay WAITING after the broadcast");
+  }
+
+  @Test
+  void broadcastWithNoMatchingWaiterReturnsZero() {
+    waitingJob("broadcast-tck-present");
+
+    assertEquals(
+        0,
+        runtime().scheduler().deliverSignal("broadcast-tck-absent", "go"),
+        "broadcasting a key that no job waits on must return 0");
+  }
+
+  private JobHandle waitingJob(String signalKey) {
+    JobHandle handle =
+        runtime()
+            .scheduler()
+            .enqueue(TckJobs::noop)
+            .awaitSignal(signalKey, signalWaitTimeout())
+            .submit();
+    runtime().probe().track(handle);
+    return handle;
+  }
+
+  protected abstract RatchetTckRuntime runtime();
+
+  protected Duration defaultTimeout() {
+    return Duration.ofSeconds(10);
+  }
+
+  /** Generous so a waiter never times out before the broadcast lands. */
+  protected Duration signalWaitTimeout() {
+    return Duration.ofMinutes(1);
+  }
+
+  protected Duration quietWindow() {
+    return Duration.ofMillis(1000);
+  }
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractBulkCancelEventContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractBulkCancelEventContract.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.event.JobCancelledEvent;
+import run.ratchet.api.event.JobsBulkCancelledEvent;
+
+/**
+ * Base contract for the bulk cancel-by-tag event semantics.
+ *
+ * <p>{@code cancelJobsByTag} MUST publish exactly one {@link JobsBulkCancelledEvent} carrying the
+ * tag and the cancelled count, and MUST NOT fire a per-job {@link JobCancelledEvent} for the jobs
+ * it cancels. This keeps a kill-switch teardown from flooding observers with one event per job.
+ */
+public abstract class AbstractBulkCancelEventContract {
+
+  private final List<Object> events = new CopyOnWriteArrayList<>();
+  private Consumer<Object> listener;
+
+  @AfterEach
+  void clearAfterEach() {
+    if (listener != null) {
+      runtime().scheduler().removeEventListener(listener);
+      listener = null;
+    }
+    runtime().clear();
+    TckJobs.resetAll();
+    events.clear();
+  }
+
+  @Test
+  void cancelJobsByTag_publishesOneBulkEventAndNoPerJobEvents() {
+    String tag = "bulk-cancel-tck-" + UUID.randomUUID();
+    waitingTaggedJob(tag);
+    waitingTaggedJob(tag);
+    waitingTaggedJob(tag);
+
+    // Register only now so creation/submit events are not captured; the cancel path fires
+    // synchronously through the listener bridge before cancelJobsByTag returns.
+    listener = events::add;
+    runtime().scheduler().addEventListener(listener);
+
+    int cancelled = runtime().scheduler().cancelJobsByTag(tag);
+    assertEquals(3, cancelled, "cancelJobsByTag must report every job it cancelled");
+
+    List<JobsBulkCancelledEvent> bulk =
+        events.stream()
+            .filter(JobsBulkCancelledEvent.class::isInstance)
+            .map(JobsBulkCancelledEvent.class::cast)
+            .filter(e -> tag.equals(e.getTag()))
+            .toList();
+    assertEquals(
+        1,
+        bulk.size(),
+        "exactly one JobsBulkCancelledEvent must be published for the cancelled tag");
+    assertEquals(3, bulk.get(0).getCount(), "the bulk event count must match the jobs cancelled");
+
+    long perJob = events.stream().filter(JobCancelledEvent.class::isInstance).count();
+    assertEquals(
+        0, perJob, "bulk cancel-by-tag must not fire a per-job JobCancelledEvent for its jobs");
+  }
+
+  private void waitingTaggedJob(String tag) {
+    JobHandle handle =
+        runtime()
+            .scheduler()
+            .enqueue(TckJobs::noop)
+            .withTags(tag)
+            .awaitSignal("bulk-cancel-never-" + UUID.randomUUID(), Duration.ofMinutes(5))
+            .submit();
+    runtime().probe().track(handle);
+  }
+
+  protected abstract RatchetTckRuntime runtime();
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobControlReturnContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobControlReturnContract.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.event.JobRetryingEvent;
+
+/**
+ * Base contract for the documented boolean returns of {@code pauseJob}, {@code resumeJob}, and
+ * {@code retryJob}.
+ *
+ * <p>Only the transaction boundary of these methods had any TCK coverage, and {@code retryJob} had
+ * none at all. This contract pins each documented return: pause is idempotent-true on an
+ * already-paused job and false on an incompatible state or unknown id; resume is true for a paused
+ * job and false otherwise; retry resets a FAILED job to PENDING (returning true, firing {@link
+ * JobRetryingEvent}, and letting the body run again) and returns false for any non-FAILED or
+ * unknown job.
+ */
+public abstract class AbstractJobControlReturnContract {
+
+  private final List<Object> events = new CopyOnWriteArrayList<>();
+  private Consumer<Object> listener;
+
+  @AfterEach
+  void clearAfterEach() {
+    if (listener != null) {
+      runtime().scheduler().removeEventListener(listener);
+      listener = null;
+    }
+    runtime().clear();
+    TckJobs.resetAll();
+    events.clear();
+  }
+
+  @Test
+  void retryJob_failedJob_returnsTrueRerunsBodyAndFiresEvent() {
+    listener = events::add;
+    runtime().scheduler().addEventListener(listener);
+
+    JobHandle handle =
+        runtime().scheduler().enqueue(TckJobs::throwIntentional).withMaxRetries(0).submit();
+    runtime().probe().track(handle);
+    assertTrue(
+        runtime().probe().awaitFailed(handle, defaultTimeout()), "job must reach FAILED first");
+    assertEquals(1, runtime().probe().invocationCount(handle), "body runs once before retry");
+
+    assertTrue(
+        runtime().scheduler().retryJob(handle.id()), "retryJob on a FAILED job returns true");
+
+    // Reset to PENDING re-enters the poller and runs the body a second time — observable proof of
+    // the FAILED -> PENDING transition without peeking at store internals.
+    awaitInvocationCount(handle, 2);
+    assertTrue(
+        events.stream().anyMatch(JobRetryingEvent.class::isInstance),
+        "retryJob must publish a JobRetryingEvent");
+  }
+
+  @Test
+  void retryJob_returnsFalseForUnknownOrNonFailedJob() {
+    assertFalse(
+        runtime().scheduler().retryJob(UUID.randomUUID()),
+        "retryJob on an unknown id returns false");
+
+    JobHandle done = completedJob();
+    assertFalse(
+        runtime().scheduler().retryJob(done.id()),
+        "retryJob on a non-FAILED (SUCCEEDED) job returns false");
+  }
+
+  @Test
+  void pauseAndResume_returnTrueAndPauseIsIdempotent() {
+    JobHandle paused = pauseFreshlyPendingJob();
+
+    assertTrue(
+        runtime().scheduler().pauseJob(paused.id()),
+        "pausing an already-PAUSED job returns true (idempotent)");
+    assertTrue(runtime().scheduler().resumeJob(paused.id()), "resuming a PAUSED job returns true");
+    assertTrue(
+        runtime().probe().awaitCompleted(paused, defaultTimeout()),
+        "a resumed job becomes eligible and runs to completion");
+  }
+
+  @Test
+  void pauseJob_returnsFalseForUnknownOrIncompatibleState() {
+    assertFalse(
+        runtime().scheduler().pauseJob(UUID.randomUUID()), "pause on an unknown id returns false");
+
+    JobHandle done = completedJob();
+    assertFalse(
+        runtime().scheduler().pauseJob(done.id()),
+        "pause on a SUCCEEDED job returns false — only PENDING is pausable");
+  }
+
+  @Test
+  void resumeJob_returnsFalseForUnknownOrNonPausedJob() {
+    assertFalse(
+        runtime().scheduler().resumeJob(UUID.randomUUID()),
+        "resume on an unknown id returns false");
+
+    JobHandle done = completedJob();
+    assertFalse(
+        runtime().scheduler().resumeJob(done.id()),
+        "resume on a non-PAUSED (SUCCEEDED) job returns false");
+  }
+
+  /**
+   * Submits noop jobs and pauses each as soon as it is created, returning the first one paused
+   * before the poller could claim it. The retry loop absorbs the inherent submit/poll race on a
+   * live scheduler without a delayed-scheduling primitive; the unpaused stragglers simply run their
+   * noop body and complete.
+   */
+  private JobHandle pauseFreshlyPendingJob() {
+    for (int attempt = 0; attempt < 10; attempt++) {
+      JobHandle handle = runtime().scheduler().enqueue(TckJobs::noop).submit();
+      runtime().probe().track(handle);
+      if (runtime().scheduler().pauseJob(handle.id())) {
+        return handle;
+      }
+    }
+    return fail("could not pause a freshly-submitted PENDING job before the poller claimed it");
+  }
+
+  private JobHandle completedJob() {
+    JobHandle handle = runtime().scheduler().enqueue(TckJobs::noop).submit();
+    runtime().probe().track(handle);
+    assertTrue(
+        runtime().probe().awaitCompleted(handle, defaultTimeout()),
+        "setup job must reach SUCCEEDED");
+    return handle;
+  }
+
+  private void awaitInvocationCount(JobHandle handle, int target) {
+    long deadlineNanos = System.nanoTime() + defaultTimeout().toNanos();
+    while (runtime().probe().invocationCount(handle) < target) {
+      if (System.nanoTime() >= deadlineNanos) {
+        fail(
+            "expected the body to run "
+                + target
+                + " times after retry but saw "
+                + runtime().probe().invocationCount(handle));
+      }
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        fail("interrupted while awaiting re-execution");
+      }
+    }
+  }
+
+  protected abstract RatchetTckRuntime runtime();
+
+  protected Duration defaultTimeout() {
+    return Duration.ofSeconds(15);
+  }
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobQueryContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobQueryContract.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobQueryService;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.JobSummary;
+
+/**
+ * Base contract for the positive {@link JobQueryService} read surface: findJobs, getJobDetail,
+ * getExecutionHistory, and getRecurringMasters round-trip a submitted job under a permit-all
+ * authorization policy. The existence-hiding and principal-scoping guarantees live in {@link
+ * AbstractJobQueryDenialContract}, which needs a read-denying policy and so runs in its own
+ * deployment.
+ */
+public abstract class AbstractJobQueryContract {
+
+  @AfterEach
+  void clearAfterEach() {
+    runtime().clear();
+    TckJobs.resetAll();
+  }
+
+  @Test
+  void getJobDetail_returnsSubmittedJob() {
+    JobHandle handle = submitTracked();
+
+    Optional<UUID> detailId =
+        queryService().getJobDetail(handle.id()).map(detail -> detail.summary().id());
+    assertTrue(detailId.isPresent(), "getJobDetail must return a submitted job");
+    assertEquals(handle.id(), detailId.get(), "the detail summary must carry the job id");
+  }
+
+  @Test
+  void getJobDetail_unknownId_returnsEmpty() {
+    assertTrue(
+        queryService().getJobDetail(UUID.randomUUID()).isEmpty(),
+        "getJobDetail for an unknown id must return empty");
+  }
+
+  @Test
+  void findJobs_includesSubmittedJob() {
+    JobHandle handle = submitTracked();
+
+    boolean found =
+        queryService().findJobs(JobFilter.builder().build(), 100, 0).items().stream()
+            .anyMatch(summary -> handle.id().equals(summary.id()));
+    assertTrue(found, "findJobs must surface a submitted job under a permit-all policy");
+  }
+
+  @Test
+  void getExecutionHistory_recordsAttemptForCompletedJob() {
+    JobHandle handle = submitTracked();
+    assertTrue(
+        runtime().probe().awaitCompleted(handle, defaultTimeout()), "setup job must complete");
+
+    assertFalse(
+        queryService().getExecutionHistory(handle.id()).isEmpty(),
+        "getExecutionHistory must record at least one attempt for a completed job");
+  }
+
+  @Test
+  void getRecurringMasters_roundTripsIncludingPausedState() {
+    // Fires once a year, so it never spawns a child during the test.
+    JobHandle master =
+        runtime().scheduler().scheduleRecurringUtc("0 0 0 1 1 ?", TckJobs::noop).submit();
+
+    assertTrue(
+        recurringMaster(master.id()).isPresent(),
+        "a registered recurring master must be visible to getRecurringMasters");
+
+    assertTrue(
+        runtime().scheduler().pauseJob(master.id()), "pausing the recurring master succeeds");
+
+    Optional<JobSummary> paused = recurringMaster(master.id());
+    assertTrue(
+        paused.isPresent(), "a paused recurring master stays visible to getRecurringMasters");
+    assertEquals(
+        JobStatus.PAUSED, paused.get().status(), "the master must report PAUSED after pause");
+  }
+
+  protected abstract RatchetTckRuntime runtime();
+
+  /** The permit-all {@link JobQueryService} under test. */
+  protected abstract JobQueryService queryService();
+
+  protected Duration defaultTimeout() {
+    return Duration.ofSeconds(15);
+  }
+
+  private JobHandle submitTracked() {
+    JobHandle handle = runtime().scheduler().enqueue(TckJobs::noop).submit();
+    runtime().probe().track(handle);
+    return handle;
+  }
+
+  private Optional<JobSummary> recurringMaster(UUID masterId) {
+    return queryService().getRecurringMasters().items().stream()
+        .filter(summary -> masterId.equals(summary.id()))
+        .findFirst();
+  }
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobQueryDenialContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractJobQueryDenialContract.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobQueryService;
+
+/**
+ * Base contract for the existence-hiding and principal-scoping guarantees of {@link
+ * JobQueryService}. Runs against {@link #deniedQueryService()} — a query service whose
+ * authorization policy denies reads and scopes list queries to a non-matching principal. A denied
+ * {@code getJobDetail} returns empty exactly as a missing job does (existence is hidden), and a
+ * scoped {@code findJobs} returns nothing. Because it needs a read-denying policy, this runs in its
+ * own deployment, separate from the permit-all {@link AbstractJobQueryContract}.
+ */
+public abstract class AbstractJobQueryDenialContract {
+
+  @AfterEach
+  void clearAfterEach() {
+    runtime().clear();
+    TckJobs.resetAll();
+  }
+
+  @Test
+  void deniedRead_hidesExistenceOfRealJob() {
+    JobQueryService denied = deniedQueryService();
+    JobHandle handle = submitTracked();
+
+    assertTrue(
+        denied.getJobDetail(handle.id()).isEmpty(),
+        "a denied read of an existing job must return empty");
+    assertTrue(
+        denied.getJobDetail(UUID.randomUUID()).isEmpty(), "an unknown job also returns empty");
+    // The two are indistinguishable — existence is hidden, not signalled by a different outcome.
+    assertTrue(
+        denied.getExecutionHistory(handle.id()).isEmpty(),
+        "a denied read must return no execution history for an existing job");
+  }
+
+  @Test
+  void principalScopedFilter_excludesJobsFromFindJobs() {
+    submitTracked();
+
+    assertTrue(
+        deniedQueryService().findJobs(JobFilter.builder().build(), 100, 0).items().isEmpty(),
+        "filterForPrincipal must scope findJobs so a caller sees no out-of-scope jobs");
+  }
+
+  protected abstract RatchetTckRuntime runtime();
+
+  /**
+   * A {@link JobQueryService} whose authorization policy denies reads and scopes list queries to a
+   * non-matching principal.
+   */
+  protected abstract JobQueryService deniedQueryService();
+
+  protected Duration defaultTimeout() {
+    return Duration.ofSeconds(15);
+  }
+
+  private JobHandle submitTracked() {
+    JobHandle handle = runtime().scheduler().enqueue(TckJobs::noop).submit();
+    runtime().probe().track(handle);
+    return handle;
+  }
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractRetryPolicyContract.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/AbstractRetryPolicyContract.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+
+/**
+ * Base contract for a custom {@link run.ratchet.spi.RetryPolicy} override.
+ *
+ * <p>{@code shouldRetry} is ANDed with the job's {@code maxRetries}: a policy can stop retries
+ * early but cannot push them past the configured ceiling. This contract installs a policy that
+ * vetoes at attempt {@link #vetoAttempt()} and submits a deterministically-failing job whose {@code
+ * maxRetries} is set strictly higher, then asserts the body ran exactly {@code vetoAttempt} times —
+ * proving the policy, not the ceiling, ended the retries.
+ *
+ * <p>Runtimes that cannot install a custom SPI bean in a test context return {@link
+ * Optional#empty()} from {@link #retryPolicyRuntime()} and the contract is reported not-applicable,
+ * mirroring the optional deny-all hook on {@link AbstractJobAuthorizationContract}.
+ */
+public abstract class AbstractRetryPolicyContract {
+
+  @AfterEach
+  void clearAfterEach() {
+    retryPolicyRuntime().ifPresent(RatchetTckRuntime::clear);
+    TckJobs.resetAll();
+  }
+
+  @Test
+  void customPolicyTerminatesRetriesBelowMaxRetries() {
+    Optional<RatchetTckRuntime> maybe = retryPolicyRuntime();
+    assumeTrue(
+        maybe.isPresent(), "runtime cannot install a custom RetryPolicy in this test context");
+    RatchetTckRuntime runtime = maybe.get();
+
+    int veto = vetoAttempt();
+    int maxRetries = veto + 5; // strictly above the veto, so the ceiling is never the limiter
+
+    JobHandle handle =
+        runtime.scheduler().enqueue(TckJobs::throwIntentional).withMaxRetries(maxRetries).submit();
+    runtime.probe().track(handle);
+
+    assertTrue(
+        runtime.probe().awaitFailed(handle, defaultTimeout()),
+        "the job must reach terminal FAILED once the policy stops retrying");
+    assertEquals(
+        veto,
+        runtime.probe().invocationCount(handle),
+        "the custom policy must cap the body at "
+            + veto
+            + " runs, well below maxRetries+1 ("
+            + (maxRetries + 1)
+            + "); the engine ANDs shouldRetry with maxRetries");
+  }
+
+  /**
+   * A runtime whose injected {@link run.ratchet.spi.RetryPolicy} returns {@code true} from {@code
+   * shouldRetry} only while the attempt is below {@link #vetoAttempt()}. Empty when the runtime
+   * cannot swap the SPI in a test context.
+   */
+  protected abstract Optional<RatchetTckRuntime> retryPolicyRuntime();
+
+  /**
+   * The 1-based attempt at which the installed policy first vetoes a retry. Equals the number of
+   * times the body runs. Subclasses override this to match the policy they install.
+   */
+  protected int vetoAttempt() {
+    return 2;
+  }
+
+  protected Duration defaultTimeout() {
+    return Duration.ofSeconds(15);
+  }
+}

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -51,7 +51,8 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractResilienceStrategyContract",
                   "AbstractJobAuthorizationContract",
                   "AbstractSignalDecisionContract",
-                  "AbstractSignalPayloadContract")),
+                  "AbstractSignalPayloadContract",
+                  "AbstractBroadcastSignalContract")),
           new ContractGroup(
               "Encryption SPI",
               "Conformance contract every PayloadEncryption engine must satisfy: AEAD round-trip,"

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -52,7 +52,8 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractJobAuthorizationContract",
                   "AbstractSignalDecisionContract",
                   "AbstractSignalPayloadContract",
-                  "AbstractBroadcastSignalContract")),
+                  "AbstractBroadcastSignalContract",
+                  "AbstractBulkCancelEventContract")),
           new ContractGroup(
               "Encryption SPI",
               "Conformance contract every PayloadEncryption engine must satisfy: AEAD round-trip,"

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -53,7 +53,8 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractSignalDecisionContract",
                   "AbstractSignalPayloadContract",
                   "AbstractBroadcastSignalContract",
-                  "AbstractBulkCancelEventContract")),
+                  "AbstractBulkCancelEventContract",
+                  "AbstractJobControlReturnContract")),
           new ContractGroup(
               "Encryption SPI",
               "Conformance contract every PayloadEncryption engine must satisfy: AEAD round-trip,"

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -54,7 +54,8 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractSignalPayloadContract",
                   "AbstractBroadcastSignalContract",
                   "AbstractBulkCancelEventContract",
-                  "AbstractJobControlReturnContract")),
+                  "AbstractJobControlReturnContract",
+                  "AbstractRetryPolicyContract")),
           new ContractGroup(
               "Encryption SPI",
               "Conformance contract every PayloadEncryption engine must satisfy: AEAD round-trip,"

--- a/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
+++ b/ratchet-tck/api/src/main/java/run/ratchet/tck/api/ApiConformanceReportExtension.java
@@ -55,7 +55,9 @@ public class ApiConformanceReportExtension extends AbstractConformanceReportExte
                   "AbstractBroadcastSignalContract",
                   "AbstractBulkCancelEventContract",
                   "AbstractJobControlReturnContract",
-                  "AbstractRetryPolicyContract")),
+                  "AbstractRetryPolicyContract",
+                  "AbstractJobQueryContract",
+                  "AbstractJobQueryDenialContract")),
           new ContractGroup(
               "Encryption SPI",
               "Conformance contract every PayloadEncryption engine must satisfy: AEAD round-trip,"

--- a/ratchet-tck/coordinator/pom.xml
+++ b/ratchet-tck/coordinator/pom.xml
@@ -24,6 +24,14 @@
             <groupId>run.ratchet</groupId>
             <artifactId>ratchet-tck-util</artifactId>
         </dependency>
+        <!-- ratchet-api declares `requires transitive jakarta.cdi` (driven by @CircuitBreakerProtected),
+             so the module graph needs the CDI API present to resolve. Provided scope: this tier never
+             touches CDI types itself. -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/ratchet-tck/coordinator/src/main/java/module-info.java
+++ b/ratchet-tck/coordinator/src/main/java/module-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module run.ratchet.tck.coordinator {
+  requires transitive run.ratchet.api;
+  requires run.ratchet.tck.util;
+  requires org.junit.jupiter.api;
+
+  exports run.ratchet.tck.coordinator;
+
+  provides org.junit.platform.launcher.TestExecutionListener with
+      run.ratchet.tck.coordinator.CoordinatorConformanceReportExtension;
+}

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
@@ -331,11 +331,10 @@ public abstract class AbstractClusterCoordinatorContract {
     fixture.nodeB().registerWakeupListener(listenerB);
 
     long before = fixture.metricsB().transportFailure();
-    // A version far above any the codec will ever support. Hardcoding the then-current+1 (e.g. 2)
-    // silently became a *valid* envelope once the wire version was bumped, so pin it well clear.
-    harness.injectRawMessage(
-        fixture.nodeB(),
-        "{\"v\":999,\"node\":\"" + fixture.identityA().value() + "\",\"prio\":\"HIGH\"}");
+    // The harness owns the wire schema: it emits an envelope whose version is far above any its
+    // codec supports. Keeping the concrete field names out of this contract lets a non-JSON
+    // coordinator exercise the same rejection path with its own wire form.
+    harness.injectRawMessage(fixture.nodeB(), harness.futureVersionRawMessage(fixture.identityA()));
 
     sleepPastLatencyWindow();
     assertTrue(

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/AbstractClusterCoordinatorContract.java
@@ -18,6 +18,7 @@ package run.ratchet.tck.coordinator;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
@@ -359,6 +360,37 @@ public abstract class AbstractClusterCoordinatorContract {
         record.source().value(),
         "source identity must round-trip exactly");
     assertEquals(JobPriority.LOW, record.priority(), "priority must round-trip exactly");
+  }
+
+  @Test
+  void envelopeRoundTripPreservesNonNullExecutionTarget() {
+    RecordingWakeupListener listenerB = new RecordingWakeupListener();
+    fixture.nodeB().registerWakeupListener(listenerB);
+
+    fixture.nodeA().notifyNewWork(JobPriority.HIGH, fixture.identityA(), "export-pool");
+
+    listenerB.awaitOne(harness.maxExpectedLatency());
+    var record = listenerB.received().get(0);
+    assertEquals(
+        "export-pool",
+        record.executionTarget(),
+        "executionTarget is the third wire field and must round-trip exactly when non-null; a codec"
+            + " that drops or corrupts it must fail here");
+  }
+
+  @Test
+  void envelopeRoundTripPreservesNullExecutionTarget() {
+    RecordingWakeupListener listenerB = new RecordingWakeupListener();
+    fixture.nodeB().registerWakeupListener(listenerB);
+
+    fixture.nodeA().notifyNewWork(JobPriority.HIGH, fixture.identityA(), null);
+
+    listenerB.awaitOne(harness.maxExpectedLatency());
+    var record = listenerB.received().get(0);
+    assertNull(
+        record.executionTarget(),
+        "an unscoped wakeup (null executionTarget) must arrive with executionTarget still null,"
+            + " never coerced to a sentinel string");
   }
 
   // ─── Metrics surface ──────────────────────────────────────────────────────────

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/CoordinatorConformanceReportExtension.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/CoordinatorConformanceReportExtension.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.coordinator;
+
+import java.nio.file.Path;
+import java.util.List;
+import run.ratchet.tck.util.AbstractConformanceReportExtension;
+
+/**
+ * Coordinator-tier conformance report listener. Writes {@code
+ * target/tck-coordinator-conformance-report.md} after any test run that exercises at least one
+ * {@code ratchet-tck-coordinator} contract class.
+ *
+ * <p>Coordinator modules inject identity via Surefire's {@code systemPropertyVariables}: {@code
+ * ratchet.tck.coordinator.name=${project.artifactId}}.
+ */
+public class CoordinatorConformanceReportExtension extends AbstractConformanceReportExtension {
+
+  private static final List<ContractGroup> GROUPS =
+      List.of(
+          new ContractGroup(
+              "Cluster Coordinator",
+              "Cross-implementation ClusterCoordinator SPI contracts: envelope round-trip,"
+                  + " self-suppression, listener isolation, transport-failure tolerance, and the"
+                  + " metrics surface. The pre-registration buffer is an implementation choice, so"
+                  + " its contract is optional.",
+              List.of("AbstractClusterCoordinatorContract"),
+              List.of("AbstractClusterCoordinatorOptionalContract")));
+
+  @Override
+  protected String tierTitle() {
+    return "Coordinator";
+  }
+
+  @Override
+  protected String runtimeProperty() {
+    return "ratchet.tck.coordinator.name";
+  }
+
+  @Override
+  protected Path reportPath() {
+    return Path.of("target", "tck-coordinator-conformance-report.md");
+  }
+
+  @Override
+  protected List<ContractGroup> contractGroups() {
+    return GROUPS;
+  }
+}

--- a/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/CoordinatorTestHarness.java
+++ b/ratchet-tck/coordinator/src/main/java/run/ratchet/tck/coordinator/CoordinatorTestHarness.java
@@ -16,6 +16,7 @@
 package run.ratchet.tck.coordinator;
 
 import java.time.Duration;
+import run.ratchet.api.NodeIdentity;
 import run.ratchet.spi.ClusterCoordinator;
 
 /**
@@ -77,6 +78,24 @@ public interface CoordinatorTestHarness extends AutoCloseable {
    * loud.
    */
   default void injectRawMessage(ClusterCoordinator receiver, String rawPayload) throws Exception {
+    throw new UnsupportedOperationException(
+        "harness does not support raw wire injection — see supportsRawWireInjection()");
+  }
+
+  /**
+   * Returns a raw wire message, addressed from {@code source}, carrying an envelope version far
+   * beyond any this coordinator's codec will ever support. The unknown-envelope-version contract
+   * injects it and expects the receiver to reject it loudly.
+   *
+   * <p>This keeps the concrete wire schema out of the abstract contract: a JSON coordinator emits a
+   * bumped JSON envelope, a protobuf coordinator emits a bumped protobuf frame, a JMS-object
+   * coordinator emits its own form. Only invoked when {@link #supportsRawWireInjection()} returns
+   * {@code true}; the default throws to make accidental calls loud.
+   *
+   * @param source the originating node identity to stamp into the envelope
+   * @return the raw, transport-ready payload string
+   */
+  default String futureVersionRawMessage(NodeIdentity source) {
     throw new UnsupportedOperationException(
         "harness does not support raw wire injection — see supportsRawWireInjection()");
   }

--- a/ratchet-tck/coordinator/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/ratchet-tck/coordinator/src/main/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+run.ratchet.tck.coordinator.CoordinatorConformanceReportExtension

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractBatchStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractBatchStoreContract.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobStatus;
 import run.ratchet.store.entity.BatchMetricsEntity;
 import run.ratchet.tck.util.ConcurrentTestRunner;
 
@@ -51,6 +52,37 @@ public abstract class AbstractBatchStoreContract implements JobStoreContractFixt
     assertEquals(2, progress.totalItems());
     assertEquals(1, progress.completedItems());
     assertEquals(0, progress.failedItems());
+  }
+
+  @Test
+  void markJobSucceededAndUpdateBatch_updatesJobAndBatchAtomically() {
+    var parent = persist(newBatchParentJob());
+    persistBatch(parent.getId(), 1);
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+
+    Instant start = Instant.now().minusSeconds(5);
+    Instant end = Instant.now();
+    boolean marked =
+        store()
+            .markJobSucceededAndUpdateBatch(
+                saved.getId(),
+                "{\"ok\":true}",
+                "java.lang.String",
+                start,
+                end,
+                5000L,
+                100L,
+                parent.getId());
+
+    assertTrue(marked, "markJobSucceededAndUpdateBatch should return true for a running job");
+    // Job-side transition is verified through the mandatory core read, so the atomic terminal
+    // move is pinned regardless of how the batch counters are exposed.
+    var reloaded = store().findById(saved.getId()).orElseThrow();
+    assertEquals(JobStatus.SUCCEEDED, reloaded.getStatus());
+    assertNotNull(reloaded.getJobResult(), "Result JSON should be persisted");
+    // Batch-side increment is the capability-specific half, asserted through the batch view.
+    assertEquals(1, batchStore().findBatchById(parent.getId()).orElseThrow().getCompletedItems());
   }
 
   @Test

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractDualWriteInvariantContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractDualWriteInvariantContract.java
@@ -135,27 +135,31 @@ public abstract class AbstractDualWriteInvariantContract implements JobStoreCont
   }
 
   @Test
-  void terminalTransition_clearsLiveStatusFromCounts() {
-    String bk = uniqueBusinessKey();
-    JobEntity job = persist(jobWithBusinessKey(bk));
-
-    long pendingBefore = analyticsStore().countJobsByStatus(JobStatus.PENDING);
-    long succeededBefore = analyticsStore().countJobsByStatus(JobStatus.SUCCEEDED);
+  void terminalTransition_clearsLiveQueueCount() {
+    // The dual-write invariant — no live-queue row survives a terminal transition — is asserted
+    // through the mandatory core countPendingJobs(), not the optional analytics capability, so a
+    // core-only store still exercises it. The SUCCEEDED-side status count is covered by the
+    // analytics contract.
+    long pendingBefore = store().countPendingJobs();
+    JobEntity job = persist(newPendingJob());
+    assertEquals(
+        pendingBefore + 1,
+        store().countPendingJobs(),
+        "a freshly persisted PENDING job must join the live-queue count");
 
     store().compareAndSwapStatus(job.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
-    store().markJobSucceededMinimal(job.getId(), Instant.now(), Instant.now(), 0L, 0L);
-
-    long pendingAfter = analyticsStore().countJobsByStatus(JobStatus.PENDING);
-    long succeededAfter = analyticsStore().countJobsByStatus(JobStatus.SUCCEEDED);
+    assertTrue(
+        store().markJobSucceededMinimal(job.getId(), Instant.now(), Instant.now(), 0L, 0L),
+        "markJobSucceededMinimal must report the RUNNING -> SUCCEEDED transition");
+    assertEquals(
+        JobStatus.SUCCEEDED,
+        store().getJobStatus(job.getId()),
+        "the job must actually reach terminal SUCCEEDED, not merely leave PENDING");
 
     assertEquals(
-        pendingBefore - 1,
-        pendingAfter,
-        "PENDING count should decrease by one after terminal SUCCEEDED");
-    assertEquals(
-        succeededBefore + 1,
-        succeededAfter,
-        "SUCCEEDED count should increase by one after terminal SUCCEEDED");
+        pendingBefore,
+        store().countPendingJobs(),
+        "after a terminal SUCCEEDED the live-queue count returns to baseline — no hot row survives");
   }
 
   @Test

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobAnalyticsStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobAnalyticsStoreContract.java
@@ -16,6 +16,7 @@
 package run.ratchet.tck.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.time.Instant;
 import java.util.List;
@@ -177,5 +178,51 @@ public abstract class AbstractJobAnalyticsStoreContract implements JobStoreContr
     Map<String, Long> counts = analyticsStore().countJobsByExecutionNodeForTag("run-tag");
 
     assertEquals(Map.of("node-a", 2L, "node-b", 1L), counts);
+  }
+
+  @Test
+  void getQueueWaitTimePercentile_outOfRange_throws() {
+    // Every store rejects NaN and out-of-[0,1] percentiles identically rather than clamping or
+    // forwarding the value to the backend.
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> analyticsStore().getQueueWaitTimePercentile(Double.NaN));
+    assertThrows(
+        IllegalArgumentException.class, () -> analyticsStore().getQueueWaitTimePercentile(-0.1));
+    assertThrows(
+        IllegalArgumentException.class, () -> analyticsStore().getQueueWaitTimePercentile(1.5));
+  }
+
+  @Test
+  void getQueueWaitTimePercentile_noData_returnsZero() {
+    assertEquals(
+        0L, analyticsStore().getQueueWaitTimePercentile(0.95), "no succeeded jobs yields 0");
+  }
+
+  @Test
+  void getQueueWaitTimePercentile_discreteNearestRank_returnsObservedValue() {
+    // Four SUCCEEDED jobs with queue_wait_ms 10, 20, 30, 40. Discrete nearest-rank
+    // (PERCENTILE_DISC)
+    // returns an actually-observed value, identical on every store. The p50 assertion is the
+    // discriminator: discrete returns 20, an interpolated percentile would return 25.
+    for (long queueWaitMs : new long[] {10L, 20L, 30L, 40L}) {
+      persistSucceededJobWithQueueWait(queueWaitMs);
+    }
+
+    assertEquals(
+        10L, analyticsStore().getQueueWaitTimePercentile(0.0), "p0 is the minimum observation");
+    assertEquals(
+        20L,
+        analyticsStore().getQueueWaitTimePercentile(0.5),
+        "discrete p50 returns an observed value (20), not the interpolated 25");
+    assertEquals(
+        40L, analyticsStore().getQueueWaitTimePercentile(1.0), "p100 is the maximum observation");
+  }
+
+  private void persistSucceededJobWithQueueWait(long queueWaitMs) {
+    var saved = persist(newPendingJob());
+    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store()
+        .markJobSucceeded(saved.getId(), null, null, Instant.now(), Instant.now(), 0L, queueWaitMs);
   }
 }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobCrudStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobCrudStoreContract.java
@@ -29,11 +29,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.JobStatus;
 import run.ratchet.store.entity.JobEntity;
-import run.ratchet.store.entity.JobPayload;
-import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.ArchiveStore;
 import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
@@ -42,7 +39,6 @@ import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.LockStore;
-import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.ResourcePermitStore;
 import run.ratchet.store.spi.SignalStore;
@@ -352,47 +348,6 @@ public abstract class AbstractJobCrudStoreContract implements JobStoreContractFi
   }
 
   @Test
-  void create_persistsRecurringMasterId() {
-    UUID masterId = UuidV7Factory.create();
-    recurringStore().createRecurring(recurringMaster(masterId));
-
-    JobEntity child = newPendingJob();
-    child.setRecurringMasterId(masterId);
-
-    JobEntity created = store().create(child);
-
-    JobEntity reread = store().findById(created.getId()).orElseThrow();
-    assertEquals(
-        masterId,
-        reread.getRecurringMasterId(),
-        "recurring_master_id must round-trip through the cold-table INSERT and the row mapper");
-  }
-
-  private RecurringJobDefinition recurringMaster(UUID id) {
-    return new RecurringJobDefinition(
-        id,
-        "0 * * * * ?",
-        "UTC",
-        Instant.now().plusSeconds(3600),
-        false,
-        null,
-        2,
-        0,
-        BackoffPolicy.NONE,
-        0,
-        0,
-        new JobPayload("run.ratchet.tck.store.NoopTask", "run", "()V", true, List.of()),
-        null,
-        null,
-        null,
-        null,
-        null,
-        Instant.now(),
-        null,
-        false);
-  }
-
-  @Test
   void save_preservesCreatedAt() {
     JobEntity job = newPendingJob();
     JobEntity created = store().create(job);
@@ -406,51 +361,5 @@ public abstract class AbstractJobCrudStoreContract implements JobStoreContractFi
         originalCreatedAt,
         updated.getCreatedAt(),
         "save() must not overwrite the createdAt set by create()");
-  }
-
-  @Test
-  void getQueueWaitTimePercentile_outOfRange_throws() {
-    // Every store rejects NaN and out-of-[0,1] percentiles identically rather than clamping or
-    // forwarding the value to the backend.
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> analyticsStore().getQueueWaitTimePercentile(Double.NaN));
-    assertThrows(
-        IllegalArgumentException.class, () -> analyticsStore().getQueueWaitTimePercentile(-0.1));
-    assertThrows(
-        IllegalArgumentException.class, () -> analyticsStore().getQueueWaitTimePercentile(1.5));
-  }
-
-  @Test
-  void getQueueWaitTimePercentile_noData_returnsZero() {
-    assertEquals(
-        0L, analyticsStore().getQueueWaitTimePercentile(0.95), "no succeeded jobs yields 0");
-  }
-
-  @Test
-  void getQueueWaitTimePercentile_discreteNearestRank_returnsObservedValue() {
-    // Four SUCCEEDED jobs with queue_wait_ms 10, 20, 30, 40. Discrete nearest-rank
-    // (PERCENTILE_DISC)
-    // returns an actually-observed value, identical on every store. The p50 assertion is the
-    // discriminator: discrete returns 20, an interpolated percentile would return 25.
-    for (long queueWaitMs : new long[] {10L, 20L, 30L, 40L}) {
-      persistSucceededJobWithQueueWait(queueWaitMs);
-    }
-
-    assertEquals(
-        10L, analyticsStore().getQueueWaitTimePercentile(0.0), "p0 is the minimum observation");
-    assertEquals(
-        20L,
-        analyticsStore().getQueueWaitTimePercentile(0.5),
-        "discrete p50 returns an observed value (20), not the interpolated 25");
-    assertEquals(
-        40L, analyticsStore().getQueueWaitTimePercentile(1.0), "p100 is the maximum observation");
-  }
-
-  private void persistSucceededJobWithQueueWait(long queueWaitMs) {
-    var saved = persist(newPendingJob());
-    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
-    store()
-        .markJobSucceeded(saved.getId(), null, null, Instant.now(), Instant.now(), 0L, queueWaitMs);
   }
 }

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobTerminalStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobTerminalStoreContract.java
@@ -70,34 +70,6 @@ public abstract class AbstractJobTerminalStoreContract implements JobStoreContra
   }
 
   @Test
-  void markJobSucceededAndUpdateBatch_updatesJobAndBatchAtomically() {
-    var parent = persist(newBatchParentJob());
-    persistBatch(parent.getId(), 1);
-    var saved = persist(newPendingJob());
-    store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
-
-    Instant start = Instant.now().minusSeconds(5);
-    Instant end = Instant.now();
-    boolean marked =
-        store()
-            .markJobSucceededAndUpdateBatch(
-                saved.getId(),
-                "{\"ok\":true}",
-                "java.lang.String",
-                start,
-                end,
-                5000L,
-                100L,
-                parent.getId());
-
-    assertTrue(marked, "markJobSucceededAndUpdateBatch should return true for a running job");
-    var reloaded = store().findById(saved.getId()).orElseThrow();
-    assertEquals(JobStatus.SUCCEEDED, reloaded.getStatus());
-    assertNotNull(reloaded.getJobResult(), "Result JSON should be persisted");
-    assertEquals(1, batchStore().findBatchById(parent.getId()).orElseThrow().getCompletedItems());
-  }
-
-  @Test
   void markJobFailedTerminal_usesCallerAttemptsAndPersistsTimingFields() {
     var saved = persist(newPendingJob());
     store().compareAndSwapStatus(saved.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractRecurringJobStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractRecurringJobStoreContract.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.ExecutorTargets;
 import run.ratchet.api.NodeTagFilter;
+import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobPayload;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.RecurringJobDefinition;
@@ -72,6 +73,14 @@ public abstract class AbstractRecurringJobStoreContract {
 
   /** Builds a no-op {@link JobPayload} so the contract is store-impl agnostic. */
   protected abstract JobPayload noopPayload();
+
+  /**
+   * Returns the core {@link JobStoreContractFixture} backing the same store as {@link
+   * #recurringStore()}. Used by the child-job round-trip contract, which needs a core {@code
+   * create}/{@code findById} plus a transient job factory. Implementors return the same fixture
+   * they use to back the recurring store.
+   */
+  protected abstract JobStoreContractFixture jobFixture();
 
   /** Removes all rows from the live + archive tables/collections. */
   protected abstract void cleanupRecurringStore();
@@ -276,9 +285,9 @@ public abstract class AbstractRecurringJobStoreContract {
    * the value it needs to stamp onto every spawned child's {@code recurring_master_id} column. The
    * child-side half of this contract — actually writing a {@link
    * run.ratchet.store.entity.JobEntity} with {@code recurringMasterId} set and re-reading it
-   * through the cold-table mapper — lives in {@link
-   * AbstractJobCrudStoreContract#create_persistsRecurringMasterId} because the write touches {@code
-   * scheduler_job}, not {@code scheduler_recurring_job}.
+   * through the cold-table mapper — lives in {@link #create_persistsRecurringMasterIdOnChildJob}:
+   * it needs both this capability (to create the master the child's foreign key references) and the
+   * core {@code create}/{@code findById} round-trip.
    */
   @Test
   void getRecurring_returnsCompleteDefinitionForChildLineage() {
@@ -453,6 +462,29 @@ public abstract class AbstractRecurringJobStoreContract {
     assertTrue(recurringStore().getRecurring(idA).isEmpty(), "empty known set cancels keyA");
     assertTrue(
         recurringStore().getRecurring(idC).isPresent(), "created_at cutoff still spares keyC");
+  }
+
+  /**
+   * A child job created with a {@code recurringMasterId} must persist that link and read it back.
+   * The child references a live master through a foreign key on SQL stores, so this contract
+   * belongs to the recurring capability rather than the core CRUD contract — it needs both a
+   * created master and the core {@code create}/{@code findById} round-trip.
+   */
+  @Test
+  void create_persistsRecurringMasterIdOnChildJob() {
+    UUID masterId = UuidV7Factory.create();
+    recurringStore()
+        .createRecurring(definition(masterId, "0 * * * * ?", Instant.now().plusSeconds(3600)));
+
+    JobEntity child = jobFixture().newPendingJob();
+    child.setRecurringMasterId(masterId);
+    JobEntity created = jobFixture().store().create(child);
+
+    JobEntity reread = jobFixture().store().findById(created.getId()).orElseThrow();
+    assertEquals(
+        masterId,
+        reread.getRecurringMasterId(),
+        "recurring_master_id must round-trip through the child INSERT and the row mapper");
   }
 
   private RecurringJobDefinition orphanCandidate(

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractTagStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractTagStoreContract.java
@@ -17,7 +17,6 @@ package run.ratchet.tck.store;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.UUID;
@@ -28,9 +27,13 @@ import org.junit.jupiter.api.Test;
 /**
  * Base contract tests for {@code TagStore} writes.
  *
- * <p>Tag writes are verified through {@code findJobIdsByTag} (a {@code JobQueryStore} read); there
- * is no read on the write-only {@code TagStore} contract itself. Tag id lookup and per-tag
- * aggregate counts have their own contracts on the optional query/analytics capabilities.
+ * <p>{@code insertTags} and {@code deleteTagsByJobId} are part of the mandatory core surface, so
+ * this contract verifies them through {@code deleteTagsByJobId}'s own row count — a core read that
+ * exists on every conforming store. It deliberately avoids {@code findJobIdsByTag}, which lives on
+ * the optional {@code JobQueryStore} capability: routing the only assertion through that accessor
+ * would skip the whole core tag-write contract on a core-only store. Tag-index reads (lookup by
+ * tag, pagination, ordering) are covered by the optional query-store contract where the capability
+ * gating is correct.
  */
 public abstract class AbstractTagStoreContract implements JobStoreContractFixture {
 
@@ -41,16 +44,14 @@ public abstract class AbstractTagStoreContract implements JobStoreContractFixtur
   }
 
   @Test
-  void insertTags_andFindByTag_returnsJobId() {
+  void insertTags_persistsOneRowPerTag() {
     var saved = persist(newPendingJob());
     store().insertTags(saved.getId(), List.of("tag1", "tag2"));
 
-    List<UUID> ids = queryStore().findJobIdsByTag("tag1", 10, 0);
-
-    assertTrue(ids.contains(saved.getId()), "findJobIdsByTag should return the tagged job");
-    assertTrue(
-        queryStore().findJobIdsByTag("tag2", 10, 0).contains(saved.getId()),
-        "findJobIdsByTag should return the job for every inserted tag");
+    assertEquals(
+        2,
+        store().deleteTagsByJobId(saved.getId()),
+        "insertTags must persist one row per tag; the delete count reflects both writes");
   }
 
   @Test
@@ -58,15 +59,12 @@ public abstract class AbstractTagStoreContract implements JobStoreContractFixtur
     var saved = persist(newPendingJob());
     store().insertTags(saved.getId(), List.of("tag1", "tag2"));
 
-    int deleted = store().deleteTagsByJobId(saved.getId());
-
-    assertTrue(deleted > 0, "deleteTagsByJobId should report removed tags");
-    assertTrue(
-        queryStore().findJobIdsByTag("tag1", 10, 0).isEmpty(),
-        "findJobIdsByTag should return empty after deletion");
-    assertTrue(
-        queryStore().findJobIdsByTag("tag2", 10, 0).isEmpty(),
-        "findJobIdsByTag should return empty after deletion");
+    assertEquals(
+        2, store().deleteTagsByJobId(saved.getId()), "deleteTagsByJobId should remove every tag");
+    assertEquals(
+        0,
+        store().deleteTagsByJobId(saved.getId()),
+        "a second delete should find nothing left to remove");
   }
 
   @Test
@@ -81,8 +79,8 @@ public abstract class AbstractTagStoreContract implements JobStoreContractFixtur
         "Inserting the same tag twice should not throw");
 
     assertEquals(
-        List.of(saved.getId()),
-        queryStore().findJobIdsByTag("dup-tag", 10, 0),
+        1,
+        store().deleteTagsByJobId(saved.getId()),
         "Duplicate tag insertion must leave a single association");
   }
 
@@ -93,6 +91,8 @@ public abstract class AbstractTagStoreContract implements JobStoreContractFixtur
     assertDoesNotThrow(
         () -> store().insertTags(saved.getId(), List.of()),
         "Inserting empty tag list should not throw");
+    assertEquals(
+        0, store().deleteTagsByJobId(saved.getId()), "an empty insert must write no tag rows");
   }
 
   @Test

--- a/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DenyReadJobAuthorizationPolicy.java
+++ b/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DenyReadJobAuthorizationPolicy.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import java.util.UUID;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.exception.JobAuthorizationException;
+import run.ratchet.spi.JobAuthorizationPolicy;
+
+/**
+ * {@link JobAuthorizationPolicy} {@code @Alternative} that permits job creation but denies every
+ * read and scopes list queries to a principal no job carries. The TCK query contract uses it to
+ * prove existence-hiding (a denied {@code getJobDetail} returns empty, indistinguishable from a
+ * missing job) and {@code filterForPrincipal} scoping (a scoped {@code findJobs} returns nothing).
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class DenyReadJobAuthorizationPolicy implements JobAuthorizationPolicy {
+
+  private static final String UNMATCHABLE_PRINCIPAL = "__denied-no-match__";
+
+  @Override
+  public void checkCreate(UUID jobId, String callerPrincipal) throws JobAuthorizationException {}
+
+  @Override
+  public void checkRead(UUID jobId, String callerPrincipal) throws JobAuthorizationException {
+    throw new JobAuthorizationException(jobId, "read", callerPrincipal, "Read denied by policy");
+  }
+
+  @Override
+  public JobFilter filterForPrincipal(JobFilter filter, String callerPrincipal) {
+    // Narrow to a principal no job carries, so list reads return nothing for this caller.
+    return filter.toBuilder().callerPrincipal(UNMATCHABLE_PRINCIPAL).build();
+  }
+
+  @Override
+  public void checkCancel(UUID jobId, String ownerPrincipal, String currentPrincipal)
+      throws JobAuthorizationException {}
+
+  @Override
+  public void checkPause(UUID jobId, String ownerPrincipal, String currentPrincipal)
+      throws JobAuthorizationException {}
+
+  @Override
+  public void checkResume(UUID jobId, String ownerPrincipal, String currentPrincipal)
+      throws JobAuthorizationException {}
+
+  @Override
+  public void checkRetry(UUID jobId, String ownerPrincipal, String currentPrincipal)
+      throws JobAuthorizationException {}
+}

--- a/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/SecondAttemptVetoRetryPolicy.java
+++ b/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/SecondAttemptVetoRetryPolicy.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import java.time.Duration;
+import run.ratchet.spi.RetryPolicy;
+
+/**
+ * A {@link RetryPolicy} that permits the first retry then vetoes: {@code shouldRetry} returns
+ * {@code true} only while the attempt is below 2, so a deterministically-failing job runs its body
+ * exactly twice regardless of a larger {@code maxRetries}. Used by the TCK retry-policy override
+ * contract to prove a policy can stop retries below the configured ceiling.
+ */
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class SecondAttemptVetoRetryPolicy implements RetryPolicy {
+
+  @Override
+  public boolean shouldRetry(int attempt, Throwable cause) {
+    return attempt < 2;
+  }
+
+  @Override
+  public Duration getDelay(int attempt) {
+    return Duration.ZERO;
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiBroadcastSignalIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiBroadcastSignalIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.tck.api.AbstractBroadcastSignalContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+
+/** RI subclass of {@link AbstractBroadcastSignalContract}. */
+@ExtendWith(ArquillianExtension.class)
+class RiBroadcastSignalIT extends AbstractBroadcastSignalContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+
+  @Override
+  protected RatchetTckRuntime runtime() {
+    return runtime;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.create();
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiBulkCancelEventIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiBulkCancelEventIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.tck.api.AbstractBulkCancelEventContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+
+/** RI subclass of {@link AbstractBulkCancelEventContract}. */
+@ExtendWith(ArquillianExtension.class)
+class RiBulkCancelEventIT extends AbstractBulkCancelEventContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+
+  @Override
+  protected RatchetTckRuntime runtime() {
+    return runtime;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.create();
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiJobControlReturnIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiJobControlReturnIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.tck.api.AbstractJobControlReturnContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+
+/** RI subclass of {@link AbstractJobControlReturnContract}. */
+@ExtendWith(ArquillianExtension.class)
+class RiJobControlReturnIT extends AbstractJobControlReturnContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+
+  @Override
+  protected RatchetTckRuntime runtime() {
+    return runtime;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.create();
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiJobQueryDenialIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiJobQueryDenialIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.api.JobQueryService;
+import run.ratchet.tck.api.AbstractJobQueryDenialContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+import run.ratchet.testsuite.app.DenyReadJobAuthorizationPolicy;
+
+/**
+ * RI subclass of {@link AbstractJobQueryDenialContract}. The deployment bundles {@link
+ * DenyReadJobAuthorizationPolicy} as an enabled {@code @Alternative}, so the injected query service
+ * denies reads and scopes list queries.
+ */
+@ExtendWith(ArquillianExtension.class)
+class RiJobQueryDenialIT extends AbstractJobQueryDenialContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+  @Inject private JobQueryService jobQueryService;
+
+  @Override
+  protected RatchetTckRuntime runtime() {
+    return runtime;
+  }
+
+  @Override
+  protected JobQueryService deniedQueryService() {
+    return jobQueryService;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.createWith(new Package[0], DenyReadJobAuthorizationPolicy.class);
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiJobQueryIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiJobQueryIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.api.JobQueryService;
+import run.ratchet.tck.api.AbstractJobQueryContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+
+/** RI subclass of {@link AbstractJobQueryContract} exercising the permit-all read surface. */
+@ExtendWith(ArquillianExtension.class)
+class RiJobQueryIT extends AbstractJobQueryContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+  @Inject private JobQueryService jobQueryService;
+
+  @Override
+  protected RatchetTckRuntime runtime() {
+    return runtime;
+  }
+
+  @Override
+  protected JobQueryService queryService() {
+    return jobQueryService;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.create();
+  }
+}

--- a/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiRetryPolicyIT.java
+++ b/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiRetryPolicyIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.tck;
+
+import jakarta.inject.Inject;
+import java.util.Optional;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.tck.api.AbstractRetryPolicyContract;
+import run.ratchet.tck.api.RatchetTckRuntime;
+import run.ratchet.testsuite.app.SecondAttemptVetoRetryPolicy;
+
+/**
+ * RI subclass of {@link AbstractRetryPolicyContract}. The deployment bundles {@link
+ * SecondAttemptVetoRetryPolicy} as an enabled {@code @Alternative}, so the whole engine in this
+ * deployment retries with that policy.
+ */
+@ExtendWith(ArquillianExtension.class)
+class RiRetryPolicyIT extends AbstractRetryPolicyContract {
+
+  @Inject private RiRatchetTckRuntime runtime;
+
+  @Override
+  protected Optional<RatchetTckRuntime> retryPolicyRuntime() {
+    return Optional.of(runtime);
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    return RiTckDeployment.createWith(new Package[0], SecondAttemptVetoRetryPolicy.class);
+  }
+}

--- a/ratchet-testsuite/src/test/resources/arquillian.xml
+++ b/ratchet-testsuite/src/test/resources/arquillian.xml
@@ -15,7 +15,7 @@
       <property name="jbossHome">${project.build.directory}/wildfly-${wildfly.version}</property>
       <property name="serverConfig">standalone.xml</property>
       <property name="javaVmArguments">
-        -Xms512m -Xmx1024m
+        -Xms512m -Xmx2048m
         -Djboss.socket.binding.port-offset=20000
         ${jacoco.it.argLine}
         -Dratchet.test.db.url=${ratchet.test.db.url}
@@ -53,7 +53,7 @@
       -->
       <property name="jbossArguments">--stability=preview</property>
       <property name="javaVmArguments">
-        -Xms512m -Xmx1024m
+        -Xms512m -Xmx2048m
         -Djboss.socket.binding.port-offset=21000
         ${jacoco.it.argLine}
         -Dratchet.test.db.url=${ratchet.test.db.url}
@@ -132,7 +132,7 @@
       <property name="serverName">${openliberty.server.name}</property>
       <property name="httpPort">${openliberty.http.port}</property>
       <property name="javaVmArguments">
-        -Xms512m -Xmx1024m
+        -Xms512m -Xmx2048m
         ${jacoco.it.argLine}
         -Dratchet.test.db.url=${ratchet.test.db.url}
         -Dratchet.test.db.username=${ratchet.test.db.username}


### PR DESCRIPTION
## What

Closes the remaining structural gaps in the TCK so each tier verifies the contract it certifies. Thirteen atomic changes across the store, API, and coordinator tiers.

### Store tier — stop routing mandatory behavior through optional capabilities

A required-tier contract that asserts only through an optional capability accessor silently degrades to N/A on a store that lacks the capability, so the conformance report reads PASS without the behavior being checked. These re-anchor the mandatory assertions on the core surface and move the capability-specific assertions into their own capability contracts:

- Tag writes verified through the core `deleteTagsByJobId` row count.
- Queue-wait percentile moved to the analytics contract; the recurring-master child round-trip moved to the recurring contract.
- The atomic job-plus-batch terminal test moved to the batch contract, with the job side asserted through a core read.
- The dual-write count-drift invariant asserted through core `countPendingJobs`.

### API tier — pin public MUST behaviors that had no cross-layer coverage

- Broadcast `deliverSignal(signalKey, …)` multi-unblock count.
- `cancelJobsByTag` publishes exactly one bulk event and no per-job events.
- The documented boolean returns of `pauseJob` / `resumeJob` / `retryJob`, plus the FAILED→PENDING retry path (which had no API-level test).
- A custom `RetryPolicy` override, with a normative note that `shouldRetry` is ANDed with `maxRetries` — a policy can stop retries early but cannot extend them past the ceiling.
- The `JobQueryService` read layer: positive round-trips plus existence-hiding on denial and principal-scoped `findJobs`.

### Coordinator tier

- Round-trip the `executionTarget` wire field (previously always null).
- Push the future-envelope wire shape into a harness hook so a non-JSON coordinator can exercise the unknown-version rejection path.
- Emit a machine-readable conformance report for the coordinator tier, matching the other tiers.

### Docs

- Document the 36-character limit on custom idempotency keys.

## Validation

- Store contracts: green against PostgreSQL via Testcontainers (89 cases).
- Coordinator contracts: green against PostgreSQL; conformance report emitted (17 cases).
- New API contracts: green through their reference-implementation integration tests on the `wildfly-managed` + `postgresql` server matrix cell (16 cases).
- Full reactor compiles; Google Java Format clean.

Stacked on #70 — review and merge that first, then this retargets to `main`.
