### PR TITLE
Close three cross-store divergences in the SQL stores

### DIFF
--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlNodeLockOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlNodeLockOperations.java
@@ -33,6 +33,8 @@ import run.ratchet.store.spi.NodeStore;
 
 final class MysqlNodeLockOperations implements NodeStore, LockStore {
 
+  private static final int MAX_INACTIVE_NODES = 1000;
+
   private final MysqlStoreContext ctx;
 
   MysqlNodeLockOperations(MysqlStoreContext ctx) {
@@ -168,10 +170,11 @@ final class MysqlNodeLockOperations implements NodeStore, LockStore {
   public List<NodeEntity> findInactiveNodesSince(Instant cutoff) {
     try {
       // language=MySQL
-      String sql = "SELECT * FROM scheduler_node WHERE heartbeat_ts < ? LIMIT 1000";
+      String sql = "SELECT * FROM scheduler_node WHERE heartbeat_ts < ? LIMIT ?";
       return ctx.em()
           .createNativeQuery(sql, NodeEntity.class)
           .setParameter(1, Timestamp.from(cutoff))
+          .setParameter(2, MAX_INACTIVE_NODES)
           .getResultList();
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("find inactive nodes", e);

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSignalOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSignalOperations.java
@@ -84,7 +84,7 @@ final class MysqlSignalOperations implements SignalStore {
         job.setJobType(row[4] != null ? JobExecutionType.valueOf((String) row[4]) : null);
         job.setPriority(
             row[5] != null
-                ? JobPriority.values()[((Number) row[5]).intValue()]
+                ? MysqlJobRowMapper.safeJobPriority(((Number) row[5]).intValue())
                 : JobPriority.NORMAL);
         job.setMaxRetries(row[6] != null ? ((Number) row[6]).intValue() : 0);
         job.setBusinessKey((String) row[7]);

--- a/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlNodeLockOperationsTest.java
+++ b/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlNodeLockOperationsTest.java
@@ -79,7 +79,7 @@ class MysqlNodeLockOperationsTest {
 
     assertEquals(List.of(inactive), result);
     assertEquals(
-        List.of("SELECT * FROM scheduler_node WHERE heartbeat_ts < ? LIMIT 1000"), sqlStatements);
+        List.of("SELECT * FROM scheduler_node WHERE heartbeat_ts < ? LIMIT ?"), sqlStatements);
   }
 
   @Test

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlAuxiliaryOperations.java
@@ -39,6 +39,8 @@ import run.ratchet.store.util.RowValues;
 final class PostgresqlAuxiliaryOperations
     implements JobAuditStore, WorkflowConditionStore, DlqAlertStore, ResourcePermitStore {
 
+  private static final int PERMIT_CLEANUP_CHUNK_SIZE = 500;
+
   private final PostgresqlStoreContext ctx;
 
   PostgresqlAuxiliaryOperations(PostgresqlStoreContext ctx) {
@@ -368,18 +370,29 @@ final class PostgresqlAuxiliaryOperations
       return 0;
     }
     try {
-      String placeholders = String.join(",", Collections.nCopies(staleNodeIds.size(), "?"));
-      // language=PostgreSQL
-      String sql = "DELETE FROM scheduler_resource_permit WHERE node_id IN (" + placeholders + ")";
-      Query query = ctx.em().createNativeQuery(sql);
-      int parameter = 1;
-      for (String nodeId : staleNodeIds) {
-        query.setParameter(parameter++, nodeId);
+      int deleted = 0;
+      for (int start = 0; start < staleNodeIds.size(); start += PERMIT_CLEANUP_CHUNK_SIZE) {
+        deleted +=
+            cleanupOrphanedPermitsChunk(
+                staleNodeIds.subList(
+                    start, Math.min(start + PERMIT_CLEANUP_CHUNK_SIZE, staleNodeIds.size())));
       }
-      return query.executeUpdate();
+      return deleted;
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("cleanup orphaned permits", e);
     }
+  }
+
+  private int cleanupOrphanedPermitsChunk(List<String> staleNodeIds) {
+    String placeholders = String.join(",", Collections.nCopies(staleNodeIds.size(), "?"));
+    // language=PostgreSQL
+    String sql = "DELETE FROM scheduler_resource_permit WHERE node_id IN (" + placeholders + ")";
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    for (String nodeId : staleNodeIds) {
+      query.setParameter(parameter++, nodeId);
+    }
+    return query.executeUpdate();
   }
 
   private void prepareCondition(WorkflowConditionEntity condition) {

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlBusinessKeyReservations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlBusinessKeyReservations.java
@@ -30,6 +30,8 @@ final class PostgresqlBusinessKeyReservations {
   static final String OWNER_TABLE_QUEUE = BusinessKeyReservations.OWNER_TABLE_QUEUE;
   static final String OWNER_TABLE_RECURRING = BusinessKeyReservations.OWNER_TABLE_RECURRING;
 
+  private static final int DELETE_RESERVATIONS_CHUNK_SIZE = 500;
+
   private final PostgresqlStoreContext ctx;
 
   PostgresqlBusinessKeyReservations(PostgresqlStoreContext ctx) {
@@ -87,6 +89,14 @@ final class PostgresqlBusinessKeyReservations {
     if (ownerJobIds.isEmpty()) {
       return;
     }
+    for (int start = 0; start < ownerJobIds.size(); start += DELETE_RESERVATIONS_CHUNK_SIZE) {
+      deleteReservationsByOwnersChunk(
+          ownerJobIds.subList(
+              start, Math.min(start + DELETE_RESERVATIONS_CHUNK_SIZE, ownerJobIds.size())));
+    }
+  }
+
+  private void deleteReservationsByOwnersChunk(List<UUID> ownerJobIds) {
     try {
       String placeholders = String.join(",", Collections.nCopies(ownerJobIds.size(), "?"));
       // language=PostgreSQL

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobReadOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobReadOperations.java
@@ -28,6 +28,7 @@ import run.ratchet.store.entity.JobEntity;
 final class PostgresqlJobReadOperations {
 
   private static final Logger log = Logger.getLogger(PostgresqlJobReadOperations.class);
+  private static final int FIND_BY_IDS_CHUNK_SIZE = 500;
 
   // language=PostgreSQL
   private static final String HYDRATION_FROM =
@@ -100,37 +101,47 @@ final class PostgresqlJobReadOperations {
     }
   }
 
-  @SuppressWarnings("unchecked")
   List<JobEntity> findByIds(List<UUID> ids) {
-    if (ids.isEmpty()) {
-      return List.of();
-    }
     try {
-      String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
-      // language=PostgreSQL
-      String sql =
-          "SELECT "
-              + PostgresqlJobRowMapper.hydrationSelect()
-              + " "
-              + HYDRATION_FROM
-              + " WHERE c.job_id IN ("
-              + placeholders
-              + ")";
-      Query query = ctx.em().createNativeQuery(sql);
-      int parameter = 1;
-      for (UUID id : ids) {
-        query.setParameter(parameter++, id);
+      if (ids.isEmpty()) {
+        return List.of();
       }
-      List<Object[]> rows = query.getResultList();
-      List<JobEntity> jobs = new ArrayList<>(rows.size());
-      for (Object[] row : rows) {
-        jobs.add(PostgresqlJobRowMapper.hydrate(row));
+      List<JobEntity> jobs = new ArrayList<>(ids.size());
+      for (int start = 0; start < ids.size(); start += FIND_BY_IDS_CHUNK_SIZE) {
+        jobs.addAll(
+            findByIdsChunk(
+                ids.subList(start, Math.min(start + FIND_BY_IDS_CHUNK_SIZE, ids.size()))));
       }
       tags.hydrateTagsBatch(jobs);
       return jobs;
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("find jobs by ids", e);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<JobEntity> findByIdsChunk(List<UUID> ids) {
+    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+    // language=PostgreSQL
+    String sql =
+        "SELECT "
+            + PostgresqlJobRowMapper.hydrationSelect()
+            + " "
+            + HYDRATION_FROM
+            + " WHERE c.job_id IN ("
+            + placeholders
+            + ")";
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    for (UUID id : ids) {
+      query.setParameter(parameter++, id);
+    }
+    List<Object[]> rows = query.getResultList();
+    List<JobEntity> jobs = new ArrayList<>(rows.size());
+    for (Object[] row : rows) {
+      jobs.add(PostgresqlJobRowMapper.hydrate(row));
+    }
+    return jobs;
   }
 
   @SuppressWarnings("unchecked")

--- a/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBulkStoreContract.java
+++ b/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobBulkStoreContract.java
@@ -20,8 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -51,6 +54,37 @@ public abstract class AbstractJobBulkStoreContract implements JobStoreContractFi
 
     var found = store().findByIds(List.of(job1.getId(), job2.getId(), job3.getId()));
     assertEquals(3, found.size(), "bulkInsert should persist all 3 jobs");
+  }
+
+  @Test
+  void findByIds_returnsEveryRowPastTheChunkBoundary() {
+    // The SQL stores read IN-lists in 500-id chunks; 501 ids forces a second, partial
+    // chunk. This catches a store that builds one unbounded IN-list (large batch
+    // recovery then exceeds the database's bind-parameter cap) and a chunk loop that
+    // drops the trailing partial chunk.
+    List<JobEntity> jobs = new ArrayList<>(501);
+    for (int i = 0; i < 501; i++) {
+      var job = newPendingJob();
+      job.setId(UuidV7Factory.create());
+      jobs.add(job);
+    }
+    store().bulkInsert(jobs);
+
+    List<UUID> ids = new ArrayList<>(jobs.size() + 1);
+    for (JobEntity job : jobs) {
+      ids.add(job.getId());
+    }
+    ids.add(UuidV7Factory.create()); // an unknown id is skipped, not an error
+
+    var found = store().findByIds(ids);
+
+    Set<UUID> expected = jobs.stream().map(JobEntity::getId).collect(Collectors.toSet());
+    Set<UUID> actual = found.stream().map(JobEntity::getId).collect(Collectors.toSet());
+    assertEquals(
+        expected,
+        actual,
+        "findByIds must return exactly the persisted ids past the chunk boundary");
+    assertEquals(501, found.size(), "findByIds must not duplicate rows across chunks");
   }
 
   @Test


### PR DESCRIPTION
## What this fixes

A code-duplication review of the SQL stores turned up three places where the MySQL and PostgreSQL implementations had silently diverged. Two are user-reachable; all three are now aligned.

**1. PostgreSQL had no chunk guards on its IN-list paths.** MySQL partitions `findByIds`, `deleteReservationsByOwners`, and `cleanupOrphanedPermits` into 500-id chunks; PostgreSQL built one unbounded IN-list for each. A large batch recovery or workflow-children read succeeds on MySQL and throws on PostgreSQL once the list passes the wire protocol's bind-parameter cap. PostgreSQL now mirrors MySQL's chunked form, helper for helper.

**2. MySQL's signal-timeout scan crashed on a corrupt priority ordinal.** The 17-column signal hydration used a raw `JobPriority.values()[ordinal]` lookup, so one bad row aborted the entire scan with `ArrayIndexOutOfBoundsException`. PostgreSQL clamps out-of-range ordinals to `NORMAL` via `safeJobPriority`; MySQL now calls the same wrapper it already uses on every other hydration path.

**3. The inactive-node scan cap was inlined on MySQL, parameterized on PostgreSQL.** Same value (1000) today, one edit away from drifting. Both now bind a named constant.

## Test coverage

The TCK missed the chunking divergence because every `findByIds` contract used 2–3 ids. `AbstractJobBulkStoreContract` now drives **501 ids** through `bulkInsert` + `findByIds` on every store — forcing a second, partial chunk — and asserts exact id-set equality, which catches an unbounded IN-list, a dropped trailing chunk, and cross-chunk duplicates.

Validation: `mvn test -am` for all three store modules against real Testcontainers databases — 368 tests, 0 failures.