### PR TITLE
Release by tag instead of pushing version bumps to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   # Branch guard: workflow_dispatch can run from any branch by default; lock to main
   # so an operator clicking "Run workflow" from a feature branch does NOT publish a
-  # release tag from non-main code.
+  # release from non-main code.
   guard:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
@@ -33,26 +33,29 @@ jobs:
       - name: Pre-flight check (pom version)
         run: |
           set -euo pipefail
-          # The root pom <version> must be -SNAPSHOT (release:prepare rewrites it to
-          # the release version and then bumps to the next development iteration).
-          # grep -m1 stops after the first match so it never writes into a closed
-          # pipe; a previous `grep ... | head -1` died with SIGPIPE (broken pipe,
-          # exit 2) under `set -o pipefail` before the version was ever checked.
+          # main must sit on a -SNAPSHOT version; the release drops the suffix to cut the
+          # release and opens a follow-up PR that moves main to the next -SNAPSHOT.
+          # grep -m1 stops after the first match so it never writes into a closed pipe;
+          # a previous `grep ... | head -1` died with SIGPIPE (broken pipe, exit 2) under
+          # `set -o pipefail` before the version was ever checked.
           POM_VERSION=$(grep -m1 -oE '<version>[^<]+</version>' pom.xml | sed 's|<[^>]*>||g')
           if [[ ! "$POM_VERSION" =~ -SNAPSHOT$ ]]; then
-            echo "::error::pom.xml <version> must end in -SNAPSHOT before release:prepare; got: $POM_VERSION"
+            echo "::error::pom.xml <version> must end in -SNAPSHOT; got: $POM_VERSION"
             exit 1
           fi
           echo "✓ Pre-flight green for ${POM_VERSION%-SNAPSHOT}"
 
   # Full CI matrix as the release gate — the release MUST NOT proceed if any cell is
-  # red. Because this gate runs the whole test suite, the maven-release-plugin's own
-  # forked builds skip tests (see <arguments> in the root pom's release plugin config).
+  # red. Tests run here, so the release job below skips them when it deploys.
   verify:
     needs: preflight
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
+  # The release never pushes commits to main. main is governed by a merge-queue rule
+  # plus signed-commit and required-status-check protection, which reject any direct
+  # push — so the released poms live only on the tag, and the next-development bump
+  # goes back through the merge queue as an ordinary PR.
   release:
     needs: verify
     permissions:
@@ -63,11 +66,9 @@ jobs:
       attestations: write
     runs-on: ubuntu-latest
     steps:
-      # Checkout with RELEASE_TOKEN (fine-grained PAT owned by a repo admin, Contents +
-      # Workflows R/W on this repo only). actions/checkout configures an http.extraheader
-      # so the git pushes from release:prepare authenticate as the PAT owner, who must be
-      # a bypass actor on the main branch protection — the `prepare release` and `prepare
-      # for next development iteration` commits push directly to main without PR checks.
+      # RELEASE_TOKEN (fine-grained PAT) pushes the tag and the bump branch. A push from
+      # the built-in GITHUB_TOKEN would not start CI on the bump PR, which the merge queue
+      # needs, so the PAT is used for those git operations.
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -87,37 +88,51 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Publish to Maven Central
+      - name: Compute release and next-development versions
         run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # The pom's <developerConnection> uses an SSH URL for local-dev convenience.
