### PR TITLE
Format Maven dependency entries in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,19 @@ Swap the retry logic, circuit-breaker behavior, polling cadence, thread/executor
 </dependencyManagement>
 
 <dependencies>
-  <dependency><groupId>run.ratchet</groupId><artifactId>ratchet-api</artifactId></dependency>
-  <dependency><groupId>run.ratchet</groupId><artifactId>ratchet</artifactId></dependency>
+  <dependency>
+    <groupId>run.ratchet</groupId>
+    <artifactId>ratchet-api</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>run.ratchet</groupId>
+    <artifactId>ratchet</artifactId>
+  </dependency>
   <!-- Pick your store: ratchet-store-{postgresql,mysql,mongodb} -->
-  <dependency><groupId>run.ratchet</groupId><artifactId>ratchet-store-postgresql</artifactId></dependency>
+  <dependency>
+    <groupId>run.ratchet</groupId>
+    <artifactId>ratchet-store-postgresql</artifactId>
+  </dependency>
 </dependencies>
 ```
 


### PR DESCRIPTION
Expand single-line <dependency> XML snippets into multi-line, indented blocks for ratchet-api, ratchet, and ratchet-store-postgresql in README.md to improve readability. No functional changes to dependencies.

## Summary

Describe the problem and the change clearly.

## Testing

List the validation you actually ran.

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl :ratchet-testsuite,:ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [ ] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

Anything reviewers should pay attention to.
