### PR TITLE
Stop the release preflight from dying on a broken pipe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,10 @@ jobs:
           set -euo pipefail
           # The root pom <version> must be -SNAPSHOT (release:prepare rewrites it to
           # the release version and then bumps to the next development iteration).
-          POM_VERSION=$(grep -oE '<version>[^<]+</version>' pom.xml | head -1 | sed 's|<[^>]*>||g')
+          # grep -m1 stops after the first match so it never writes into a closed
+          # pipe; a previous `grep ... | head -1` died with SIGPIPE (broken pipe,
+          # exit 2) under `set -o pipefail` before the version was ever checked.
+          POM_VERSION=$(grep -m1 -oE '<version>[^<]+</version>' pom.xml | sed 's|<[^>]*>||g')
           if [[ ! "$POM_VERSION" =~ -SNAPSHOT$ ]]; then
             echo "::error::pom.xml <version> must end in -SNAPSHOT before release:prepare; got: $POM_VERSION"
             exit 1


### PR DESCRIPTION
## Summary

The latest Release run failed at the `preflight` job — but not for the reason it reports. The pom version is a valid `0.1.0-SNAPSHOT`; the job died on the command that extracts the version:

```bash
set -euo pipefail
POM_VERSION=$(grep -oE '<version>[^<]+</version>' pom.xml | head -1 | sed 's|<[^>]*>||g')
```

The root pom has many `<version>` tags, so `grep -oE` keeps writing while `head -1` closes the pipe after the first line. `grep` then hits `SIGPIPE` and exits 2 (`grep: write error: Broken pipe` in the log). Under `set -o pipefail` the pipeline inherits that failure and `set -e` fails the job — before the `-SNAPSHOT` comparison ever runs. `verify` and `release` are then skipped.

The fix replaces `grep ... | head -1` with `grep -m1`, which stops after the first match and never writes into a closed pipe. `head` is no longer needed.

## Testing

- `release.yml` parses as valid YAML.
- `grep -m1 -oE '<version>[^<]+</version>' pom.xml | sed 's|<[^>]*>||g'` returns `0.1.0-SNAPSHOT` cleanly under `set -euo pipefail` with no broken-pipe exit.

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [x] Security-sensitive change (CI/release workflow)
- [ ] Follow-up work remains
