### PR TITLE
Grant pull-requests read to the release workflow gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ permissions:
   packages: write
   statuses: write
   checks: write
+  # The release gate calls ci.yml, whose `changes` job requests `pull-requests: read`.
+  # A reusable workflow can't be granted more than its caller holds, so without this
+  # the call is rejected at parse time ("requesting 'pull-requests: read', but is only
+  # allowed 'pull-requests: none'").
+  pull-requests: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Fixes an invalid-workflow error that blocks the Release workflow from running at all:

```
.github/workflows/release.yml: Error calling workflow 'ci.yml'.
The nested job 'changes' is requesting 'pull-requests: read',
but is only allowed 'pull-requests: none'.
```

`release.yml` runs `ci.yml` as its release gate via `uses: ./.github/workflows/ci.yml`. A reusable workflow's jobs can never hold more permission than the caller grants, and `release.yml`'s top-level `permissions:` block did not include `pull-requests`. `ci.yml`'s `changes` job (the `dorny/paths-filter` lane) requests `pull-requests: read`, so the call was capped to `none` and GitHub rejected the file before it could run.

The fix adds `pull-requests: read` to `release.yml`'s top-level permissions, making the caller a superset of what the called workflow needs. `ci.yml` declares per-job permissions in only that one place, so this single scope is all that was missing.

## Testing

- `release.yml` parses as valid YAML.
- The added scope matches exactly what `ci.yml`'s `changes` job requests (`contents: read` is already covered by the existing `contents: write`).

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [x] Security-sensitive change (CI workflow permissions)
- [ ] Follow-up work remains
