### PR TITLE
Run the showcase against a throwaway database container

### DIFF
--- a/testing/ratchet-showcase/README.md
+++ b/testing/ratchet-showcase/README.md
@@ -16,16 +16,19 @@ Generated output under `target/` and `.flattened-pom.xml` is ignored and should 
 
 ## Run Locally
 
-The launcher expects an already-running database. Defaults are:
+The only prerequisite is Docker. By default the launcher starts a throwaway
+database container, runs the demo against it, and removes it on exit.
 
-- PostgreSQL: `localhost:5432`, database/user/password `ratchet`
-- MySQL: `localhost:3306`, database/user/password `ratchet`
-- MongoDB: `mongodb://localhost:27017`, database `ratchet`
-
-Example WildFly/PostgreSQL run:
+Build the reactor once so the sibling artifacts are in your local repository:
 
 ```bash
-POSTGRES_PORT=5432 \
+mvn install -DskipTests
+```
+
+Then launch the showcase with a single command — it packages the WAR and runs
+the server, starting (and later removing) its own database:
+
+```bash
 mvn -pl :ratchet-showcase \
   -P wildfly-managed,postgresql \
   -DskipTests \
@@ -33,10 +36,40 @@ mvn -pl :ratchet-showcase \
   -Dshowcase.context.path=/app \
   -Dwildfly.management.port=19993 \
   -Dwildfly.https.port=18446 \
-  exec:exec@run-showcase
+  package exec:exec@run-showcase
 ```
 
-Open `http://127.0.0.1:4176/app/`.
+Open `http://127.0.0.1:4176/app/`. Stop with Ctrl-C; the server and the
+database container both shut down.
+
+> Don't add `-am` to the run command: `exec:exec@run-showcase` would then also
+> fire on the parent reactor module, which has no executable configured, and the
+> build fails. Use `mvn install` (above) to refresh siblings instead.
+
+The embedded container publishes on a random loopback port, so a Postgres,
+MySQL, or Mongo already running on the standard port won't collide.
+
+### Using your own database
+
+Set `-Dshowcase.db.embedded=false` (or `SHOWCASE_DB_EMBEDDED=false`) and point
+the launcher at an existing database. Supplying a connection target also
+disables the embedded container on its own. Connection defaults:
+
+- PostgreSQL: `POSTGRES_HOST=localhost`, `POSTGRES_PORT=5432`, database/user/password `ratchet`
+- MySQL: `MYSQL_HOST=localhost`, `MYSQL_PORT=3306`, database/user/password `ratchet`
+- MongoDB: `MONGO_URI=mongodb://localhost:27017`, database `ratchet`
+
+```bash
+POSTGRES_HOST=db.internal POSTGRES_PORT=5432 \
+mvn -pl :ratchet-showcase \
+  -P wildfly-managed,postgresql \
+  -DskipTests -Dshowcase.http.port=4176 -Dshowcase.context.path=/app \
+  -Dwildfly.management.port=19993 -Dwildfly.https.port=18446 \
+  package exec:exec@run-showcase
+```
+
+If the script is hard-killed (SIGKILL) the cleanup trap can't run; remove any
+stray container with `docker rm -f $(docker ps -q --filter name=ratchet-showcase-db-)`.
 
 The WAR can be packaged for these managed server profiles:
 

--- a/testing/ratchet-showcase/pom.xml
+++ b/testing/ratchet-showcase/pom.xml
@@ -21,6 +21,7 @@
     <maven.deploy.skip>true</maven.deploy.skip>
     <showcase.server>unconfigured</showcase.server>
     <showcase.db>postgresql</showcase.db>
+    <showcase.db.embedded>true</showcase.db.embedded>
     <showcase.context.path>/</showcase.context.path>
     <showcase.datasource.jndi>java:jboss/datasources/RatchetDS</showcase.datasource.jndi>
     <showcase.http.port>8080</showcase.http.port>
