### PR TITLE
Pre-0.1.0 security and correctness sweep

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,18 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Skip if triggered by a failed CI run
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Only build/deploy for trusted runs. A workflow_run completion fires for
+    # fork-PR CI runs too, and we publish the downloaded conformance-report
+    # markdown straight to GitHub Pages. Without these guards a fork's PR code
+    # could inject arbitrary content into the project's Pages origin. So for a
+    # workflow_run trigger we require: a successful CI run, that came from a
+    # push (not a pull_request), and from this same repo (not a fork).
+    if: >-
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event != 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      )
     steps:
       - uses: actions/checkout@v6
 

--- a/ratchet-api/src/main/java/run/ratchet/api/JobOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobOptions.java
@@ -70,18 +70,24 @@ public record JobOptions(
   }
 
   /**
-   * Returns a copy with the specified execution timeout. Use {@link Duration#ZERO} to disable
-   * timeout enforcement. The timeout is stored in whole seconds and must fit in a signed 32-bit
-   * integer.
+   * Returns a copy with the specified execution timeout. The timeout is stored in whole seconds and
+   * must fit in a signed 32-bit integer. Use {@link Duration#ZERO} to disable timeout enforcement;
+   * a positive timeout must be at least 1 second.
    *
    * @throws NullPointerException if {@code t} is null
-   * @throws IllegalArgumentException if {@code t} is negative or exceeds {@link Integer#MAX_VALUE}
-   *     seconds
+   * @throws IllegalArgumentException if {@code t} is negative, is positive but shorter than 1
+   *     second (which would truncate to 0 and silently disable enforcement), or exceeds {@link
+   *     Integer#MAX_VALUE} seconds
    */
   public JobOptions withTimeout(Duration t) {
-    long timeoutSeconds = Objects.requireNonNull(t, "timeout must not be null").toSeconds();
-    if (timeoutSeconds < 0) {
+    Objects.requireNonNull(t, "timeout must not be null");
+    if (t.isNegative()) {
       throw new IllegalArgumentException("timeout must be >= 0 seconds");
+    }
+    long timeoutSeconds = t.toSeconds();
+    if (timeoutSeconds == 0 && !t.isZero()) {
+      throw new IllegalArgumentException(
+          "timeout must be at least 1 second when positive; use Duration.ZERO to disable");
     }
     if (timeoutSeconds > Integer.MAX_VALUE) {
       throw new IllegalArgumentException("timeout must be <= " + Integer.MAX_VALUE + " seconds");

--- a/ratchet-api/src/main/java/run/ratchet/api/exception/DuplicateIdempotencyKeyException.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/exception/DuplicateIdempotencyKeyException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.api.exception;
+
+import java.io.Serial;
+
+/**
+ * Thrown by a store when an insert collides with the unique constraint on a job's idempotency key.
+ *
+ * <p>This signals a concurrent submission that lost the race to insert. The scheduler converges to
+ * the documented idempotent result by re-resolving the existing job and returning its handle, so
+ * application code does not normally observe this exception.
+ */
+public class DuplicateIdempotencyKeyException extends RuntimeException {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  private final String idempotencyKey;
+
+  public DuplicateIdempotencyKeyException(String idempotencyKey, Throwable cause) {
+    super("Idempotency key already in use: " + idempotencyKey, cause);
+    this.idempotencyKey = idempotencyKey;
+  }
+
+  /** Returns the idempotency key that triggered the unique-constraint violation. */
+  public String idempotencyKey() {
+    return idempotencyKey;
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/ClassPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ClassPolicy.java
@@ -33,4 +33,26 @@ public interface ClassPolicy {
    * @return {@code true} to allow the class, {@code false} to deny it
    */
   boolean isAllowed(String className);
+
+  /**
+   * Returns whether a class name may be instantiated when deserializing a persisted job result (the
+   * {@code result_type} column) so a workflow condition can inspect the typed value.
+   *
+   * <p>This is deliberately separate from {@link #isAllowed(String)}. The invocation allowlist
+   * gates classes that own a matching predicate method; result deserialization has no such
+   * constraint, so any invocation-allowed class with a JSON-constructable shape could otherwise be
+   * instantiated with attacker-supplied field values given write access to the result columns.
+   * Implementations MUST therefore treat this as a strictly narrower control and default to deny.
+   *
+   * <p>When a result type is denied, the engine falls back to parsing the stored JSON into its
+   * native representation (numbers, strings, maps, lists) rather than instantiating the named
+   * class.
+   *
+   * @param className fully qualified binary class name; {@code null} or blank input must be denied
+   * @return {@code true} to allow instantiating the class for result deserialization, {@code false}
+   *     to deny it (the default)
+   */
+  default boolean isAllowedForResultType(String className) {
+    return false;
+  }
 }

--- a/ratchet-api/src/test/java/run/ratchet/api/JobOptionsTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/JobOptionsTest.java
@@ -87,6 +87,23 @@ class JobOptionsTest {
   }
 
   @Test
+  void withTimeout_rejectsSubSecondPositiveDuration() {
+    IllegalArgumentException ex =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> JobOptions.defaults().withTimeout(Duration.ofMillis(500)));
+
+    assertTrue(ex.getMessage().contains("at least 1 second"));
+  }
+
+  @Test
+  void withTimeout_acceptsOneSecond() {
+    JobOptions opts = JobOptions.defaults().withTimeout(Duration.ofSeconds(1));
+
+    assertEquals(1, opts.timeoutSec());
+  }
+
+  @Test
   void withTimeout_rejectsNegativeDuration() {
     assertThrows(
         IllegalArgumentException.class,

--- a/ratchet-encryption/src/main/java/run/ratchet/encryption/AesGcmPayloadEncryption.java
+++ b/ratchet-encryption/src/main/java/run/ratchet/encryption/AesGcmPayloadEncryption.java
@@ -34,21 +34,29 @@ import run.ratchet.spi.PayloadEncryption;
  * probabilistic.
  *
  * <p><b>Deterministic nonce (NIST SP 800-38D §8.2.1).</b> The 96-bit nonce is a 64-bit per-instance
- * <em>epoch</em> concatenated with a 32-bit monotonic <em>counter</em>. The epoch is drawn from
- * {@link SecureRandom} when the engine is constructed; the counter increments per encryption and a
- * fresh epoch is drawn when it would overflow (after 2^32 encryptions). Because each engine
- * instance holds a distinct epoch and the counter never repeats within one, an (epoch, counter)
- * pair — and therefore a nonce — is never reused under one key. The whole nonce is produced under a
- * single lock so the epoch read, counter increment, and overflow redraw are one atomic step; a
- * non-atomic construction could pair a stale epoch with a reset counter and reuse a nonce, which is
- * catastrophic for GCM.
+ * <em>epoch</em> concatenated with a 32-bit monotonic <em>counter</em>. The epoch is drawn lazily
+ * on the first {@link #encrypt}; the counter increments per encryption and a fresh epoch is drawn
+ * when it would overflow (after 2^32 encryptions). Because each engine instance holds a distinct
+ * epoch and the counter never repeats within one, an (epoch, counter) pair — and therefore a nonce
+ * — is never reused under one key. The whole nonce is produced under a single lock so the epoch
+ * draw, counter increment, and overflow redraw are one atomic step; a non-atomic construction could
+ * pair a stale epoch with a reset counter and reuse a nonce, which is catastrophic for GCM.
  *
- * <p><b>Process/clone uniqueness.</b> Two engines (two nodes) that share a key must not share an
- * epoch. The 64-bit random epoch makes an accidental collision between independently seeded
- * processes negligible, but a checkpoint/restore or forked JVM can inherit its parent's {@link
- * SecureRandom} state and redraw an identical epoch. To stay safe under cloning, the deployment
- * mixes per-node entropy into the epoch via {@link #AesGcmPayloadEncryption(SecureRandom, long)}:
- * as long as the node identity differs, the epoch differs even when the RNG state is shared.
+ * <p><b>Process/clone uniqueness — and its limits.</b> Two engines (two nodes) that share a key
+ * must not share an epoch. Each drawn epoch mixes three sources: {@link SecureRandom}, the optional
+ * per-node entropy passed to {@link #AesGcmPayloadEncryption(SecureRandom, long)}, and {@link
+ * System#nanoTime()} captured at the moment of the draw. The nanoTime fold is the one component a
+ * snapshot/restore cannot reproduce: because the epoch is drawn lazily on the first encrypt rather
+ * than at construction, two processes resumed from the same checkpoint — sharing both {@link
+ * SecureRandom} state and node identity — still draw different epochs the first time each encrypts.
+ *
+ * <p>This is a mitigation, not a guarantee. A checkpoint/restore of a <em>live</em> engine — one
+ * that has already drawn its epoch and advanced its counter — clones the in-flight nonce state
+ * verbatim, and both clones then continue the same (epoch, counter) stream under the same key. That
+ * is unrecoverable nonce reuse and the operator must avoid snapshotting a running engine, or call
+ * {@link #reseed()} on each restored process before it encrypts. For deployments that cannot make
+ * that guarantee, {@link XChaCha20Poly1305PayloadEncryption} draws a fresh random 192-bit nonce per
+ * write and carries no cross-call nonce state to clone.
  *
  * <p><b>Thread-safety.</b> {@link Cipher} is not thread-safe, so a fresh instance is created per
  * call; only the small nonce-state critical section is synchronized. Safe for concurrent use by
@@ -67,6 +75,7 @@ public final class AesGcmPayloadEncryption implements PayloadEncryption {
   private final SecureRandom random;
   private final long nodeEntropy;
 
+  private boolean epochDrawn;
   private long epoch;
   private long counter;
 
@@ -89,8 +98,18 @@ public final class AesGcmPayloadEncryption implements PayloadEncryption {
   public AesGcmPayloadEncryption(SecureRandom random, long nodeEntropy) {
     this.random = random;
     this.nodeEntropy = nodeEntropy;
-    this.epoch = random.nextLong() ^ nodeEntropy;
+    this.epochDrawn = false;
     this.counter = 0L;
+  }
+
+  /**
+   * Forces a fresh epoch on the next nonce, discarding the current (epoch, counter) state. Call
+   * this on a process restored from a checkpoint, before it encrypts, so a restored engine cannot
+   * resume the parent's nonce stream under the same key.
+   */
+  public synchronized void reseed() {
+    epochDrawn = false;
+    counter = 0L;
   }
 
   @Override
@@ -133,19 +152,29 @@ public final class AesGcmPayloadEncryption implements PayloadEncryption {
   }
 
   /**
-   * Produces the next 96-bit nonce under a single lock so the epoch read, counter increment, and
-   * overflow redraw are atomic. A fresh epoch is drawn before the counter would exceed 32 bits, so
-   * no (epoch, counter) pair ever repeats.
+   * Produces the next 96-bit nonce under a single lock so the epoch draw, counter increment, and
+   * overflow redraw are atomic. The epoch is drawn on first use and again before the counter would
+   * exceed 32 bits, so no (epoch, counter) pair ever repeats within one engine.
    */
   private synchronized byte[] nextNonce() {
-    if (counter > COUNTER_MAX) {
-      epoch = random.nextLong() ^ nodeEntropy;
+    if (!epochDrawn || counter > COUNTER_MAX) {
+      epoch = drawEpoch();
+      epochDrawn = true;
       counter = 0L;
     }
     long currentEpoch = epoch;
     int currentCounter = (int) counter;
     counter++;
     return ByteBuffer.allocate(NONCE_LENGTH).putLong(currentEpoch).putInt(currentCounter).array();
+  }
+
+  /**
+   * Draws a fresh epoch by folding the RNG, the per-node entropy, and {@link System#nanoTime()}.
+   * nanoTime is the component a checkpoint/restore cannot reproduce, so two processes resumed from
+   * the same snapshot draw different epochs on their first encrypt.
+   */
+  private long drawEpoch() {
+    return random.nextLong() ^ nodeEntropy ^ System.nanoTime();
   }
 
   private static SecretKey material(EncryptionContext ctx) {

--- a/ratchet-encryption/src/test/java/run/ratchet/encryption/AesGcmNonceLifecycleTest.java
+++ b/ratchet-encryption/src/test/java/run/ratchet/encryption/AesGcmNonceLifecycleTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.encryption;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+import run.ratchet.spi.EncryptionContext;
+import run.ratchet.spi.LocalEncryptionKey;
+import run.ratchet.spi.ProtectedSurface;
+
+/**
+ * Verifies the AES-256-GCM nonce lifecycle: the epoch is drawn lazily and folds a per-process
+ * component so a cloned RNG cannot reproduce the nonce stream, while uniqueness within a single
+ * engine stays intact.
+ */
+class AesGcmNonceLifecycleTest {
+
+  private static final byte[] AAD = "nonce-lifecycle-aad".getBytes(StandardCharsets.UTF_8);
+  private static final int NONCE_LENGTH = 12;
+  private static final int EPOCH_LENGTH = 8;
+
+  private static EncryptionContext ctx() {
+    return new EncryptionContext(ProtectedSurface.PAYLOAD_ARGS, UUID.randomUUID(), key(), AAD);
+  }
+
+  private static LocalEncryptionKey key() {
+    byte[] raw = new byte[32];
+    new SecureRandom().nextBytes(raw);
+    SecretKey material = new SecretKeySpec(raw, "AES");
+    return new LocalEncryptionKey() {
+      @Override
+      public String keyId() {
+        return "k";
+      }
+
+      @Override
+      public SecretKey material() {
+        return material;
+      }
+    };
+  }
+
+  /** A SecureRandom that returns a fixed nextLong(), simulating two clones sharing RNG state. */
+  private static SecureRandom fixedRandom(long value) {
+    return new SecureRandom() {
+      @Override
+      public long nextLong() {
+        return value;
+      }
+    };
+  }
+
+  private static byte[] epochOf(byte[] body) {
+    return Arrays.copyOfRange(body, 0, EPOCH_LENGTH);
+  }
+
+  @Test
+  void clonedRngAndNodeEntropy_stillProduceDifferentEpochs() {
+    // Identical SecureRandom output and identical node entropy: the only thing separating the two
+    // engines is the per-process nanoTime fold drawn lazily at first encrypt.
+    long sharedRngValue = 0x0123456789ABCDEFL;
+    long sharedNodeEntropy = 0xCAFEBABEL;
+    AesGcmPayloadEncryption a =
+        new AesGcmPayloadEncryption(fixedRandom(sharedRngValue), sharedNodeEntropy);
+    AesGcmPayloadEncryption b =
+        new AesGcmPayloadEncryption(fixedRandom(sharedRngValue), sharedNodeEntropy);
+
+    byte[] epochA = epochOf(a.encrypt(new byte[] {1}, ctx()));
+    byte[] epochB = epochOf(b.encrypt(new byte[] {1}, ctx()));
+
+    assertFalse(
+        Arrays.equals(epochA, epochB),
+        "two clones sharing RNG state and node id must not share a nonce epoch");
+  }
+
+  @Test
+  void nonceIsUniqueWithinOneEngine() {
+    AesGcmPayloadEncryption engine = new AesGcmPayloadEncryption();
+    Set<String> seen = new HashSet<>();
+    for (int i = 0; i < 5000; i++) {
+      byte[] nonce = Arrays.copyOfRange(engine.encrypt(new byte[] {2}, ctx()), 0, NONCE_LENGTH);
+      assertTrue(seen.add(Arrays.toString(nonce)), "nonce repeated within a single engine");
+    }
+  }
+
+  @Test
+  void reseed_changesTheEpochStream() {
+    AesGcmPayloadEncryption engine = new AesGcmPayloadEncryption();
+    byte[] before = epochOf(engine.encrypt(new byte[] {3}, ctx()));
+
+    engine.reseed();
+    byte[] after = epochOf(engine.encrypt(new byte[] {3}, ctx()));
+
+    assertNotEquals(
+        Arrays.toString(before), Arrays.toString(after), "reseed must draw a fresh epoch");
+  }
+}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/ConstraintDetector.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/ConstraintDetector.java
@@ -76,6 +76,27 @@ public interface ConstraintDetector {
   }
 
   /**
+   * Returns true if the exception was raised by a unique-constraint violation on a job's
+   * idempotency key.
+   *
+   * <p>All stores name this constraint with an {@code idempotency} token: the SQL stores use {@code
+   * uk_idempotency_key} and the Mongo store uses {@code idx_job_idempotency_key}. The
+   * vendor-specific detectors still provide duplicate-key and constraint-name parsing because those
+   * signals differ by database, but this composed idempotency-key check is shared.
+   *
+   * @param e exception thrown by the JDBC / JPA layer; never {@code null}
+   * @return {@code true} when the exception encodes a duplicate-key violation whose constraint name
+   *     targets a job idempotency key, {@code false} otherwise
+   */
+  default boolean isDuplicateIdempotencyKey(Exception e) {
+    if (!isDuplicateKey(e)) {
+      return false;
+    }
+    String name = constraintName(e);
+    return name != null && name.contains("idempotency");
+  }
+
+  /**
    * Reports whether the exception was raised by a deadlock detected by the database engine.
    *
    * @param e exception thrown by the JDBC / JPA layer; never {@code null}

--- a/ratchet-store-core/src/main/java/run/ratchet/store/util/EncryptionEnvelope.java
+++ b/ratchet-store-core/src/main/java/run/ratchet/store/util/EncryptionEnvelope.java
@@ -177,11 +177,13 @@ public final class EncryptionEnvelope {
     ByteBuffer buf = ByteBuffer.wrap(full);
     int version;
     try {
-      version = buf.get();
+      // Read unsigned: a version byte >= 0x80 must not sign-extend to a negative int, or the upper
+      // half of the version space would be misread as a corrupt frame instead of upgrade-pending.
+      version = buf.get() & 0xFF;
     } catch (BufferUnderflowException e) {
       throw new PayloadDecryptionException("Corrupt or truncated encryption envelope", e);
     }
-    if (version <= 0) {
+    if (version == 0) {
       throw new PayloadDecryptionException(
           "Corrupt encryption envelope: invalid version " + version);
     }

--- a/ratchet-store-core/src/test/java/run/ratchet/store/util/EncryptionEnvelopeTest.java
+++ b/ratchet-store-core/src/test/java/run/ratchet/store/util/EncryptionEnvelopeTest.java
@@ -125,6 +125,25 @@ class EncryptionEnvelopeTest {
   }
 
   @Test
+  void decode_highVersion_isUpgradePendingNotPoison() {
+    // A version byte in the upper half of the space (0xC8 = 200) must read unsigned. A signed read
+    // would sign-extend it to a negative int and route it to the corrupt-frame (poison) branch
+    // instead of upgrade-pending.
+    String highVersion =
+        EncryptionEnvelope.MARKER
+            + java.util.Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(new byte[] {(byte) 0xC8});
+
+    UnsupportedEnvelopeVersionException ex =
+        assertThrows(
+            UnsupportedEnvelopeVersionException.class,
+            () -> EncryptionEnvelope.decode(highVersion));
+    assertEquals(200, ex.version());
+    assertEquals(EncryptionEnvelope.MAX_READABLE_VERSION, ex.maxSupportedVersion());
+  }
+
+  @Test
   void decode_invalidVersionZero_isPoison() {
     // A zero/negative version byte is not a future version — it is a corrupt frame.
     String zeroVersion =

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/DocumentMapper.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/DocumentMapper.java
@@ -16,6 +16,7 @@
 package run.ratchet.store.mongodb;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -815,7 +816,17 @@ public final class DocumentMapper {
   }
 
   static Date toDate(Instant instant) {
-    return instant == null ? null : Date.from(instant);
+    return instant == null ? null : Date.from(truncateToMillis(instant));
+  }
+
+  /**
+   * Truncates to millisecond precision, matching what a BSON {@code Date} can store. Persisting an
+   * Instant with sub-millisecond nanos and reading it back otherwise returns an earlier value,
+   * which would let a claim fire up to a millisecond early. Callers persisting an entity should
+   * truncate the entity's own Instant fields with this so the in-memory object matches storage.
+   */
+  static Instant truncateToMillis(Instant instant) {
+    return instant == null ? null : instant.truncatedTo(ChronoUnit.MILLIS);
   }
 
   static Instant toInstant(Date date) {

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.UUID;
 import org.bson.Document;
 import org.bson.conversions.Bson;
+import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.ArchivedJobEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
@@ -81,7 +82,17 @@ final class MongoArchiveOperations implements ArchiveStore {
       session.withTransaction(
           () -> {
             ctx.archives().insertOne(session, doc);
-            ctx.jobs().deleteOne(session, eq(ID, job.getId()));
+            // Only delete a job that is still terminal: a concurrent reset to PENDING must not be
+            // archived away. If nothing was deleted, the snapshot is stale, so roll back.
+            DeleteResult deleted =
+                ctx.jobs()
+                    .deleteOne(
+                        session,
+                        and(eq(ID, job.getId()), in(STATUS, MongoStoreContext.TERMINAL_STATUSES)));
+            if (deleted.getDeletedCount() == 0) {
+              throw new RatchetTransientStoreException(
+                  "Archive raced a status change on job " + job.getId() + "; rolling back");
+            }
             return Boolean.TRUE;
           });
     } catch (RuntimeException e) {
@@ -101,7 +112,25 @@ final class MongoArchiveOperations implements ArchiveStore {
             int archived = archiveJobsBatch(session, jobList, reason, archivedBy);
             if (archived > 0) {
               List<UUID> ids = jobList.stream().limit(archived).map(JobEntity::getId).toList();
-              ctx.jobs().deleteMany(session, in(ID, ids));
+              // Guard the delete on terminal status: a job reset to PENDING (e.g. a dashboard
+              // retry)
+              // between findJobsForArchiving and this transaction must not be deleted, or the retry
+              // silently vanishes. Deleting fewer rows than we archived means a snapshot went
+              // stale,
+              // so roll the whole batch back and let the next retention pass re-pick the survivors.
+              DeleteResult deleted =
+                  ctx.jobs()
+                      .deleteMany(
+                          session,
+                          and(in(ID, ids), in(STATUS, MongoStoreContext.TERMINAL_STATUSES)));
+              if (deleted.getDeletedCount() != archived) {
+                throw new RatchetTransientStoreException(
+                    "Archive batch raced a status change: archived "
+                        + archived
+                        + " but deleted "
+                        + deleted.getDeletedCount()
+                        + "; rolling back");
+              }
             }
             return archived;
           });

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoFieldNames.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoFieldNames.java
@@ -82,6 +82,7 @@ final class MongoFieldNames {
   static final String ARCHIVED_AT = "archived_at";
   static final String ORIGINAL_JOB_ID = "original_job_id";
   static final String ORIGINAL_CREATED_AT = "original_created_at";
+  static final String ORIGINAL_SCHEDULED_TIME = "original_scheduled_time";
   static final String COMPLETION_TIME = "completion_time";
   static final String METHOD_NAME = "method_name";
   static final String SUPERSEDED_BY = "superseded_by";

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoIndexHints.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoIndexHints.java
@@ -19,16 +19,13 @@ package run.ratchet.store.mongodb;
  * Index hint names passed to {@code AggregateIterable.hintString(...)} to force the Mongo planner
  * onto the covering indexes created by {@link MongoCollectionInitializer}.
  *
- * <p>Both values must exist as index names in {@code MongoCollectionInitializer} or hinted
+ * <p>Every value must exist as an index name in {@code MongoCollectionInitializer} or hinted
  * aggregations fail at runtime.
  */
 final class MongoIndexHints {
 
   /** Covering index for executable job claim queries sorted by {@code scheduled_time}. */
   static final String JOB_CLAIM_EXEC = "idx_job_claim_exec";
-
-  /** Covering index for recurring job claim queries sorted by {@code next_fire}. */
-  static final String JOB_CLAIM_RECURRING = "idx_job_claim_recurring";
 
   /**
    * Covering claim index on the dedicated {@code scheduler_recurring_job} collection, filtered by

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobClaimOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobClaimOperations.java
@@ -69,19 +69,28 @@ final class MongoJobClaimOperations {
 
   private final MongoStoreContext ctx;
 
+  // Fires once between candidate selection and the claim write. Production wiring leaves it a
+  // no-op;
+  // tests install a mutation here to exercise the claim guard against a concurrent reschedule.
+  private Runnable beforeClaimWriteHook = () -> {};
+
   MongoJobClaimOperations(MongoStoreContext ctx) {
     this.ctx = ctx;
   }
 
+  void setBeforeClaimWriteHook(Runnable hook) {
+    this.beforeClaimWriteHook = hook == null ? () -> {} : hook;
+  }
+
   List<JobEntity> claimNextBatch(int limit, String nodeId, NodeTagFilter tagFilter) {
-    List<UUID> candidateIds =
+    Candidates candidates =
         findCandidatesByBoostedPriority(
             MongoStoreContext.EXECUTABLE_JOB_TYPES,
             SCHEDULED_TIME,
             limit,
             tagFilter,
             ExecutionTargetFilter.any());
-    return claimByIds(candidateIds, nodeId, DocumentMapper::toJobEntity);
+    return claimByIds(candidates, nodeId, DocumentMapper::toJobEntity);
   }
 
   List<JobClaimDto> claimNextBatchOptimized(
@@ -93,21 +102,30 @@ final class MongoJobClaimOperations {
     if (limit <= 0 || !StatusClassifier.isPollerExecutable(jobType)) {
       return List.of();
     }
-    List<UUID> candidateIds =
+    Candidates candidates =
         findCandidatesByBoostedPriority(
             List.of(jobType.name()), SCHEDULED_TIME, limit, tagFilter, executionTargetFilter);
-    return claimByIds(candidateIds, nodeId, DocumentMapper::toJobClaimDto);
+    return claimByIds(candidates, nodeId, DocumentMapper::toJobClaimDto);
   }
 
+  /**
+   * Candidate plan output: the ordered candidate ids plus the exact predicate that selected them.
+   * MongoDB has no {@code FOR UPDATE SKIP LOCKED}, so the candidate aggregation and the claim write
+   * are not one locked operation. Re-asserting {@code guard} on each claim update closes that
+   * window — a job whose {@code scheduled_time} was pushed into the future, or whose tags/execution
+   * target moved it out of this filter, no longer matches and stays unclaimed.
+   */
+  private record Candidates(List<UUID> ids, Bson guard) {}
+
   /** Finds candidate job IDs sorted by effective priority (raw priority + age-based boost). */
-  private List<UUID> findCandidatesByBoostedPriority(
+  private Candidates findCandidatesByBoostedPriority(
       List<String> jobTypes,
       String timeColumn,
       int limit,
       NodeTagFilter tagFilter,
       ExecutionTargetFilter executionTargetFilter) {
     if (limit <= 0 || jobTypes.isEmpty()) {
-      return List.of();
+      return new Candidates(List.of(), null);
     }
     String operation = NEXT_FIRE.equals(timeColumn) ? "claim_recurring_lookup" : "claim_lookup";
 
@@ -161,9 +179,14 @@ final class MongoJobClaimOperations {
               ids.add(cursor.next().get(ID, UUID.class));
             }
           }
-          return ids;
+          // The guard re-asserts every candidate condition (status, time<=now, exec-target, tags)
+          // with the same now used for selection, so the claim write can re-check the full
+          // predicate
+          // rather than status alone.
+          Bson guard = conditions.size() == 1 ? conditions.get(0) : and(conditions);
+          return new Candidates(ids, guard);
         },
-        ids -> ids.isEmpty() ? "empty" : "hit");
+        candidates -> candidates.ids().isEmpty() ? "empty" : "hit");
   }
 
   private Bson executionTargetCondition(ExecutionTargetFilter filter) {
@@ -235,10 +258,15 @@ final class MongoJobClaimOperations {
    * recovery has already taken responsibility for them, so dropping is safer than potentially
    * double-executing.
    */
-  private <T> List<T> claimByIds(List<UUID> ids, String nodeId, Function<Document, T> mapper) {
+  private <T> List<T> claimByIds(
+      Candidates candidates, String nodeId, Function<Document, T> mapper) {
+    List<UUID> ids = candidates.ids();
     if (ids.isEmpty()) {
       return List.of();
     }
+    Bson guard = candidates.guard();
+
+    beforeClaimWriteHook.run();
 
     return ctx.timedStoreOperation(
         "claim_mark_running_batch",
@@ -246,9 +274,13 @@ final class MongoJobClaimOperations {
           Date nowDate = DocumentMapper.toDate(Instant.now());
           List<UpdateOneModel<Document>> ops = new ArrayList<>(ids.size());
           for (UUID id : ids) {
+            // Re-assert the candidate predicate (not just status) under each id: with no SKIP
+            // LOCKED
+            // a concurrent reschedule or tag move between selection and this write must invalidate
+            // the claim instead of promoting a job that no longer qualifies.
             ops.add(
                 new UpdateOneModel<>(
-                    and(eq(ID, id), eq(STATUS, "PENDING")),
+                    guard == null ? and(eq(ID, id), eq(STATUS, "PENDING")) : and(eq(ID, id), guard),
                     combine(
                         set(STATUS, "RUNNING"),
                         set(PICKED_BY, nodeId),

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobClaimOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobClaimOperations.java
@@ -165,13 +165,10 @@ final class MongoJobClaimOperations {
           Bson batchLimit = new Document("$limit", limit);
 
           var query =
-              ctx.jobs().aggregate(List.of(match, project, sort, batchLimit)).allowDiskUse(true);
-
-          if (NEXT_FIRE.equals(timeColumn)) {
-            query.hintString(MongoIndexHints.JOB_CLAIM_RECURRING);
-          } else {
-            query.hintString(MongoIndexHints.JOB_CLAIM_EXEC);
-          }
+              ctx.jobs()
+                  .aggregate(List.of(match, project, sort, batchLimit))
+                  .allowDiskUse(true)
+                  .hintString(MongoIndexHints.JOB_CLAIM_EXEC);
 
           List<UUID> ids = new ArrayList<>(limit);
           try (MongoCursor<Document> cursor = query.cursor()) {

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
@@ -70,6 +70,7 @@ import org.bson.conversions.Bson;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
 import run.ratchet.api.exception.RatchetOptimisticLockException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.JobEntity;
@@ -127,6 +128,9 @@ final class MongoJobCrudOperations {
     try {
       ctx.jobs().insertOne(DocumentMapper.toDocument(job));
     } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateIdempotencyKey(e)) {
+        throw new DuplicateIdempotencyKeyException(job.getIdempotencyKey(), e);
+      }
       if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
         throw new RatchetTransientStoreException(
             "Active business key in use for job " + job.getId(), e);

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobCrudOperations.java
@@ -97,6 +97,22 @@ final class MongoJobCrudOperations {
     this.ctx = ctx;
   }
 
+  /**
+   * Truncates the entity's Instant fields to millisecond precision before persisting. A BSON Date
+   * stores milliseconds, so without this the in-memory entity keeps sub-millisecond nanos that the
+   * document does not, and a later findById returns a different Instant than was written.
+   */
+  private static void truncateInstantsToMillis(JobEntity job) {
+    job.setScheduledTime(DocumentMapper.truncateToMillis(job.getScheduledTime()));
+    job.setPickedAt(DocumentMapper.truncateToMillis(job.getPickedAt()));
+    job.setCreatedAt(DocumentMapper.truncateToMillis(job.getCreatedAt()));
+    job.setUpdatedAt(DocumentMapper.truncateToMillis(job.getUpdatedAt()));
+    job.setExecutionStartTime(DocumentMapper.truncateToMillis(job.getExecutionStartTime()));
+    job.setExecutionEndTime(DocumentMapper.truncateToMillis(job.getExecutionEndTime()));
+    job.setSignalTimeout(DocumentMapper.truncateToMillis(job.getSignalTimeout()));
+    job.setSignalDeliveredAt(DocumentMapper.truncateToMillis(job.getSignalDeliveredAt()));
+  }
+
   JobEntity create(JobEntity job) {
     if (job.getId() == null) {
       job.setId(UuidV7Factory.create());
@@ -107,6 +123,7 @@ final class MongoJobCrudOperations {
     if (job.getVersion() == null) {
       job.setVersion(0);
     }
+    truncateInstantsToMillis(job);
     try {
       ctx.jobs().insertOne(DocumentMapper.toDocument(job));
     } catch (RuntimeException e) {
@@ -131,6 +148,7 @@ final class MongoJobCrudOperations {
     // reflects reality (prevents phantom version on reuse after catch).
     Integer expectedVersion = job.getVersion() != null ? job.getVersion() : 0;
     job.setVersion(expectedVersion + 1);
+    truncateInstantsToMillis(job);
     Document doc = DocumentMapper.toDocument(job);
     UpdateResult result;
     try {
@@ -482,6 +500,7 @@ final class MongoJobCrudOperations {
       if (job.getVersion() == null) {
         job.setVersion(0);
       }
+      truncateInstantsToMillis(job);
       docs.add(DocumentMapper.toDocument(job));
     }
     try {

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
@@ -254,7 +254,7 @@ final class MongoJobQueryOperations {
   private static String archiveSortField(JobQuerySortField field) {
     return switch (field) {
       case CREATED_AT -> MongoFieldNames.ORIGINAL_CREATED_AT;
-      case SCHEDULED_TIME -> MongoFieldNames.SCHEDULED_TIME;
+      case SCHEDULED_TIME -> MongoFieldNames.ORIGINAL_SCHEDULED_TIME;
       case UPDATED_AT -> MongoFieldNames.ARCHIVED_AT;
       case PRIORITY -> MongoFieldNames.PRIORITY;
       case STATUS -> MongoFieldNames.FINAL_STATUS;
@@ -438,8 +438,8 @@ final class MongoJobQueryOperations {
     appendParentJobId(filter, conditions);
     appendInstantGte(MongoFieldNames.ORIGINAL_CREATED_AT, filter.createdAfter(), conditions);
     appendInstantLt(MongoFieldNames.ORIGINAL_CREATED_AT, filter.createdBefore(), conditions);
-    appendInstantGte(MongoFieldNames.SCHEDULED_TIME, filter.scheduledAfter(), conditions);
-    appendInstantLt(MongoFieldNames.SCHEDULED_TIME, filter.scheduledBefore(), conditions);
+    appendInstantGte(MongoFieldNames.ORIGINAL_SCHEDULED_TIME, filter.scheduledAfter(), conditions);
+    appendInstantLt(MongoFieldNames.ORIGINAL_SCHEDULED_TIME, filter.scheduledBefore(), conditions);
     appendInstantGte(MongoFieldNames.ARCHIVED_AT, filter.updatedAfter(), conditions);
     appendCursorCondition(filter, conditions, true);
 

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
@@ -283,6 +283,12 @@ class MongoJobStoreImpl implements MongoJobStore {
     return crud.getQueueWaitTimePercentile(percentile);
   }
 
+  // Test seam: installs a hook the claim pipeline runs between candidate selection and the claim
+  // write, used to reproduce a concurrent reschedule landing inside that window.
+  void setBeforeClaimWriteHook(Runnable hook) {
+    claims.setBeforeClaimWriteHook(hook);
+  }
+
   @Override
   public List<JobEntity> claimNextBatch(int limit, String nodeId, NodeTagFilter tagFilter) {
     return claims.claimNextBatch(limit, nodeId, tagFilter);

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.bson.BsonBinaryWriter;
 import org.bson.codecs.Codec;
 import org.bson.codecs.EncoderContext;
@@ -502,6 +503,12 @@ class MongoJobStoreImpl implements MongoJobStore {
   @Override
   public boolean updateBatchTotalItems(UUID batchId, int totalItems) {
     return batches.updateBatchTotalItems(batchId, totalItems);
+  }
+
+  // Test seam: pins the lock clock to a fixed instant so two renewals can compute the same
+  // millisecond expiry, exercising renewLock's matched-vs-modified semantics.
+  void setLockClock(Supplier<Instant> clock) {
+    nodeLocks.setLockClock(clock);
   }
 
   @Override

--- a/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoNodeLockOperations.java
+++ b/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoNodeLockOperations.java
@@ -46,6 +46,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Supplier;
 import org.bson.Document;
 import org.jboss.logging.Logger;
 import run.ratchet.store.entity.NodeEntity;
@@ -67,8 +68,16 @@ final class MongoNodeLockOperations implements LockStore, NodeStore {
 
   private final MongoStoreContext ctx;
 
+  // Source of the lock clock. Production reads the database server time; tests pin it to a fixed
+  // instant to reproduce two renewals computing the same millisecond expiry.
+  private Supplier<Instant> lockClock = this::getDatabaseTime;
+
   MongoNodeLockOperations(MongoStoreContext ctx) {
     this.ctx = ctx;
+  }
+
+  void setLockClock(Supplier<Instant> clock) {
+    this.lockClock = clock == null ? this::getDatabaseTime : clock;
   }
 
   @Override
@@ -76,7 +85,7 @@ final class MongoNodeLockOperations implements LockStore, NodeStore {
     requireLockName(name);
     requirePositiveDuration(ttl, "ttl");
     Objects.requireNonNull(nodeId, "nodeId");
-    Instant nowInstant = getDatabaseTime();
+    Instant nowInstant = lockClock.get();
     Date now = DocumentMapper.toDate(nowInstant);
     Date expiresAt = DocumentMapper.toDate(nowInstant.plus(ttl));
 
@@ -112,11 +121,15 @@ final class MongoNodeLockOperations implements LockStore, NodeStore {
     requireLockName(name);
     requirePositiveDuration(extension, "extension");
     Objects.requireNonNull(nodeId, "nodeId");
-    Date newExpiry = DocumentMapper.toDate(getDatabaseTime().plus(extension));
+    Date newExpiry = DocumentMapper.toDate(lockClock.get().plus(extension));
     UpdateResult result =
         ctx.locks()
             .updateOne(and(eq(ID, name), eq(OWNER_NODE, nodeId)), set(EXPIRES_AT, newExpiry));
-    return result.getModifiedCount() > 0;
+    // Match, not modify: with millisecond-precision expiry two renewals in the same millisecond
+    // compute the same expires_at, so the second matches the owned lock but changes nothing. A
+    // matched row means the caller still owns a renewable lock; the owner filter keeps an unowned
+    // lock returning false.
+    return result.getMatchedCount() > 0;
   }
 
   @Override

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/IdempotencyIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/IdempotencyIT.java
@@ -20,10 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.mongodb.MongoWriteException;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.store.entity.JobEntity;
 
@@ -40,7 +40,7 @@ class IdempotencyIT extends BaseDocumentStoreIT {
     JobEntity job2 = newPendingJob();
     job2.setIdempotencyKey(key);
 
-    assertThrows(MongoWriteException.class, () -> store().save(job2));
+    assertThrows(DuplicateIdempotencyKeyException.class, () -> store().save(job2));
   }
 
   @Test

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoArchiveScheduledTimeFilterIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoArchiveScheduledTimeFilterIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+
+/**
+ * Regression coverage for the archive scheduled-time field. Archive documents persist the schedule
+ * as {@code original_scheduled_time}; the query layer must apply {@link
+ * JobFilter#scheduledAfter()}/{@link JobFilter#scheduledBefore()} against that field, not the live
+ * {@code scheduled_time} the archive document lacks.
+ */
+class MongoArchiveScheduledTimeFilterIT extends BaseDocumentStoreIT {
+
+  @Test
+  void includeArchivedHonorsScheduledTimeBoundsAgainstOriginalScheduledTime() {
+    Instant scheduled = Instant.now().truncatedTo(ChronoUnit.MILLIS).minus(2, ChronoUnit.HOURS);
+
+    JobEntity job = newPendingJob();
+    job.setScheduledTime(scheduled);
+    job = complete(store().save(job));
+
+    int archived = store().archiveJobsBatch(List.of(job), "retention", "system");
+    assertEquals(1, archived);
+    assertTrue(store().findById(job.getId()).isEmpty(), "live job should be gone after archiving");
+
+    JobFilter inWindow =
+        JobFilter.builder()
+            .includeArchived(true)
+            .scheduledAfter(scheduled.minus(1, ChronoUnit.HOURS))
+            .scheduledBefore(scheduled.plus(1, ChronoUnit.HOURS))
+            .build();
+    List<JobEntity> hits = store().searchJobs(inWindow, 50, 0);
+    assertEquals(1, hits.size(), "archived job within the scheduled-time window must be returned");
+    assertEquals(job.getId(), hits.get(0).getId());
+
+    JobFilter outsideWindow =
+        JobFilter.builder()
+            .includeArchived(true)
+            .scheduledAfter(scheduled.plus(1, ChronoUnit.HOURS))
+            .build();
+    assertTrue(
+        store().searchJobs(outsideWindow, 50, 0).isEmpty(),
+        "archived job outside the scheduled-time window must be excluded");
+  }
+
+  private JobEntity complete(JobEntity job) {
+    store().compareAndSwapStatus(job.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store().markJobSucceeded(job.getId(), null, null, Instant.now(), Instant.now(), 100L, 50L);
+    return store().findById(job.getId()).orElseThrow();
+  }
+}

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoArchiveTerminalGuardIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoArchiveTerminalGuardIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.ArchivedJobEntity;
+import run.ratchet.store.entity.JobEntity;
+
+/**
+ * Retention archiving snapshots terminal jobs, then deletes them in a later transaction. If a job
+ * is reset to PENDING in that window (e.g. a dashboard retry), the delete must not remove the
+ * now-live job, or the retry silently vanishes. The delete is guarded on terminal status and the
+ * batch rolls back when the snapshot no longer matches.
+ */
+class MongoArchiveTerminalGuardIT extends BaseDocumentStoreIT {
+
+  @Test
+  void retryDuringArchiveWindowIsNotDeleted() {
+    JobEntity job = fail(store().save(newPendingJob()));
+
+    // Stale snapshot the retention pass would carry into the archive transaction.
+    JobEntity staleSnapshot = store().findById(job.getId()).orElseThrow();
+    assertEquals(JobStatus.FAILED, staleSnapshot.getStatus());
+
+    // Dashboard retry resurrects the job before the archive transaction runs.
+    assertTrue(store().resetFailedToPending(job.getId()));
+
+    // Archiving the stale FAILED snapshot must not delete the now-PENDING live job.
+    assertThrows(
+        RuntimeException.class,
+        () -> store().archiveJobsBatch(List.of(staleSnapshot), "retention", "system"));
+
+    JobEntity reloaded = store().findById(job.getId()).orElseThrow();
+    assertEquals(JobStatus.PENDING, reloaded.getStatus(), "resurrected job must survive");
+
+    List<ArchivedJobEntity> archived = store().findArchivedJobs(null, null, null, null, 10);
+    assertTrue(archived.isEmpty(), "stale snapshot must not be left in the archive");
+  }
+
+  private JobEntity fail(JobEntity job) {
+    store().compareAndSwapStatus(job.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store().markJobFailedTerminal(job.getId(), "boom", 1);
+    return store().findById(job.getId()).orElseThrow();
+  }
+}

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoClaimGuardIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoClaimGuardIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.set;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.dto.JobClaimDto;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+
+/**
+ * MongoDB has no {@code FOR UPDATE SKIP LOCKED}, so a job can be mutated between candidate
+ * selection and the claim write. The claim write must re-assert the candidate predicate (here,
+ * {@code scheduled_time <= now}) so a job rescheduled into the future in that window is not claimed
+ * early.
+ */
+class MongoClaimGuardIT extends BaseDocumentStoreIT {
+
+  @Test
+  void rescheduleIntoFutureWithinClaimWindowBlocksClaim() {
+    JobEntity job = newPendingJob();
+    job.setScheduledTime(Instant.now().minusSeconds(5));
+    job = store().save(job);
+    UUID jobId = job.getId();
+
+    AtomicBoolean fired = new AtomicBoolean(false);
+    ((MongoJobStoreImpl) store())
+        .setBeforeClaimWriteHook(
+            () -> {
+              if (fired.compareAndSet(false, true)) {
+                // Concurrent reschedule: push the job an hour out, after it was selected as a
+                // candidate but before the claim write commits.
+                database()
+                    .getCollection("scheduler_job")
+                    .updateOne(
+                        eq("_id", jobId),
+                        set("scheduled_time", Date.from(Instant.now().plusSeconds(3600))));
+              }
+            });
+
+    List<JobClaimDto> claimed =
+        store().claimNextBatchOptimized(JobExecutionType.SINGLE, 10, "node-1");
+
+    assertTrue(claimed.isEmpty(), "rescheduled job must not be claimed inside the race window");
+    JobEntity reloaded = store().findById(jobId).orElseThrow();
+    assertEquals(
+        JobStatus.PENDING, reloaded.getStatus(), "rescheduled job must stay PENDING, not RUNNING");
+  }
+}

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoIndexConformanceTest.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoIndexConformanceTest.java
@@ -35,8 +35,12 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.Indexes;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterEach;
@@ -79,6 +83,31 @@ class MongoIndexConformanceTest {
   void tearDown() {
     database.drop();
     client.close();
+  }
+
+  @Test
+  void everyHintNamesAnIndexThatGetsCreated() throws IllegalAccessException {
+    Set<String> created = allCreatedIndexNames();
+    for (Field field : MongoIndexHints.class.getDeclaredFields()) {
+      if (field.getType() != String.class || !Modifier.isStatic(field.getModifiers())) {
+        continue;
+      }
+      field.setAccessible(true);
+      String hintName = (String) field.get(null);
+      assertTrue(
+          created.contains(hintName),
+          "MongoIndexHints." + field.getName() + " (" + hintName + ") names no created index");
+    }
+  }
+
+  private Set<String> allCreatedIndexNames() {
+    Set<String> names = new HashSet<>();
+    for (String collection : database.listCollectionNames()) {
+      for (Document idx : database.getCollection(collection).listIndexes()) {
+        names.add(idx.getString("name"));
+      }
+    }
+    return names;
   }
 
   @Test

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoInstantPrecisionIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoInstantPrecisionIT.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.JobEntity;
+
+/**
+ * A BSON Date stores milliseconds, so persisting an Instant with sub-millisecond nanos and reading
+ * it back must not surprise the caller. The store truncates the in-memory entity to milliseconds at
+ * the write boundary so the saved object equals what a later findById returns.
+ */
+class MongoInstantPrecisionIT extends BaseDocumentStoreIT {
+
+  @Test
+  void saveTruncatesInstantsToMillisSoWriteThenReadIsStable() {
+    Instant subMillis = Instant.now().truncatedTo(ChronoUnit.SECONDS).plusNanos(123_456_789L);
+
+    JobEntity job = newPendingJob();
+    job.setScheduledTime(subMillis);
+    job = store().save(job);
+
+    // The in-memory entity must already reflect what storage can hold.
+    assertEquals(subMillis.truncatedTo(ChronoUnit.MILLIS), job.getScheduledTime());
+
+    JobEntity reloaded = store().findById(job.getId()).orElseThrow();
+    assertEquals(
+        job.getScheduledTime(),
+        reloaded.getScheduledTime(),
+        "scheduled_time must round-trip without precision drift");
+  }
+}

--- a/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRenewLockSameInstantIT.java
+++ b/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoRenewLockSameInstantIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lock expiry is stored at millisecond precision, so two renewals computing the same expires_at
+ * leave the row matched but unmodified. renewLock must report success on a matched row it still
+ * owns, otherwise a lease holder treating false as "lease lost" abandons a lease it actually holds.
+ */
+class MongoRenewLockSameInstantIT extends BaseDocumentStoreIT {
+
+  @Test
+  void twoRenewalsInTheSameInstantBothSucceed() {
+    Instant fixed = Instant.now();
+    ((MongoJobStoreImpl) store()).setLockClock(() -> fixed);
+
+    assertTrue(store().tryLock("lease-A", Duration.ofSeconds(30), "node-1"));
+
+    // Same clock + same extension on both renewals yields an identical expires_at: the second
+    // update
+    // matches the owned lock but modifies nothing.
+    assertTrue(
+        store().renewLock("lease-A", Duration.ofSeconds(30), "node-1"),
+        "first renewal must succeed");
+    assertTrue(
+        store().renewLock("lease-A", Duration.ofSeconds(30), "node-1"),
+        "no-op renewal on an owned lock must still report success");
+
+    assertFalse(
+        store().renewLock("lease-A", Duration.ofSeconds(30), "node-2"),
+        "renewal by a non-owner must fail");
+  }
+}

--- a/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobWriteOperations.java
+++ b/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobWriteOperations.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
 import run.ratchet.api.exception.RatchetOptimisticLockException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
@@ -159,6 +160,9 @@ final class MysqlJobWriteOperations {
         }
       }
     } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateIdempotencyKey(e)) {
+        throw new DuplicateIdempotencyKeyException(job.getIdempotencyKey(), e);
+      }
       if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
         throw new RatchetTransientStoreException(
             "Active business key in use for job " + job.getId(), e);

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRecurringAndResetOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRecurringAndResetOperations.java
@@ -15,6 +15,10 @@
  */
 package run.ratchet.store.postgresql;
 
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 // Reset + cancel-by-tag operations against the executable scheduler_job table. Recurring-master
@@ -66,59 +70,85 @@ final class PostgresqlJobRecurringAndResetOperations {
   }
 
   int cancelJobsByTag(String tag) {
+    return ctx.timedStoreOperation(
+        "cancel_jobs_by_tag",
+        () -> doCancelJobsByTag(tag),
+        cancelled -> cancelled > 0 ? "updated" : "miss");
+  }
+
+  private int doCancelJobsByTag(String tag) {
+    // Lock the candidate hot rows first, inside the method transaction, before touching the cold
+    // row. PostgreSQL's UPDATE ... FROM does NOT lock the FROM-referenced rows, so a cold UPDATE
+    // alone leaves the queue row free for a concurrent poller to claim into RUNNING between the
+    // cancel and the hot DELETE — the DELETE (which only matches PENDING/PAUSED/WAITING) would then
+    // skip the now-RUNNING row, stranding it forever while the reservation is still freed. Holding
+    // FOR UPDATE on each queue row makes the claim path's FOR UPDATE SKIP LOCKED step past it, so a
+    // claim cannot interleave. Mirrors the single-job cancel gate in
+    // PostgresqlJobTerminalOperations.
     // language=PostgreSQL
-    String coldSql =
+    String lockSql =
         """
-        UPDATE scheduler_job j
-        SET terminal_status = 'CANCELED',
-            terminated_at = statement_timestamp()
-        FROM scheduler_job_tag t, scheduler_job_queue q
-        WHERE t.job_id = j.job_id
-          AND q.job_id = j.job_id
-          AND t.tag = ?
+        SELECT q.job_id
+        FROM scheduler_job_queue q
+        JOIN scheduler_job j ON j.job_id = q.job_id
+        JOIN scheduler_job_tag t ON t.job_id = q.job_id
+        WHERE t.tag = ?
           AND j.job_type <> 'RECURRING'
           AND j.terminal_status IS NULL
           AND q.status IN ('PENDING','PAUSED','WAITING')
+        FOR UPDATE OF q
         """;
-    int cancelled =
-        ctx.timedStoreOperation(
-            "cancel_jobs_by_tag",
-            () -> ctx.em().createNativeQuery(coldSql).setParameter(1, tag).executeUpdate(),
-            updated -> updated > 0 ? "updated" : "miss");
-    if (cancelled == 0) {
+    @SuppressWarnings("unchecked")
+    List<Object> lockedRows =
+        ctx.em().createNativeQuery(lockSql).setParameter(1, tag).getResultList();
+    if (lockedRows.isEmpty()) {
       return 0;
     }
+    List<UUID> ids = new ArrayList<>(lockedRows.size());
+    for (Object row : lockedRows) {
+      ids.add((UUID) row);
+    }
+    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+
     // language=PostgreSQL
-    String hotSql =
+    String coldSql =
         """
-        DELETE FROM scheduler_job_queue q
-        USING scheduler_job j, scheduler_job_tag t
-        WHERE q.job_id = j.job_id
-          AND t.job_id = j.job_id
-          AND t.tag = ?
-          AND j.job_type <> 'RECURRING'
-          AND j.terminal_status = 'CANCELED'
-          AND q.status IN ('PENDING','PAUSED','WAITING')
-        """;
-    ctx.timedStoreOperation(
-        "cancel_jobs_by_tag_hot",
-        () -> ctx.em().createNativeQuery(hotSql).setParameter(1, tag).executeUpdate(),
-        updated -> updated > 0 ? "updated" : "miss");
+        UPDATE scheduler_job
+        SET terminal_status = 'CANCELED',
+            terminated_at = statement_timestamp()
+        WHERE job_id IN (%s)
+          AND terminal_status IS NULL
+        """
+            .formatted(placeholders);
+    int cancelled = bindIds(coldSql, ids).executeUpdate();
+
+    // language=PostgreSQL
+    String hotSql = "DELETE FROM scheduler_job_queue WHERE job_id IN (%s)".formatted(placeholders);
+    int hotDeleted = bindIds(hotSql, ids).executeUpdate();
+    if (hotDeleted != cancelled) {
+      throw new IllegalStateException(
+          "cancel-by-tag canceled "
+              + cancelled
+              + " cold rows but removed "
+              + hotDeleted
+              + " hot rows for tag "
+              + tag);
+    }
+
     // language=PostgreSQL
     String reservationsSql =
-        """
-        DELETE FROM scheduler_business_key_reservation r
-        USING scheduler_job j, scheduler_job_tag t
-        WHERE r.owner_job_id = j.job_id
-          AND t.job_id = j.job_id
-          AND t.tag = ?
-          AND j.job_type <> 'RECURRING'
-          AND j.terminal_status = 'CANCELED'
-        """;
-    ctx.timedStoreOperation(
-        "cancel_jobs_by_tag_reservations",
-        () -> ctx.em().createNativeQuery(reservationsSql).setParameter(1, tag).executeUpdate(),
-        updated -> updated > 0 ? "updated" : "miss");
+        "DELETE FROM scheduler_business_key_reservation WHERE owner_job_id IN (%s)"
+            .formatted(placeholders);
+    bindIds(reservationsSql, ids).executeUpdate();
     return cancelled;
+  }
+
+  private Query bindIds(String sql, List<UUID> ids) {
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    for (UUID id : ids) {
+      query.setParameter(parameter++, id);
+    }
+    return query;
   }
 }

--- a/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobWriteOperations.java
+++ b/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobWriteOperations.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
 import run.ratchet.api.exception.RatchetOptimisticLockException;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
@@ -187,6 +188,9 @@ final class PostgresqlJobWriteOperations {
         tags.insertTags(job.getId(), job.getTags());
       }
     } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateIdempotencyKey(e)) {
+        throw new DuplicateIdempotencyKeyException(job.getIdempotencyKey(), e);
+      }
       if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
         throw new RatchetTransientStoreException(
             "Active business key in use for job " + job.getId(), e);

--- a/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlCancelByTagClaimConcurrencyTest.java
+++ b/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlCancelByTagClaimConcurrencyTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.JobStore;
+
+/**
+ * Regression for the cancel-by-tag / claim race on PostgreSQL.
+ *
+ * <p>{@code cancelJobsByTag} marks the cold {@code scheduler_job} row CANCELED and then deletes the
+ * hot {@code scheduler_job_queue} row. PostgreSQL's {@code UPDATE ... FROM} does not lock the
+ * FROM-referenced queue row, so before the fix a poller could claim the tagged job into RUNNING in
+ * the window between the cold update and the hot delete. The hot delete only matched
+ * PENDING/PAUSED/WAITING, so it skipped the now-RUNNING row, stranding it forever — while the
+ * reservation delete still freed the business key, allowing a duplicate to run.
+ *
+ * <p>The window is internal to the cancel method, so this races a real {@code cancelJobsByTag}
+ * against a real {@code claimNextBatchOptimized} on a shared barrier across many repetitions. The
+ * fix locks the candidate queue row {@code FOR UPDATE} as the cancel's first statement, so the
+ * claim's {@code FOR UPDATE SKIP LOCKED} always skips it. The post-invariant after each round is
+ * exact: either the cancel won (job CANCELED, zero queue rows, zero reservations) or the claim won
+ * (job still PENDING-or-RUNNING, exactly one queue row, reservation intact). The broken interleave
+ * produced the forbidden mix — a CANCELED cold row with a surviving RUNNING queue row and a freed
+ * reservation — which trips the assertions below.
+ */
+class PostgresqlCancelByTagClaimConcurrencyTest {
+
+  private static final long TIMEOUT_SECONDS = 20;
+  private static final String TAG = "cancel-race-tag";
+
+  private final PostgresqlTestFixture fixture = new PostgresqlTestFixture();
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    fixture.cleanupStore();
+  }
+
+  @RepeatedTest(40)
+  void cancelAndClaimNeverStrandARunningRow() throws Exception {
+    JobStore store = fixture.store();
+
+    AtomicReference<UUID> jobIdRef = new AtomicReference<>();
+    JobEntity job = fixture.newPendingJob();
+    job.setBusinessKey("cancel-race-key");
+    fixture.runInTransaction(
+        () -> {
+          UUID id = store.create(job).getId();
+          store.insertTags(id, List.of(TAG));
+          jobIdRef.set(id);
+        });
+    UUID jobId = jobIdRef.get();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CyclicBarrier start = new CyclicBarrier(2);
+    try {
+      Future<?> cancelFuture =
+          executor.submit(
+              () -> {
+                awaitBarrier(start);
+                store.cancelJobsByTag(TAG);
+                return null;
+              });
+      Future<?> claimFuture =
+          executor.submit(
+              () -> {
+                awaitBarrier(start);
+                store.claimNextBatchOptimized(JobExecutionType.SINGLE, 10, "poller-node");
+                return null;
+              });
+      claimFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      cancelFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      assertConsistentOutcome(jobId);
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("worker threw asynchronously", e.getCause());
+    } finally {
+      executor.shutdown();
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  /**
+   * After cancel and claim settle, the job must be in exactly one of two consistent states. The
+   * forbidden state the bug produced — cold row CANCELED, a surviving RUNNING queue row,
+   * reservation freed — fails here.
+   */
+  private void assertConsistentOutcome(UUID jobId) throws Exception {
+    try (Connection conn = fixture.openConnection()) {
+      String terminal = terminalStatus(conn, jobId);
+      String queueStatus = queueStatus(conn, jobId);
+      long reservations = reservationCount(conn, jobId);
+
+      if ("CANCELED".equals(terminal)) {
+        assertEquals(
+            null,
+            queueStatus,
+            "cancel won, so the hot queue row must be gone — a surviving "
+                + queueStatus
+                + " row is the stranded-orphan bug");
+        assertEquals(0, reservations, "cancel won, so the reservation must be freed");
+      } else {
+        assertEquals(null, terminal, "claim won, so the cold row must not be terminal");
+        // claim transitioned PENDING -> RUNNING (or it lost the claim and the row stays PENDING)
+        if (queueStatus == null) {
+          throw new AssertionError("claim won but the queue row vanished");
+        }
+        assertEquals(1, reservations, "claim won, so the reservation must remain held");
+      }
+    }
+  }
+
+  private String terminalStatus(Connection conn, UUID jobId) throws Exception {
+    try (PreparedStatement ps =
+        conn.prepareStatement("SELECT terminal_status FROM scheduler_job WHERE job_id = ?")) {
+      ps.setObject(1, jobId);
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() ? rs.getString(1) : null;
+      }
+    }
+  }
+
+  private String queueStatus(Connection conn, UUID jobId) throws Exception {
+    try (PreparedStatement ps =
+        conn.prepareStatement("SELECT status FROM scheduler_job_queue WHERE job_id = ?")) {
+      ps.setObject(1, jobId);
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() ? rs.getString(1) : null;
+      }
+    }
+  }
+
+  private long reservationCount(Connection conn, UUID jobId) throws Exception {
+    try (PreparedStatement ps =
+        conn.prepareStatement(
+            "SELECT COUNT(*) FROM scheduler_business_key_reservation WHERE owner_job_id = ?")) {
+      ps.setObject(1, jobId);
+      try (ResultSet rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    }
+  }
+
+  private static void awaitBarrier(CyclicBarrier barrier) {
+    try {
+      barrier.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      throw new IllegalStateException("barrier wait failed", e);
+    }
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/EncryptionInstaller.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/EncryptionInstaller.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.util.List;
 import java.util.Optional;
+import org.jboss.logging.Logger;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.exception.EncryptionConfigurationException;
 import run.ratchet.ri.cdi.ReferenceEncryptionFactory.ReferenceEncryption;
@@ -61,6 +62,8 @@ import run.ratchet.store.util.EncryptionIntegrity;
  */
 @ApplicationScoped
 public class EncryptionInstaller {
+
+  private static final Logger log = Logger.getLogger(EncryptionInstaller.class);
 
   private final Instance<PayloadEncryption> engines;
   private final Instance<KeyProvider> keyProvider;
@@ -187,12 +190,41 @@ public class EncryptionInstaller {
    */
   private long resolveNodeEntropy() {
     if (nodeIdProvider == null) {
+      warnNoNodeEntropy(null);
       return 0L;
     }
+    long entropy;
     try {
-      return ReferenceEncryptionFactory.nodeEntropy(nodeIdProvider.getNodeId());
+      entropy = ReferenceEncryptionFactory.nodeEntropy(nodeIdProvider.getNodeId());
     } catch (RuntimeException e) {
+      warnNoNodeEntropy(e);
       return 0L;
+    }
+    if (entropy == 0L) {
+      // A blank/empty node id hashes to 0 (ReferenceEncryptionFactory.nodeEntropy), so the engine
+      // gets no per-node component even though resolution did not throw.
+      warnNoNodeEntropy(null);
+    }
+    return entropy;
+  }
+
+  /**
+   * Warns that the reference engine starts with no per-node entropy. Without it, two nodes that
+   * share a key and were cloned from the same image draw a less-distinct nonce epoch, weakening the
+   * nonce-clone protection. Encryption still works; this is a posture warning, not a startup abort.
+   */
+  private void warnNoNodeEntropy(RuntimeException cause) {
+    if (cause != null) {
+      log.warnf(
+          cause,
+          "Node identity could not be resolved for the reference encryption engine; starting with"
+              + " no per-node nonce entropy (reduced nonce-clone protection). Ensure a"
+              + " NodeIdentityProvider yields a stable, non-empty node id.");
+    } else {
+      log.warn(
+          "Node identity is unavailable for the reference encryption engine; starting with no"
+              + " per-node nonce entropy (reduced nonce-clone protection). Ensure a"
+              + " NodeIdentityProvider yields a stable, non-empty node id.");
     }
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RatchetProducer.java
@@ -201,7 +201,8 @@ public class RatchetProducer {
       Clock clock,
       InternalEventPublisher eventPublisher,
       WorkflowScheduler workflowScheduler,
-      Instance<SignalStore> signalStore) {
+      Instance<SignalStore> signalStore,
+      SingletonLeaseService singletonLeaseService) {
     int softTimeoutPercent = options.timeout().softTimeoutPercent();
     long defaultTimeoutSeconds = options.timeout().defaultSlaSeconds();
     int signalTimeoutBatchSize = options.timeout().signalTimeoutBatchSize();
@@ -219,7 +220,8 @@ public class RatchetProducer {
         signalStore.isResolvable() ? signalStore.get() : null,
         metricsCollector,
         signalTimeoutBatchSize,
-        resolveTxRegistry());
+        resolveTxRegistry(),
+        singletonLeaseService);
   }
 
   private TransactionSynchronizationRegistry resolveTxRegistry() {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -44,6 +44,7 @@ import run.ratchet.api.SerializableFunction;
 import run.ratchet.api.SerializablePredicate;
 import run.ratchet.api.WorkflowBranch;
 import run.ratchet.api.event.JobSignalWaitingEvent;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
 import run.ratchet.api.internal.JobBuilderState;
 import run.ratchet.ri.core.internal.ChainScheduler;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
@@ -360,7 +361,29 @@ class DefaultJobCreationService
     }
     checkCreateAuthorization(job);
 
-    JobEntity saved = jobCrudStore.create(job);
+    JobEntity saved;
+    try {
+      saved = jobCrudStore.create(job);
+    } catch (DuplicateIdempotencyKeyException e) {
+      // A concurrent submission with the same idempotency key won the race to insert. Converge on
+      // the documented idempotent result: re-resolve and return the existing job rather than
+      // letting the constraint violation escape.
+      JobEntity existing =
+          jobCrudStore
+              .findByIdempotencyKey(idempotencyKey)
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Idempotency key '"
+                              + idempotencyKey
+                              + "' collided on insert but no job resolves by that key",
+                          e));
+      UUID existingId = existing.getId();
+      log.debugf(
+          "Idempotency key '%s' raced on insert, returning existing job %s",
+          idempotencyKey, existingId);
+      return () -> existingId;
+    }
     UUID jobId = saved.getId();
 
     if (isSignalWaiting && eventPublisher != null) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/RetryBufferManager.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/RetryBufferManager.java
@@ -17,7 +17,6 @@ package run.ratchet.ri.core;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,12 +33,10 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.ri.core.internal.DeadLetterService;
-import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.store.dto.JobClaimDto;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.ExecutionTargetFilter;
-import run.ratchet.store.spi.JobBatchStatusStore;
 
 /**
  * Priority-ordered retry buffers for claimed jobs awaiting executor capacity. Separate bounded
@@ -55,8 +52,7 @@ class RetryBufferManager {
   private static final Logger log = Logger.getLogger(RetryBufferManager.class);
 
   private final DeadLetterService deadLetterService;
-  private final JobBatchStatusStore jobBatchStatusStore;
-  private final NodeIdentityProvider nodeIdentityProvider;
+  private final JobStateManager jobStateManager;
 
   private final Map<JobExecutionType, Queue<BufferedClaim>> retryBuffers =
       new EnumMap<>(JobExecutionType.class);
@@ -66,18 +62,13 @@ class RetryBufferManager {
 
   protected RetryBufferManager() {
     this.deadLetterService = null;
-    this.jobBatchStatusStore = null;
-    this.nodeIdentityProvider = null;
+    this.jobStateManager = null;
   }
 
   @Inject
-  public RetryBufferManager(
-      DeadLetterService deadLetterService,
-      JobBatchStatusStore jobBatchStatusStore,
-      NodeIdentityProvider nodeIdentityProvider) {
+  public RetryBufferManager(DeadLetterService deadLetterService, JobStateManager jobStateManager) {
     this.deadLetterService = deadLetterService;
-    this.jobBatchStatusStore = jobBatchStatusStore;
-    this.nodeIdentityProvider = nodeIdentityProvider;
+    this.jobStateManager = jobStateManager;
 
     Comparator<BufferedClaim> jobComparator =
         Comparator.comparing(
@@ -219,14 +210,21 @@ class RetryBufferManager {
   }
 
   /**
-   * Runs in a transaction because shutdown flush repairs persistent claims for jobs held only in
-   * memory by this node.
+   * Flushes every buffered claim back to PENDING so jobs this node holds only in memory can be
+   * picked up elsewhere after shutdown.
+   *
+   * <p>Each claim is reset in its own transaction by delegating to {@link
+   * JobStateManager#resetJobToPending(java.util.UUID)} (transaction attribute REQUIRED, invoked
+   * across a bean boundary so a new transaction begins per claim). This method is deliberately not
+   * {@code @Transactional}: a single enclosing transaction would let one failed reset mark the
+   * whole batch rollback-only and silently undo every claim already flushed.
+   *
+   * <p>Failed resets are requeued and counted. The method never throws after a partial flush, since
+   * doing so would discard claims it already moved back to PENDING.
    */
-  @Transactional
   public void flushOnShutdown() {
     int flushed = 0;
-    List<BufferedClaim> failed = new ArrayList<>();
-    String nodeId = nodeIdentityProvider.getNodeId();
+    int failedCount = 0;
     for (Map.Entry<JobExecutionType, Queue<BufferedClaim>> entry : retryBuffers.entrySet()) {
       Queue<BufferedClaim> buffer = entry.getValue();
       ReentrantLock lock = bufferLocks.get(entry.getKey());
@@ -236,7 +234,7 @@ class RetryBufferManager {
         BufferedClaim buffered;
         while ((buffered = buffer.poll()) != null) {
           try {
-            if (jobBatchStatusStore.resetRunningJob(buffered.jobId(), nodeId)) {
+            if (jobStateManager.resetJobToPending(buffered.jobId())) {
               flushed++;
             }
           } catch (Exception e) {
@@ -245,7 +243,7 @@ class RetryBufferManager {
           }
         }
         buffer.addAll(failedForType);
-        failed.addAll(failedForType);
+        failedCount += failedForType.size();
       } finally {
         lock.unlock();
       }
@@ -253,9 +251,11 @@ class RetryBufferManager {
     if (flushed > 0) {
       log.infof("RetryBufferManager shutdown: flushed %s buffered job(s) back to PENDING", flushed);
     }
-    if (!failed.isEmpty()) {
-      throw new IllegalStateException(
-          "Failed to flush " + failed.size() + " buffered job(s) during shutdown");
+    if (failedCount > 0) {
+      log.warnf(
+          "RetryBufferManager shutdown: %s buffered job(s) could not be reset and will rely on"
+              + " orphan recovery",
+          failedCount);
     }
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/WorkflowConditionEvaluator.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/WorkflowConditionEvaluator.java
@@ -358,6 +358,16 @@ public class WorkflowConditionEvaluator {
     throw new NoSuchMethodException(payload.method() + " not found in " + cls.getName());
   }
 
+  /**
+   * Deserializes a persisted job result for workflow-condition evaluation.
+   *
+   * <p>The stored {@code result_type} class name is attacker-controllable given write access to the
+   * result columns, so it is gated by {@link ClassPolicy#isAllowedForResultType(String)} — a
+   * control strictly narrower than the invocation allowlist used for predicate targets. A result
+   * type that is not explicitly allowed for result deserialization is NOT instantiated; the stored
+   * JSON is parsed into its native representation (numbers, strings, maps, lists) instead, which is
+   * still enough for value comparisons while denying class instantiation by default.
+   */
   private Object parseJobResult(String jobResultJson, String resultType, UUID jobId) {
     if (jobResultJson == null) {
       return null;
@@ -367,19 +377,14 @@ public class WorkflowConditionEvaluator {
         PayloadEncryptor.decryptJsonColumn(
             jobResultJson, EncryptionTarget.rowBound(ProtectedSurface.RESULT, jobId));
     try {
-      if (resultType != null) {
-        if (classPolicy != null && !classPolicy.isAllowed(resultType)) {
-          throw new SecurityException(
-              "Class " + resultType + " is not allowed by ClassPolicy for result deserialization.");
-        }
+      if (resultType != null
+          && classPolicy != null
+          && classPolicy.isAllowedForResultType(resultType)) {
         Class<?> clazz =
             Class.forName(resultType, false, Thread.currentThread().getContextClassLoader());
         return payloadSerializer.deserialize(jobResultJson, clazz);
-      } else {
-        return payloadSerializer.deserialize(jobResultJson, Object.class);
       }
-    } catch (SecurityException e) {
-      throw e;
+      return payloadSerializer.deserialize(jobResultJson, Object.class);
     } catch (Exception e) {
       log.warnf(e, "Job result JSON parse error: %s", e.getMessage());
       return jobResultJson;

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultJobExecutorService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultJobExecutorService.java
@@ -316,6 +316,7 @@ public class DefaultJobExecutorService implements JobExecutorService {
         resultPersistenceStrategy,
         authorizationPolicy,
         payloadSerializer,
+        timeoutHandler,
         effective());
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultRecurringScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultRecurringScheduler.java
@@ -62,6 +62,9 @@ public class DefaultRecurringScheduler implements RecurringScheduler {
   private volatile Config config = new Config(1000, 60000, 20);
   private volatile long currentDelayMs;
 
+  private boolean cycleRunning;
+  private boolean wakeupPending;
+
   @SuppressWarnings("java:S3077")
   private volatile Future<?> handle;
 
@@ -157,11 +160,12 @@ public class DefaultRecurringScheduler implements RecurringScheduler {
       if (!started.get()) {
         return;
       }
-      Future<?> current = handle;
-      if (current != null) {
-        current.cancel(false);
-        handle = null;
+      if (cycleRunning) {
+        wakeupPending = true;
+        log.debug("RecurringScheduler kick coalesced into running scan");
+        return;
       }
+      cancelCurrentScheduleLocked();
       scheduleNextLocked(config.minPollMs());
     }
     log.debug("RecurringScheduler kicked — immediate scan scheduled");
@@ -171,70 +175,95 @@ public class DefaultRecurringScheduler implements RecurringScheduler {
   public void stop() {
     started.set(false);
     synchronized (scheduleLock) {
-      if (handle != null) {
-        handle.cancel(false);
-      }
-      handle = null;
+      wakeupPending = false;
+      cancelCurrentScheduleLocked();
     }
   }
 
   void run() {
-    if (!started.get()) {
-      return;
+    synchronized (scheduleLock) {
+      if (!started.get()) {
+        return;
+      }
+      if (cycleRunning) {
+        wakeupPending = true;
+        return;
+      }
+      cycleRunning = true;
+      handle = null;
     }
 
+    long nextDelay = config.minPollMs();
+    boolean reschedule = true;
     ScheduledFuture<?> renewalTask = null;
     Optional<SingletonLease> lease = Optional.empty();
     try {
       lease = singletonLeaseService.tryAcquire(LEASE_NAME, LEASE_TTL);
-      if (lease.isEmpty()) {
-        scheduleNext(config.minPollMs());
-        return;
+      if (lease.isPresent()) {
+        SingletonLease acquiredLease = lease.get();
+        AtomicBoolean leaseValid = new AtomicBoolean(true);
+        renewalTask =
+            executor.scheduleWithFixedDelay(
+                () -> renewLease(acquiredLease, leaseValid), 2, 2, TimeUnit.MINUTES);
+
+        int processedCount =
+            recurringJobExecutor.process(config.batchLimit(), nodeIdentityProvider.getNodeId());
+
+        if (!leaseValid.get()) {
+          reschedule = false;
+        } else {
+          if (processedCount > 0) {
+            pollerScheduler.wakeup();
+          }
+          nextDelay = calculateNextDelay(processedCount);
+        }
       }
-
-      SingletonLease acquiredLease = lease.get();
-      AtomicBoolean leaseValid = new AtomicBoolean(true);
-      renewalTask =
-          executor.scheduleWithFixedDelay(
-              () -> renewLease(acquiredLease, leaseValid), 2, 2, TimeUnit.MINUTES);
-
-      int processedCount =
-          recurringJobExecutor.process(config.batchLimit(), nodeIdentityProvider.getNodeId());
-
-      if (!leaseValid.get()) {
-        return;
-      }
-
-      if (processedCount > 0) {
-        pollerScheduler.wakeup();
-      }
-
-      long nextDelay = calculateNextDelay(processedCount);
-      scheduleNext(nextDelay);
     } catch (Exception ex) {
       if (!started.get()) {
-        return;
-      }
-      // CDI context gone (e.g. Arquillian undeploy) — stop permanently, next deploy starts fresh
-      if (SchedulerUtils.isCdiContextGone(ex)) {
+        reschedule = false;
+      } else if (SchedulerUtils.isCdiContextGone(ex)) {
+        // CDI context gone (e.g. Arquillian undeploy) — stop permanently, next deploy starts fresh
         started.set(false);
+        reschedule = false;
         log.info("RecurringScheduler detected inactive CDI context — stopping permanently");
-        return;
-      }
-      log.error("RecurringScheduler failed", ex);
-      try {
-        scheduleNext(config.minPollMs());
-      } catch (Exception e) {
-        log.debug("Cannot reschedule recurring scan — scheduler will restart on next deploy", e);
+      } else {
+        log.error("RecurringScheduler failed", ex);
+        nextDelay = config.minPollMs();
       }
     } catch (Error error) {
       log.error("RecurringScheduler failed with unrecoverable error", error);
+      cancelRenewal(renewalTask);
+      lease.ifPresent(SingletonLease::close);
+      finishCycle(0, false);
       throw error;
     } finally {
-      if (renewalTask != null && !renewalTask.isCancelled()) {
-        renewalTask.cancel(false);
-      }
+      cancelRenewal(renewalTask);
       lease.ifPresent(SingletonLease::close);
+    }
+
+    finishCycle(nextDelay, reschedule);
+  }
+
+  private void cancelRenewal(ScheduledFuture<?> renewalTask) {
+    if (renewalTask != null && !renewalTask.isCancelled()) {
+      renewalTask.cancel(false);
+    }
+  }
+
+  private void finishCycle(long nextDelayMs, boolean reschedule) {
+    synchronized (scheduleLock) {
+      cycleRunning = false;
+      if (!reschedule || !started.get()) {
+        wakeupPending = false;
+        return;
+      }
+      long delayMs = wakeupPending ? config.minPollMs() : nextDelayMs;
+      wakeupPending = false;
+      try {
+        scheduleNextLocked(delayMs);
+      } catch (Exception e) {
+        log.debug("Cannot reschedule recurring scan — scheduler will restart on next deploy", e);
+      }
     }
   }
 
@@ -293,6 +322,14 @@ public class DefaultRecurringScheduler implements RecurringScheduler {
     }
     currentDelayMs = delayMs;
     handle = executor.schedule(this::run, delayMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void cancelCurrentScheduleLocked() {
+    Future<?> currentHandle = handle;
+    if (currentHandle != null && !currentHandle.isDone()) {
+      currentHandle.cancel(false);
+    }
+    handle = null;
   }
 
   private record Config(long minPollMs, long maxPollMs, int batchLimit) {}

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultRecurringScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultRecurringScheduler.java
@@ -210,7 +210,9 @@ public class DefaultRecurringScheduler implements RecurringScheduler {
             recurringJobExecutor.process(config.batchLimit(), nodeIdentityProvider.getNodeId());
 
         if (!leaseValid.get()) {
-          reschedule = false;
+          // A renewal failed mid-scan (e.g. a transient lock-store error): abandon this lease but
+          // keep polling so the next cycle re-acquires the lease rather than halting the node.
+          nextDelay = config.minPollMs();
         } else {
           if (processedCount > 0) {
             pollerScheduler.wakeup();
@@ -301,12 +303,10 @@ public class DefaultRecurringScheduler implements RecurringScheduler {
       if (!lease.renew(LEASE_TTL)) {
         log.warnf("RecurringScheduler could not renew singleton lease %s", lease.name());
         leaseValid.set(false);
-        stop();
       }
     } catch (Exception e) {
       log.warnf(e, "RecurringScheduler lease renewal failed for %s", lease.name());
       leaseValid.set(false);
-      stop();
     }
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -120,6 +120,7 @@ public class JobTask implements Callable<Void> {
   private final ResultPersistenceStrategy resultPersistenceStrategy;
   private final JobAuthorizationPolicy authorizationPolicy;
   private final PayloadSerializer payloadSerializer;
+  private final JobTimeoutHandler timeoutHandler;
   private final Clock clock;
   private JobEntity job;
   private JobClaimDto claim;
@@ -149,6 +150,7 @@ public class JobTask implements Callable<Void> {
     this.resultPersistenceStrategy = null;
     this.authorizationPolicy = null;
     this.payloadSerializer = null;
+    this.timeoutHandler = null;
     this.clock = null;
   }
 
@@ -169,6 +171,7 @@ public class JobTask implements Callable<Void> {
       ResultPersistenceStrategy resultPersistenceStrategy,
       JobAuthorizationPolicy authorizationPolicy,
       PayloadSerializer payloadSerializer,
+      JobTimeoutHandler timeoutHandler,
       Clock clock) {
     this.jobStore = jobStore;
     this.resourcePermitService = resourcePermitService;
@@ -185,6 +188,7 @@ public class JobTask implements Callable<Void> {
     this.resultPersistenceStrategy = resultPersistenceStrategy;
     this.authorizationPolicy = authorizationPolicy;
     this.payloadSerializer = payloadSerializer;
+    this.timeoutHandler = timeoutHandler;
     this.clock = Objects.requireNonNull(clock, "clock must not be null");
   }
 
@@ -760,6 +764,17 @@ public class JobTask implements Callable<Void> {
     log.errorf(
         ex, "Job %s failed with %s: %s", job.getId(), ex.getClass().getName(), ex.getMessage());
 
+    // The hard-timeout watchdog interrupted this worker and already owns the retry/finalize for the
+    // timeout (including the attempt increment). Defer to it so a single timeout does not burn two
+    // attempts. A non-watchdog interrupt is not marked and falls through to count as normal.
+    if (isWatchdogOwnedInterrupt(ex)) {
+      log.infof(
+          "Job %s interrupted by hard-timeout watchdog — deferring retry to the watchdog",
+          job.getId());
+      logIfTimeout(ex);
+      return;
+    }
+
     // Non-retryable: skip retry count increment
     if (validationFacade.shouldNotRetry(ex)) {
       observabilityFacade.recordJobFailure(job, ex, job.getAttempts());
@@ -930,6 +945,22 @@ public class JobTask implements Callable<Void> {
       log.warnf("Job %s finalization retry interrupted", job.getId());
       return false;
     }
+  }
+
+  /**
+   * True when this failure is the worker noticing the hard-timeout watchdog's interrupt and the
+   * watchdog has claimed the job's timeout retry/finalize. Both conditions are required: the
+   * interrupt narrows it to a cancel-driven failure, and the watchdog marker confirms this node's
+   * own watchdog (not, say, a shutdown interrupt) owns the attempt. The marker is set before the
+   * worker is interrupted, so it is already visible here.
+   */
+  private boolean isWatchdogOwnedInterrupt(Throwable ex) {
+    if (timeoutHandler == null) {
+      return false;
+    }
+    boolean interrupted =
+        ex instanceof InterruptedException || ex.getCause() instanceof InterruptedException;
+    return interrupted && timeoutHandler.isWatchdogCancelled(job.getId());
   }
 
   // Matches JobTimeoutException, TimeoutException, and InterruptedException at top level and

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -543,7 +543,11 @@ public class JobTask implements Callable<Void> {
             + " claim for an upgraded peer. Upgrade this node to drain these rows.",
         jobId, ex.version(), ex.maxSupportedVersion());
     Instant newScheduledTime = effective().instant().plus(UPGRADE_PENDING_BACKOFF);
-    int attempts = claim != null ? claim.attempts() : 0;
+    // A claim-initialized task carries the attempt count on the claim; an entity-initialized one
+    // (buffered-entity resubmission, claim == null) carries it on the job. Reading only the claim
+    // would zero a non-zero persisted count on the entity path, contrary to the preserve-attempts
+    // contract this method documents.
+    int attempts = claim != null ? claim.attempts() : (job != null ? job.getAttempts() : 0);
     try {
       jobStore.scheduleJobRetry(jobId, ex.getMessage(), newScheduledTime, attempts);
     } catch (Throwable t) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,7 @@ import run.ratchet.api.event.JobDlqEvent;
 import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.event.JobSignalTimedOutEvent;
 import run.ratchet.api.exception.SignalTimeoutException;
+import run.ratchet.ri.core.SingletonLease;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.spi.JobBatchStatusStore;
@@ -50,6 +52,8 @@ import run.ratchet.store.spi.SignalStore;
 public class JobTimeoutHandler {
 
   static final int DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE = 500;
+  private static final String SIGNAL_TIMEOUT_LEASE_NAME = "signalTimeoutScan";
+  private static final Duration SIGNAL_TIMEOUT_LEASE_TTL = Duration.ofMinutes(2);
   private static final Logger log = Logger.getLogger(JobTimeoutHandler.class);
   private final JobCrudStore jobCrudStore;
   private final JobRetryStore jobRetryStore;
@@ -64,6 +68,7 @@ public class JobTimeoutHandler {
   private final Clock clock;
   private final int signalTimeoutBatchSize;
   private final TransactionSynchronizationRegistry txRegistry;
+  private final SingletonLeaseService singletonLeaseService;
 
   /**
    * Job ids the hard-timeout watchdog has cancelled and is about to retry/finalize itself. The
@@ -88,6 +93,7 @@ public class JobTimeoutHandler {
     this.clock = null;
     this.signalTimeoutBatchSize = 0;
     this.txRegistry = null;
+    this.singletonLeaseService = null;
   }
 
   public JobTimeoutHandler(
@@ -116,6 +122,7 @@ public class JobTimeoutHandler {
         signalStore,
         metricsCollector,
         signalTimeoutBatchSize,
+        null,
         null);
   }
 
@@ -133,6 +140,38 @@ public class JobTimeoutHandler {
       MetricsCollector metricsCollector,
       int signalTimeoutBatchSize,
       TransactionSynchronizationRegistry txRegistry) {
+    this(
+        jobCrudStore,
+        jobRetryStore,
+        jobBatchStatusStore,
+        lifecycleFacade,
+        softTimeoutPercent,
+        defaultTimeoutSeconds,
+        clock,
+        eventPublisher,
+        chainScheduler,
+        signalStore,
+        metricsCollector,
+        signalTimeoutBatchSize,
+        txRegistry,
+        null);
+  }
+
+  public JobTimeoutHandler(
+      JobCrudStore jobCrudStore,
+      JobRetryStore jobRetryStore,
+      JobBatchStatusStore jobBatchStatusStore,
+      PostExecutionHandler lifecycleFacade,
+      int softTimeoutPercent,
+      long defaultTimeoutSeconds,
+      Clock clock,
+      InternalEventPublisher eventPublisher,
+      ChainScheduler chainScheduler,
+      SignalStore signalStore,
+      MetricsCollector metricsCollector,
+      int signalTimeoutBatchSize,
+      TransactionSynchronizationRegistry txRegistry,
+      SingletonLeaseService singletonLeaseService) {
     this.jobCrudStore = jobCrudStore;
     this.jobRetryStore = jobRetryStore;
     this.jobBatchStatusStore = jobBatchStatusStore;
@@ -146,6 +185,7 @@ public class JobTimeoutHandler {
     this.metricsCollector = metricsCollector;
     this.signalTimeoutBatchSize = Math.max(1, signalTimeoutBatchSize);
     this.txRegistry = txRegistry;
+    this.singletonLeaseService = singletonLeaseService;
   }
 
   public TimeoutHandles scheduleTimeoutMonitoring(
@@ -194,11 +234,33 @@ public class JobTimeoutHandler {
    * Scans for WAITING jobs whose signal timeout has elapsed and fails them. Should be called
    * periodically (e.g., from the poller tick). No-op if no {@code SignalStore} was wired at
    * construction time.
+   *
+   * <p>The scan runs under a cluster-wide singleton lease, the same coordination the orphan, batch,
+   * and dead-letter recoveries use. Every node ticks the poller, so without the lease two nodes
+   * scanning the same window both fail and re-increment the same WAITING job, which can also write
+   * back a stale lower attempt count. When no {@code LockStore} is present the lease degrades to
+   * single-node semantics (always granted), so a core-only store still scans.
    */
   public void scanSignalTimeouts() {
     if (signalStore == null) {
       return;
     }
+    if (singletonLeaseService == null) {
+      scanSignalTimeoutsWithLease();
+      return;
+    }
+    Optional<SingletonLease> lease =
+        singletonLeaseService.tryAcquire(SIGNAL_TIMEOUT_LEASE_NAME, SIGNAL_TIMEOUT_LEASE_TTL);
+    if (lease.isEmpty()) {
+      log.debug("Signal timeout scan skipped - singleton lease held by another node");
+      return;
+    }
+    try (SingletonLease ignored = lease.get()) {
+      scanSignalTimeoutsWithLease();
+    }
+  }
+
+  private void scanSignalTimeoutsWithLease() {
     Instant now = effective().instant();
     List<JobEntity> timedOut = signalStore.findTimedOutSignalJobs(now, signalTimeoutBatchSize);
     for (JobEntity job : timedOut) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
@@ -21,7 +21,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -62,6 +64,15 @@ public class JobTimeoutHandler {
   private final Clock clock;
   private final int signalTimeoutBatchSize;
   private final TransactionSynchronizationRegistry txRegistry;
+
+  /**
+   * Job ids the hard-timeout watchdog has cancelled and is about to retry/finalize itself. The
+   * watchdog records the id before it interrupts the worker, so when the interrupt lands in {@link
+   * JobTask#handleFailure} the worker can see the timeout is watchdog-owned and skip its own
+   * attempt increment. Without this, both the watchdog and the interrupted worker increment while
+   * the row is still RUNNING and a single timeout burns two attempts.
+   */
+  private final Set<UUID> watchdogCancelledJobIds = ConcurrentHashMap.newKeySet();
 
   protected JobTimeoutHandler() {
     this.jobCrudStore = null;
@@ -420,6 +431,11 @@ public class JobTimeoutHandler {
         "Job %s exceeded timeout of %ds. Cancelling execution. Elapsed: %s",
         jobId, timeoutSec, formatDuration(elapsed));
 
+    // Claim ownership of the retry/finalize for this timeout BEFORE interrupting the worker, so the
+    // interrupt that lands in JobTask.handleFailure already sees the marker and defers to us. The
+    // marker is cleared in processHardTimeout's finally once this path is done with it.
+    watchdogCancelledJobIds.add(jobId);
+
     future.cancel(true);
 
     try {
@@ -427,7 +443,19 @@ public class JobTimeoutHandler {
     } catch (Exception e) {
       log.errorf(e, "Timeout post-processing error for job %s", jobId);
       throw new IllegalStateException("Timeout post-processing failed for job " + jobId, e);
+    } finally {
+      watchdogCancelledJobIds.remove(jobId);
     }
+  }
+
+  /**
+   * Reports whether the hard-timeout watchdog has claimed this job's timeout retry/finalize. When
+   * the interrupted worker sees {@code true} it must skip its own attempt increment and let the
+   * watchdog own the transition — otherwise one timeout consumes two attempts. A genuine,
+   * non-watchdog interrupt is absent from the set and still counts as a normal failed attempt.
+   */
+  boolean isWatchdogCancelled(UUID jobId) {
+    return watchdogCancelledJobIds.contains(jobId);
   }
 
   /**

--- a/ratchet/src/main/java/run/ratchet/ri/security/PackagePrefixClassPolicy.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/PackagePrefixClassPolicy.java
@@ -24,8 +24,9 @@ import run.ratchet.spi.ClassPolicy;
 /**
  * Allowlist-based {@link ClassPolicy} that permits job target classes only if their fully-qualified
  * name starts with a configured package prefix. A hardcoded denylist of RCE gadgets is checked
- * first, regardless of the allowlist. Constructor rejects prefixes shorter than 3 characters or
- * containing leading/trailing whitespace.
+ * first, regardless of the allowlist. The constructor rejects prefixes shorter than 3 characters,
+ * those containing leading/trailing whitespace, and single top-level segments such as {@code
+ * "com."} or {@code "java."} that would match nearly the whole classpath and defeat the allowlist.
  *
  * <p>Configured allowlist prefixes are normalized to end with {@code .} so matches line up on
  * package boundaries: configuring {@code "com.foo"} matches {@code com.foo.Bar} but NOT {@code
@@ -70,13 +71,23 @@ public class PackagePrefixClassPolicy implements ClassPolicy {
       List.of(
           "java.lang.reflect.",
           "java.lang.invoke.",
+          "java.lang.Runtime",
+          "java.lang.ProcessBuilder",
+          "java.lang.ProcessImpl",
+          "java.lang.System",
           "javax.script.",
+          "javax.naming.",
           "jdk.",
           "sun.",
           "com.sun.",
           "jdk.internal.",
+          "groovy.lang.",
+          "bsh.",
           "org.codehaus.groovy.runtime.",
           "org.apache.commons.collections.functors.",
+          "org.apache.commons.collections4.functors.",
+          "org.apache.commons.beanutils.",
+          "org.yaml.snakeyaml.",
           "org.apache.xalan.",
           "org.springframework.context.support.");
 
@@ -137,7 +148,27 @@ public class PackagePrefixClassPolicy implements ClassPolicy {
         throw new IllegalArgumentException(
             "Allowed package prefix must be at least 3 characters: '" + prefix + "'");
       }
+      if (isSingleTopLevelSegment(prefix)) {
+        throw new IllegalArgumentException(
+            "Allowed package prefix is too broad — a single top-level segment such as 'com.' or"
+                + " 'org.' would allow nearly every class on the classpath: '"
+                + prefix
+                + "'. Configure at least a two-segment prefix (e.g. 'com.example.').");
+      }
     }
+  }
+
+  /**
+   * Returns true when {@code prefix} names only a single top-level package segment, with or without
+   * a trailing dot (e.g. {@code "com"}, {@code "com."}, {@code "org."}, {@code "java."}). Such a
+   * prefix matches almost the entire classpath and defeats the allowlist, so it is rejected. A
+   * two-segment prefix such as {@code "com.example."} is fine because it contains a dot before the
+   * trailing one.
+   */
+  private static boolean isSingleTopLevelSegment(String prefix) {
+    String withoutTrailingDot =
+        prefix.endsWith(".") ? prefix.substring(0, prefix.length() - 1) : prefix;
+    return withoutTrailingDot.indexOf('.') < 0;
   }
 
   public Set<String> getAllowedPackages() {

--- a/ratchet/src/main/java/run/ratchet/ri/security/PackagePrefixClassPolicy.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/PackagePrefixClassPolicy.java
@@ -28,6 +28,10 @@ import run.ratchet.spi.ClassPolicy;
  * those containing leading/trailing whitespace, and single top-level segments such as {@code
  * "com."} or {@code "java."} that would match nearly the whole classpath and defeat the allowlist.
  *
+ * <p>Result-type deserialization has a separate, narrower allowlist (see {@link
+ * #isAllowedForResultType(String)}); a class being allowed for invocation does NOT make it
+ * instantiable from a stored {@code result_type} column.
+ *
  * <p>Configured allowlist prefixes are normalized to end with {@code .} so matches line up on
  * package boundaries: configuring {@code "com.foo"} matches {@code com.foo.Bar} but NOT {@code
  * com.foobar.Gadget}. This mirrors the {@link #DENIED_PREFIXES} invariant.
@@ -100,21 +104,43 @@ public class PackagePrefixClassPolicy implements ClassPolicy {
   private static final Set<String> DEFAULT_ALLOWED_PACKAGES = Set.of();
 
   private final Set<String> allowedPackages;
+  private final Set<String> allowedResultTypePackages;
 
   public PackagePrefixClassPolicy() {
     this(DEFAULT_ALLOWED_PACKAGES);
   }
 
   /**
-   * Creates a new PackagePrefixClassPolicy with specified allowed packages.
+   * Creates a new PackagePrefixClassPolicy with specified invocation allowed packages and an empty
+   * result-type allowlist (result deserialization falls back to JSON-native parsing).
    *
-   * @param allowedPackages the set of package prefixes to allow
-   * @throws IllegalArgumentException if any prefix is null, blank, shorter than 3 characters, or
-   *     otherwise trivially unsafe (e.g. {@code ""} or {@code " "})
+   * @param allowedPackages the set of package prefixes to allow for job/predicate targets
+   * @throws IllegalArgumentException if any prefix is null, blank, shorter than 3 characters, a
+   *     single top-level segment, or otherwise trivially unsafe (e.g. {@code ""} or {@code " "})
    */
   public PackagePrefixClassPolicy(Set<String> allowedPackages) {
+    this(allowedPackages, DEFAULT_ALLOWED_PACKAGES);
+  }
+
+  /**
+   * Creates a new PackagePrefixClassPolicy with separate allowlists for invocation targets and for
+   * result-type deserialization. The result-type allowlist is intentionally distinct and narrower:
+   * a class being invocation-allowed does NOT make it instantiable from a stored {@code
+   * result_type} column. Leave {@code allowedResultTypePackages} empty to keep result
+   * deserialization on the JSON-native fallback.
+   *
+   * @param allowedPackages the set of package prefixes to allow for job/predicate targets
+   * @param allowedResultTypePackages the set of package prefixes to allow for result-type
+   *     deserialization
+   * @throws IllegalArgumentException if any prefix is null, blank, shorter than 3 characters, a
+   *     single top-level segment, or otherwise trivially unsafe (e.g. {@code ""} or {@code " "})
+   */
+  public PackagePrefixClassPolicy(
+      Set<String> allowedPackages, Set<String> allowedResultTypePackages) {
     validatePrefixes(allowedPackages);
+    validatePrefixes(allowedResultTypePackages);
     this.allowedPackages = normalize(allowedPackages);
+    this.allowedResultTypePackages = normalize(allowedResultTypePackages);
   }
 
   private static Set<String> normalize(Set<String> prefixes) {
@@ -175,12 +201,31 @@ public class PackagePrefixClassPolicy implements ClassPolicy {
     return allowedPackages;
   }
 
+  public Set<String> getAllowedResultTypePackages() {
+    return allowedResultTypePackages;
+  }
+
   /**
    * Returns true only if {@code className} passes the hardcoded denylist and matches at least one
    * configured allowlist prefix.
    */
   @Override
   public boolean isAllowed(String className) {
+    return matches(className, allowedPackages);
+  }
+
+  /**
+   * Returns true only if {@code className} passes the hardcoded denylist and matches at least one
+   * prefix in the separate, narrower result-type allowlist. The invocation allowlist is NOT
+   * consulted here, so an invocation-allowed class is not instantiable from a stored result type
+   * unless it was also opted in for result deserialization.
+   */
+  @Override
+  public boolean isAllowedForResultType(String className) {
+    return matches(className, allowedResultTypePackages);
+  }
+
+  private boolean matches(String className, Set<String> allowlist) {
     if (className == null || className.isEmpty()) {
       return false;
     }
@@ -199,14 +244,13 @@ public class PackagePrefixClassPolicy implements ClassPolicy {
       }
     }
 
-    for (String allowedPackage : allowedPackages) {
+    for (String allowedPackage : allowlist) {
       if (className.startsWith(allowedPackage)) {
         return true;
       }
     }
 
-    log.warnf(
-        "Class %s is not in allowed packages: %s", loggableClassName(className), allowedPackages);
+    log.warnf("Class %s is not in allowed packages: %s", loggableClassName(className), allowlist);
     return false;
   }
 

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/EncryptionInstallerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/EncryptionInstallerTest.java
@@ -18,11 +18,17 @@ package run.ratchet.ri.cdi;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 import jakarta.enterprise.inject.Instance;
 import java.util.Base64;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -149,6 +155,80 @@ class EncryptionInstallerTest {
 
     assertEquals("AES-256-GCM", EncryptionHolder.writeEngine().algorithmId());
     assertFalse(EncryptionHolder.isGloballyEnabled());
+  }
+
+  @Test
+  void nodeIdThrows_installsAnyway_andWarnsAboutReducedProtection() {
+    System.setProperty(ReferenceEncryptionFactory.KEYS_PROPERTY, "k1:" + base64Key());
+    when(nodeIdProvider.getNodeId()).thenThrow(new IllegalStateException("no node id yet"));
+    EncryptionInstaller installer = installer(options(null), false /* providerResolvable */);
+
+    CapturingHandler handler = attachHandler();
+    try {
+      installer.onStartup(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    // Encryption still installs (no startup abort) but the degraded posture is now visible.
+    assertEquals("AES-256-GCM", EncryptionHolder.writeEngine().algorithmId());
+    assertTrue(
+        handler.warnedAboutEntropy(), "expected a WARN about reduced nonce-clone protection");
+  }
+
+  @Test
+  void blankNodeId_installsAnyway_andWarnsAboutReducedProtection() {
+    System.setProperty(ReferenceEncryptionFactory.KEYS_PROPERTY, "k1:" + base64Key());
+    when(nodeIdProvider.getNodeId()).thenReturn("");
+    EncryptionInstaller installer = installer(options(null), false /* providerResolvable */);
+
+    CapturingHandler handler = attachHandler();
+    try {
+      installer.onStartup(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    assertEquals("AES-256-GCM", EncryptionHolder.writeEngine().algorithmId());
+    assertTrue(
+        handler.warnedAboutEntropy(), "expected a WARN about reduced nonce-clone protection");
+  }
+
+  private static CapturingHandler attachHandler() {
+    Logger logger = Logger.getLogger(EncryptionInstaller.class.getName());
+    logger.setLevel(Level.ALL);
+    CapturingHandler handler = new CapturingHandler();
+    logger.addHandler(handler);
+    return handler;
+  }
+
+  private static void detachHandler(CapturingHandler handler) {
+    Logger.getLogger(EncryptionInstaller.class.getName()).removeHandler(handler);
+  }
+
+  /** Collects WARN records so a test can assert the degraded-entropy warning was emitted. */
+  private static final class CapturingHandler extends Handler {
+    private final CopyOnWriteArrayList<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+
+    boolean warnedAboutEntropy() {
+      return records.stream()
+          .anyMatch(
+              r ->
+                  r.getLevel().intValue() >= Level.WARNING.intValue()
+                      && r.getMessage() != null
+                      && r.getMessage().contains("per-node nonce entropy"));
+    }
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceIdempotencyRaceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceIdempotencyRaceTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
+import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.payload.DefaultJobInvocationResolver;
+import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.JobBulkStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultJobCreationServiceIdempotencyRaceTest {
+
+  @Mock private JobBatchStatusStore jobBatchStatusStore;
+  @Mock private JobTerminalStore jobTerminalStore;
+  @Mock private JobCrudStore jobCrudStore;
+  @Mock private JobBulkStore jobBulkStore;
+  @Mock private BatchStore batchStore;
+  @Mock private TagStore tagStore;
+  @Mock private WorkflowConditionStore workflowConditionStore;
+  @Mock private RecurringJobStore recurringJobStore;
+  @Mock private RecurringScheduler recurringScheduler;
+
+  public static void noopTask() {}
+
+  private static class NoopJobWakeupService extends JobWakeupService {
+    @Override
+    public void notify(JobPriority priority, boolean immediate, String executionTarget) {}
+
+    @Override
+    public void notifyIfNeeded(
+        JobExecutionType jobType, JobPriority priority, Duration delay, String executionTarget) {}
+  }
+
+  private DefaultJobCreationService newService() {
+    return new DefaultJobCreationService(
+        jobBatchStatusStore,
+        jobTerminalStore,
+        jobCrudStore,
+        jobBulkStore,
+        batchStore,
+        tagStore,
+        workflowConditionStore,
+        recurringJobStore,
+        new NoopJobWakeupService(),
+        recurringScheduler,
+        new DefaultJobInvocationResolver(),
+        new JobPayloadInputValidator(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        Clock.fixed(Instant.parse("2026-05-27T12:00:00Z"), ZoneOffset.UTC));
+  }
+
+  @Test
+  void submit_convergesToExistingJob_whenIdempotencyKeyRacesOnInsert() {
+    DefaultJobCreationService service = newService();
+    String key = "order-42";
+    UUID existingId = UUID.randomUUID();
+
+    JobEntity existing = new JobEntity();
+    existing.setId(existingId);
+    existing.setIdempotencyKey(key);
+
+    // No job is visible at the pre-insert lookup (the racer has not committed yet), so the insert
+    // proceeds and loses the unique-constraint race. The store reports the collision; the
+    // post-insert re-resolve now sees the winner's row.
+    when(jobCrudStore.findByIdempotencyKey(key))
+        .thenReturn(Optional.empty())
+        .thenReturn(Optional.of(existing));
+    when(jobCrudStore.create(any(JobEntity.class)))
+        .thenThrow(new DuplicateIdempotencyKeyException(key, new RuntimeException("dup")));
+
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                service, DefaultJobCreationServiceIdempotencyRaceTest::noopTask, Duration.ZERO);
+    builder.withIdempotencyKey(key);
+
+    JobHandle handle = service.submit(builder);
+
+    assertEquals(existingId, handle.id());
+    verify(jobCrudStore, times(1)).create(any(JobEntity.class));
+    verify(jobCrudStore, times(2)).findByIdempotencyKey(eq(key));
+  }
+
+  @Test
+  void submit_returnsExistingJob_whenIdempotencyKeyResolvesBeforeInsert() {
+    DefaultJobCreationService service = newService();
+    String key = "order-7";
+    UUID existingId = UUID.randomUUID();
+
+    JobEntity existing = new JobEntity();
+    existing.setId(existingId);
+    existing.setIdempotencyKey(key);
+
+    when(jobCrudStore.findByIdempotencyKey(key)).thenReturn(Optional.of(existing));
+
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                service, DefaultJobCreationServiceIdempotencyRaceTest::noopTask, Duration.ZERO);
+    builder.withIdempotencyKey(key);
+
+    JobHandle handle = service.submit(builder);
+
+    assertEquals(existingId, handle.id());
+    // The happy-path short-circuit never reaches create().
+    verify(jobCrudStore, times(0)).create(any(JobEntity.class));
+  }
+}

--- a/ratchet/src/test/java/run/ratchet/ri/core/RetryBufferManagerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/RetryBufferManagerTest.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.ri.core;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -79,7 +80,9 @@ class RetryBufferManagerTest {
 
   @BeforeEach
   void setUp() {
-    manager = new RetryBufferManager(deadLetterService, jobBatchStatusStore, nodeIdentityProvider);
+    JobStateManager jobStateManager =
+        new JobStateManager(jobBatchStatusStore, nodeIdentityProvider);
+    manager = new RetryBufferManager(deadLetterService, jobStateManager);
   }
 
   @Test
@@ -88,11 +91,13 @@ class RetryBufferManagerTest {
   }
 
   @Test
-  void transactionBoundary_onlyAppliesToPersistentFlush() throws Exception {
+  void flushOnShutdown_hasNoEnclosingTransaction() throws Exception {
     assertNull(RetryBufferManager.class.getAnnotation(Transactional.class));
 
+    // Each claim is reset in its own transaction via JobStateManager. A method-level
+    // @Transactional here would let one failed reset roll back every successful one.
     Method flushOnShutdown = RetryBufferManager.class.getMethod("flushOnShutdown");
-    assertNotNull(flushOnShutdown.getAnnotation(Transactional.class));
+    assertNull(flushOnShutdown.getAnnotation(Transactional.class));
   }
 
   @Test
@@ -366,7 +371,7 @@ class RetryBufferManagerTest {
   }
 
   @Test
-  void flushOnShutdown_resetExceptionRequeuesClaimAndSignalsFailure() {
+  void flushOnShutdown_oneResetFailureDoesNotUndoSuccessfulResets() {
     manager.offer(standardJob(1L));
     manager.offer(standardJob(2L));
     when(nodeIdentityProvider.getNodeId()).thenReturn("node-1");
@@ -375,15 +380,20 @@ class RetryBufferManagerTest {
         .resetRunningJob(new UUID(0L, 1L), "node-1");
     when(jobBatchStatusStore.resetRunningJob(new UUID(0L, 2L), "node-1")).thenReturn(true);
 
-    IllegalStateException failure =
-        assertThrows(IllegalStateException.class, manager::flushOnShutdown);
+    // A single per-claim failure must not throw; throwing after a partial flush would discard
+    // the claims already reset back to PENDING.
+    assertDoesNotThrow(manager::flushOnShutdown);
 
     verify(jobBatchStatusStore).resetRunningJob(new UUID(0L, 1L), "node-1");
     verify(jobBatchStatusStore).resetRunningJob(new UUID(0L, 2L), "node-1");
-    assertTrue(failure.getMessage().contains("Failed to flush 1 buffered job"));
+
+    // Only the failed claim is requeued; the successful reset stays flushed.
     assertEquals(1, manager.totalSize());
     assertTrue(
         manager.getBuffer(JobExecutionType.SINGLE).stream()
             .anyMatch(claim -> new UUID(0L, 1L).equals(claim.jobId())));
+    assertFalse(
+        manager.getBuffer(JobExecutionType.SINGLE).stream()
+            .anyMatch(claim -> new UUID(0L, 2L).equals(claim.jobId())));
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/WorkflowConditionEvaluatorTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/WorkflowConditionEvaluatorTest.java
@@ -478,6 +478,88 @@ class WorkflowConditionEvaluatorTest {
             parent));
   }
 
+  /**
+   * Result type that is invocation-allowed but must NOT be instantiated from {@code result_type}.
+   */
+  public static final class ForbiddenResult {
+    public String value;
+
+    public boolean matches() {
+      return true;
+    }
+  }
+
+  @Test
+  void resultValue_invocationAllowedButNotResultRegistered_isNotInstantiated() {
+    // The class is on the invocation allowlist (isAllowed -> true) but NOT on the narrower
+    // result-type allowlist (isAllowedForResultType -> false). The stored result_type must not be
+    // instantiated; the engine falls back to JSON-native parsing instead.
+    ClassPolicy invocationOnly =
+        new ClassPolicy() {
+          @Override
+          public boolean isAllowed(String className) {
+            return true;
+          }
+          // isAllowedForResultType defaults to false (deny).
+        };
+    WorkflowConditionEvaluator restrictedEvaluator =
+        new WorkflowConditionEvaluator(batchStore, beanResolver, invocationOnly, payloadSerializer);
+
+    JobEntity parent = parentJob(JobStatus.SUCCEEDED);
+    parent.setJobResult("{\"value\":\"x\"}");
+    parent.setResultType(ForbiddenResult.class.getName());
+    // Predicate asserts the value it receives is NOT a ForbiddenResult instance — it is the
+    // JSON-native map produced by the fallback.
+    String expression =
+        serializeCondition(
+            (SerializablePredicate<Object>) WorkflowConditionEvaluatorTest::notForbidden);
+
+    assertTrue(
+        restrictedEvaluator.evaluate(
+            conditionWithExpression(WorkflowCondition.ConditionType.RESULT_VALUE, expression),
+            parent));
+  }
+
+  public static boolean notForbidden(Object value) {
+    return !(value instanceof ForbiddenResult);
+  }
+
+  @Test
+  void resultValue_resultTypeRegistered_isInstantiated() {
+    // When the result type is opted in to the narrower result-type allowlist, it IS instantiated.
+    ClassPolicy allowResultType =
+        new ClassPolicy() {
+          @Override
+          public boolean isAllowed(String className) {
+            return true;
+          }
+
+          @Override
+          public boolean isAllowedForResultType(String className) {
+            return ForbiddenResult.class.getName().equals(className);
+          }
+        };
+    WorkflowConditionEvaluator restrictedEvaluator =
+        new WorkflowConditionEvaluator(
+            batchStore, beanResolver, allowResultType, payloadSerializer);
+
+    JobEntity parent = parentJob(JobStatus.SUCCEEDED);
+    parent.setJobResult("{\"value\":\"x\"}");
+    parent.setResultType(ForbiddenResult.class.getName());
+    String expression =
+        serializeCondition(
+            (SerializablePredicate<Object>) WorkflowConditionEvaluatorTest::isForbidden);
+
+    assertTrue(
+        restrictedEvaluator.evaluate(
+            conditionWithExpression(WorkflowCondition.ConditionType.RESULT_VALUE, expression),
+            parent));
+  }
+
+  public static boolean isForbidden(Object value) {
+    return value instanceof ForbiddenResult;
+  }
+
   @Test
   void resultValue_classPolicyDenied_returnsFalse() {
     ClassPolicy denyAll = className -> false;

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/DefaultRecurringSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/DefaultRecurringSchedulerTest.java
@@ -128,7 +128,7 @@ class DefaultRecurringSchedulerTest {
     DefaultRecurringScheduler scheduler =
         new DefaultRecurringScheduler(
             executorProvider,
-            mock(run.ratchet.store.spi.RecurringJobStore.class),
+            mock(RecurringJobStore.class),
             singletonLeaseService,
             nodeIdentityProvider,
             recurringJobExecutor,
@@ -140,14 +140,57 @@ class DefaultRecurringSchedulerTest {
     scheduler.run();
 
     verify(lockStore).unlock("recurringScheduler", "node-1");
-    verify(scheduledScan).cancel(false);
     verify(renewalTask).cancel(false);
     verify(pollerScheduler, never()).wakeup();
     verify(executor, never()).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
   }
 
-  private static DefaultRecurringScheduler scheduler(
-      run.ratchet.store.spi.RecurringJobStore recurringJobStore) {
+  @Test
+  void kick_duringInFlightScanCoalescesIntoSingleChain() {
+    var executorProvider = mock(ExecutorProvider.class);
+    var executor = mock(ScheduledExecutorService.class);
+    var scheduledScan = mock(ScheduledFuture.class);
+    when(executorProvider.getScheduledExecutor()).thenReturn(executor);
+    when(executor.schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS)))
+        .thenReturn(scheduledScan);
+
+    var singletonLeaseService = mock(SingletonLeaseService.class);
+    when(singletonLeaseService.tryAcquire("recurringScheduler", Duration.ofMinutes(5)))
+        .thenReturn(Optional.empty());
+    var nodeIdentityProvider = mock(NodeIdentityProvider.class);
+    when(nodeIdentityProvider.getNodeId()).thenReturn("node-1");
+    var recurringJobExecutor = mock(RecurringJobExecutor.class);
+    var pollerScheduler = mock(PollerScheduler.class);
+
+    DefaultRecurringScheduler scheduler =
+        new DefaultRecurringScheduler(
+            executorProvider,
+            mock(RecurringJobStore.class),
+            singletonLeaseService,
+            nodeIdentityProvider,
+            recurringJobExecutor,
+            pollerScheduler,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    // A kick arriving while a cycle is in flight must coalesce, not spawn a second poll chain.
+    when(singletonLeaseService.tryAcquire("recurringScheduler", Duration.ofMinutes(5)))
+        .thenAnswer(
+            invocation -> {
+              scheduler.kick();
+              return Optional.empty();
+            });
+
+    scheduler.init();
+    clearInvocations(executor);
+
+    scheduler.run();
+
+    // Exactly one reschedule from the finishing cycle — the in-flight kick was coalesced, not a
+    // second self-perpetuating chain.
+    verify(executor).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+  }
+
+  private static DefaultRecurringScheduler scheduler(RecurringJobStore recurringJobStore) {
     DefaultRecurringScheduler scheduler =
         new DefaultRecurringScheduler(
             mock(ExecutorProvider.class),

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/DefaultRecurringSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/DefaultRecurringSchedulerTest.java
@@ -91,7 +91,7 @@ class DefaultRecurringSchedulerTest {
   }
 
   @Test
-  void run_failedLeaseRenewalReleasesLeaseAndStopsScheduling() {
+  void run_failedLeaseRenewalReleasesLeaseButKeepsPolling() {
     var executorProvider = mock(ExecutorProvider.class);
     var executor = mock(ScheduledExecutorService.class);
     var scheduledScan = mock(ScheduledFuture.class);
@@ -109,8 +109,10 @@ class DefaultRecurringSchedulerTest {
 
     var lockStore = mock(LockStore.class);
     var lease = new SingletonLease(lockStore, "recurringScheduler", "node-1");
+    // A transient lock-store blip on the renewal — the next cycle would re-acquire cleanly.
     when(lockStore.renewLock("recurringScheduler", Duration.ofMinutes(5), "node-1"))
-        .thenReturn(false);
+        .thenThrow(new RuntimeException("transient lock-store blip"))
+        .thenReturn(true);
     var singletonLeaseService = mock(SingletonLeaseService.class);
     when(singletonLeaseService.tryAcquire("recurringScheduler", Duration.ofMinutes(5)))
         .thenReturn(Optional.of(lease));
@@ -139,10 +141,12 @@ class DefaultRecurringSchedulerTest {
 
     scheduler.run();
 
+    // The current lease is released and the renewal task cancelled, but the poll loop keeps going:
+    // a transient renewal failure must not permanently stop recurring scheduling on the node.
     verify(lockStore).unlock("recurringScheduler", "node-1");
     verify(renewalTask).cancel(false);
     verify(pollerScheduler, never()).wakeup();
-    verify(executor, never()).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+    verify(executor).schedule(any(Runnable.class), eq(1000L), eq(TimeUnit.MILLISECONDS));
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskAuthorizationTest.java
@@ -113,6 +113,7 @@ class JobTaskAuthorizationTest {
             resultPersistenceStrategy,
             authorizationPolicy,
             null,
+            null,
             Clock.systemUTC());
   }
 
@@ -256,6 +257,7 @@ class JobTaskAuthorizationTest {
             new DefaultResultPersistenceStrategy(RatchetOptions.defaults(), serializer, null),
             null,
             serializer,
+            null,
             Clock.systemUTC());
 
     JobEntity job = createBaseJob();

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskClassCacheBypassTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskClassCacheBypassTest.java
@@ -128,6 +128,7 @@ class JobTaskClassCacheBypassTest {
         new DefaultResultPersistenceStrategy(RatchetOptions.defaults(), serializer, null),
         null,
         serializer,
+        null,
         Clock.systemUTC());
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -578,6 +578,25 @@ class JobTaskTest {
   }
 
   @Test
+  void requeueForUpgrade_entityInitPath_preservesPersistedAttempts() throws Exception {
+    // A task initialized via the entity path (buffered-entity resubmission) has claim == null but
+    // job != null. requeueForUpgrade must release the job with its persisted attempt count, not 0 —
+    // an upgrade requeue is not a failed attempt and must never reset the count.
+    JobEntity job = createTestJob();
+    job.setAttempts(2);
+    jobTask.init(job);
+    when(jobStore.scheduleJobRetry(any(UUID.class), any(), any(), anyInt())).thenReturn(true);
+
+    java.lang.reflect.Method requeue =
+        JobTask.class.getDeclaredMethod(
+            "requeueForUpgrade", UUID.class, UnsupportedEnvelopeVersionException.class);
+    requeue.setAccessible(true);
+    requeue.invoke(jobTask, JOB_UUID, new UnsupportedEnvelopeVersionException(2, 1));
+
+    verify(jobStore).scheduleJobRetry(eq(JOB_UUID), any(), any(), eq(2));
+  }
+
+  @Test
   void call_signalDecryptTransientKeyOutage_retriesInsteadOfDlq() {
     // A transient key-provider outage during signal-payload decrypt must stay retryable, not be
     // flattened into a non-retryable IllegalArgumentException that dead-letters a recoverable job.

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -22,6 +22,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.jboss.logging.MDC;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -151,6 +153,7 @@ class JobTaskTest {
                 null,
                 null,
                 null,
+                null,
                 null));
   }
 
@@ -194,6 +197,7 @@ class JobTaskTest {
             new DefaultResultPersistenceStrategy(RatchetOptions.defaults(), serializer, null),
             null,
             serializer,
+            null,
             Clock.systemUTC());
   }
 
@@ -414,6 +418,117 @@ class JobTaskTest {
     jobTask.call();
 
     verify(lifecycleFacade).moveToDlq(eq(job), eq(error));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void hardTimeoutAndInterruptedWorker_consumeExactlyOneAttempt() throws Exception {
+    // A hard timeout interrupts the worker. The watchdog (processHardTimeout) and the interrupted
+    // worker (handleFailure) both run while the row is still RUNNING. Without coordination both
+    // increment the attempt and one timeout burns two attempts, dead-lettering at half maxRetries.
+    JobEntity job = createTestJob();
+    job.setMaxRetries(3);
+
+    AtomicInteger attempts = new AtomicInteger(0);
+    // Mirror the store: incrementRetryAttempt only matches a RUNNING/WAITING row. The watchdog's
+    // reschedule moves the row off RUNNING, so a later increment returns -1.
+    AtomicInteger running = new AtomicInteger(1);
+    when(jobStore.incrementRetryAttempt(JOB_UUID))
+        .thenAnswer(inv -> running.get() == 1 ? attempts.incrementAndGet() : -1);
+    when(jobStore.findById(JOB_UUID)).thenReturn(Optional.of(job));
+
+    JobTimeoutHandler timeoutHandler =
+        new JobTimeoutHandler(
+            jobStore,
+            jobStore,
+            jobStore,
+            lifecycleFacade,
+            80,
+            60L,
+            FIXED_CLOCK,
+            null,
+            null,
+            null,
+            null,
+            JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE);
+
+    JobTask task = newJobTaskWithTimeoutHandler(timeoutHandler);
+    initJobTaskWithDefaultStubs(task, job);
+    when(jobStore.getJobStatus(JOB_UUID)).thenReturn(JobStatus.RUNNING);
+    when(resilienceStrategy.isServiceAvailable(anyString())).thenReturn(true);
+
+    InterruptedException interrupt = new InterruptedException("cancelled by hard timeout");
+    when(resilienceStrategy.execute(anyString(), any(Callable.class))).thenThrow(interrupt);
+    // The deferring worker never reaches shouldNotRetry, so keep this lenient.
+    lenient().when(validationFacade.shouldNotRetry(interrupt)).thenReturn(false);
+
+    // Reproduce the both-increment-before-either-CAS window: the worker's handleFailure runs while
+    // the watchdog still holds the marker and the row is still RUNNING — i.e. exactly when the
+    // watchdog is mid-reschedule. scheduleJobRetry runs the worker first, THEN flips the row off
+    // RUNNING, just as the real CAS would. With the fix the worker defers (no second increment).
+    when(jobStore.scheduleJobRetry(eq(JOB_UUID), any(), any(), anyInt()))
+        .thenAnswer(
+            inv -> {
+              task.call();
+              running.set(0);
+              return true;
+            });
+
+    java.util.concurrent.FutureTask<Void> future =
+        new java.util.concurrent.FutureTask<>(() -> null);
+    java.lang.reflect.Method handleHard =
+        JobTimeoutHandler.class.getDeclaredMethod(
+            "handleHardTimeoutById",
+            UUID.class,
+            java.util.concurrent.Future.class,
+            Instant.class,
+            long.class);
+    handleHard.setAccessible(true);
+    handleHard.invoke(timeoutHandler, JOB_UUID, future, FIXED_NOW, 30L);
+
+    Assertions.assertEquals(
+        1, attempts.get(), "a single hard timeout must consume exactly one attempt");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void normalInterruptedWorker_stillCountsOneAttempt() throws Exception {
+    // A genuine, non-watchdog interrupt (no timeout marker) must still count as a failed attempt.
+    JobEntity job = createTestJob();
+    job.setMaxRetries(3);
+
+    JobTimeoutHandler timeoutHandler =
+        new JobTimeoutHandler(
+            jobStore,
+            jobStore,
+            jobStore,
+            lifecycleFacade,
+            80,
+            60L,
+            FIXED_CLOCK,
+            null,
+            null,
+            null,
+            null,
+            JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE);
+
+    JobTask task = newJobTaskWithTimeoutHandler(timeoutHandler);
+    initJobTaskWithDefaultStubs(task, job);
+    when(jobStore.getJobStatus(JOB_UUID)).thenReturn(JobStatus.RUNNING);
+    when(resilienceStrategy.isServiceAvailable(anyString())).thenReturn(true);
+
+    InterruptedException interrupt = new InterruptedException("not a timeout");
+    when(resilienceStrategy.execute(anyString(), any(Callable.class))).thenThrow(interrupt);
+    when(validationFacade.shouldNotRetry(interrupt)).thenReturn(false);
+    when(jobStore.incrementRetryAttempt(JOB_UUID)).thenReturn(1);
+    when(retryPolicy.shouldRetry(1, interrupt)).thenReturn(false);
+    when(jobStore.compareAndSwapStatus(
+            eq(JOB_UUID), eq(JobStatus.RUNNING), eq(JobStatus.FAILED), any()))
+        .thenReturn(true);
+
+    task.call();
+
+    verify(jobStore, times(1)).incrementRetryAttempt(JOB_UUID);
   }
 
   @Test
@@ -873,6 +988,7 @@ class JobTaskTest {
             resultPersistenceStrategy,
             null,
             signalSerializer,
+            null,
             Clock.systemUTC());
     JobEntity job = createTestJob();
     job.setPayload(
@@ -926,6 +1042,7 @@ class JobTaskTest {
             resultPersistenceStrategy,
             null,
             signalSerializer,
+            null,
             Clock.systemUTC());
     JobEntity job = createTestJob();
     job.setPayload(
@@ -1031,6 +1148,29 @@ class JobTaskTest {
         .thenReturn(TracingCollector.NoOpExecutionScope.INSTANCE);
   }
 
+  private JobTask newJobTaskWithTimeoutHandler(JobTimeoutHandler timeoutHandler) {
+    ResultPersistenceStrategy resultPersistenceStrategy =
+        (jobId, result) -> SerializedJobResult.empty();
+    return new JobTask(
+        jobStore,
+        resourcePermitService,
+        lifecycleFacade,
+        nodeIdProvider,
+        observabilityFacade,
+        validationFacade,
+        beanResolver,
+        retryPolicy,
+        resilienceStrategy,
+        errorSanitizer,
+        classPolicy,
+        context -> noopLogger(),
+        resultPersistenceStrategy,
+        null,
+        null,
+        timeoutHandler,
+        FIXED_CLOCK);
+  }
+
   private JobTask newJobTaskWithClock(Clock taskClock) {
     ResultPersistenceStrategy resultPersistenceStrategy =
         (jobId, result) -> SerializedJobResult.empty();
@@ -1048,6 +1188,7 @@ class JobTaskTest {
         classPolicy,
         context -> noopLogger(),
         resultPersistenceStrategy,
+        null,
         null,
         null,
         taskClock);

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTimeoutHandlerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTimeoutHandlerTest.java
@@ -54,6 +54,7 @@ import run.ratchet.api.event.JobDlqEvent;
 import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.event.JobSignalTimedOutEvent;
 import run.ratchet.api.exception.SignalTimeoutException;
+import run.ratchet.ri.core.SingletonLease;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
@@ -357,6 +358,31 @@ class JobTimeoutHandlerTest {
   }
 
   @Test
+  void scanSignalTimeoutsSkippedWhenSingletonLeaseNotHeld() {
+    SingletonLeaseService leaseService = org.mockito.Mockito.mock(SingletonLeaseService.class);
+    when(leaseService.tryAcquire(anyString(), any(Duration.class))).thenReturn(Optional.empty());
+    JobTimeoutHandler leasedHandler = newLeasedHandler(leaseService);
+
+    leasedHandler.scanSignalTimeouts();
+
+    verify(signalStore, never()).findTimedOutSignalJobs(any(Instant.class), anyInt());
+    verify(jobRetryStore, never()).incrementRetryAttempt(any(UUID.class));
+  }
+
+  @Test
+  void scanSignalTimeoutsRunsWhenSingletonLeaseGranted() {
+    SingletonLeaseService leaseService = org.mockito.Mockito.mock(SingletonLeaseService.class);
+    when(leaseService.tryAcquire(anyString(), any(Duration.class)))
+        .thenReturn(Optional.of(new SingletonLease(null, "signalTimeoutScan", "node-1")));
+    JobTimeoutHandler leasedHandler = newLeasedHandler(leaseService);
+    when(signalStore.findTimedOutSignalJobs(any(Instant.class), anyInt())).thenReturn(List.of());
+
+    leasedHandler.scanSignalTimeouts();
+
+    verify(signalStore).findTimedOutSignalJobs(any(Instant.class), anyInt());
+  }
+
+  @Test
   void scanSignalTimeoutsIsolatesPerJobFailuresAndProcessesRemainingJobs() {
     JobTimeoutHandler scanHandler =
         newHandler(
@@ -538,5 +564,23 @@ class JobTimeoutHandlerTest {
         metricsCollector,
         signalTimeoutBatchSize,
         txRegistry);
+  }
+
+  private JobTimeoutHandler newLeasedHandler(SingletonLeaseService singletonLeaseService) {
+    return new JobTimeoutHandler(
+        jobCrudStore,
+        jobRetryStore,
+        jobBatchStatusStore,
+        lifecycleFacade,
+        80,
+        60L,
+        Clock.systemUTC(),
+        null,
+        null,
+        signalStore,
+        metricsCollector,
+        JobTimeoutHandler.DEFAULT_SIGNAL_TIMEOUT_BATCH_SIZE,
+        null,
+        singletonLeaseService);
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/security/PackagePrefixClassPolicyTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/security/PackagePrefixClassPolicyTest.java
@@ -225,6 +225,31 @@ class PackagePrefixClassPolicyTest {
   }
 
   @Test
+  void resultType_deniedByDefaultEvenWhenInvocationAllowed() {
+    // A class allowed for invocation is NOT instantiable from a stored result type unless it was
+    // also opted in to the separate, narrower result-type allowlist.
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("com.example."));
+    assertTrue(policy.isAllowed("com.example.MyJob"));
+    assertFalse(policy.isAllowedForResultType("com.example.MyJob"));
+  }
+
+  @Test
+  void resultType_allowedWhenOptedIn() {
+    PackagePrefixClassPolicy policy =
+        new PackagePrefixClassPolicy(Set.of("com.example."), Set.of("com.example.dto."));
+    assertTrue(policy.isAllowedForResultType("com.example.dto.OrderResult"));
+    // The invocation allowlist still does not grant result-type instantiation outside the dto pkg.
+    assertFalse(policy.isAllowedForResultType("com.example.MyJob"));
+  }
+
+  @Test
+  void resultType_respectsDenylist() {
+    PackagePrefixClassPolicy policy =
+        new PackagePrefixClassPolicy(Set.of("com.example."), Set.of("java.lang."));
+    assertFalse(policy.isAllowedForResultType("java.lang.Runtime"));
+  }
+
+  @Test
   void allowlist_prefixNormalizationIdempotent() {
     // Explicit trailing dot and absent trailing dot must produce the same policy.
     PackagePrefixClassPolicy withDot = new PackagePrefixClassPolicy(Set.of("com.example."));

--- a/ratchet/src/test/java/run/ratchet/ri/security/PackagePrefixClassPolicyTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/security/PackagePrefixClassPolicyTest.java
@@ -77,52 +77,109 @@ class PackagePrefixClassPolicyTest {
 
   @Test
   void denylist_rejectsRuntimeEvenWithBroadJavaAllowlist() {
-    // Regression for the "Set.of('java')" misconfiguration attack scenario.
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java."));
+    // Regression for the broad-allowlist misconfiguration attack scenario.
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java.lang."));
     assertFalse(
         policy.isAllowed("java.lang.Runtime"),
-        "java.lang.Runtime must be blocked by hardcoded denylist even with 'java.' in allowlist");
+        "java.lang.Runtime must be blocked by hardcoded denylist even with 'java.lang.' allowed");
   }
 
   @Test
   void denylist_rejectsProcessBuilder() {
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java."));
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java.lang."));
     assertFalse(policy.isAllowed("java.lang.ProcessBuilder"));
   }
 
   @Test
+  void denylist_rejectsSystem() {
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java.lang."));
+    assertFalse(policy.isAllowed("java.lang.System"));
+  }
+
+  @Test
   void denylist_rejectsObjectInputStream() {
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java."));
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java.io."));
     assertFalse(policy.isAllowed("java.io.ObjectInputStream"));
   }
 
   @Test
   void denylist_rejectsReflectionEntries() {
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java."));
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("java.lang."));
     assertFalse(policy.isAllowed("java.lang.reflect.Method"));
     assertFalse(policy.isAllowed("java.lang.invoke.MethodHandles"));
   }
 
   @Test
   void denylist_rejectsScriptEngine() {
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("javax."));
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("javax.script."));
     assertFalse(policy.isAllowed("javax.script.ScriptEngineManager"));
   }
 
   @Test
+  void denylist_rejectsNamingFactories() {
+    // javax.naming. is now denied as a PREFIX, not just the exact InitialContext, so LDAP/RMI
+    // reference factories and the SPI package are blocked too.
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("javax.naming."));
+    assertFalse(policy.isAllowed("javax.naming.spi.ObjectFactory"));
+    assertFalse(policy.isAllowed("javax.naming.ldap.LdapContext"));
+    assertFalse(policy.isAllowed("javax.naming.InitialContext"));
+  }
+
+  @Test
   void denylist_rejectsJdkInternals() {
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("jdk."));
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("jdk.internal."));
     assertFalse(policy.isAllowed("jdk.internal.misc.Unsafe"));
-    assertFalse(policy.isAllowed("sun.misc.Unsafe"));
+    PackagePrefixClassPolicy sunPolicy = new PackagePrefixClassPolicy(Set.of("sun.misc."));
+    assertFalse(sunPolicy.isAllowed("sun.misc.Unsafe"));
   }
 
   @Test
   void denylist_rejectsDeserializationGadgets() {
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("org."));
-    assertFalse(policy.isAllowed("org.apache.commons.collections.functors.InvokerTransformer"));
-    assertFalse(policy.isAllowed("org.codehaus.groovy.runtime.MethodClosure"));
+    PackagePrefixClassPolicy commons = new PackagePrefixClassPolicy(Set.of("org.apache.commons."));
+    assertFalse(commons.isAllowed("org.apache.commons.collections.functors.InvokerTransformer"));
+    assertFalse(commons.isAllowed("org.apache.commons.collections4.functors.InvokerTransformer"));
+    assertFalse(commons.isAllowed("org.apache.commons.beanutils.BeanComparator"));
+
+    PackagePrefixClassPolicy groovy = new PackagePrefixClassPolicy(Set.of("groovy.lang."));
+    assertFalse(groovy.isAllowed("groovy.lang.GroovyShell"));
+
+    PackagePrefixClassPolicy codehaus =
+        new PackagePrefixClassPolicy(Set.of("org.codehaus.groovy."));
+    assertFalse(codehaus.isAllowed("org.codehaus.groovy.runtime.MethodClosure"));
+
+    PackagePrefixClassPolicy snake = new PackagePrefixClassPolicy(Set.of("org.yaml."));
+    assertFalse(snake.isAllowed("org.yaml.snakeyaml.Yaml"));
+
+    PackagePrefixClassPolicy bsh = new PackagePrefixClassPolicy(Set.of("bsh.x."));
+    assertFalse(bsh.isAllowed("bsh.Interpreter"));
+
+    PackagePrefixClassPolicy spring = new PackagePrefixClassPolicy(Set.of("org.springframework."));
     assertFalse(
-        policy.isAllowed("org.springframework.context.support.FileSystemXmlApplicationContext"));
+        spring.isAllowed("org.springframework.context.support.FileSystemXmlApplicationContext"));
+  }
+
+  @Test
+  void constructor_rejectsSingleTopLevelSegmentPrefix() {
+    // A single top-level segment like "com." or "java." matches nearly the whole classpath and
+    // would defeat the allowlist, so it must be rejected at construction.
+    assertThrows(
+        IllegalArgumentException.class, () -> new PackagePrefixClassPolicy(Set.of("com.")));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PackagePrefixClassPolicy(Set.of("org.")));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PackagePrefixClassPolicy(Set.of("java.")));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PackagePrefixClassPolicy(Set.of("javax.")));
+    assertThrows(
+        IllegalArgumentException.class, () -> new PackagePrefixClassPolicy(Set.of("jakarta.")));
+    // Without the trailing dot too.
+    assertThrows(IllegalArgumentException.class, () -> new PackagePrefixClassPolicy(Set.of("net")));
+  }
+
+  @Test
+  void constructor_acceptsTwoSegmentPrefix() {
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("com.example."));
+    assertTrue(policy.isAllowed("com.example.MyJob"));
   }
 
   @Test
@@ -138,10 +195,10 @@ class PackagePrefixClassPolicyTest {
   }
 
   @Test
-  void constructor_acceptsThreeCharMinimumPrefix() {
-    // 3 chars is the minimum, though this should still feel wrong in practice.
-    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("foo"));
-    assertTrue(policy.isAllowed("foo.bar.Baz"));
+  void constructor_acceptsShortTwoSegmentPrefix() {
+    // A short but two-segment prefix is fine; only single top-level segments are rejected.
+    PackagePrefixClassPolicy policy = new PackagePrefixClassPolicy(Set.of("a.b."));
+    assertTrue(policy.isAllowed("a.b.Baz"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

A full pre-release security and correctness sweep of the codebase ahead of 0.1.0. Six parallel audits (cryptography, deserialization/reflection, the SQL stores, the Mongo store, the core engine, and the coordinators/CI) surfaced 21 issues; each was verified against the source, reproduced with a test where practical, and fixed as its own atomic commit. No externally reachable RCE/authentication vulnerabilities were found — the items here are concurrency/correctness bugs, defense-in-depth hardening, and a CI publishing guard.

### Correctness and concurrency

- **PostgreSQL cancel-by-tag race.** `UPDATE ... FROM` only locked `scheduler_job`, not the queue rows the claim path takes with `FOR UPDATE SKIP LOCKED`, so a tagged job could be claimed RUNNING between the cancel UPDATE and the hot DELETE — stranding the queue row and freeing its business key. The cancel now locks the candidate queue rows first.
- **Mongo archive search.** Archive filters and sort used `scheduled_time`, a field archived documents do not carry (they store `original_scheduled_time`), so scheduled-time-bounded archive searches silently returned nothing and paged on an undefined field. Now aligned with the SQL stores.
- **Mongo claim predicate.** The claim write re-checked only `status=PENDING`; a concurrent reschedule or tag change in the claim window could run a job early or on an excluded node. The candidate predicate is now re-asserted in the claim update.
- **Mongo lock renewal / precision.** `renewLock` reported failure on a matched-but-unmodified update (a same-millisecond renewal), risking a lease holder abandoning a lease it still owns; Instants are now truncated to millisecond precision on write so round-trips are stable.
- **Mongo retention delete** now guards on terminal status, so a job resurrected to PENDING between scan and delete is not silently lost; a dead index hint was removed.
- **Hard-timeout retry accounting.** A hard timeout could burn two retry attempts (the watchdog and the interrupted worker both incremented), sending jobs to the DLQ at half their configured retries. The two paths are now mutually exclusive.
- **Signal-timeout scan** now runs under the same singleton lease as the other periodic recoveries, so multiple nodes no longer double-count the same waiting job.
- **Recurring scheduler** no longer spawns duplicate poll chains when kicked mid-scan, and recovers after a transient lease-renewal failure instead of halting until redeploy.
- **Shutdown buffer flush** resets each claim in its own transaction so one failure can no longer roll back the others.
- **`requeueForUpgrade`** keeps the attempt count on the entity-init path instead of zeroing it.
- **`JobOptions.withTimeout`** rejects a positive sub-second duration instead of silently truncating it to "no timeout".
- **Idempotent submit** converges concurrent duplicate submits to the existing job rather than surfacing a unique-constraint error.

### Security hardening (defense-in-depth)

- **Workflow result deserialization** no longer reuses the broad invocation allowlist; result types are deny-by-default with a separate opt-in.
- **Class policy** gains the missing gadget prefixes and rejects over-broad single-segment allowlist entries at construction.
- **AES-GCM nonce** epoch is drawn lazily with a per-process component so a snapshot/clone cannot resume an identical nonce stream; the javadoc no longer over-states the guarantee, and a `reseed()` entry point is provided.
- **Encryption envelope** reads the version byte unsigned, and the reference engine warns when it starts with no node entropy.

### CI

- The docs site no longer publishes conformance artifacts built by an untrusted fork run.

## Testing

- Full reactor `mvn clean test spotless:check` is green across all 28 modules, including the live MySQL, PostgreSQL, and MongoDB Testcontainers suites.
- Each fix ships with a test: the PostgreSQL race reproduction fails ~31/40 before the fix and passes 40/40 after; the Mongo, core-engine, scheduler, crypto, and policy fixes each have a red-before/green-after unit or contced test.

## Docs

- [x] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change (adds `ConstraintDetector.isDuplicateIdempotencyKey`, `DuplicateIdempotencyKeyException`, `ClassPolicy.isAllowedForResultType`, and `JobOptions.withTimeout` now validates sub-second input)
- [x] Security-sensitive change
- [ ] Follow-up work remains
