### PR TITLE
Keep non-pom versions in sync and make release commits verified

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: Ratchet version or commit SHA
-      placeholder: 0.1.0-SNAPSHOT or a commit SHA
+      placeholder: 0.1.1-SNAPSHOT or a commit SHA
     validations:
       required: true
   - type: input

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,16 +195,65 @@ jobs:
       - name: Tag the release
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           # The release-version poms live only on this tag, never on main. Branch
           # protection and the merge queue govern refs/heads/main, not refs/tags/*, so
-          # the tag push is allowed where a direct push of these commits to main is not.
+          # the tag is allowed where a direct push of these commits to main is not.
           # Deploy already succeeded above, so a tag here means the artifacts are out.
-          git commit -s -aqm "Release ${RELEASE_VERSION}"
-          git tag -a "${RELEASE_TAG}" -m "Release ${RELEASE_VERSION}"
-          git push origin "${RELEASE_TAG}"
+          #
+          # The tagged commit is made through the GitHub GraphQL createCommitOnBranch
+          # mutation so it is signed by GitHub and shows as Verified — no signing key to
+          # manage in CI. createCommitOnBranch only writes to a branch, so we land it on
+          # a short-lived branch, point the annotated tag at the resulting commit, then
+          # delete the branch.
+          OWNER_REPO="${GITHUB_REPOSITORY}"
+          MAIN_OID="$(git rev-parse HEAD)"   # checkout sits on main's head (fetch-depth 0)
+          TMP_BRANCH="release-tag/${RELEASE_TAG}"
+
+          # Sync the non-pom references to the release version before committing, so the
+          # tag carries docs that match its poms. versions:set already set the poms above.
+          scripts/sync-version.sh "${RELEASE_VERSION}"
+
+          # Commit body with a Signed-off-by trailer (committer identity comes from the
+          # token's account; resolve its name/email via the API).
+          ACTOR_NAME="$(gh api user --jq '.name // .login')"
+          ACTOR_LOGIN="$(gh api user --jq '.login')"
+          ACTOR_ID="$(gh api user --jq '.id')"
+          ACTOR_EMAIL="${ACTOR_ID}+${ACTOR_LOGIN}@users.noreply.github.com"
+          printf 'Signed-off-by: %s <%s>\n' "$ACTOR_NAME" "$ACTOR_EMAIL" > /tmp/release-body.txt
+
+          # Create the short-lived branch ref at main's head, then commit the
+          # release-version poms + synced docs onto it (Verified). Clear any leftover
+          # ref from a half-finished prior run first so a rerun does not 422.
+          gh api -X DELETE "repos/${OWNER_REPO}/git/refs/heads/${TMP_BRANCH}" 2>/dev/null || true
+          gh api "repos/${OWNER_REPO}/git/refs" \
+            -f ref="refs/heads/${TMP_BRANCH}" \
+            -f sha="${MAIN_OID}"
+          COMMIT_OID="$(scripts/gh-signed-commit.sh \
+            "${OWNER_REPO}" "${TMP_BRANCH}" "${MAIN_OID}" \
+            "Release ${RELEASE_VERSION}" /tmp/release-body.txt)"
+          echo "Release commit ${COMMIT_OID} created on ${TMP_BRANCH}"
+
+          # Annotated tag object pointing at the Verified release commit, then a tag ref.
+          TAG_OID="$(gh api "repos/${OWNER_REPO}/git/tags" \
+            -f tag="${RELEASE_TAG}" \
+            -f message="Release ${RELEASE_VERSION}" \
+            -f object="${COMMIT_OID}" \
+            -f type=commit \
+            --jq '.sha')"
+          gh api "repos/${OWNER_REPO}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="${TAG_OID}"
+
+          # The tag now captures the release commit; drop the short-lived branch.
+          gh api -X DELETE "repos/${OWNER_REPO}/git/refs/heads/${TMP_BRANCH}"
+
+          # Restore the working tree to main's state so later steps (release notes,
+          # the bump) start clean rather than on the release-version edits.
+          git checkout -- .
+
           echo "Released ${RELEASE_TAG} 🚀" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Create GitHub Release
         # Release notes come from the commit list (Haiku-categorized when an API key is
