### PR TITLE
Add the Maven Central release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  # Lets release.yml and snapshot.yml reuse the full matrix as their verify gate.
+  workflow_call:
 
 # Ryuk, the Testcontainers resource reaper, is unnecessary on ephemeral GitHub runners — the VM is
 # thrown away after each job, so anything it would reap dies with it. Its image pull is also an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,208 @@
+name: Release
+
+permissions:
+  contents: write
+  packages: write
+  statuses: write
+  checks: write
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Branch guard: workflow_dispatch can run from any branch by default; lock to main
+  # so an operator clicking "Run workflow" from a feature branch does NOT publish a
+  # release tag from non-main code.
+  guard:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "branch guard ok — running release on main"
+
+  # Fast operator-mistake checks (~5s) before the ~20-minute verify matrix.
+  preflight:
+    needs: guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Pre-flight check (pom version)
+        run: |
+          set -euo pipefail
+          # The root pom <version> must be -SNAPSHOT (release:prepare rewrites it to
+          # the release version and then bumps to the next development iteration).
+          POM_VERSION=$(grep -oE '<version>[^<]+</version>' pom.xml | head -1 | sed 's|<[^>]*>||g')
+          if [[ ! "$POM_VERSION" =~ -SNAPSHOT$ ]]; then
+            echo "::error::pom.xml <version> must end in -SNAPSHOT before release:prepare; got: $POM_VERSION"
+            exit 1
+          fi
+          echo "✓ Pre-flight green for ${POM_VERSION%-SNAPSHOT}"
+
+  # Full CI matrix as the release gate — the release MUST NOT proceed if any cell is
+  # red. Because this gate runs the whole test suite, the maven-release-plugin's own
+  # forked builds skip tests (see <arguments> in the root pom's release plugin config).
+  verify:
+    needs: preflight
+    uses: ./.github/workflows/ci.yml
+    secrets: inherit
+
+  release:
+    needs: verify
+    permissions:
+      contents: write
+      # id-token + attestations are needed by actions/attest-build-provenance, which
+      # mints a sigstore-backed attestation against the GitHub OIDC token.
+      id-token: write
+      attestations: write
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout with RELEASE_TOKEN (fine-grained PAT owned by a repo admin, Contents +
+      # Workflows R/W on this repo only). actions/checkout configures an http.extraheader
+      # so the git pushes from release:prepare authenticate as the PAT owner, who must be
+      # a bypass actor on the main branch protection — the `prepare release` and `prepare
+      # for next development iteration` commits push directly to main without PR checks.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+          # OSSRH_USERNAME/OSSRH_TOKEN are a Central Portal token generated at
+          # https://central.sonatype.com/account (the names keep mjml-java/magika-java
+          # parity; the credentials are NOT legacy oss.sonatype.org).
+          server-id: central
+          server-username: OSSRH_USERNAME
+          server-password: OSSRH_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish to Maven Central
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # The pom's <developerConnection> uses an SSH URL for local-dev convenience.
+          # release:prepare reads it directly and offers no CLI override, so rewrite
+          # SSH to HTTPS globally — the http.extraheader from actions/checkout then
+          # authenticates the push with the RELEASE_TOKEN PAT.
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          mvn -B -ntp -Dstyle.color=always release:prepare -P sign
+          cat release.properties
+          RELEASE_TAG=$(grep '^scm.tag=' release.properties | cut -d'=' -f2)
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
+          mvn -B -ntp -Dstyle.color=always release:perform -P sign \
+            -DconnectionUrl=scm:git:https://github.com/${REPO}.git
+          echo "Released ${RELEASE_TAG} 🚀" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          REPO: ${{ github.repository }}
+
+      # release:perform checks the tagged code into target/checkout/ and runs the
+      # central+sign release profiles; cyclonedx makeBom (bound in the default build)
+      # drops bom.{json,xml} into each module's target/. Collect everything under
+      # versioned names so release-asset downloads identify their module/version.
+      - name: Collect release artifacts (JARs + SBOMs)
+        run: |
+          set -euo pipefail
+          RELEASE_VERSION="${RELEASE_TAG#v}"
+          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
+          mkdir -p release-assets
+          missing=0
+          # Every Central-published jar artifact. ratchet-tck's five sub-modules live
+          # one level deeper; ratchet-bom and the ratchet-tck aggregator are
+          # pom-packaging (no jar). The six test/dev modules are never published.
+          JAR_PATHS=""
+          for m in ratchet-api ratchet ratchet-store-core ratchet-encryption \
+                   ratchet-store-mysql ratchet-store-postgresql ratchet-store-mongodb \
+                   ratchet-coordinator-common ratchet-coordinator-postgresql \
+                   ratchet-coordinator-jms ratchet-coordinator-infinispan \
+                   ratchet-coordinator-hazelcast ratchet-micrometer ratchet-otel; do
+            JAR_PATHS="$JAR_PATHS target/checkout/${m}:${m}"
+          done
+          for m in util store api jakarta coordinator; do
+            JAR_PATHS="$JAR_PATHS target/checkout/ratchet-tck/${m}:ratchet-tck-${m}"
+          done
+          for entry in $JAR_PATHS; do
+            dir="${entry%%:*}"; artifact="${entry##*:}"
+            jar="${dir}/target/${artifact}-${RELEASE_VERSION}.jar"
+            if [ -f "$jar" ]; then
+              cp "$jar" "release-assets/"
+            else
+              echo "::error::Expected JAR not found at $jar"
+              missing=1
+            fi
+            # SBOMs — both formats, required for every published jar module: a missing
+            # SBOM means cyclonedx didn't run and the release config is broken.
+            for fmt in json xml; do
+              src="${dir}/target/bom.${fmt}"
+              if [ -f "$src" ]; then
+                cp "$src" "release-assets/${artifact}-${RELEASE_VERSION}-cyclonedx.${fmt}"
+              else
+                echo "::error::Expected SBOM not found at $src"
+                missing=1
+              fi
+            done
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::Required release artifacts are missing (see errors above); aborting before GitHub Release"
+            exit 1
+          fi
+          ls -la release-assets/
+
+      - name: Attest build provenance for JARs
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: 'release-assets/*.jar'
+
+      - name: Create GitHub Release
+        # Release notes come from the commit list (Haiku-categorized when an API key is
+        # available, raw list otherwise) — the project keeps no tracked CHANGELOG.
+        # Commit subjects are passed through shell vars + jq --arg, never interpolated
+        # into the script via ${{ }}, so a crafted commit message cannot inject commands.
+        run: |
+          set -euo pipefail
+          PREV_TAG=$(git describe --tags --abbrev=0 "${RELEASE_TAG}^" 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            COMMITS=$(git log "${PREV_TAG}..${RELEASE_TAG}" --pretty=format:"- %s" \
+              | grep -v -E 'prepare release|prepare for next development iteration')
+          else
+            COMMITS=$(git log "${RELEASE_TAG}" --pretty=format:"- %s" \
+              | grep -v -E 'prepare release|prepare for next development iteration')
+          fi
+
+          printf '%s\n' "$COMMITS" > release-notes.md
+          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            NOTES=$(curl -sf https://api.anthropic.com/v1/messages \
+              -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+              -H "anthropic-version: 2023-06-01" \
+              -H "content-type: application/json" \
+              -d "$(jq -n --arg commits "$COMMITS" '{
+                model: "claude-haiku-4-5-20251001",
+                max_tokens: 1024,
+                messages: [{role: "user", content: ("Categorize these git commits into GitHub release notes. Use these sections as needed: ## New Features, ## Bug Fixes, ## Dependency Updates, ## Other Changes. Use bulleted markdown lists. Only include sections that have entries. Do not add any preamble or explanation, just the categorized notes.\n\nCommits:\n" + $commits)}]
+              }')" | jq -r '.content[0].text') || NOTES=""
+            if [ -n "$NOTES" ]; then
+              printf '%s\n' "$NOTES" > release-notes.md
+            fi
+          fi
+
+          # SBOMs attach as release assets; JARs live on Maven Central. Collect via a
+          # counted array so an empty glob is a hard error, not a silent mis-expansion.
+          shopt -s nullglob
+          sboms=(release-assets/*-cyclonedx.json release-assets/*-cyclonedx.xml)
+          if [ "${#sboms[@]}" -lt 2 ]; then
+            echo "::error::No SBOM assets found to attach"
+            exit 1
+          fi
+          gh release create "${RELEASE_TAG}" \
+            --title "${RELEASE_TAG}" \
+            --notes-file release-notes.md \
+            --latest \
+            "${sboms[@]}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,41 @@
+name: Snapshot
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  snapshot-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: temurin
+          cache: maven
+          # setup-java materializes ~/.m2/settings.xml with a <server> entry whose id
+          # matches the github profile's <distributionManagement><repository><id>.
+          # Without it the upload to maven.pkg.github.com fails with 401 Unauthorized.
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Publish snapshot to GitHub Packages
+        # No verify gate here, unlike release.yml: every push to main already ran the
+        # full CI matrix through the "CI required" branch protection, and re-running
+        # the 15-cell Arquillian matrix per push would roughly double CI cost. The six
+        # test/dev modules set maven.deploy.skip=true, so only library artifacts upload.
+        run: mvn -B -ntp -Dstyle.color=always deploy -P github,sign -DskipTests -Dspotbugs.skip=true
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-parent</artifactId>
-  <version>${revision}</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Ratchet</name>
@@ -69,9 +69,11 @@
   </modules>
 
   <properties>
-    <revision>0.1.0-SNAPSHOT</revision>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- Reproducible builds: two builds of the same tag produce identical jar hashes.
+         maven-release-plugin refreshes this on each release:prepare. -->
+    <project.build.outputTimestamp>2026-06-06T00:00:00Z</project.build.outputTimestamp>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>
@@ -120,6 +122,9 @@
     <maven-war-plugin.version>3.5.1</maven-war-plugin.version>
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
+    <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
     <google-java-format.version>1.35.0</google-java-format.version>
@@ -843,6 +848,82 @@
         </plugins>
       </build>
     </profile>
+    <!-- Release publishing profiles. maven-release-plugin activates central+sign together
+         via releaseProfiles during release:perform; none are active in normal builds. -->
+    <profile>
+      <id>sign</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven-gpg-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>central</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central-publishing-maven-plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>false</autoPublish>
+              <waitUntil>validated</waitUntil>
+              <deploymentName>${project.artifactId}:${project.version}</deploymentName>
+              <!-- Test/dev infrastructure stays out of the Central bundle. Central artifacts
+                   are immutable, so a stray deploy of these could never be undone. Each of
+                   these modules also sets maven.deploy.skip=true, which guards the plain
+                   mvn-deploy path (e.g. GitHub Packages snapshots). -->
+              <excludeArtifacts>
+                <excludeArtifact>ratchet-testsuite</excludeArtifact>
+                <excludeArtifact>ratchet-testsuite-jpms</excludeArtifact>
+                <excludeArtifact>ratchet-loadtest</excludeArtifact>
+                <excludeArtifact>ratchet-showcase</excludeArtifact>
+                <excludeArtifact>ratchet-coverage</excludeArtifact>
+                <excludeArtifact>ratchet-arch-tests</excludeArtifact>
+              </excludeArtifacts>
+            </configuration>
+          </plugin>
+          <!-- Central requires -sources.jar and -javadoc.jar for every jar artifact.
+               Listed explicitly (instead of relying on the super-POM release-profile,
+               which Maven 4 removes) so the managed attach-sources/attach-javadocs
+               executions run whenever this profile is active. -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>github</id>
+      <distributionManagement>
+        <repository>
+          <id>github</id>
+          <name>GitHub Packages</name>
+          <url>https://maven.pkg.github.com/ratchet-run/ratchet</url>
+        </repository>
+      </distributionManagement>
+    </profile>
   </profiles>
 
   <build>
@@ -883,11 +964,44 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>${maven-source-plugin.version}</version>
+          <executions>
+            <execution>
+              <id>attach-sources</id>
+              <goals>
+                <goal>jar-no-fork</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>${maven-javadoc-plugin.version}</version>
+          <configuration>
+            <additionalOptions>-Xdoclint:-missing</additionalOptions>
+          </configuration>
+          <executions>
+            <execution>
+              <id>attach-javadocs</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>${maven-release-plugin.version}</version>
+          <configuration>
+            <!-- The release workflow gates on the full CI matrix before release:prepare
+                 runs, so the forked builds skip tests and SpotBugs instead of repeating
+                 the Testcontainers suites. -->
+            <arguments>-ntp -DskipTests -Dspotbugs.skip=true</arguments>
+            <scmCommentPrefix />
+            <tagNameFormat>v@{project.version}</tagNameFormat>
+            <releaseProfiles>central,sign</releaseProfiles>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1245,6 +1359,10 @@
           <schemaVersion>1.6</schemaVersion>
           <outputFormat>all</outputFormat>
           <includeTestScope>false</includeTestScope>
+          <!-- The central-publishing extension disables the standard deploy step for
+               every module, which the default skipNotDeployed=true misreads as "don't
+               need an SBOM" — release builds would silently ship without bom.{json,xml}. -->
+          <skipNotDeployed>false</skipNotDeployed>
         </configuration>
       </plugin>
     </plugins>

--- a/ratchet-api/pom.xml
+++ b/ratchet-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-api</artifactId>

--- a/ratchet-arch-tests/pom.xml
+++ b/ratchet-arch-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-arch-tests</artifactId>
@@ -20,6 +20,11 @@
     against: CDI bootstrap defects (CdiBeanArchitectureTest) and module
     boundary drift (LayeringArchitectureTest).
   </description>
+
+  <properties>
+    <!-- Test/dev infrastructure: never published. Guards plain mvn deploy; Central is additionally gated by excludeArtifacts in the central profile. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
 
   <dependencies>
     <!--

--- a/ratchet-bom/pom.xml
+++ b/ratchet-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-bom</artifactId>

--- a/ratchet-coordinator-common/pom.xml
+++ b/ratchet-coordinator-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-coordinator-common</artifactId>

--- a/ratchet-coordinator-hazelcast/pom.xml
+++ b/ratchet-coordinator-hazelcast/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-coordinator-hazelcast</artifactId>

--- a/ratchet-coordinator-infinispan/pom.xml
+++ b/ratchet-coordinator-infinispan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-coordinator-infinispan</artifactId>

--- a/ratchet-coordinator-jms/pom.xml
+++ b/ratchet-coordinator-jms/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-coordinator-jms</artifactId>

--- a/ratchet-coordinator-postgresql/pom.xml
+++ b/ratchet-coordinator-postgresql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-coordinator-postgresql</artifactId>

--- a/ratchet-coverage/pom.xml
+++ b/ratchet-coverage/pom.xml
@@ -7,13 +7,18 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-coverage</artifactId>
   <packaging>pom</packaging>
   <name>Ratchet :: Coverage Report</name>
   <description>Aggregate JaCoCo coverage report across all Ratchet modules</description>
+
+  <properties>
+    <!-- Test/dev infrastructure: never published. Guards plain mvn deploy; Central is additionally gated by excludeArtifacts in the central profile. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/ratchet-encryption/pom.xml
+++ b/ratchet-encryption/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-encryption</artifactId>

--- a/ratchet-loadtest/pom.xml
+++ b/ratchet-loadtest/pom.xml
@@ -7,13 +7,18 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-loadtest</artifactId>
   <packaging>war</packaging>
   <name>Ratchet :: Load Test Harness</name>
   <description>REST-driven Ratchet load-test harness for Docker Compose clusters</description>
+
+  <properties>
+    <!-- Test/dev infrastructure: never published. Guards plain mvn deploy; Central is additionally gated by excludeArtifacts in the central profile. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/ratchet-micrometer/pom.xml
+++ b/ratchet-micrometer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-micrometer</artifactId>

--- a/ratchet-otel/pom.xml
+++ b/ratchet-otel/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-otel</artifactId>

--- a/ratchet-showcase/pom.xml
+++ b/ratchet-showcase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-showcase</artifactId>
@@ -16,6 +16,8 @@
   <description>Order fulfillment showcase WAR with a live Ratchet dashboard</description>
 
   <properties>
+    <!-- Test/dev infrastructure: never published. Guards plain mvn deploy; Central is additionally gated by excludeArtifacts in the central profile. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
     <showcase.server>unconfigured</showcase.server>
     <showcase.db>postgresql</showcase.db>
     <showcase.context.path>/</showcase.context.path>

--- a/ratchet-store-core/pom.xml
+++ b/ratchet-store-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-store-core</artifactId>

--- a/ratchet-store-mongodb/pom.xml
+++ b/ratchet-store-mongodb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-store-mongodb</artifactId>

--- a/ratchet-store-mysql/pom.xml
+++ b/ratchet-store-mysql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-store-mysql</artifactId>

--- a/ratchet-store-postgresql/pom.xml
+++ b/ratchet-store-postgresql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-store-postgresql</artifactId>

--- a/ratchet-tck/api/pom.xml
+++ b/ratchet-tck/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ratchet-tck/coordinator/pom.xml
+++ b/ratchet-tck/coordinator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ratchet-tck/jakarta/pom.xml
+++ b/ratchet-tck/jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ratchet-tck/pom.xml
+++ b/ratchet-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-tck</artifactId>

--- a/ratchet-tck/store/pom.xml
+++ b/ratchet-tck/store/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ratchet-tck/util/pom.xml
+++ b/ratchet-tck/util/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/ratchet-testsuite-jpms/pom.xml
+++ b/ratchet-testsuite-jpms/pom.xml
@@ -7,12 +7,17 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-testsuite-jpms</artifactId>
   <name>Ratchet :: JPMS Consumer Test</name>
   <description>JPMS consumer tests for Ratchet module descriptors</description>
+
+  <properties>
+    <!-- Test/dev infrastructure: never published. Guards plain mvn deploy; Central is additionally gated by excludeArtifacts in the central profile. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/ratchet-testsuite/pom.xml
+++ b/ratchet-testsuite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>${revision}</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-testsuite</artifactId>
@@ -17,6 +17,8 @@
   <description>Integration test suite for Ratchet</description>
 
   <properties>
+    <!-- Test/dev infrastructure: never published. Guards plain mvn deploy; Central is additionally gated by excludeArtifacts in the central profile. -->
+    <maven.deploy.skip>true</maven.deploy.skip>
     <skipITs>true</skipITs>
     <jacoco.it.argLine></jacoco.it.argLine>
     <openliberty.server.config.dir>${project.build.directory}/openliberty/wlp/usr/servers/defaultServer</openliberty.server.config.dir>

--- a/ratchet/pom.xml
+++ b/ratchet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>${revision}</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet</artifactId>


### PR DESCRIPTION
## What this does

Duplicates the proven release process from mjml-java and magika-java: maven-release-plugin driving `release:prepare`/`release:perform`, the central-publishing-maven-plugin uploading to the Central Portal, GPG signing, CycloneDX SBOMs, build-provenance attestation, and a GitHub Release with generated notes. The `run.ratchet` namespace is already verified on Central.

## Changes

**Versioning.** The reactor moves from `${revision}` CI-friendly versioning to a literal `0.1.0-SNAPSHOT` (28 poms). maven-release-plugin still mangles `${revision}` parent refs in multi-module reactors (MRELEASE-1109); both reference repos publish literal versions through this plugin. The flatten plugin stays — its `bom` mode produces the consumer-facing poms Central expects.

**Publishing profiles** (never active in normal builds):
- `central` — central-publishing-maven-plugin (`autoPublish=false`, `waitUntil=validated`, so a human presses Publish in the portal), plus source/javadoc jar attachment. Bound explicitly rather than via the super-POM `release-profile`, which Maven 4 removes.
- `sign` — GPG signing at verify.
- `github` — distributionManagement for snapshot deploys to GitHub Packages.

**Deploy fencing.** The six test/dev modules (testsuite, testsuite-jpms, loadtest, showcase, coverage, arch-tests) are excluded twice: `maven.deploy.skip=true` per module (guards plain `mvn deploy`) and `excludeArtifacts` in the central plugin (guards the Central bundle). Central artifacts are immutable — a stray upload of a test harness could never be removed.

**Workflows.**
- `release.yml` (manual dispatch): branch guard → SNAPSHOT preflight → full CI matrix as the gate → prepare/perform → collect all 19 published jars + SBOMs (hard-fails on any missing artifact) → provenance attestation → GitHub Release. Release notes are Haiku-categorized from the commit list, with a raw-list fallback.
- `snapshot.yml`: GitHub Packages deploy on each main push. No verify gate of its own — main is already gated by the required CI matrix, and rerunning 15 Arquillian cells per push would double CI cost.
- `ci.yml`: gains `workflow_call` so release.yml can reuse the matrix.

**Two non-obvious fixes the references encode:**
- `skipNotDeployed=false` on cyclonedx: the central-publishing extension disables the standard deploy step, which cyclonedx's default misreads as "no SBOM needed" — release builds would silently lose their SBOMs.
- `project.build.outputTimestamp` for reproducible jars; `release:prepare` refreshes it each release.

## Deviations from the references

- Release notes from commits (mjml style), not a CHANGELOG preflight — this repo doesn't track a changelog.
- Per-jar SBOM attestations skipped (19 jars; magika attests 2). Provenance covers every jar in one step; SBOMs attach to the GitHub Release.
- The release plugin's forked builds run `-DskipTests -Dspotbugs.skip=true` — the CI matrix gate already ran everything; magika's 3-OS verify is cheap enough to repeat, ratchet's matrix is not.
- snapshot.yml does not re-run CI (see above).

## Secrets to create before the first release

| Secret | Value |
|---|---|
| `OSSRH_USERNAME` / `OSSRH_TOKEN` | Central Portal token from central.sonatype.com/account (names kept for parity with the sibling repos) |
| `MAVEN_GPG_PRIVATE_KEY` / `MAVEN_GPG_PASSPHRASE` | Release signing key (ASCII-armored export) |
| `RELEASE_TOKEN` | Fine-grained PAT, Contents+Workflows R/W on this repo, owner must bypass branch protection (the prepare commits push directly to main) |
| `ANTHROPIC_API_KEY` | Optional — Haiku-categorized release notes; falls back to the raw commit list |

## Validation

- Full reactor `mvn clean test-compile` after the version flip: BUILD SUCCESS.
- `mvn release:prepare -DdryRun=true -B`: BUILD SUCCESS — simulated poms show `0.1.0` for the tag and `0.1.1-SNAPSHOT` for the next iteration. (Dispatch with `-DdevelopmentVersion` later if a different next version is wanted.)
- `mvn package -P central -pl ratchet-api`: produces main, `-sources`, and `-javadoc` jars plus `bom.json`/`bom.xml`.
- `excludeArtifacts` verified in the effective pom under `-P central`.