### PR TITLE
Name the Central bundle after a literal artifact, not the last module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,7 +884,11 @@
               <publishingServerId>central</publishingServerId>
               <autoPublish>false</autoPublish>
               <waitUntil>validated</waitUntil>
-              <deploymentName>${project.artifactId}:${project.version}</deploymentName>
+              <!-- Literal artifact id, not ${project.artifactId}: the aggregated upload runs
+                   in the last reactor module's deploy phase, so ${project.artifactId} would
+                   label the whole bundle after whichever module sorts last (e.g.
+                   ratchet-arch-tests) even though that module's jar is excluded. -->
+              <deploymentName>run.ratchet:ratchet:${project.version}</deploymentName>
               <!-- Test/dev infrastructure stays out of the Central bundle. Central artifacts
                    are immutable, so a stray deploy of these could never be undone. Each of
                    these modules also sets maven.deploy.skip=true, which guards the plain


### PR DESCRIPTION
## Summary

The `0.1.0` Central deployment came out labeled `ratchet-arch-tests:0.1.0`. The bundle *contents* are correct (arch-tests is excluded), but the **deployment name** was set to:

```xml
<deploymentName>${project.artifactId}:${project.version}</deploymentName>
```

`central-publishing` performs its aggregated upload during the **last reactor module's** deploy phase, so `${project.artifactId}` resolved to `ratchet-arch-tests` (the module that sorts last) and labeled the whole bundle after it.

Pinning the artifact part to a literal makes the deployment read `run.ratchet:ratchet:<version>` regardless of which module runs the upload. `${project.version}` is left dynamic — it's uniform across the reactor, so it stays correct per release.

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [x] Security-sensitive change (release/publish config)
- [ ] Follow-up work remains