@@ -134,6 +135,7 @@
                 <SHOWCASE_WAR>${project.build.directory}/${project.build.finalName}.war</SHOWCASE_WAR>
                 <SHOWCASE_SERVER>${showcase.server}</SHOWCASE_SERVER>
                 <SHOWCASE_DB>${showcase.db}</SHOWCASE_DB>
+                <SHOWCASE_DB_EMBEDDED>${showcase.db.embedded}</SHOWCASE_DB_EMBEDDED>
                 <SHOWCASE_CONTEXT_PATH>${showcase.context.path}</SHOWCASE_CONTEXT_PATH>
                 <SHOWCASE_DATASOURCE_JNDI>${showcase.datasource.jndi}</SHOWCASE_DATASOURCE_JNDI>
                 <SHOWCASE_HTTP_PORT>${showcase.http.port}</SHOWCASE_HTTP_PORT>

--- a/testing/ratchet-showcase/src/showcase/scripts/run-showcase.sh
+++ b/testing/ratchet-showcase/src/showcase/scripts/run-showcase.sh
@@ -29,6 +29,18 @@ export RATCHET_RECURRING_STARTUP_GRACE_SECONDS="${RATCHET_RECURRING_STARTUP_GRAC
 export RATCHET_NODE_ID="${RATCHET_NODE_ID:-showcase-${server}-${db}-$$}"
 export TZ="${TZ:-UTC}"
 
+# An explicitly supplied connection target means "use my external database" and
+# turns off the embedded container, whatever SHOWCASE_DB_EMBEDDED says. We record
+# that before applying defaults below, so the unset case can be served by a
+# container we start ourselves.
+embedded_db="${SHOWCASE_DB_EMBEDDED:-true}"
+external_db_configured=false
+case "$db" in
+  postgresql) [[ -n "${POSTGRES_HOST:-}" ]] && external_db_configured=true ;;
+  mysql) [[ -n "${MYSQL_HOST:-}" ]] && external_db_configured=true ;;
+  mongodb) [[ -n "${MONGO_URI:-}" ]] && external_db_configured=true ;;
+esac
+
 postgres_host="${POSTGRES_HOST:-localhost}"
 postgres_port="${POSTGRES_PORT:-5432}"
 postgres_db="${POSTGRES_DB:-ratchet}"
@@ -46,6 +58,113 @@ export MONGO_DATABASE="${MONGO_DATABASE:-ratchet}"
 
 jdbc_dir="$build_dir/showcase-jdbc"
 ds_jndi="${SHOWCASE_DATASOURCE_JNDI:-java:jboss/datasources/RatchetDS}"