@@ -262,23 +311,63 @@ jobs:
       - name: Open next-development version bump PR
         run: |
           set -euo pipefail
+          OWNER_REPO="${GITHUB_REPOSITORY}"
           BRANCH="chore/bump-${NEXT_VERSION}"
-          git checkout -B "$BRANCH" origin/main
+          MAIN_OID="$(git rev-parse origin/main)"
+
+          # Bump the reactor poms and the non-pom references to the next -SNAPSHOT.
           mvn -B -ntp versions:set \
             -DnewVersion="${NEXT_VERSION}" -DprocessAllModules=true -DgenerateBackupPoms=false
-          git commit -s -aqm "Start ${NEXT_VERSION} development"
-          git push -f origin "$BRANCH"
-          if gh pr create --base main --head "$BRANCH" \
-               --title "Start ${NEXT_VERSION} development" \
-               --body "Automated reactor bump to ${NEXT_VERSION} after the ${RELEASE_TAG} release."; then
-            gh pr merge "$BRANCH" --auto --squash || true
+          scripts/sync-version.sh "${NEXT_VERSION}"
+
+          # Signed-off-by trailer with the token account's identity.
+          ACTOR_NAME="$(gh api user --jq '.name // .login')"
+          ACTOR_LOGIN="$(gh api user --jq '.login')"
+          ACTOR_ID="$(gh api user --jq '.id')"
+          ACTOR_EMAIL="${ACTOR_ID}+${ACTOR_LOGIN}@users.noreply.github.com"
+          printf 'Signed-off-by: %s <%s>\n' "$ACTOR_NAME" "$ACTOR_EMAIL" > /tmp/bump-body.txt
+
+          # Recreate the bump branch at main's current head. Deleting any stale ref first
+          # makes a rerun idempotent: a previous run that pushed the branch but failed to
+          # merge no longer dead-ends. (A 422 on delete just means it was absent.)
+          gh api -X DELETE "repos/${OWNER_REPO}/git/refs/heads/${BRANCH}" 2>/dev/null || true
+          gh api "repos/${OWNER_REPO}/git/refs" \
+            -f ref="refs/heads/${BRANCH}" \
+            -f sha="${MAIN_OID}"
+
+          # Commit the bump onto the branch through the GraphQL mutation so it is Verified
+          # and (unlike a GITHUB_TOKEN push) triggers the CI the merge queue waits on.
+          scripts/gh-signed-commit.sh \
+            "${OWNER_REPO}" "${BRANCH}" "${MAIN_OID}" \
+            "Start ${NEXT_VERSION} development" /tmp/bump-body.txt >/dev/null
+          echo "Pushed bump branch ${BRANCH}"
+
+          # Open the PR, or recover an existing open one. `gh pr create` errors when a PR
+          # for the branch already exists, so probe first and only create when none is open.
+          EXISTING_STATE="$(gh pr view "$BRANCH" --json state --jq '.state' 2>/dev/null || echo "")"
+          if [ "$EXISTING_STATE" = "OPEN" ]; then
+            echo "An open bump PR already exists for ${BRANCH}; enabling auto-merge."
           else
-            echo "::warning::Could not open the bump PR automatically; push of '$BRANCH' succeeded — open the PR by hand."
+            gh pr create --base main --head "$BRANCH" \
+              --title "Start ${NEXT_VERSION} development" \
+              --body "Automated reactor bump to ${NEXT_VERSION} after the ${RELEASE_TAG} release."
+          fi
+
+          # Enable auto-merge (squash). No `|| true`: a genuine failure here must surface.
+          # This step runs AFTER the release is published, so a failure to merge the bump
+          # does not retro-fail the release — the summary tells the operator what to finish
+          # by hand, but the step still exits non-zero so the failure is visible.
+          if gh pr merge "$BRANCH" --auto --squash; then
+            echo "Auto-merge enabled for the ${NEXT_VERSION} bump PR."
+          else
+            echo "::error::Bump PR for ${BRANCH} could not be set to auto-merge."
             {
               echo "### Manual step needed"
-              echo "The next-development bump branch \`$BRANCH\` was pushed, but the PR could not be opened automatically."
-              echo "Open a PR from \`$BRANCH\` into \`main\` to move the reactor to ${NEXT_VERSION}."
+              echo "The ${RELEASE_TAG} release is published. The next-development bump branch"
+              echo "\`$BRANCH\` exists with a Verified commit, but enabling auto-merge failed."
+              echo "Merge its PR by hand to move the reactor to ${NEXT_VERSION}."
             } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Swap the retry logic, circuit-breaker behavior, polling cadence, thread/executor
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -167,7 +167,7 @@ mvn spotless:apply       # auto-format (Google Java Format)
 
 ## Project Status
 