-          # release:prepare reads it directly and offers no CLI override, so rewrite
-          # SSH to HTTPS globally — the http.extraheader from actions/checkout then
-          # authenticates the push with the RELEASE_TOKEN PAT.
-          git config --global url."https://github.com/".insteadOf "git@github.com:"
-          mvn -B -ntp -Dstyle.color=always release:prepare -P sign
-          cat release.properties
-          RELEASE_TAG=$(grep '^scm.tag=' release.properties | cut -d'=' -f2)
-          echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_ENV"
-          mvn -B -ntp -Dstyle.color=always release:perform -P sign \
-            -DconnectionUrl=scm:git:https://github.com/${REPO}.git
-          echo "Released ${RELEASE_TAG} 🚀" >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          POM_VERSION=$(grep -m1 -oE '<version>[^<]+</version>' pom.xml | sed 's|<[^>]*>||g')
+          RELEASE_VERSION="${POM_VERSION%-SNAPSHOT}"
+          if [ "$RELEASE_VERSION" = "$POM_VERSION" ]; then
+            echo "::error::pom version is not a -SNAPSHOT: $POM_VERSION"; exit 1
+          fi
+          IFS='.' read -r MAJ MIN PATCH <<< "$RELEASE_VERSION"
+          NEXT_VERSION="${MAJ}.${MIN}.$((PATCH + 1))-SNAPSHOT"
+          RELEASE_TAG="v${RELEASE_VERSION}"
+          # Re-run safety: refuse to clobber an existing tag.
+          if git rev-parse -q --verify "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1 \
+             || git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "::error::tag ${RELEASE_TAG} already exists; bump the version or delete the tag first"
+            exit 1
+          fi
+          {
+            echo "RELEASE_VERSION=${RELEASE_VERSION}"
+            echo "NEXT_VERSION=${NEXT_VERSION}"
+            echo "RELEASE_TAG=${RELEASE_TAG}"
+          } >> "$GITHUB_ENV"
+          echo "Releasing ${RELEASE_VERSION}; next development version ${NEXT_VERSION}"
+
+      - name: Set release version, build, sign, and deploy to Maven Central
+        run: |
+          set -euo pipefail
+          mvn -B -ntp -Dstyle.color=always versions:set \
+            -DnewVersion="${RELEASE_VERSION}" -DprocessAllModules=true -DgenerateBackupPoms=false
+          # central+sign are the same profiles the maven-release-plugin used to activate
+          # via releaseProfiles. central-publishing uploads the signed bundle to the
+          # Central Portal (autoPublish=false, so it stages for a manual publish, exactly
+          # as before). Tests and spotbugs already ran in the verify gate.
+          mvn -B -ntp -Dstyle.color=always -DskipTests -Dspotbugs.skip=true deploy -P central,sign
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-          REPO: ${{ github.repository }}
 
-      # release:perform checks the tagged code into target/checkout/ and runs the
-      # central+sign release profiles; cyclonedx makeBom (bound in the default build)
-      # drops bom.{json,xml} into each module's target/. Collect everything under
-      # versioned names so release-asset downloads identify their module/version.
+      # cyclonedx makeBom (bound in the default build) drops bom.{json,xml} into each
+      # module's target/. Collect the published jars and their SBOMs under versioned
+      # names so release-asset downloads identify their module/version.
       - name: Collect release artifacts (JARs + SBOMs)
         run: |
           set -euo pipefail
-          RELEASE_VERSION="${RELEASE_TAG#v}"
-          echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_ENV"
           mkdir -p release-assets
           missing=0
           # Every Central-published jar artifact. ratchet-tck's five sub-modules live
@@ -129,10 +144,10 @@ jobs:
                    ratchet-coordinator-common ratchet-coordinator-postgresql \
                    ratchet-coordinator-jms ratchet-coordinator-infinispan \
                    ratchet-coordinator-hazelcast ratchet-micrometer ratchet-otel; do
-            JAR_PATHS="$JAR_PATHS target/checkout/${m}:${m}"
+            JAR_PATHS="$JAR_PATHS ${m}:${m}"
           done
           for m in util store api jakarta coordinator; do
-            JAR_PATHS="$JAR_PATHS target/checkout/ratchet-tck/${m}:ratchet-tck-${m}"
+            JAR_PATHS="$JAR_PATHS ratchet-tck/${m}:ratchet-tck-${m}"
           done
           for entry in $JAR_PATHS; do
             dir="${entry%%:*}"; artifact="${entry##*:}"
@@ -156,7 +171,7 @@ jobs:
             done
           done
           if [ "$missing" -ne 0 ]; then
-            echo "::error::Required release artifacts are missing (see errors above); aborting before GitHub Release"
+            echo "::error::Required release artifacts are missing (see errors above); aborting before tag/Release"
             exit 1
           fi
           ls -la release-assets/
@@ -165,6 +180,20 @@ jobs:
         uses: actions/attest-build-provenance@v4
         with:
           subject-path: 'release-assets/*.jar'
+
+      - name: Tag the release
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # The release-version poms live only on this tag, never on main. Branch
+          # protection and the merge queue govern refs/heads/main, not refs/tags/*, so
+          # the tag push is allowed where a direct push of these commits to main is not.
+          # Deploy already succeeded above, so a tag here means the artifacts are out.
+          git commit -s -aqm "Release ${RELEASE_VERSION}"
+          git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_VERSION}"
+          git push origin "${RELEASE_TAG}"
+          echo "Released ${RELEASE_TAG} 🚀" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create GitHub Release
         # Release notes come from the commit list (Haiku-categorized when an API key is
