### PR TITLE
Document recent features and refine docs-only CI gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
   # output is empty, which the downstream `!= 'false'` guards read as "run".
   changes:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,32 @@ env:
   TESTCONTAINERS_RYUK_DISABLED: "true"
 
 jobs:
+  # Detects whether a pull request touches anything other than documentation, so
+  # the heavy integration matrix, the EE 11 lane, and CodeQL can be skipped on
+  # docs-only PRs. Only pull_request events are eligible — pushes to main, the
+  # merge queue, and release builds (workflow_call) always run the full pipeline,
+  # so main is never merged without full validation. The leading '**' is the base
+  # set; the '!' rules subtract documentation from it, so code == 'true' only when
+  # a non-doc file changed. On non-PR events the filter step is skipped and the
+  # output is empty, which the downstream `!= 'false'` guards read as "run".
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.adoc'
+              - '!website/**'
+              - '!LICENSE'
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -68,6 +94,8 @@ jobs:
         run: mvn -B -ntp -DskipTests clean test-compile spotbugs:check
 
   ee11-verify:
+    needs: changes
+    if: ${{ needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -86,7 +114,8 @@ jobs:
         run: mvn -P jakarta-ee11-verify clean test -B
 
   integration-test:
-    needs: build
+    needs: [build, changes]
+    if: ${{ needs.changes.outputs.code != 'false' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -141,7 +170,7 @@ jobs:
   ci-required:
     name: CI required
     if: ${{ always() }}
-    needs: [build, spotbugs, ee11-verify, integration-test]
+    needs: [changes, build, spotbugs, ee11-verify, integration-test]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs passed

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,8 +13,36 @@ permissions:
   contents: read
 
 jobs:
+  # See ci.yml for the rationale: code == 'false' marks a docs-only pull request.
+  # Only pull_request events are eligible; pushes, the merge queue, and the weekly
+  # schedule always run the full scan.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.adoc'
+              - '!website/**'
+              - '!LICENSE'
+
   analyze:
     name: Analyze (Java)
+    # "Analyze (Java)" is a required status check, so the job must always run and
+    # report — skipping it at the job level would leave the context unreported and
+    # hard-block docs-only PRs. Instead the job runs and the expensive steps are
+    # individually guarded, so a docs-only change reports success in seconds.
+    needs: changes
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -24,24 +52,33 @@ jobs:
       contents: read
 
     steps:
+      - name: Skip notice (docs-only change)
+        if: needs.changes.outputs.code == 'false'
+        run: echo "Docs-only pull request — skipping CodeQL analysis."
+
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.code != 'false'
 
       - uses: actions/setup-java@v5
+        if: needs.changes.outputs.code != 'false'
         with:
           java-version: '25'
           distribution: 'temurin'
           cache: 'maven'
 
       - name: Initialize CodeQL
+        if: needs.changes.outputs.code != 'false'
         uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           queries: security-extended,security-and-quality
 
       - name: Build with Maven
+        if: needs.changes.outputs.code != 'false'
         run: mvn -B -ntp clean compile -DskipTests
 
       - name: Perform CodeQL Analysis
+        if: needs.changes.outputs.code != 'false'
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:java-kotlin"

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ scheduler.enqueue(() -> chargeCard(cardToken))
     .submit();
 ```
 
-Encryption covers the protected surfaces, the job payload and its result, while routing and bookkeeping columns (target class, business key, timing) stay queryable. An opted-in job fails the node at startup if no engine and key are installed, so it never silently persists data it was told to protect. To back keys with a KMS instead of the environment, supply your own `KeyProvider` and `PayloadEncryption` beans. The Payload encryption guide on the docs site covers that path, key rotation, and exactly what is and isn't protected.
+Encryption covers the protected surfaces, the job payload and its result, while routing and bookkeeping columns (target class, business key, timing) stay queryable. If a job asks for encryption but no engine and key are installed, it fails when it is submitted rather than silently persisting unprotected data. Enabling the global switch with nothing installed fails the node at startup instead. To back keys with a KMS instead of the environment, supply your own `KeyProvider` and `PayloadEncryption` beans. The Payload encryption guide on the docs site covers that path, key rotation, and exactly what is and isn't protected.
 
 ### Event Observation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ---
 
-Ratchet gives Jakarta EE 10/11 applications a clean, annotation-driven API for background job scheduling with persistent storage, automatic retries, workflow orchestration, and built-in resilience — all without pulling in heavyweight frameworks.
+Ratchet gives Jakarta EE 10/11 applications a clean, annotation-driven API for background job scheduling with persistent storage, automatic retries, workflow orchestration, and built-in resilience, all without pulling in heavyweight frameworks.
 
 ---
 
@@ -14,12 +14,16 @@ Ratchet gives Jakarta EE 10/11 applications a clean, annotation-driven API for b
 |----------|-------------|
 | **Scheduling** | Immediate, delayed, cron-based recurring jobs |
 | **Workflows** | Job chaining, conditional branching, success/failure callbacks |
+| **Signals** | Jobs that wait on a named external signal (an approval gate, a webhook) and resume via `deliverSignal`, targeted or broadcast, with a timeout |
 | **Batching** | In-memory batch builder and streaming batch for large datasets |
 | **Resilience** | Configurable retries with backoff (fixed/exponential), built-in circuit breaker, dead letter queue |
-| **Persistence** | Pluggable store SPI — MySQL, PostgreSQL, and MongoDB out of the box |
-| **Observability** | Rich event system (CDI + programmatic), Micrometer metrics adapter |
+| **Persistence** | Pluggable store SPI: MySQL, PostgreSQL, and MongoDB out of the box |
+| **Security** | Payload encryption at rest with a pluggable `KeyProvider` (AES-256-GCM or XChaCha20-Poly1305) and a deserialization allowlist |
+| **Observability** | Rich event system (CDI + programmatic), Micrometer metrics adapter, and a read-only `JobQueryService` for job search, history, and queue health |
 | **Concurrency** | Permit-based backpressure, adaptive polling, resource limiting |
-| **CDI Integration** | Zero-ceremony wiring — inject `JobSchedulerService` and go |
+| **Routing** | Per-job thread-mode targeting (`virtual()` / `platform()`) and worker-node tag affinity |
+| **Clustering** | Database-backed multi-node claiming, plus optional push wakeups over PostgreSQL `LISTEN`/`NOTIFY`, JMS, Infinispan, or Hazelcast |
+| **CDI Integration** | Zero-ceremony wiring: inject `JobSchedulerService` and go |
 
 ## Showcase App
 
@@ -100,7 +104,7 @@ For demos and tests only, you can bypass the fail-fast startup check with `Ratch
 
 ### 3. Apply or Initialize the Schema
 
-SQL stores ship DDL as plain SQL files — no Flyway dependency, no migration lock-in. Apply the schema however your project manages DDL:
+SQL stores ship DDL as plain SQL files, with no Flyway dependency or migration lock-in. Apply the schema however your project manages DDL:
 
 ```bash
 # PostgreSQL
@@ -142,7 +146,7 @@ public class OrderService {
 ```
 
 > Job IDs are UUIDv7 values (`java.util.UUID`). The factory generates
-> time-ordered IDs without operational coordination — no node-ID knob
+> time-ordered IDs without operational coordination, so no node-ID knob
 > is required.
 
 ## Usage Guide
@@ -225,9 +229,30 @@ scheduler.<Invoice>streamingBatch("import-invoices")
     .start();
 ```
 
+### Waiting on External Signals
+
+Park a job until something outside the scheduler lets it continue, like an operator approval or an inbound webhook. The job holds in `WAITING` until its signal arrives or the timeout fires:
+
+```java
+// The shipment waits for an operator to approve the order, for up to 24 hours.
+scheduler.enqueue(() -> shipOrder(orderId))
+    .awaitSignal("order:" + orderId + ":approved", Duration.ofHours(24))
+    .submit();
+```
+
+Deliver it from a REST endpoint, an admin action, or another job. Target one waiting job by id, or broadcast to every job parked on the key, carrying an approval or rejection:
+
+```java
+scheduler.deliverSignal(
+    "order:" + orderId + ":approved",
+    SignalDecision.approved(approverId));
+```
+
+The resumed job reads whatever the signal carried via `JobContext.signalPayload(...)`.
+
 ### Circuit Breaker Protection
 
-Protect external service calls with the built-in circuit breaker — no Resilience4j required:
+Protect external service calls with the built-in circuit breaker, which needs no Resilience4j:
 
 ```java
 @CircuitBreakerProtected(
@@ -238,6 +263,32 @@ public PaymentResult processPayment(PaymentRequest request) {
     return gateway.charge(request);
 }
 ```
+
+### Encrypting Sensitive Payloads
+
+Encrypt job parameters at rest with authenticated encryption. Add the `ratchet-encryption` module, supply key material through the environment, and switch encryption on. With keys configured, the bundled AES-256-GCM engine and key provider are wired up for you:
+
+```bash
+# Comma-separated keyId:base64Key entries; the current key is the write key.
+export RATCHET_ENCRYPTION_KEYS="2026-06:$(openssl rand -base64 32)"
+```
+
+```java
+// Encrypt every job's payload and result across the deployment...
+RatchetOptions.builder()
+    .encryption(e -> e.enabled(true))
+    .build();
+```
+
+Or leave the global switch off and opt in per job:
+
+```java
+scheduler.enqueue(() -> chargeCard(cardToken))
+    .withEncryptedPayload()
+    .submit();
+```
+
+Encryption covers the protected surfaces, the job payload and its result, while routing and bookkeeping columns (target class, business key, timing) stay queryable. An opted-in job fails the node at startup if no engine and key are installed, so it never silently persists data it was told to protect. To back keys with a KMS instead of the environment, supply your own `KeyProvider` and `PayloadEncryption` beans. The Payload encryption guide on the docs site covers that path, key rotation, and exactly what is and isn't protected.
 
 ### Event Observation
 
@@ -322,8 +373,8 @@ flowchart TD
 | Module | Purpose | Dependencies |
 |--------|---------|-------------|
 | `ratchet-api` | Public API, annotations, events, SPI interfaces | Jakarta CDI / Interceptors APIs (provided) |
-| `ratchet` | Core engine — polling, execution, retry, circuit breaker, CDI wiring | ratchet-api, ratchet-store-core, ASM, cron-utils, JBoss Logging; Jakarta EE APIs provided by the runtime |
-| `ratchet-store-core` | Persistence abstractions — entities and composed `JobStore` SPI | ratchet-api, Jakarta Persistence / JSON APIs |
+| `ratchet` | Core engine: polling, execution, retry, circuit breaker, CDI wiring | ratchet-api, ratchet-store-core, ASM, cron-utils, JBoss Logging; Jakarta EE APIs provided by the runtime |
+| `ratchet-store-core` | Persistence abstractions: entities and composed `JobStore` SPI | ratchet-api, Jakarta Persistence / JSON APIs |
 | `ratchet-store-mysql` | MySQL store implementation with optimized DDL | ratchet-store-core |
 | `ratchet-store-postgresql` | PostgreSQL store with partial indexes and JSONB | ratchet-store-core |
 | `ratchet-store-mongodb` | MongoDB document store implementation | ratchet-store-core |
@@ -332,14 +383,15 @@ flowchart TD
 | `ratchet-coordinator-jms` | JMS-topic-backed cross-node wakeups for deployments that already run a JMS broker | ratchet-coordinator-common, Jakarta Messaging API (provided) |
 | `ratchet-coordinator-infinispan` | Infinispan-clustered-cache wakeup notifications for WildFly / Quarkus deployments | ratchet-coordinator-common, Infinispan API (provided) |
 | `ratchet-coordinator-hazelcast` | Hazelcast topic-backed wakeup notifications for Hazelcast clusters | ratchet-coordinator-common, Hazelcast client (provided) |
+| `ratchet-encryption` | Reference payload-encryption engines (AES-256-GCM, XChaCha20-Poly1305) and a `SecretKeyProvider` | ratchet-api |
 | `ratchet-micrometer` | Micrometer metrics adapter | ratchet-api, Micrometer |
 | `ratchet-otel` | OpenTelemetry-based `TracingCollector` implementation (incubating; not yet in the BOM) | ratchet-api, OpenTelemetry API |
 | `ratchet-showcase` | Runnable order-fulfillment dashboard demonstrating workflows, signals, retries, resource limits, and Micrometer metrics | ratchet, store modules, ratchet-micrometer, Jakarta EE Web APIs |
 | `ratchet-tck` | Aggregator (pom-packaging) for the four TCK submodules below | — |
 | `ratchet-tck-util` | JUnit-only helpers shared across TCK modules | JUnit 5 |
-| `ratchet-tck-store` | Store SPI conformance — CRUD, claiming, status transitions, archiving, batches, locks | ratchet-store-core, ratchet-tck-util, JUnit 5 |
-| `ratchet-tck-api` | Public-API conformance — submit / cancel / retry / idempotency / workflow / delayed scheduling. Container-free, pure-JVM JUnit | ratchet-api, ratchet-tck-util, JUnit 5 |
-| `ratchet-tck-jakarta` | Jakarta-EE conformance — CDI injection, CDI events, JTA enqueue (Arquillian-driven) | ratchet-tck-api, Jakarta CDI / Transaction API, Arquillian |
+| `ratchet-tck-store` | Store SPI conformance: CRUD, claiming, status transitions, archiving, batches, locks | ratchet-store-core, ratchet-tck-util, JUnit 5 |
+| `ratchet-tck-api` | Public-API conformance: submit / cancel / retry / idempotency / workflow / delayed scheduling. Container-free, pure-JVM JUnit | ratchet-api, ratchet-tck-util, JUnit 5 |
+| `ratchet-tck-jakarta` | Jakarta-EE conformance: CDI injection, CDI events, JTA enqueue (Arquillian-driven) | ratchet-tck-api, Jakarta CDI / Transaction API, Arquillian |
 | `ratchet-bom` | Bill of Materials for version alignment | — |
 
 ### SPI Extension Points
@@ -350,9 +402,11 @@ Ratchet is designed to be extended. Provide a CDI `@Alternative @Priority(APPLIC
 |---------------|---------|---------|
 | `RetryPolicy` | Custom retry/no-retry decisions | Defers to `maxRetries` |
 | `ResilienceStrategy` | Circuit breaker behavior | Built-in 3-state machine |
-| `ClassPolicy` | Security — which classes can be deserialized | `PackagePrefixClassPolicy` with an empty allowlist; startup fails fast until you provide an override |
-| `JobAuthorizationPolicy` | Authorization — gate create/cancel/pause/resume/retry/deliver-signal and read access (incubating) | `PermitAllJobAuthorizationPolicy` (permit all) |
+| `ClassPolicy` | Security: which classes can be deserialized | `PackagePrefixClassPolicy` with an empty allowlist; startup fails fast until you provide an override |
+| `JobAuthorizationPolicy` | Authorization: gate create/cancel/pause/resume/retry/deliver-signal and read access (incubating) | `PermitAllJobAuthorizationPolicy` (permit all) |
 | `ErrorSanitizer` | Scrub sensitive data from error messages | `DefaultErrorSanitizer` |
+| `PayloadEncryption` | Authenticated-encryption engine for payloads at rest | Reference AES-256-GCM / XChaCha20-Poly1305 in `ratchet-encryption`; inactive until a `KeyProvider` is installed |
+| `KeyProvider` | Encryption key storage, active-key selection, and rotation | None; required when encryption is enabled. `SecretKeyProvider` ships in `ratchet-encryption` |
 | `RatchetOptions` | Required runtime options bean; deployment fails without a CDI producer | Application-provided via `@Produces`; use `RatchetOptionsFactory.fromEnvironment()` for env-driven configuration |
 | `RatchetConfigSource` | Platform config overlay passed to `RatchetOptionsFactory.fromEnvironment(...)` | Optional |
 | `ExecutionTuningProvider` | Per-execution-type concurrency and virtual-thread limits | Config-backed defaults |
@@ -369,6 +423,7 @@ Ratchet is designed to be extended. Provide a CDI `@Alternative @Priority(APPLIC
 | `ExecutorProvider` | Thread pool / virtual thread configuration | Jakarta Concurrency managed executors |
 | `RatchetEntityManagerProvider` | SQL store `EntityManager` binding | Unnamed `@PersistenceContext` |
 | `NodeIdentityProvider` | Node identification in clusters | Hostname-based |
+| `NodeTagAffinityProvider` | Restrict which jobs a worker node claims, by tag | No filter; every node claims any job |
 | `JobLogger` | Per-job job-scoped logging facade | Created per execution by `JobLoggerFactory` |
 
 ### Custom Store Implementation
@@ -396,10 +451,10 @@ public class MyCustomStoreTest extends AbstractJobCrudStoreContract {
 
 Ratchet uses tiered conformance. Each TCK submodule earns a distinct compatibility label:
 
-- **Ratchet Store Compatible** — passes `ratchet-tck-store` against a custom `JobStore` (CRUD, claiming, status transitions, archiving, execution tracking, batches, locks).
-- **Ratchet API Compatible** — passes `ratchet-tck-api` against a custom `JobSchedulerService` implementation. Pure-JVM JUnit, no container required. Covers submit / cancel / retry / idempotency / simple workflow; delayed-scheduling contracts skip when no `TestClock` is provided.
-- **Ratchet Jakarta Runtime Compatible** — passes `ratchet-tck-api` plus `ratchet-tck-jakarta` (CDI injection, CDI events, JTA enqueue) in a Jakarta EE 10/11 container, typically via Arquillian.
-- **Ratchet RI Verified** — the project's reference-implementation tests pass on a named runtime / database matrix. This is implementation-specific and lives in `ratchet-testsuite`.
+- **Ratchet Store Compatible.** Passes `ratchet-tck-store` against a custom `JobStore` (CRUD, claiming, status transitions, archiving, execution tracking, batches, locks).
+- **Ratchet API Compatible.** Passes `ratchet-tck-api` against a custom `JobSchedulerService` implementation. Pure-JVM JUnit, no container required. Covers submit / cancel / retry / idempotency / simple workflow; delayed-scheduling contracts skip when no `TestClock` is provided.
+- **Ratchet Jakarta Runtime Compatible.** Passes `ratchet-tck-api` plus `ratchet-tck-jakarta` (CDI injection, CDI events, JTA enqueue) in a Jakarta EE 10/11 container, typically via Arquillian.
+- **Ratchet RI Verified.** The project's reference-implementation tests pass on a named runtime / database matrix. This is implementation-specific and lives in `ratchet-testsuite`.
 
 ## Production Checklist
 
@@ -419,7 +474,7 @@ Before deploying Ratchet to a production-shaped environment, work through this c
   ```
   A hardcoded denylist (`Runtime`, `ProcessBuilder`, `javax.script`, reflection, JDK internals) blocks well-known RCE gadgets regardless of allowlist content. To opt out of the fail-fast guard for demos and tests, set `RatchetOptions.security().allowEmptyClassPolicy(true)`.
 
-- [ ] **Apply or initialize the schema.** SQL stores ship DDL as plain SQL files — no Flyway lock-in. Apply once per database before starting any node. See `ratchet-store-{mysql,postgresql}/src/main/resources/ddl/`. MongoDB collections and indexes are initialized by `ratchet-store-mongodb` at startup.
+- [ ] **Apply or initialize the schema.** SQL stores ship DDL as plain SQL files, with no Flyway lock-in. Apply once per database before starting any node. See `ratchet-store-{mysql,postgresql}/src/main/resources/ddl/`. MongoDB collections and indexes are initialized by `ratchet-store-mongodb` at startup.
 
 - [ ] **Use the store-specific UUID wiring.** PostgreSQL stores UUIDv7 IDs as native `uuid`. MySQL stores them as `BINARY(16)` and production persistence units must include `META-INF/orm-mysql.xml` from `ratchet-store-mysql` so non-Hibernate JPA providers route UUID fields through the store-local converter. MongoDB clients must use `UuidRepresentation.STANDARD`; prefer `MongoClientFactory.create(...)` or configure the supplied client explicitly.
 
@@ -478,7 +533,7 @@ mvn spotless:apply
 
 ## Project Status
 
-Ratchet is currently in **0.1.0-SNAPSHOT** — the API is stabilizing but interfaces marked `@Incubating` may change. Feedback and contributions are welcome.
+Ratchet is currently in **0.1.0-SNAPSHOT**. The API is stabilizing, but interfaces marked `@Incubating` may change. Feedback and contributions are welcome.
 
 ## Community
 

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -33,6 +33,12 @@ export default defineConfig({
   title: 'Ratchet',
   description: 'The background job scheduler Jakarta EE has been missing.',
 
+  // Architecture Decision Records stay in the repo for contributors (readable on
+  // GitHub under website/docs/adr/) but are not part of the published user-facing
+  // site. The payload-encryption decision is covered for users by the Payload
+  // Encryption guide under Advanced.
+  srcExclude: ['adr/**'],
+
   head: [
     ['link', { rel: 'icon', href: '/img/favicon.ico' }],
     ['link', { rel: 'icon', type: 'image/svg+xml', href: '/img/favicon.svg' }],
@@ -116,6 +122,7 @@ export default defineConfig({
             { text: 'Circuit Breakers', link: '/advanced/circuit-breakers' },
             { text: 'Custom Retry Policies', link: '/advanced/custom-retry-policies' },
             { text: 'Custom Serialization', link: '/advanced/custom-serialization' },
+            { text: 'Payload Encryption', link: '/advanced/payload-encryption' },
             { text: 'Custom Logging', link: '/advanced/custom-logging' },
             { text: 'Metrics Collection', link: '/advanced/metrics-collection' },
           ],
@@ -225,18 +232,6 @@ export default defineConfig({
                 { text: 'GlassFish + PostgreSQL', link: '/conformance/jakarta/glassfish-managed-postgresql' },
                 { text: 'GlassFish + MongoDB', link: '/conformance/jakarta/glassfish-managed-mongodb' },
               ],
-            },
-          ],
-        },
-      ],
-      '/adr/': [
-        {
-          text: 'Architecture Decision Records',
-          items: [
-            { text: 'Overview', link: '/adr/' },
-            {
-              text: '0001 — Payload encryption threat model',
-              link: '/adr/0001-payload-encryption-threat-model',
             },
           ],
         },

--- a/website/docs/advanced/payload-encryption.md
+++ b/website/docs/advanced/payload-encryption.md
@@ -77,9 +77,10 @@ scheduler.enqueue(() -> billingService.charge(cardToken))
     .submit();
 ```
 
-Either way, an engine and a key provider must be installed. An opted-in job whose
-deployment has neither fails the node at startup rather than persist data it was asked to
-protect. See [Failure behavior](#failure-behavior) below.
+Either way, an engine and a key provider must be installed. A per-job opt-in whose
+deployment has neither fails when the job is submitted rather than persisting data it was
+asked to protect; enabling the global switch with nothing installed fails at startup
+instead. See [Failure behavior](#failure-behavior) below.
 
 ## What is protected, and what is not
 

--- a/website/docs/advanced/payload-encryption.md
+++ b/website/docs/advanced/payload-encryption.md
@@ -1,0 +1,200 @@
+---
+sidebar_position: 6
+title: Payload Encryption
+description: Encrypt sensitive job parameters and results at rest with authenticated encryption
+---
+
+# Payload Encryption
+
+Ratchet can encrypt sensitive job data at rest. When it is enabled, a job's payload (its
+parameter values) and its result are stored as authenticated ciphertext, while the columns
+the scheduler needs to claim, query, and correlate jobs stay in cleartext. The word
+"encrypted" carries a promise, so this page is specific about what the feature protects and
+what it leaves readable.
+
+The mechanism is authenticated encryption (AEAD): every value is encrypted under a key and
+bound to the row and column it belongs to, so decrypting corrupted, tampered, or
+moved-around bytes fails rather than returning a wrong value. Two pieces plug in: a
+`PayloadEncryption` engine that does the AEAD transform, and a `KeyProvider` that owns the
+keys. The `ratchet-encryption` module ships a reference engine and a static-key provider so
+a deployment can turn the feature on without writing code.
+
+## Quick start
+
+Add the module:
+
+```xml
+<dependency>
+  <groupId>run.ratchet</groupId>
+  <artifactId>ratchet-encryption</artifactId>
+</dependency>
+```
+
+Supply key material through the environment. Keys are 32-byte (AES-256) values, base64
+encoded, given as a comma-separated list of `keyId:base64Key` entries:
+
+```bash
+# The current key is the write key; older ids stay available for decryption.
+export RATCHET_ENCRYPTION_KEYS="2026-06:$(openssl rand -base64 32)"
+```
+
+Then switch encryption on for the whole deployment:
+
+```java
+RatchetOptions.builder()
+    .encryption(e -> e.enabled(true))
+    .build();
+```
+
+With keys configured and `ratchet-encryption` on the classpath, Ratchet builds the
+reference AES-256-GCM engine and a `SecretKeyProvider` from those keys for you. Keys are
+read from the environment rather than from `RatchetOptions` on purpose: secret material
+belongs in your secrets manager, not in an in-memory options object.
+
+::: tip Keys live in the environment
+You can also use the system properties `ratchet.encryption.keys` and
+`ratchet.encryption.current-key` instead of the `RATCHET_ENCRYPTION_*` variables. With a
+single key the current-key id may be omitted.
+:::
+
+## Choosing the scope
+
+The global switch and the per-job opt-in answer two different questions.
+
+Turn the global switch on to encrypt every job:
+
+```java
+RatchetOptions.builder()
+    .encryption(e -> e.enabled(true))
+    .build();
+```
+
+Or leave the global switch off and encrypt only the jobs that carry sensitive data:
+
+```java
+scheduler.enqueue(() -> billingService.charge(cardToken))
+    .withEncryptedPayload()
+    .submit();
+```
+
+Either way, an engine and a key provider must be installed. An opted-in job whose
+deployment has neither fails the node at startup rather than persist data it was asked to
+protect. See [Failure behavior](#failure-behavior) below.
+
+## What is protected, and what is not
+
+Encryption covers two surfaces: the **parameter values** of a job and its **result**.
+Everything else stays readable so the scheduler keeps working. Be explicit with your
+compliance reviewers about this boundary.
+
+**Protected against**
+
+- Read access to the database at rest: a DBA browsing rows, a SQL-injection bug that reads
+  tables, a stolen or decommissioned disk. Protected values are ciphertext.
+- Backup and snapshot theft: dumps carry ciphertext for the protected surfaces.
+- Read-replica leaks: replicas inherit the ciphertext.
+- A payload column echoed into a log line or diagnostic dump shows ciphertext, not the
+  value.
+
+**Not protected against**
+
+- Live worker memory. A job's arguments are plaintext on the JVM heap while the job runs;
+  decryption happens before execution by necessity.
+- The submitting application, which holds the plaintext before Ratchet ever sees it.
+- A compromised node. A worker that runs jobs holds, or can reach, the keys. Encryption
+  defends the store, not the compute tier.
+- `KeyProvider` compromise. The scheme is only as strong as the provider behind it.
+- Routing and correlation metadata, cleartext by design. `target_class`, `method_name`,
+  `business_key`, `idempotency_key`, `caller_principal`, `tags`, `signal_key`, the W3C
+  trace context, and parameter **keys** (only parameter *values* are encrypted) stay
+  readable so claim, query, dedup, and tracing keep working.
+- Timing and structural shape: when a job ran, how long it took, how often a recurring job
+  fires, which workflow branch was taken.
+- Application-emitted free text such as `last_error` or anything your job writes to its own
+  logs. A worker that logs its arguments defeats the feature, and Ratchet cannot prevent
+  that.
+- An attacker with write access to the database, which is outside the trust boundary.
+
+## Choosing an engine
+
+The reference engine is AES-256-GCM, which is the right default for most deployments. The
+`ratchet-encryption` module also ships an XChaCha20-Poly1305 engine, whose larger random
+nonce suits very high write volumes under a single key. To use it, provide it as a bean
+(see below) and name it as the write algorithm:
+
+```java
+RatchetOptions.builder()
+    .encryption(e -> e.enabled(true).writeAlgorithm("XChaCha20-Poly1305"))
+    .build();
+```
+
+Each stored value records the id of the engine that wrote it, so reads always decrypt with
+the matching algorithm even after you change the write engine.
+
+## Backing keys with a KMS
+
+The reference `SecretKeyProvider` holds keys in memory from the environment. To source keys
+from a KMS or `KeyStore` instead, provide your own `KeyProvider`, and provide a
+`PayloadEncryption` engine alongside it. Application beans take precedence over the
+reference stack.
+
+```java
+@Produces
+@ApplicationScoped
+public KeyProvider kmsKeyProvider() {
+    return new MyKmsKeyProvider(kmsClient);
+}
+
+@Produces
+@ApplicationScoped
+public PayloadEncryption engine() {
+    return new AesGcmPayloadEncryption(new SecureRandom(), nodeEntropy());
+}
+```
+
+For a KMS that hands back wrapped data keys rather than raw key bytes, implement
+`WrappedKeyProvider`, the `KeyProvider` variant built for that pattern.
+
+::: warning Install the engine and the provider together
+A `KeyProvider` bean with no `PayloadEncryption` engine bean (or the reverse) is a
+misconfiguration and aborts startup. The reference stack is only used when the application
+provides neither.
+:::
+
+## Key rotation
+
+Rotation is additive. Add the new key, point the current-key id at it, and keep the old
+keys available:
+
+```bash
+export RATCHET_ENCRYPTION_KEYS="2026-06:$OLD_KEY,2026-09:$NEW_KEY"
+export RATCHET_ENCRYPTION_CURRENT_KEY="2026-09"
+```
+
+New writes use the current key; existing rows keep their old key id and decrypt under the
+old key. Keep a retired key resolvable until every row written under it has been rewritten
+or deleted. A reference to a key the provider has permanently forgotten is poison data that
+no read can recover.
+
+## Failure behavior
+
+Encryption fails loud and never falls back to plaintext. At startup the deployment is in one
+of three states:
+
+- **Disabled.** No engine or provider is installed and the global switch is off. Jobs are
+  stored as before. An opted-in job later fails at write time rather than silently writing
+  plaintext.
+- **Enabled.** An engine and a provider are installed. New writes use the configured write
+  algorithm, or the only engine when just one is installed.
+- **Misconfigured.** The global switch is on but nothing is installed, only one of the
+  engine and provider is present, or several engines are installed without a
+  `writeAlgorithm` to choose between them. Startup aborts with
+  `EncryptionConfigurationException`.
+
+At read time, a value that cannot be decrypted because the bytes are corrupt, the key is
+wrong, or the binding does not match fails the job instead of looping into a retry storm.
+
+## See also
+
+- [JobBuilder.withEncryptedPayload](/api-reference/job-builder#withencryptedpayload)
+- [PayloadEncryption, KeyProvider, and EncryptionContext SPIs](/api-reference/spi-interfaces#payloadencryption)

--- a/website/docs/api-reference/job-builder.md
+++ b/website/docs/api-reference/job-builder.md
@@ -288,7 +288,7 @@ JobBuilder withEncryptedPayload()
 
 Opts this job in to payload encryption at rest. Its protected surfaces, the job payload and result, are encrypted before they are stored, while routing and bookkeeping columns stay in cleartext so the job is still claimable and queryable. This is the per-job equivalent of the deployment-wide switch on [`RatchetOptions`](./job-options).
 
-Encryption takes effect only when the deployment has a `PayloadEncryption` engine and a `KeyProvider` installed. Without them, an opted-in job fails the node at startup rather than persist data it was asked to protect.
+Encryption takes effect only when the deployment has a `PayloadEncryption` engine and a `KeyProvider` installed. Without them, an opted-in job fails when it is submitted rather than persisting data it was asked to protect. Enabling encryption globally with nothing installed is a startup-time failure instead.
 
 ```java
 scheduler.enqueue(() -> billingService.charge(cardToken))

--- a/website/docs/api-reference/job-builder.md
+++ b/website/docs/api-reference/job-builder.md
@@ -214,6 +214,36 @@ scheduler.enqueue(() -> urgentService.handle(alert))
     .submit();
 ```
 
+### virtual
+
+```java
+JobBuilder virtual()
+```
+
+Routes the job to the virtual-thread executor pool (`ExecutorTargets.VIRTUAL`). Mutually exclusive with [`platform()`](#platform); the last call wins. If you call neither, the job runs on the deployment's default threading mode.
+
+A target selects a pool, not a guarantee about thread type: the container decides what backs each pool. If no virtual executor is configured, a virtual-targeted job falls back to the platform pool, recorded with a metric and a one-time warning. Because a node only claims work it has a pool for, execution targets also shape which jobs a node picks up.
+
+```java
+scheduler.enqueue(() -> externalApi.fetchAll(batchId))
+    .virtual()
+    .submit();
+```
+
+### platform
+
+```java
+JobBuilder platform()
+```
+
+Routes the job to the platform-thread executor pool (`ExecutorTargets.PLATFORM`), which is always present. Mutually exclusive with [`virtual()`](#virtual); the last call wins.
+
+```java
+scheduler.enqueue(() -> reportService.render(reportId))
+    .platform()
+    .submit();
+```
+
 ### awaitSignal
 
 ```java
@@ -249,6 +279,24 @@ public void continueOrder(UUID orderId) {
     fulfillment.start(orderId);
 }
 ```
+
+### withEncryptedPayload
+
+```java
+JobBuilder withEncryptedPayload()
+```
+
+Opts this job in to payload encryption at rest. Its protected surfaces, the job payload and result, are encrypted before they are stored, while routing and bookkeeping columns stay in cleartext so the job is still claimable and queryable. This is the per-job equivalent of the deployment-wide switch on [`RatchetOptions`](./job-options).
+
+Encryption takes effect only when the deployment has a `PayloadEncryption` engine and a `KeyProvider` installed. Without them, an opted-in job fails the node at startup rather than persist data it was asked to protect.
+
+```java
+scheduler.enqueue(() -> billingService.charge(cardToken))
+    .withEncryptedPayload()
+    .submit();
+```
+
+See the [Payload Encryption](../advanced/payload-encryption) guide for setup, engine choice, and key rotation.
 
 ## Callback Methods
 

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -260,6 +260,35 @@ public class PiiSanitizer implements ErrorSanitizer {
 }
 ```
 
+## PayloadEncryption
+
+Keyed authenticated-encryption (AEAD) engine that protects sensitive job data at rest. The engine owns its nonce and returns an opaque body carrying everything decryption needs except the key and the additional authenticated data. `algorithmId()` is recorded in each value's envelope so the matching engine is selected at read time. Reference AES-256-GCM and XChaCha20-Poly1305 engines ship in `ratchet-encryption`.
+
+```java
+public interface PayloadEncryption {
+    String algorithmId();
+    byte[] encrypt(byte[] plaintext, EncryptionContext ctx);
+    byte[] decrypt(byte[] ciphertext, EncryptionContext ctx);
+}
+```
+
+See the [Payload Encryption](/advanced/payload-encryption) guide for setup and the protected-surface boundary.
+
+## KeyProvider
+
+Owns key storage, the active write key, lookup by id, and the rotation lifecycle. This is the seam a deployment replaces to back encryption with a static key, an environment variable, a JCA `KeyStore`, or an external key service such as AWS KMS, GCP KMS, or HashiCorp Vault. `currentKey()` answers "which key do I write with now?", and `keyById()` resolves a recorded key id; a provider must keep old keys resolvable until every row written under them has been rewritten or deleted. `SecretKeyProvider` in `ratchet-encryption` is a ready-made static-key implementation, and `WrappedKeyProvider` is the variant for KMS-wrapped data keys.
+
+```java
+public interface KeyProvider {
+    EncryptionKey currentKey();
+    EncryptionKey keyById(String keyId);
+}
+```
+
+## EncryptionContext
+
+The framework-computed context passed to every `encrypt` and `decrypt` call. It identifies the surface being protected (which job, which column) so the engine can bind the ciphertext to it as additional authenticated data, which is what stops a value from being moved between rows or fields. Applications never construct it; Ratchet hands it to the engine.
+
 ## JobInvocationResolver
 
 Custom callback-to-job invocation resolution. The default RI uses ASM to derive a persisted target class, method, method descriptor, static flag, and argument list from serializable callbacks.
@@ -727,6 +756,18 @@ public class KubernetesNodeProvider implements NodeIdentityProvider {
     }
 }
 ```
+
+## NodeTagAffinityProvider
+
+Restricts which jobs a worker node will claim, by tag. The provider returns a `NodeTagFilter` that the poller compiles into an `EXISTS` / `NOT EXISTS` guard on the claim query, so a node picks up only work whose tags match its affinity. The default applies no filter, and every node claims any job. This is the seam for pinning GPU, licensed, or tenant-specific work to the nodes that can run it.
+
+```java
+public interface NodeTagAffinityProvider {
+    NodeTagFilter tagFilter();
+}
+```
+
+See [Multi-Cell Deployment](/deployment/multi-cell) for a worked example.
 
 ## LambdaAnalyzer
 


### PR DESCRIPTION
## Summary

Documents recently shipped features that were missing from the README and docs site, and updates CI so docs-only pull requests skip heavy jobs while required checks still report correctly.

This also includes follow-up corrections from review feedback:
- Clarifies payload encryption failure behavior in docs: per-job opt-in without configured encryption fails at submit/write time (node can still start when globally disabled); startup abort applies to global-on misconfiguration cases.
- Grants `pull-requests: read` to the `changes` gate job in both CI and CodeQL workflows so `dorny/paths-filter` can read PR file changes without permission errors.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl ratchet-testsuite,ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [x] Follow-up work remains

## Additional Context

Scope remains docs + workflow behavior only:
- README and website API/advanced docs now cover recent features and corrected encryption behavior wording.
- Docs-only detection and CI/CodeQL gating remain scoped to `pull_request`; pushes, merge queue, and release builds still run full pipelines.