-Ratchet is in **0.1.0-SNAPSHOT**. The API is stabilizing; interfaces marked `@Incubating` may change between alpha releases. Feedback and contributions are welcome.
+Ratchet is in **0.1.1-SNAPSHOT**. The API is stabilizing; interfaces marked `@Incubating` may change between alpha releases. Feedback and contributions are welcome.
 
 ## Community
 

--- a/infra/loadtest/Dockerfile
+++ b/infra/loadtest/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p \
 COPY --from=build /drivers/postgresql.jar /opt/jboss/ratchet/drivers/postgresql.jar
 COPY --from=build /drivers/mysql.jar /opt/jboss/ratchet/drivers/mysql.jar
 COPY infra/loadtest/wildfly/${STORE}.cli /opt/jboss/ratchet/store.cli
-COPY --from=build /workspace/testing/ratchet-loadtest/target/ratchet-loadtest-0.1.0-SNAPSHOT.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
+COPY --from=build /workspace/testing/ratchet-loadtest/target/ratchet-loadtest-0.1.1-SNAPSHOT.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
 RUN chown -R jboss:root /opt/jboss/ratchet /opt/jboss/wildfly/standalone \
     && chmod -R ug+rwX /opt/jboss/ratchet /opt/jboss/wildfly/standalone \
     && /opt/jboss/wildfly/bin/jboss-cli.sh --file=/opt/jboss/ratchet/store.cli \

