### PR TITLE
Isolate observability SPI failures from the job execution path

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -190,8 +190,9 @@ public interface JobSchedulerService {
    * transaction commits, so a rollback suppresses the event and a listener cannot roll the source
    * transaction back. (When no transaction is active, dispatch is immediate.) Any listener that
    * does heavyweight work (I/O, network calls, cross-system notifications) MUST offload to its own
-   * thread pool. For CDI observers of the same events, prefer {@code @ObservesAsync} when the
-   * observer does not need to run on the publishing thread.
+   * thread pool. CDI observers of these events are delivered on this same synchronous, after-commit
+   * path, so the same rule applies to them; an {@code @ObservesAsync} observer is never notified.
+   * See the {@code run.ratchet.api.event} package documentation for the full observation contract.
    *
    * <p>Event types delivered:
    *
@@ -204,7 +205,7 @@ public interface JobSchedulerService {
    *       ChainFailedEvent}, {@code WorkflowBranchTriggeredEvent}
    *   <li><b>Signals:</b> {@code JobSignalWaitingEvent}, {@code JobSignaledEvent}, {@code
    *       JobsBulkSignaledEvent}, {@code JobSignalTimedOutEvent}
-   *   <li><b>Observability:</b> {@code JobDlqEvent}
+   *   <li><b>Observability:</b> {@code JobDlqEvent}, {@code JobCallbackFailedEvent}
    * </ul>
    *
    * <p><b>Transaction attribute:</b> {@code NOT_SUPPORTED}. Listener registration is an in-memory

--- a/ratchet-api/src/main/java/run/ratchet/api/event/package-info.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/package-info.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Job lifecycle events published by Ratchet, and the contract for observing them.
+ *
+ * <p>Every event in this package reaches application code two ways:
+ *
+ * <ul>
+ *   <li><b>CDI observers</b> — declare an observer method such as {@code void on(@Observes
+ *       JobCompletedEvent event)} on any managed bean. The container delivers only the event types
+ *       a method declares.
+ *   <li><b>Programmatic listeners</b> — register a {@link java.util.function.Consumer} through
+ *       {@link run.ratchet.api.JobSchedulerService#addEventListener}. A listener receives every
+ *       event type and is the right choice outside CDI (Spring, Micronaut, plain Java).
+ * </ul>
+ *
+ * <h2>Delivery contract</h2>
+ *
+ * <p>The delivery contract:
+ *
+ * <ul>
+ *   <li><b>Synchronous.</b> Observers run on the publishing thread, which is typically the job
+ *       execution thread. Ratchet publishes through the synchronous CDI {@code fire} path only, so
+ *       an {@code @ObservesAsync} observer is never notified. To move work off the publishing
+ *       thread, hand it to your own executor from inside a synchronous observer.
+ *   <li><b>After commit.</b> A state-change event raised inside a transaction is delivered after
+ *       that transaction commits. A rollback suppresses the event, and an observer cannot roll the
+ *       source transaction back. When no transaction is active, delivery is immediate.
+ *   <li><b>Contained failures.</b> A programmatic listener runs in its own guard: one that throws
+ *       is logged, and the remaining listeners still run. CDI observers follow standard synchronous
+ *       {@code fire} semantics — a {@code @Observes} method that throws aborts delivery to the
+ *       remaining CDI observers for that event. In both cases the failure stays with the observers
+ *       and never rolls back or otherwise disturbs the committed transaction; a CDI observer that
+ *       must not block its peers should avoid throwing.
+ *   <li><b>Offload heavyweight work.</b> Because delivery sits on the job hot path, any observer
+ *       that does I/O, network calls, or other slow work MUST offload it to its own thread pool. A
+ *       slow or blocking observer adds latency to job execution and can stall the scheduler.
+ * </ul>
+ */
+package run.ratchet.api.event;

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/ExecutionObserver.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/ExecutionObserver.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import org.jboss.logging.Logger;
 import run.ratchet.spi.ExecutorProvider;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.TracingCollector;
@@ -34,6 +35,8 @@ import run.ratchet.store.spi.JobAuditStore;
  * @see JobTask
  */
 public class ExecutionObserver {
+
+  private static final Logger log = Logger.getLogger(ExecutionObserver.class);
 
   private final MetricsCollector metricsCollector;
   private final TracingCollector tracingCollector;
@@ -67,31 +70,45 @@ public class ExecutionObserver {
   }
 
   public void recordJobStart(JobEntity job) {
-    metricsCollector.jobStarted(job.getId(), job.getPublicJobType(), job.getPriority());
+    recordQuietly(
+        "jobStarted",
+        () -> metricsCollector.jobStarted(job.getId(), job.getPublicJobType(), job.getPriority()));
   }
 
   public void recordJobSuccess(JobEntity job, long executionTimeMs) {
-    metricsCollector.jobCompleted(job.getId(), job.getPublicJobType(), executionTimeMs);
+    recordQuietly(
+        "jobCompleted",
+        () -> metricsCollector.jobCompleted(job.getId(), job.getPublicJobType(), executionTimeMs));
   }
 
   public void recordJobFailure(JobEntity job, Throwable ex, int attempt) {
-    metricsCollector.jobFailed(job.getId(), job.getPublicJobType(), ex, attempt);
+    recordQuietly(
+        "jobFailed",
+        () -> metricsCollector.jobFailed(job.getId(), job.getPublicJobType(), ex, attempt));
   }
 
   public void recordCallbackFailure(JobEntity job, Throwable ex, int attempt) {
-    metricsCollector.callbackFailed(job.getId(), job.getPublicJobType(), ex, attempt);
+    recordQuietly(
+        "callbackFailed",
+        () -> metricsCollector.callbackFailed(job.getId(), job.getPublicJobType(), ex, attempt));
   }
 
   public void recordSuccessFinalizationRetry(JobEntity job) {
-    metricsCollector.successFinalizationRetried(job.getId(), job.getPublicJobType());
+    recordQuietly(
+        "successFinalizationRetried",
+        () -> metricsCollector.successFinalizationRetried(job.getId(), job.getPublicJobType()));
   }
 
   public void recordSuccessFinalizationMinimal(JobEntity job) {
-    metricsCollector.successFinalizationMinimal(job.getId(), job.getPublicJobType());
+    recordQuietly(
+        "successFinalizationMinimal",
+        () -> metricsCollector.successFinalizationMinimal(job.getId(), job.getPublicJobType()));
   }
 
   public void recordSuccessFinalizationStuck(JobEntity job) {
-    metricsCollector.successFinalizationStuck(job.getId(), job.getPublicJobType());
+    recordQuietly(
+        "successFinalizationStuck",
+        () -> metricsCollector.successFinalizationStuck(job.getId(), job.getPublicJobType()));
   }
 
   public void recordJobCancellation(JobEntity job) {
@@ -99,7 +116,21 @@ public class ExecutionObserver {
   }
 
   public void recordEnvelopeVersionSkew(UUID jobId, int version, int maxSupportedVersion) {
-    metricsCollector.encryptionEnvelopeVersionSkew(jobId, version, maxSupportedVersion);
+    recordQuietly(
+        "encryptionEnvelopeVersionSkew",
+        () -> metricsCollector.encryptionEnvelopeVersionSkew(jobId, version, maxSupportedVersion));
+  }
+
+  /**
+   * Runs a metrics callback, swallowing and logging any failure. The {@link MetricsCollector} SPI
+   * is integrator-supplied observability; a throwing collector must never change a job's outcome.
+   */
+  private void recordQuietly(String metric, Runnable action) {
+    try {
+      action.run();
+    } catch (Throwable t) {
+      log.warnf(t, "MetricsCollector.%s threw; metrics for this event are dropped", metric);
+    }
   }
 
   public void publishEvent(Object event) {
@@ -144,13 +175,26 @@ public class ExecutionObserver {
     if (tracingCollector == null) {
       return TracingCollector.NoOpExecutionScope.INSTANCE;
     }
-    Map<String, String> parentContext = job.getTraceContext();
-    return tracingCollector.jobExecutionStarted(
-        job.getId(),
-        job.getPublicJobType(),
-        job.getPriority(),
-        parentContext != null ? parentContext : Map.of(),
-        signalTraceAttributes(job));
+    try {
+      Map<String, String> parentContext = job.getTraceContext();
+      TracingCollector.ExecutionScope scope =
+          tracingCollector.jobExecutionStarted(
+              job.getId(),
+              job.getPublicJobType(),
+              job.getPriority(),
+              parentContext != null ? parentContext : Map.of(),
+              signalTraceAttributes(job));
+      return scope == null
+          ? TracingCollector.NoOpExecutionScope.INSTANCE
+          : new GuardedExecutionScope(scope);
+    } catch (Throwable t) {
+      log.warnf(
+          t,
+          "TracingCollector failed to start an execution scope for job %s; tracing is disabled for"
+              + " this attempt",
+          job.getId());
+      return TracingCollector.NoOpExecutionScope.INSTANCE;
+    }
   }
 
   private Map<String, String> signalTraceAttributes(JobEntity job) {
@@ -170,5 +214,45 @@ public class ExecutionObserver {
       attributes.put("ratchet.signal.wait_ms", Long.toString(Math.max(0L, waitMs)));
     }
     return Map.copyOf(attributes);
+  }
+
+  /**
+   * Wraps a {@link TracingCollector.ExecutionScope} so an exception from the integrator's tracer
+   * cannot escape onto the job hot path. Tracing is observability: a throwing scope must never
+   * change a job's outcome.
+   */
+  private static final class GuardedExecutionScope implements TracingCollector.ExecutionScope {
+    private final TracingCollector.ExecutionScope delegate;
+
+    GuardedExecutionScope(TracingCollector.ExecutionScope delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void success(long executionTimeMs) {
+      try {
+        delegate.success(executionTimeMs);
+      } catch (Throwable t) {
+        log.warnf(t, "TracingCollector scope.success threw; continuing");
+      }
+    }
+
+    @Override
+    public void failure(Throwable cause, int attempt) {
+      try {
+        delegate.failure(cause, attempt);
+      } catch (Throwable t) {
+        log.warnf(t, "TracingCollector scope.failure threw; continuing");
+      }
+    }
+
+    @Override
+    public void close() {
+      try {
+        delegate.close();
+      } catch (Throwable t) {
+        log.warnf(t, "TracingCollector scope.close threw; continuing");
+      }
+    }
   }
 }

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/InternalEventPublisher.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/InternalEventPublisher.java
@@ -27,9 +27,11 @@ import org.jboss.logging.Logger;
  * Synchronous event publisher for internal RI use. Fires events to both programmatic listeners
  * (registered via {@link #addListener}) and CDI observers (via {@link Event#fire}).
  *
- * <p>Listener and CDI observer failures are logged and suppressed so one broken observer does not
- * stop later observers. Callers must not rely on {@link #publish(Object)} to roll back their
- * transaction when an observer fails.
+ * <p>A programmatic listener that throws is logged and suppressed so the remaining listeners still
+ * run. A CDI observer exception is logged and suppressed too, but only after CDI's synchronous
+ * {@link Event#fire} has already aborted the remaining observers for that event. Either way,
+ * callers must not rely on {@link #publish(Object)} to roll back their transaction when an observer
+ * fails.
  */
 @ApplicationScoped
 public class InternalEventPublisher {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -314,8 +314,20 @@ public class JobTask implements Callable<Void> {
       observabilityFacade.recordJobStart(jobEntity);
 
       int attemptNumber = jobEntity.getAttempts() + 1;
-      currentExecution =
-          observabilityFacade.startExecution(jobId, attemptNumber, nodeIdProvider.getNodeId());
+      try {
+        currentExecution =
+            observabilityFacade.startExecution(jobId, attemptNumber, nodeIdProvider.getNodeId());
+      } catch (Throwable executionRecordError) {
+        // The execution-history write is durable state, not a metric. When it fails before the
+        // payload runs, fail the job through normal failure handling so it reaches a terminal
+        // state (or a policy-driven retry) instead of stranding in RUNNING until orphan recovery.
+        log.errorf(
+            executionRecordError,
+            "Job %s execution-history start write failed; failing the job",
+            jobId);
+        handleFailureSafely(executionRecordError);
+        return null;
+      }
 
       Instant start = effective().instant();
       observabilityFacade.publishEvent(

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -315,8 +315,7 @@ public class JobTask implements Callable<Void> {
 
       int attemptNumber = jobEntity.getAttempts() + 1;
       try {
-        currentExecution =
-            observabilityFacade.startExecution(jobId, attemptNumber, nodeIdProvider.getNodeId());
+        currentExecution = observabilityFacade.startExecution(jobId, attemptNumber, nodeId);
       } catch (Throwable executionRecordError) {
         // The execution-history write is durable state, not a metric. When it fails before the
         // payload runs, fail the job through normal failure handling so it reaches a terminal

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/ExecutionObserverTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/ExecutionObserverTest.java
@@ -15,8 +15,10 @@
  */
 package run.ratchet.ri.core.internal;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -246,5 +248,64 @@ class ExecutionObserverTest {
     TracingCollector.ExecutionScope scope = observer.startExecutionScope(job(48L));
 
     assertSame(TracingCollector.NoOpExecutionScope.INSTANCE, scope);
+  }
+
+  @Test
+  void recordJobStart_swallowsMetricsCollectorException() {
+    JobEntity job = job(42L);
+    doThrow(new RuntimeException("collector down"))
+        .when(metricsCollector)
+        .jobStarted(job.getId(), job.getPublicJobType(), job.getPriority());
+
+    assertDoesNotThrow(() -> observer.recordJobStart(job));
+  }
+
+  @Test
+  void recordJobSuccess_swallowsMetricsCollectorException() {
+    JobEntity job = job(42L);
+    doThrow(new RuntimeException("collector down"))
+        .when(metricsCollector)
+        .jobCompleted(job.getId(), job.getPublicJobType(), 5L);
+
+    assertDoesNotThrow(() -> observer.recordJobSuccess(job, 5L));
+  }
+
+  @Test
+  void startExecutionScope_returnsNoOpWhenTracerThrows() {
+    when(tracingCollector.jobExecutionStarted(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any()))
+        .thenThrow(new RuntimeException("tracer down"));
+
+    assertSame(
+        TracingCollector.NoOpExecutionScope.INSTANCE, observer.startExecutionScope(job(42L)));
+  }
+
+  @Test
+  void startExecutionScope_returnedScopeSwallowsTracerExceptions() {
+    TracingCollector.ExecutionScope throwingScope = mock(TracingCollector.ExecutionScope.class);
+    doThrow(new RuntimeException("span boom"))
+        .when(throwingScope)
+        .success(ArgumentMatchers.anyLong());
+    doThrow(new RuntimeException("span boom"))
+        .when(throwingScope)
+        .failure(ArgumentMatchers.any(), ArgumentMatchers.anyInt());
+    doThrow(new RuntimeException("span boom")).when(throwingScope).close();
+    when(tracingCollector.jobExecutionStarted(
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any(),
+            ArgumentMatchers.any()))
+        .thenReturn(throwingScope);
+
+    TracingCollector.ExecutionScope scope = observer.startExecutionScope(job(42L));
+
+    assertDoesNotThrow(() -> scope.success(5L));
+    assertDoesNotThrow(() -> scope.failure(new RuntimeException("x"), 1));
+    assertDoesNotThrow(scope::close);
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -53,6 +53,7 @@ import run.ratchet.api.event.JobCallbackFailedEvent;
 import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.api.event.JobDlqEvent;
 import run.ratchet.api.event.JobFailedEvent;
+import run.ratchet.api.event.JobStartedEvent;
 import run.ratchet.api.exception.CircuitBreakerOpenException;
 import run.ratchet.api.exception.KeyProviderUnavailableException;
 import run.ratchet.api.exception.PayloadDecryptionException;
@@ -223,27 +224,40 @@ class JobTaskTest {
   }
 
   @Test
-  void call_clearsBoundContextWhenStartupObservabilityThrows() {
-    // JobContext/MDC are bound before the per-execution try/finally that clears them. A throw from
-    // the startup observability calls must not leave this job's identity on the pooled worker.
+  @SuppressWarnings("unchecked")
+  void call_failsJobWhenExecutionHistoryStartWriteFails() throws Exception {
+    // The execution-history write (startExecution) is durable state, not a metric. When it fails
+    // before the payload runs, the job must fail through normal handling — not escape to the
+    // worker thread and strand the claimed job in RUNNING until orphan recovery.
     JobMdcContext.clear();
     JobEntity job = createTestJob();
+    job.setMaxRetries(3);
     jobTask.init(job);
     when(nodeIdProvider.getNodeId()).thenReturn("node-1");
-    doThrow(new RuntimeException("metrics collector down"))
-        .when(observabilityFacade)
-        .recordJobStart(any(JobEntity.class));
+    RuntimeException auditError = new RuntimeException("audit store down");
+    when(observabilityFacade.startExecution(any(UUID.class), anyInt(), anyString()))
+        .thenThrow(auditError);
+    when(validationFacade.shouldNotRetry(auditError)).thenReturn(false);
+    when(jobStore.incrementRetryAttempt(JOB_UUID)).thenReturn(1);
+    when(retryPolicy.shouldRetry(1, auditError)).thenReturn(false);
+    when(jobStore.compareAndSwapStatus(
+            eq(JOB_UUID), eq(JobStatus.RUNNING), eq(JobStatus.FAILED), any()))
+        .thenReturn(true);
 
-    // The startup failure propagates: the payload never ran, so orphan recovery retries the job.
-    Assertions.assertThrows(RuntimeException.class, () -> jobTask.call());
+    jobTask.call();
 
+    // The payload never ran, and the job was failed cleanly through the terminal DLQ path.
+    verify(resilienceStrategy, never()).execute(anyString(), any(Callable.class));
+    verify(lifecycleFacade).moveToDlq(eq(job), eq(auditError));
+    // No JobStartedEvent is published when the job fails before it begins executing.
+    verify(observabilityFacade, never()).publishEvent(any(JobStartedEvent.class));
     Assertions.assertNull(
         MDC.get(JobMdcContext.MDC_JOB_ID),
-        "MDC job id must be cleared after a startup failure, not leaked to the next job");
+        "MDC job id must be cleared after an execution-history write failure");
     Assertions.assertThrows(
         IllegalStateException.class,
         JobContext::current,
-        "JobContext must be unbound after a startup failure, not leaked to the next job");
+        "JobContext must be unbound after an execution-history write failure");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Two related changes that came out of looking at how the engine invokes integrator-supplied observability code, plus the docs that describe event observation.

**Keep observability failures off the job execution path.** `JobTask` called the integrator-supplied `MetricsCollector` and `TracingCollector` directly on the worker thread. A throwing collector during job start escaped uncaught before the payload ran, leaving the claimed job stuck in `RUNNING` until orphan recovery reclaimed it. A throwing collector on the success path could divert a finished job into failure handling, and on the failure path could push a retryable job to terminal `FAILED`.

`ExecutionObserver` is now the single boundary for those SPIs: every `MetricsCollector` call swallows and logs, and `startExecutionScope` returns a guarding scope wrapper so `success`, `failure`, and `close` cannot throw either. `JobTask` trusts that boundary, so its own per-call guards are gone. The execution-history write in `startExecution` is a `JobAuditStore` write of durable state rather than a metric, so it keeps failing the job through the normal retry and DLQ path instead of being swallowed.

**Document the event observation contract accurately.** The event package docs claimed an observer that throws is logged and skipped without stopping later observers. That holds for the programmatic `Consumer` listeners (each runs in its own guard) but not for CDI observers: synchronous `fire()` aborts on the first throwing `@Observes` method and rethrows, so the publisher's catch shields the engine without making CDI observers independent of each other. The docs also told developers to prefer `@ObservesAsync`, which never fires because the publisher only calls `fire()`. Added a `package-info` describing the delivery contract for both channels, corrected the per-channel failure wording, and added `JobCallbackFailedEvent` to the delivered-events list.

## Testing

What I actually ran (from the `ratchet` and `ratchet-api` modules, `-am`):

- [x] `mvn -pl ratchet -am test` — 816 module tests plus upstream, all green
- [x] `mvn -pl ratchet-api,ratchet spotless:check` — clean
- [x] `mvn -pl ratchet-api javadoc:javadoc` — clean (this module publishes Javadoc)
- [ ] `mvn verify -P wildfly-managed,postgresql ...` — not run (no container-wiring change)
- [ ] website build — not applicable

## Docs

- [x] Docs updated where behavior changed (API Javadoc + new `event/package-info.java`)
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

No API or SPI signatures change. The event-delivery behavior is unchanged; the docs are corrected to match it (an `@ObservesAsync` observer never received events before this and still does not). The runtime behavior that does change is internal to the RI: a failing observability SPI can no longer strand a job or flip its outcome.

## Additional Context

`startExecution` keeps its fail-the-job contract on purpose. `JobAuditStore` is an optional capability, so when it is absent the engine proceeds with a transient execution entity; when it is present and its durable write fails, failing through the normal retry/DLQ path is better than silently leaving a gap in the audit history.

The swallow-vs-fail split is verified in `ExecutionObserverTest` (metrics and tracer exceptions are swallowed) and `JobTaskTest` (a failing `startExecution` fails the job through the DLQ path, with no `JobStartedEvent` and the bound context cleared).