+
+# --- Embedded database container -------------------------------------------
+# When no external database is configured, the launcher starts a throwaway
+# container so the whole demo is one Maven command with Docker as the only
+# prerequisite. The container publishes on a random loopback port (so a local
+# Postgres/MySQL/Mongo on the standard port doesn't collide) and is removed on
+# exit. Set SHOWCASE_DB_EMBEDDED=false, or point POSTGRES_HOST/MYSQL_HOST/
+# MONGO_URI at your own database, to opt out.
+db_container_id=""
+
+docker_available() {
+  command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
+}
+
+cleanup_db_container() {
+  if [[ -n "$db_container_id" ]]; then
+    docker rm -f "$db_container_id" >/dev/null 2>&1 || true
+    db_container_id=""
+  fi
+}
+
+# Maps a container's internal port to the host port Docker assigned it.
+published_port() {
+  docker port "$db_container_id" "$1/tcp" 2>/dev/null | head -n 1 | awk -F: '{print $NF}'
+}
+
+wait_for_db_ready() {
+  local probe=("$@")
+  local deadline=$((SECONDS + 60))
+  until docker exec "$db_container_id" "${probe[@]}" >/dev/null 2>&1; do
+    if ! docker ps -q --no-trunc | grep -q "$db_container_id"; then
+      echo "Embedded database container exited before becoming ready." >&2
+      docker logs "$db_container_id" 2>&1 | tail -n 20 >&2 || true
+      exit 1
+    fi
+    if ((SECONDS >= deadline)); then
+      echo "Embedded database did not become ready within 60s." >&2
+      exit 1
+    fi
+    sleep 1
+  done
+}
+
+start_embedded_db() {
+  if ! docker_available; then
+    echo "Docker is required to start the embedded showcase database, but the Docker daemon is not reachable." >&2
+    echo "Start Docker and retry, set SHOWCASE_DB_EMBEDDED=false, or point POSTGRES_HOST/MYSQL_HOST/MONGO_URI at an external database." >&2
+    exit 1
+  fi
+
+  local name="ratchet-showcase-db-$$"
+  echo "Starting embedded $db database (Docker)..."
+  case "$db" in
+    postgresql)
+      db_container_id="$(docker run -d --rm --name "$name" \
+        -e POSTGRES_USER="$postgres_user" \
+        -e POSTGRES_PASSWORD="$postgres_password" \
+        -e POSTGRES_DB="$postgres_db" \
+        -p 127.0.0.1::5432 postgres:16)"
+      wait_for_db_ready pg_isready -U "$postgres_user" -d "$postgres_db"
+      postgres_host="127.0.0.1"
+      postgres_port="$(published_port 5432)"
+      ;;
+    mysql)
+      db_container_id="$(docker run -d --rm --name "$name" \
+        -e MYSQL_ROOT_PASSWORD="root" \
+        -e MYSQL_DATABASE="$mysql_db" \
+        -e MYSQL_USER="$mysql_user" \
+        -e MYSQL_PASSWORD="$mysql_password" \
+        -p 127.0.0.1::3306 mysql:8)"
+      # Probe over TCP as the application user, not `mysqladmin ping`: mysql:8
+      # runs a socket-only temp server during init that answers ping before the
+      # real server, user, and database exist, which would let migration race in
+      # and fail with "Access denied".
+      wait_for_db_ready mysql -h127.0.0.1 -u"$mysql_user" -p"$mysql_password" "$mysql_db" -e "SELECT 1"
+      mysql_host="127.0.0.1"
+      mysql_port="$(published_port 3306)"
+      ;;
+    mongodb)
+      db_container_id="$(docker run -d --rm --name "$name" \
+        -p 127.0.0.1::27017 mongo:7)"
+      wait_for_db_ready mongosh --quiet --eval "db.adminCommand({ping:1})"
+      export MONGO_URI="mongodb://127.0.0.1:$(published_port 27017)"
+      ;;
+    *)
+      echo "Embedded database is not supported for SHOWCASE_DB=$db." >&2
+      exit 1
+      ;;
+  esac
+  echo "Embedded $db ready (container ${db_container_id:0:12})."
+}
+
+maybe_start_embedded_db() {
+  if [[ "$external_db_configured" == "true" ]]; then
+    return
+  fi
+  if [[ "$embedded_db" != "true" ]]; then
+    return
+  fi
+  # Arm cleanup before starting, so a Ctrl-C during the readiness wait still
+  # removes the container. cleanup_db_container is a no-op until the run
+  # succeeds and sets db_container_id.
+  trap cleanup_db_container EXIT
+  trap 'cleanup_db_container; exit 130' INT
+  trap 'cleanup_db_container; exit 143' TERM
+  start_embedded_db
+}
 
 java_major() {
   local java_bin="${JAVA_HOME:+$JAVA_HOME/bin/java}"
@@ -261,6 +380,7 @@ cleanup_wildfly() {
   if [[ -n "$wildfly_cleanup_home" && -n "$wildfly_cleanup_management_port" && -n "$wildfly_cleanup_server_pid" ]]; then
     shutdown_wildfly "$wildfly_cleanup_home" "$wildfly_cleanup_management_port" "$wildfly_cleanup_server_pid"
   fi
+  cleanup_db_container
 }
 
 cleanup_wildfly_int() {
@@ -437,7 +557,11 @@ EOF
   wait_for_showcase_http "$port" "$context"
   local status=0
   wait "$server_pid" || status=$?
-  trap - EXIT INT TERM
+  # Drop the WildFly-specific handlers but keep an EXIT trap so an embedded
+  # database container is still removed when the script finishes. The nulled
+  # cleanup vars below make cleanup_wildfly a no-op for the (now stopped) server.
+  trap cleanup_wildfly EXIT
+  trap - INT TERM
   wildfly_cleanup_home=""
   wildfly_cleanup_management_port=""
   wildfly_cleanup_server_pid=""
@@ -474,7 +598,7 @@ run_glassfish_family() {
     cp "$jdbc_dir"/*.jar "$home/glassfish/domains/domain1/lib/"
   fi
   "$home/bin/asadmin" --port "$admin_port" start-domain domain1
-  trap '"$home/bin/asadmin" --port "$admin_port" stop-domain domain1 >/dev/null 2>&1 || true' EXIT
+  trap '"$home/bin/asadmin" --port "$admin_port" stop-domain domain1 >/dev/null 2>&1 || true; cleanup_db_container' EXIT
   "$home/bin/asadmin" --port "$admin_port" undeploy ratchet-showcase >/dev/null 2>&1 || true
   if [[ "$db" != "mongodb" ]]; then
     "$home/bin/asadmin" --port "$admin_port" delete-jdbc-resource "$ds_jndi" >/dev/null 2>&1 || true
@@ -536,8 +660,12 @@ EOF
 EOF
   } > "$config/server.xml"
   echo "Ratchet Showcase: http://localhost:$http_port$context"
-  exec "$home/bin/server" run "$server_name"
+  # Run in the foreground (not exec) so the script's EXIT/INT/TERM traps still
+  # fire and remove an embedded database container when the server stops.
+  "$home/bin/server" run "$server_name"
 }
+
+maybe_start_embedded_db
 
 case "$server" in
   wildfly)


### PR DESCRIPTION
## What

The showcase advertised a one-command start, but the launcher only *connected* to a database — you still had to stand up Postgres/MySQL/Mongo yourself first. This makes the claim true.

When no external database is configured, `run-showcase.sh` now starts its own container, waits for it to accept connections, runs the demo against it, and removes it on exit. **Docker becomes the only prerequisite.**

## Details

- Embedded container publishes on a **random loopback port** (`-p 127.0.0.1::5432`), so it won't collide with a database already running on the standard port.
- Cleanup is wired into the existing EXIT/INT/TERM traps across all four server paths (and OpenLiberty no longer `exec`s, so its traps fire). `--rm` plus an idempotent `docker rm -f` means no orphaned container on a clean stop.
- **Opt out** by pointing `POSTGRES_HOST`/`MYSQL_HOST`/`MONGO_URI` at your own database, or with `-Dshowcase.db.embedded=false`.
- Schema migration still runs **out-of-process before deploy**, unchanged — that path stays uniform across WildFly/Payara/GlassFish/OpenLiberty and is intentionally not the in-container auto-migrate hook (which needs a CDI `DataSource` the showcase doesn't expose).
- README updated: Docker prerequisite, the true single command, and the external-database escape hatch.

## Validation

- Launched **WildFly + PostgreSQL with no database running**: container starts on a random port, migration applies, WAR deploys, `GET /app/` returns 200, `/api/runtime` serves live JSON.
- **SIGTERM**: container removed in ~3s, server stopped, port freed, no orphan.
- MySQL and Mongo branches are covered by review, not launched locally; the MySQL readiness probe connects over TCP as the app user to avoid the mysql:8 temp-server init race.

## Reviewed

Codex peer review (two passes) confirmed the design and the trap correctness across all four server paths, and caught the MySQL readiness race, which is fixed here.