--- a/scripts/gh-signed-commit.sh
+++ b/scripts/gh-signed-commit.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# gh-signed-commit.sh — create a Verified commit via the GitHub GraphQL
+# `createCommitOnBranch` mutation, so the release workflow never has to manage
+# a signing key. GitHub signs commits made through this API with its own key,
+# and they show up as "Verified".
+#
+# It takes the changes already present in the working tree (staged or not),
+# turns them into a fileChanges payload, and commits them onto an existing
+# branch ref at a known head oid.
+#
+# Usage:
+#   gh-signed-commit.sh <owner/repo> <branch> <expected-head-oid> <headline> <body-file>
+#
+# Arguments:
+#   owner/repo         e.g. ratchet-run/ratchet
+#   branch             the branch ref to commit onto (must already exist)
+#   expected-head-oid  the commit oid the branch is expected to point at; the
+#                      mutation fails if the branch moved, which is the
+#                      optimistic-lock that keeps reruns honest
+#   headline           the commit message headline
+#   body-file          path to a file holding the commit message body (already
+#                      including the Signed-off-by trailer); pass /dev/null for
+#                      no body
+#
+# Requires: gh (authenticated), jq, git. Reads the changed files from
+# `git diff --name-only HEAD` plus `git diff --name-only --cached`.
+#
+# Prints the new commit oid on stdout.
+
+set -euo pipefail
+
+REPO="$1"
+BRANCH="$2"
+EXPECTED_HEAD_OID="$3"
+HEADLINE="$4"
+BODY_FILE="${5:-/dev/null}"
+
+# Collect every TRACKED path that differs from HEAD — modifications, staged
+# changes, and deletions (`git diff HEAD` plus `--cached`). Untracked files are
+# deliberately NOT swept in: the release/bump callers only ever edit tracked
+# files (poms + the synced docs), and ignoring untracked paths means stray
+# build output left in the tree can never leak into a release commit. The union
+# is sorted and de-duplicated. A portable while-read loop (not mapfile) keeps
+# this working on bash 3.x too.
+CHANGED_LIST="$(
+  {
+    git diff --name-only HEAD
+    git diff --name-only --cached
+  } | sort -u
+)"
+
+if [[ -z "$CHANGED_LIST" ]]; then
+  echo "gh-signed-commit: no changes to commit" >&2
+  exit 1
+fi
+
+# Build the additions/deletions arrays in one pass. A file still present in the
+# working tree is an addition carrying its base64 contents (base64 -w0 keeps
+# each blob on one line); a path that has vanished is a deletion.
+ADDITIONS='[]'
+DELETIONS='[]'
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  if [[ -f "$path" ]]; then
+    b64="$(base64 -w0 < "$path")"
+    ADDITIONS="$(jq -c --arg p "$path" --arg c "$b64" \
+      '. + [{path: $p, contents: $c}]' <<<"$ADDITIONS")"
+  else
+    DELETIONS="$(jq -c --arg p "$path" '. + [{path: $p}]' <<<"$DELETIONS")"
+  fi
+done <<<"$CHANGED_LIST"
+
+BODY="$(cat "$BODY_FILE")"
+
+MUTATION='mutation($input: CreateCommitOnBranchInput!) {
+  createCommitOnBranch(input: $input) {
+    commit { oid }
+  }
+}'
+
+# Assemble the COMPLETE GraphQL request body ({query, variables}) with jq so
+# nothing is shell-interpolated into the payload. `gh api graphql --input -`
+# reads the whole body from stdin, so query and variables both ride along
+# rather than being passed as flat field flags (which can't express a nested
+# input object). The message is {headline, body}; an empty body is allowed.
+REQUEST="$(jq -n \
+  --arg query "$MUTATION" \
+  --arg repo "$REPO" \
+  --arg branch "$BRANCH" \
+  --arg oid "$EXPECTED_HEAD_OID" \
+  --arg headline "$HEADLINE" \
+  --arg body "$BODY" \
+  --argjson additions "$ADDITIONS" \
+  --argjson deletions "$DELETIONS" \
+  '{
+    query: $query,
+    variables: {
+      input: {
+        branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+        expectedHeadOid: $oid,
+        message: { headline: $headline, body: $body },
+        fileChanges: { additions: $additions, deletions: $deletions }
+      }
+    }
+  }')"
+
+# Capture the new commit oid for the caller.
+NEW_OID="$(printf '%s' "$REQUEST" \
+  | gh api graphql --input - \
+  | jq -r '.data.createCommitOnBranch.commit.oid')"
+
+if [[ -z "$NEW_OID" || "$NEW_OID" == "null" ]]; then
+  echo "gh-signed-commit: createCommitOnBranch returned no commit oid" >&2
+  exit 1
+fi
+
+printf '%s\n' "$NEW_OID"

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# sync-version.sh — set every non-pom reference to the Ratchet artifact version.
+#
+# The Maven poms carry the canonical version (managed by `mvn versions:set`).
+# A scattering of docs, the loadtest Dockerfile, and the bug-report template
+# repeat that version by hand, so they drift the moment a release bumps the
+# poms. This script rewrites those hand-written copies to whatever version you
+# pass in, so the two can never disagree again.
+#
+# Usage:
+#   scripts/sync-version.sh <version>
+#   scripts/sync-version.sh 0.1.1-SNAPSHOT
+#
+# It is idempotent: it SETS each reference to <version> regardless of the value
+# already there, so you never need to know the old version. Running it twice
+# with the same argument produces no diff.
+#
+# It only touches the Ratchet artifact version. Replacements are anchored to
+# Ratchet context (a run.ratchet dependency block, a ratchet-* jar/war
+# filename, or a specific sentence/placeholder), so unrelated versions — Java
+# 17, MySQL 8, Jakarta EE 10/11, MongoDB 6, etc. — are left alone.
+
+set -euo pipefail
+
+if [[ $# -ne 1 || -z "${1:-}" ]]; then
+  echo "usage: $0 <version>   (e.g. 0.1.1-SNAPSHOT)" >&2
+  exit 2
+fi
+
+VERSION="$1"
+
+# Resolve repo root so the script works from any cwd.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# A Ratchet version is a SemVer core with an optional -SNAPSHOT (or other
+# qualifier). This matches whatever is currently written so we can overwrite it
+# without knowing it. It deliberately does NOT match bare "8" / "17" style
+# numbers used for Java/MySQL/etc.
+VER_RE='[0-9]+\.[0-9]+\.[0-9]+(?:-[A-Za-z0-9.]+)?'
+
+changed_files=()
+
+# Run a perl in-place substitution against one file, anchored to Ratchet
+# context. Echoes the file + a label when it actually changes something.
+#   apply <file> <label> <perl-substitution>
+apply() {
+  local file="$1" label="$2" subst="$3"
+  [[ -f "$file" ]] || { echo "skip (missing): $file" >&2; return; }
+  local before after
+  before="$(cat "$file")"
+  VERSION="$VERSION" VER_RE="$VER_RE" perl -0777 -i -pe "$subst" "$file"
+  after="$(cat "$file")"
+  if [[ "$before" != "$after" ]]; then
+    echo "  changed [$label]: $file"
+    changed_files+=("$file")
+  fi
+}
+
+# 1. Maven dependency snippets: a <version>…</version> line whose immediately
+#    preceding artifactId is a Ratchet artifact under groupId run.ratchet.
+#    Anchored on "run.ratchet" so non-Ratchet dependency blocks are untouched.
+#    Files: README, getting-started + deployment install/quickstart/overview,
+#    plus the per-module snippets (store-mongodb, micrometer).
+MAVEN_FILES=(
+  "README.md"                                 # ratchet-bom quick-start snippet
+  "website/docs/getting-started/installation.md"  # ratchet-bom
+  "website/docs/getting-started/quickstart.md"     # ratchet-bom
+  "website/docs/deployment/installation.md"        # ratchet-bom
+  "website/docs/deployment/overview.md"            # ratchet-bom
+  "website/docs/deployment/mongodb.md"             # ratchet-store-mongodb
+  "website/docs/deployment/monitoring.md"          # ratchet-micrometer
+)
+for f in "${MAVEN_FILES[@]}"; do
+  apply "$f" "maven-version" \
+    's{(<groupId>run\.ratchet</groupId>\s*<artifactId>ratchet[A-Za-z0-9-]*</artifactId>\s*<version>)$ENV{VER_RE}(</version>)}{$1$ENV{VERSION}$2}g'
+done
+
+# 2. ratchet-* jar/war filenames (extract-the-DDL snippets + the loadtest
+#    Dockerfile artifact path). Anchored on the "ratchet-<artifact>-" prefix.
+JAR_FILES=(
+  "website/docs/deployment/database-setup.md"  # jar xf ratchet-store-*-VER.jar (x2)
+  "website/docs/deployment/docker.md"          # jar xf ratchet-store-postgresql-VER.jar
+  "infra/loadtest/Dockerfile"                  # ratchet-loadtest-VER.war COPY path
+)
+for f in "${JAR_FILES[@]}"; do
+  apply "$f" "jar-war-filename" \
+    's{(ratchet-[A-Za-z0-9-]*?-)$ENV{VER_RE}(\.(?:jar|war))}{$1$ENV{VERSION}$2}g'
+done
+
+# 3. Prose "version" sentences (bold **VER**). Anchored on the leading phrase so
+#    only the project-status sentence is touched, never some other bold number.
+apply "README.md" "prose-status" \
+  's{(Ratchet is in \*\*)$ENV{VER_RE}(\*\*)}{$1$ENV{VERSION}$2}g'
+apply "website/docs/getting-started/introduction.md" "prose-status" \
+  's{(Ratchet is currently at version \*\*)$ENV{VER_RE}(\*\*)}{$1$ENV{VERSION}$2}g'
+
+# 4. Bug-report template placeholder. Anchored on the trailing " or a commit SHA".
+apply ".github/ISSUE_TEMPLATE/bug_report.yml" "issue-placeholder" \
+  's{(placeholder: )$ENV{VER_RE}( or a commit SHA)}{$1$ENV{VERSION}$2}g'
+
+echo ""
+if [[ ${#changed_files[@]} -eq 0 ]]; then
+  echo "sync-version: all references already at $VERSION (no changes)."
+else
+  echo "sync-version: set ${#changed_files[@]} file(s) to $VERSION."
+fi

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -39,7 +39,7 @@ The DDL file is at `stores/ratchet-store-postgresql/src/main/resources/ddl/postg
 psql -U ratchet -d ratchet -f stores/ratchet-store-postgresql/src/main/resources/ddl/postgresql-schema.sql
 
 # Or extract from the JAR
-jar xf ratchet-store-postgresql-0.1.0-SNAPSHOT.jar ddl/postgresql-schema.sql
+jar xf ratchet-store-postgresql-0.1.1-SNAPSHOT.jar ddl/postgresql-schema.sql
 psql -U ratchet -d ratchet -f ddl/postgresql-schema.sql
 ```
 
@@ -163,7 +163,7 @@ FLUSH PRIVILEGES;
 mysql -u ratchet -p ratchet < stores/ratchet-store-mysql/src/main/resources/ddl/mysql-schema.sql
 
 # Or extract from the JAR
-jar xf ratchet-store-mysql-0.1.0-SNAPSHOT.jar ddl/mysql-schema.sql
+jar xf ratchet-store-mysql-0.1.1-SNAPSHOT.jar ddl/mysql-schema.sql
 mysql -u ratchet -p ratchet < ddl/mysql-schema.sql
 ```
 

--- a/website/docs/deployment/docker.md
+++ b/website/docs/deployment/docker.md
@@ -229,7 +229,7 @@ To extract the DDL from the Ratchet JAR:
 
 ```bash
 # Extract from the store module JAR
-jar xf ratchet-store-postgresql-0.1.0-SNAPSHOT.jar ddl/postgresql-schema.sql
+jar xf ratchet-store-postgresql-0.1.1-SNAPSHOT.jar ddl/postgresql-schema.sql
 cp ddl/postgresql-schema.sql schema/
 ```
 

--- a/website/docs/deployment/installation.md
+++ b/website/docs/deployment/installation.md
@@ -23,7 +23,7 @@ Add the Ratchet BOM to your `dependencyManagement`:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/deployment/mongodb.md
+++ b/website/docs/deployment/mongodb.md
@@ -24,7 +24,7 @@ availability.
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-store-mongodb</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -18,7 +18,7 @@ Add the Micrometer module:
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-micrometer</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/website/docs/deployment/overview.md
+++ b/website/docs/deployment/overview.md
@@ -42,7 +42,7 @@ All versions are managed through the `ratchet-bom`:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -18,7 +18,7 @@ The Bill of Materials (BOM) ensures all Ratchet modules use the same version. Im
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/getting-started/introduction.md
+++ b/website/docs/getting-started/introduction.md
@@ -164,7 +164,7 @@ If you're building a microservice on Spring Boot or Quarkus and not targeting a 
 
 ## Project status
 
-Ratchet is currently at version **0.1.0-SNAPSHOT**. The core API is stabilizing, but interfaces marked with `@Incubating` (such as `CircuitBreakerProtected` and `CircuitBreakerProfile`) may change in future releases. Feedback and contributions are welcome.
+Ratchet is currently at version **0.1.1-SNAPSHOT**. The core API is stabilizing, but interfaces marked with `@Incubating` (such as `CircuitBreakerProtected` and `CircuitBreakerProfile`) may change in future releases. Feedback and contributions are welcome.
 
 ## What's next
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -27,7 +27,7 @@ If you haven't done steps 3 and 4 yet, here's the minimum `pom.xml` setup:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.1.0-SNAPSHOT</version>
+      <version>0.1.1-SNAPSHOT</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>


### PR DESCRIPTION
versions:set only updates pom files, so 12 tracked files (README, website docs, the bug-report template, the loadtest Dockerfile) were stuck at 0.1.0-SNAPSHOT, a coordinate that was never published and does not resolve. This corrects them to the current 0.1.1-SNAPSHOT and adds scripts/sync-version.sh, which rewrites every non-pom Ratchet version reference to a target version. Replacements are anchored to Ratchet contexts so unrelated versions (Java, MySQL, Jakarta) are untouched, and the script is idempotent.

Reworks release.yml so the release tag-commit and the next-development bump commit are created through the GitHub createCommitOnBranch API. Both come back Verified, which the signed-commit rule on main requires. The silent "|| true" that hid bump-PR merge failures is removed, and the bump step is now idempotent on rerun. sync-version.sh runs in both the release and bump steps so the docs always match the reactor version.

Requires RELEASE_TOKEN to carry Contents: write and Pull requests: write, and the repo's "Allow auto-merge" setting to be on.