@@ -176,10 +205,10 @@ jobs:
           PREV_TAG=$(git describe --tags --abbrev=0 "${RELEASE_TAG}^" 2>/dev/null || echo "")
           if [ -n "$PREV_TAG" ]; then
             COMMITS=$(git log "${PREV_TAG}..${RELEASE_TAG}" --pretty=format:"- %s" \
-              | grep -v -E 'prepare release|prepare for next development iteration')
+              | grep -v -E 'Release [0-9]|Start [0-9].*development')
           else
             COMMITS=$(git log "${RELEASE_TAG}" --pretty=format:"- %s" \
-              | grep -v -E 'prepare release|prepare for next development iteration')
+              | grep -v -E 'Release [0-9]|Start [0-9].*development')
           fi
 
           printf '%s\n' "$COMMITS" > release-notes.md
@@ -214,3 +243,31 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      # Move main to the next -SNAPSHOT through an ordinary PR so the merge queue and
+      # branch protection stay intact. This runs after the release is already out, so a
+      # hiccup here (e.g. the PAT lacking pull-request scope) leaves a pushed branch to
+      # open by hand and never blocks the published release.
+      - name: Open next-development version bump PR
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-${NEXT_VERSION}"
+          git checkout -B "$BRANCH" origin/main
+          mvn -B -ntp versions:set \
+            -DnewVersion="${NEXT_VERSION}" -DprocessAllModules=true -DgenerateBackupPoms=false
+          git commit -s -aqm "Start ${NEXT_VERSION} development"
+          git push -f origin "$BRANCH"
+          if gh pr create --base main --head "$BRANCH" \
+               --title "Start ${NEXT_VERSION} development" \
+               --body "Automated reactor bump to ${NEXT_VERSION} after the ${RELEASE_TAG} release."; then
+            gh pr merge "$BRANCH" --auto --squash || true
+          else
+            echo "::warning::Could not open the bump PR automatically; push of '$BRANCH' succeeded — open the PR by hand."
+            {
+              echo "### Manual step needed"
+              echo "The next-development bump branch \`$BRANCH\` was pushed, but the PR could not be opened automatically."
+              echo "Open a PR from \`$BRANCH\` into \`main\` to move the reactor to ${NEXT_VERSION}."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Summary

Every Release run failed at the final step, where `release:prepare` pushes its version-bump commits to `main`:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
  - Changes must be made through the merge queue
  - Commits must have verified signatures.
  - 2 of 2 required status checks are expected.
! [remote rejected] main -> main (push declined due to repository rule violations)
```

`main` is protected by a merge-queue rule plus signed-commit and required-status-check branch protection with `enforce_admins: true`. The maven-release-plugin's model — commit the release version and the next `-SNAPSHOT`, then push both straight to the release branch — is fundamentally incompatible with that. No token or bypass short of dismantling the protections makes a direct push work.

This reworks the `release` job so it **never pushes to `main`**:

- Set the literal release version across the reactor (`versions:set -DprocessAllModules=true`), then build, sign, and deploy to Maven Central through the same `central` + `sign` profiles `release:perform` activated via `releaseProfiles`. Publish semantics are unchanged (`autoPublish=false` still stages for a manual Portal publish).
- Commit the released poms locally and push **only the tag** `vX.Y.Z`. Branch protection and the merge queue govern `refs/heads/main`, not `refs/tags/*`, so the tag push is allowed (there is no tag-targeted ruleset).
- Move `main` to the next `-SNAPSHOT` via an ordinary PR that auto-merges through the merge queue, so the protections stay fully intact. If the PR can't be opened automatically, the branch is still pushed and a step-summary note tells the operator to open it by hand — the already-published release is never blocked.

`guard`, `preflight`, and the full-matrix `verify` gate are unchanged. Artifact/SBOM collection now reads each module's own `target/` (there is no `release:perform` checkout dir anymore). `attest-build-provenance` and the GitHub Release step are preserved.

## Testing

- `release.yml` parses as valid YAML.
- Dry-ran `versions:set -DnewVersion=0.1.0 -DprocessAllModules=true -DgenerateBackupPoms=false` against the tree: it rewrites all **28** poms (root, `ratchet-api`, `ratchet-tck/store`, … all to `0.1.0`), confirming the literal-version reactor is handled the same way `release:prepare` handled it. Reverted the change afterward.

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [x] Security-sensitive change (release workflow; keeps branch protections intact rather than bypassing them)
- [x] Follow-up work remains (publishing the staged Central deployment is still a manual Portal step, unchanged from before)
