### PR TITLE
Add a both-theme accessibility scan to CI and fix the violations it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      web: ${{ steps.filter.outputs.web }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -44,7 +45,9 @@ jobs:
           # 'every' makes a file count as code only when it matches ALL rules
           # (not md, not adoc, not under website, not LICENSE). The default
           # 'some' quantifier lets the base '**' match every file, so the '!'
-          # rules never subtract and docs-only PRs run the full matrix.
+          # rules never subtract and docs-only PRs run the full matrix. The same
+          # 'every' quantifier is harmless for the single-pattern web filter: a
+          # changed file counts as web only when it lives under website/.
           predicate-quantifier: 'every'
           filters: |
             code:
@@ -53,6 +56,8 @@ jobs:
               - '!**/*.adoc'
               - '!website/**'
               - '!LICENSE'
+            web:
+              - 'website/**'
 
   build:
     runs-on: ubuntu-latest
@@ -250,6 +255,43 @@ jobs:
       - name: Copyleft dependency-license gate
         run: bash infra/ci/check-dependency-licenses.sh
 
+  # Builds the VitePress site and runs the axe-core accessibility scan against
+  # every page in both the light and dark themes (website/a11y/scan.mjs). Gated
+  # on the web filter so it runs whenever anything under website/ changes —
+  # including docs-only edits the code filter would otherwise let skip the
+  # pipeline. Skipped in the merge queue (it ran on the PR). Generated Javadoc is
+  # not present in this clean-checkout build and is excluded from the scan
+  # anyway, so the site builds without it.
+  a11y:
+    needs: changes
+    if: ${{ github.event_name != 'merge_group' && needs.changes.outputs.web != 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('website/package-lock.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+      - name: Install Playwright Chromium
+        working-directory: website
+        run: npx playwright install --with-deps chromium
+      - name: Build site
+        working-directory: website
+        run: npm run build
+      - name: Accessibility scan (light + dark)
+        working-directory: website
+        run: npm run a11y
+
   # Single aggregating gate. Branch protection requires only this context (plus
   # CodeQL's "Analyze (Java)" and DCO), so the volatile set of CI jobs lives
   # here in the workflow instead of being re-enumerated in repo settings. Adding
@@ -263,7 +305,7 @@ jobs:
   ci-required:
     name: CI required
     if: ${{ always() }}
-    needs: [changes, build, spotbugs, ee11-verify, integration-test, dash-license-check, license-gate]
+    needs: [changes, build, spotbugs, ee11-verify, integration-test, dash-license-check, license-gate, a11y]
     runs-on: ubuntu-latest
     steps:
       - name: Verify all required jobs passed

--- a/website/a11y/scan.mjs
+++ b/website/a11y/scan.mjs
@@ -1,0 +1,221 @@
+// Accessibility scanner for the built VitePress site.
+//
+// Serves docs/.vitepress/dist over a throwaway HTTP server and runs axe-core
+// against every built page in BOTH the light and dark themes, because the two
+// themes have independent colour palettes and a contrast failure in one is
+// invisible in the other. Fails (exit 1) if axe reports any WCAG 2 A/AA
+// violation; prints `incomplete` results separately for manual review without
+// failing, since axe flags those when it cannot decide on its own (most often
+// contrast computed through a translucent fixed header).
+//
+// Usage: node a11y/scan.mjs            (scan everything, both themes)
+//        node a11y/scan.mjs --json out.json
+//
+// Assumes the site is already built (`npm run build`).
+
+import { createServer } from 'node:http'
+import { readFile, readdir, stat } from 'node:fs/promises'
+import { join, extname, relative, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright'
+import { AxeBuilder } from '@axe-core/playwright'
+
+const here = dirname(fileURLToPath(import.meta.url))
+const DIST = join(here, '..', 'docs', '.vitepress', 'dist')
+const THEMES = ['light', 'dark']
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+const CONCURRENCY = 4
+
+// Generated Javadoc is third-party HTML we do not author or control, so it is
+// out of scope for this gate. 404.html is never linked.
+const EXCLUDE = [/^javadoc\//, /^404\.html$/]
+
+// Documented, justified exceptions. Keep this list short, cite why, and prefer
+// fixing the markup over adding an entry. Suppressed counts are always printed.
+const ALLOWLIST = [
+  {
+    rule: 'nested-interactive',
+    match: /\.collapsible.*\.item\[role="button"\]/,
+    why: 'VitePress default-theme sidebar renders a collapsible group title as role="button" wrapping its link. Upstream component, not ours.',
+  },
+]
+const isAllowed = (id, target) => ALLOWLIST.some((a) => a.rule === id && a.match.test(target))
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.map': 'application/json; charset=utf-8',
+}
+
+async function walkHtml(dir, base = dir) {
+  const out = []
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await walkHtml(full, base)))
+    } else if (extname(entry.name) === '.html') {
+      out.push(relative(base, full))
+    }
+  }
+  return out
+}
+
+// Resolve a request path to a file inside dist, trying VitePress-style
+// fallbacks so client-side asset and page requests both work.
+async function resolveFile(pathname) {
+  const clean = decodeURIComponent(pathname.split('?')[0])
+  const candidates = [clean, `${clean}.html`, join(clean, 'index.html')]
+  for (const c of candidates) {
+    const p = join(DIST, c)
+    if (!p.startsWith(DIST)) continue // no traversal out of dist
+    try {
+      if ((await stat(p)).isFile()) return p
+    } catch {
+      /* try next */
+    }
+  }
+  return null
+}
+
+function startServer() {
+  const server = createServer(async (req, res) => {
+    const file = await resolveFile(new URL(req.url, 'http://localhost').pathname)
+    if (!file) {
+      res.writeHead(404)
+      res.end('not found')
+      return
+    }
+    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' })
+    res.end(await readFile(file))
+  })
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address()
+      resolve({ server, base: `http://127.0.0.1:${port}` })
+    })
+  })
+}
+
+async function scanTheme(browser, base, routes, theme) {
+  const context = await browser.newContext()
+  // Set the theme the way a real visitor would: VitePress reads this key in an
+  // inline pre-paint script, so seeding it before navigation applies the right
+  // `.dark` class with no flash and no hydration race (Chromium runs init
+  // scripts before page scripts).
+  await context.addInitScript(
+    ([key, val]) => window.localStorage.setItem(key, val),
+    ['vitepress-theme-appearance', theme],
+  )
+
+  const findings = []
+  const queue = [...routes]
+
+  async function worker() {
+    const page = await context.newPage()
+    for (let route = queue.shift(); route; route = queue.shift()) {
+      await page.goto(`${base}/${route}`, { waitUntil: 'networkidle' })
+      const isDark = await page.evaluate(() => document.documentElement.classList.contains('dark'))
+      if (isDark !== (theme === 'dark')) {
+        throw new Error(`theme mismatch on ${route}: wanted ${theme}, page isDark=${isDark}`)
+      }
+      const results = await new AxeBuilder({ page }).withTags(WCAG_TAGS).analyze()
+      findings.push({ route, theme, violations: results.violations, incomplete: results.incomplete })
+    }
+    await page.close()
+  }
+
+  await Promise.all(Array.from({ length: CONCURRENCY }, worker))
+  await context.close()
+  return findings
+}
+
+function summarize(nodes) {
+  return nodes.flatMap((v) =>
+    v.nodes.map((n) => ({
+      id: v.id,
+      impact: v.impact,
+      help: v.help,
+      target: n.target.join(' '),
+      detail: (n.failureSummary ?? '').replace(/\s+/g, ' ').trim().slice(0, 200),
+    })),
+  )
+}
+
+async function main() {
+  const routes = (await walkHtml(DIST)).filter((r) => !EXCLUDE.some((re) => re.test(r))).sort()
+  if (routes.length === 0) {
+    console.error(`No built HTML found under ${DIST}. Run "npm run build" first.`)
+    process.exit(2)
+  }
+  console.log(`Scanning ${routes.length} pages × ${THEMES.length} themes (${THEMES.join(', ')})\n`)
+
+  const { server, base } = await startServer()
+  const browser = await chromium.launch()
+  const all = []
+  try {
+    for (const theme of THEMES) {
+      all.push(...(await scanTheme(browser, base, routes, theme)))
+    }
+  } finally {
+    await browser.close()
+    server.close()
+  }
+
+  const violations = []
+  const incomplete = []
+  let suppressed = 0
+  for (const f of all) {
+    for (const row of summarize(f.violations)) {
+      if (isAllowed(row.id, row.target)) {
+        suppressed++
+        continue
+      }
+      violations.push({ route: f.route, theme: f.theme, ...row })
+    }
+    for (const row of summarize(f.incomplete)) incomplete.push({ route: f.route, theme: f.theme, ...row })
+  }
+
+  if (suppressed) {
+    console.log(`\n${suppressed} finding(s) suppressed by the documented allowlist:`)
+    for (const a of ALLOWLIST) console.log(`  · ${a.rule}: ${a.why}`)
+  }
+
+  const jsonFlag = process.argv.indexOf('--json')
+  if (jsonFlag !== -1 && process.argv[jsonFlag + 1]) {
+    const { writeFile } = await import('node:fs/promises')
+    await writeFile(process.argv[jsonFlag + 1], JSON.stringify({ violations, incomplete }, null, 2))
+  }
+
+  if (incomplete.length) {
+    console.log(`\n${incomplete.length} incomplete result(s) — review manually, not failing the build:`)
+    const byRule = new Map()
+    for (const i of incomplete) byRule.set(i.id, (byRule.get(i.id) ?? 0) + 1)
+    for (const [id, n] of byRule) console.log(`  · ${id}: ${n}`)
+  }
+
+  if (violations.length) {
+    console.log(`\n✗ ${violations.length} accessibility violation(s):\n`)
+    for (const v of violations) {
+      console.log(`  [${v.theme}] ${v.route}`)
+      console.log(`    ${v.id} (${v.impact}) — ${v.target}`)
+      console.log(`    ${v.detail}\n`)
+    }
+    process.exit(1)
+  }
+
+  console.log('\n✓ No accessibility violations in either theme.')
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(2)
+})

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -1,5 +1,38 @@
 import { defineConfig, type HeadConfig } from 'vitepress'
+import { bundledThemes } from 'shiki'
 import { heroCodePlugin } from './heroCodePlugin'
+
+// A handful of syntax-highlighting tokens in the stock github-light and dracula
+// themes fall just under the WCAG AA 4.5:1 contrast floor against VitePress's
+// code-block backgrounds. Rather than swap the whole theme, the specific
+// offending colours are remapped to darker (light) / lighter (dark) variants
+// that clear AA while staying visually close. The accessibility CI scan
+// (website/a11y) is what flagged these; if a future token regresses it will
+// fail there too.
+async function contrastSafeTheme(name: string, remap: Record<string, string>) {
+  const loaded = await bundledThemes[name]()
+  const theme = JSON.parse(JSON.stringify(loaded.default))
+  const lower: Record<string, string> = {}
+  for (const [from, to] of Object.entries(remap)) lower[from.toLowerCase()] = to
+  const fix = (c?: string) => (c && lower[c.toLowerCase()]) || c
+  if (theme.fg) theme.fg = fix(theme.fg)
+  for (const entry of theme.settings ?? theme.tokenColors ?? []) {
+    if (entry.settings?.foreground) entry.settings.foreground = fix(entry.settings.foreground)
+  }
+  return theme
+}
+
+const [githubLightAA, draculaAA] = await Promise.all([
+  contrastSafeTheme('github-light', {
+    '#d73a49': '#b31d28', // keyword / tag — 4.23 -> 6.2
+    '#22863a': '#176f2c', // string — 4.28 -> 5.8
+    '#6a737d': '#586069', // comment — 4.45 -> 5.9
+    '#e36209': '#a04100', // number / constant — 3.23 -> 6.0
+  }),
+  contrastSafeTheme('dracula', {
+    '#6272a4': '#8a97cf', // comment — 3.83 -> 6.4
+  }),
+])
 
 const umamiHost = process.env.UMAMI_HOST
 const umamiSiteId = process.env.UMAMI_SITE_ID
@@ -281,8 +314,8 @@ export default defineConfig({
 
   markdown: {
     theme: {
-      light: 'github-light',
-      dark: 'dracula',
+      light: githubLightAA,
+      dark: draculaAA,
     },
   },
 

--- a/website/docs/.vitepress/theme/ComparisonMatrix.vue
+++ b/website/docs/.vitepress/theme/ComparisonMatrix.vue
@@ -161,7 +161,7 @@ const rows: Row[] = [
   {
     capability: 'Spring Boot starter',
     cells: [
-      { status: 'partial', label: 'Planned' },
+      { status: 'no', label: 'Unplanned' },
       { status: 'yes' },
       { status: 'yes' },
       { status: 'yes', label: 'Native' },
@@ -215,7 +215,12 @@ const statusLabel = (s: Status) => ({
 
 <template>
   <div class="cm-wrapper">
-    <div class="cm-scroll">
+    <div
+      class="cm-scroll"
+      tabindex="0"
+      role="region"
+      aria-label="Feature comparison across job schedulers (scroll horizontally)"
+    >
       <table class="cm-matrix">
         <thead>
           <tr>
@@ -302,11 +307,10 @@ const statusLabel = (s: Status) => ({
   padding: 0.65rem 0.5rem;
   border-radius: 6px;
   background: var(--vp-c-brand-1);
-  color: #1a1a1a;
   font-weight: 700;
+  /* Text colour is theme-keyed in custom.css (white on the light amber fill,
+     near-black on the dark gold fill) to avoid the scoped light/dark tie. */
 }
-
-:global(.dark) .cm-ratchet-header { color: #0d1117; }
 
 .cm-capability {
   text-align: left;
@@ -335,12 +339,15 @@ const statusLabel = (s: Status) => ({
   line-height: 1;
 }
 
+/* Labels and footnotes inherit the cell's status colour. They are small text,
+   so they sit fully opaque on it (any opacity drops them below AA) and the
+   status colours below are chosen to clear 4.5:1 against the blended cell
+   background in both themes. */
 .cm-label {
   display: block;
   font-size: 0.7rem;
   font-weight: 500;
   margin-top: 0.2rem;
-  opacity: 0.85;
 }
 
 .cm-fn {
@@ -349,18 +356,12 @@ const statusLabel = (s: Status) => ({
   right: 4px;
   font-size: 0.65rem;
   color: inherit;
-  opacity: 0.6;
 }
 
-.cm-yes { background: rgba(46, 160, 67, 0.16); color: #2da44e; }
-.cm-no { background: rgba(207, 34, 46, 0.14); color: #cf222e; }
-.cm-partial { background: rgba(191, 135, 0, 0.16); color: #bf8700; }
-.cm-na { background: rgba(110, 119, 129, 0.16); color: #6e7781; }
-
-:global(.dark) .cm-yes { background: rgba(63, 185, 80, 0.18); color: #3fb950; }
-:global(.dark) .cm-no { background: rgba(248, 81, 73, 0.16); color: #f85149; }
-:global(.dark) .cm-partial { background: rgba(210, 153, 34, 0.18); color: #d29922; }
-:global(.dark) .cm-na { background: rgba(139, 148, 158, 0.18); color: #8b949e; }
+/* Status colours (cells + legend swatches) live in custom.css, keyed on
+   html:not(.dark) / html.dark so light and dark are mutually exclusive. As
+   scoped rules the dark overrides tied with the light rules on specificity and
+   source order — not the theme — decided the winner. */
 
 .cm-legend {
   display: flex;

--- a/website/docs/.vitepress/theme/HeroTrustStrip.vue
+++ b/website/docs/.vitepress/theme/HeroTrustStrip.vue
@@ -22,7 +22,7 @@ const facts = [
         <p class="eyebrow">Standards-based and conformance-tested</p>
         <p class="trust-runtimes">
           <span v-for="r in runtimes" :key="r" class="runtime-chip">{{ r }}</span>
-          <span class="trust-times">×</span>
+          <span class="trust-times" aria-hidden="true">×</span>
           <span v-for="d in databases" :key="d" class="runtime-chip db">{{ d }}</span>
         </p>
       </div>
@@ -101,7 +101,10 @@ const facts = [
 }
 
 .trust-times {
-  color: var(--vp-c-text-3);
+  /* text-2, not text-3: the muted text-3 measured ~2.5:1 on the soft strip
+     background, under the WCAG AA floor. aria-hidden in the template keeps this
+     decorative separator out of the screen-reader line. */
+  color: var(--vp-c-text-2);
   font-weight: 700;
   padding: 0 0.15rem;
 }

--- a/website/docs/.vitepress/theme/custom.css
+++ b/website/docs/.vitepress/theme/custom.css
@@ -21,10 +21,14 @@ html { color-scheme: light; }
 /* ------------------------------------------------------------------ */
 
 :root {
-  --vp-c-brand-1: #b45309;
-  --vp-c-brand-2: #92400e;
-  --vp-c-brand-3: #78350f;
-  --vp-c-brand-soft: rgba(180, 83, 9, 0.14);
+  /* brand-1 is the primary accent: link text, inline code, and button fills.
+     At #b45309 it measured 4.4:1 on the soft inline-code background, just under
+     the WCAG AA 4.5:1 floor, so it is darkened to amber-800 (~6.2:1) and the
+     hover/active ramp is pushed down to keep the darkening visible on hover. */
+  --vp-c-brand-1: #92400e;
+  --vp-c-brand-2: #7c350a;
+  --vp-c-brand-3: #5e2c0a;
+  --vp-c-brand-soft: rgba(146, 64, 14, 0.14);
 
   --vp-button-brand-border: var(--vp-c-brand-1);
   --vp-button-brand-text: #ffffff;
@@ -353,7 +357,11 @@ html { color-scheme: light; }
   border-collapse: collapse;
 }
 
-.vp-doc table th {
+/* The ComparisonMatrix renders its own <table class="cm-matrix"> with bespoke
+   header styling, so the brand-filled markdown-table header treatment is scoped
+   away from it — otherwise the dark `#1f1306` header text lands on the matrix's
+   grey header cells and fails contrast. */
+.vp-doc table:not(.cm-matrix) th {
   background-color: var(--vp-c-brand-1);
   color: white;
   padding: 0.75rem;
@@ -362,8 +370,15 @@ html { color-scheme: light; }
 }
 
 /* In dark mode brand-1 becomes a bright amber — dark text reads better than white */
-.dark .vp-doc table th {
+.dark .vp-doc table:not(.cm-matrix) th {
   color: #1f1306;
+}
+
+/* Inline code in a brand-filled header inherits the header's text colour
+   instead of the brand colour, which would otherwise match the background. */
+.vp-doc table:not(.cm-matrix) th code {
+  color: inherit;
+  background: transparent;
 }
 
 .vp-doc table td {
@@ -373,6 +388,25 @@ html { color-scheme: light; }
   border-left: 0;
   border-right: 0;
 }
+
+/* ComparisonMatrix status colours. Defined globally and keyed on the theme
+   class so light and dark are mutually exclusive — kept in the scoped component
+   they tied with each other on specificity. Each colour clears WCAG AA (4.5:1)
+   against its blended cell tint; the same classes style the legend swatches. */
+html:not(.dark) .cm-yes { background: rgba(46, 160, 67, 0.16); color: #216e39; }
+html:not(.dark) .cm-no { background: rgba(207, 34, 46, 0.14); color: #a40e26; }
+html:not(.dark) .cm-partial { background: rgba(191, 135, 0, 0.16); color: #854d0e; }
+html:not(.dark) .cm-na { background: rgba(110, 119, 129, 0.16); color: #4b5563; }
+
+html.dark .cm-yes { background: rgba(63, 185, 80, 0.18); color: #3fb950; }
+html.dark .cm-no { background: rgba(248, 81, 73, 0.16); color: #ff7b72; }
+html.dark .cm-partial { background: rgba(210, 153, 34, 0.18); color: #d29922; }
+html.dark .cm-na { background: rgba(139, 148, 158, 0.18); color: #9da7b3; }
+
+/* The Ratchet header sits on the brand fill: white on the light amber,
+   near-black on the dark gold. Theme-keyed for the same reason as above. */
+html:not(.dark) .cm-ratchet-header { color: #ffffff; }
+html.dark .cm-ratchet-header { color: #0d1117; }
 
 .vp-doc table tr {
   background-color: transparent !important;

--- a/website/docs/concepts/batches.md
+++ b/website/docs/concepts/batches.md
@@ -12,25 +12,25 @@ Ratchet provides two batch processing APIs: `BatchBuilder` for in-memory collect
 
 A batch consists of a **parent job** (BATCH_PARENT) and many **child jobs** (BATCH_CHILD). The parent tracks overall progress but performs no work itself. Each child executes independently and in parallel, following the normal job lifecycle with its own retry and failure handling.
 
-<div className="docs-diagram" role="img" aria-label="Batch execution flow: submit creates a parent job, the parent creates child jobs, children execute independently, then parent evaluates success or failure callbacks.">
-  <div className="docs-diagram-flow">
-    <div className="docs-diagram-card docs-diagram-card--primary">
+<div class="docs-diagram" role="img" aria-label="Batch execution flow: submit creates a parent job, the parent creates child jobs, children execute independently, then parent evaluates success or failure callbacks.">
+  <div class="docs-diagram-flow">
+    <div class="docs-diagram-card docs-diagram-card--primary">
       <strong>`BatchBuilder.submit()`</strong>
       <small>Persists the batch parent and child job definitions.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--muted">
+    <div class="docs-diagram-card docs-diagram-card--muted">
       <strong>BATCH_PARENT</strong>
       <small>Tracks progress and owns callbacks, but performs no user work.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>N child jobs</strong>
       <small>Each child is a normal job with independent retry and failure handling.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--store">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>Progress aggregation</strong>
       <small>Child completions update batch metrics and parent progress.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--success">
+    <div class="docs-diagram-card docs-diagram-card--success">
       <strong>Batch callbacks</strong>
       <small>`onBatchSuccess` runs if all pass; `onBatchFailure` runs if any fail.</small>
     </div>

--- a/website/docs/concepts/clustering.md
+++ b/website/docs/concepts/clustering.md
@@ -10,36 +10,36 @@ Ratchet is designed to run on multiple nodes without additional coordination inf
 
 ## Multi-Node Architecture
 
-<div className="docs-diagram" role="img" aria-label="Ratchet multi-node architecture: each application node runs its own poller and workers, and all nodes coordinate through the shared store using SKIP LOCKED, node heartbeats, and scheduler locks.">
-  <div className="docs-diagram-row">
-    <div className="docs-diagram-card docs-diagram-card--active">
+<div class="docs-diagram" role="img" aria-label="Ratchet multi-node architecture: each application node runs its own poller and workers, and all nodes coordinate through the shared store using SKIP LOCKED, node heartbeats, and scheduler locks.">
+  <div class="docs-diagram-row">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Node A</strong>
       <small>Poller + workers claim their own jobs.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Node B</strong>
       <small>Runs independently; no master node.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Node C</strong>
       <small>Uses the same store-backed coordination rules.</small>
     </div>
   </div>
 
-  <div className="docs-diagram-connector">
+  <div class="docs-diagram-connector">
     <span>`SELECT ... FOR UPDATE SKIP LOCKED` gives each node a disjoint claim set</span>
   </div>
 
-  <div className="docs-diagram-row">
-    <div className="docs-diagram-card docs-diagram-card--store">
+  <div class="docs-diagram-row">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>scheduler_job_queue</strong>
       <small>Hot PENDING/RUNNING/PAUSED/WAITING state and claim ownership.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--store">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>scheduler_node</strong>
       <small>Node registration and heartbeat timestamps.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--store">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>scheduler_lock</strong>
       <small>Leases for singleton recurring scans and startup cleanup.</small>
     </div>

--- a/website/docs/concepts/error-handling.md
+++ b/website/docs/concepts/error-handling.md
@@ -10,52 +10,52 @@ When a job throws an exception, Ratchet's error handling pipeline determines whe
 
 ## Error Handling Pipeline
 
-<div className="docs-diagram docs-decision-grid" role="img" aria-label="Error handling decision tree: check DoNotRetry, increment attempts on the retryable path, consult RetryPolicy, compare attempt count, then either route to DLQ or schedule a retry.">
-  <div className="docs-diagram-card docs-diagram-card--danger">
+<div class="docs-diagram docs-decision-grid" role="img" aria-label="Error handling decision tree: check DoNotRetry, increment attempts on the retryable path, consult RetryPolicy, compare attempt count, then either route to DLQ or schedule a retry.">
+  <div class="docs-diagram-card docs-diagram-card--danger">
     <strong>Job throws exception</strong>
     <small>The engine runs the `@DoNotRetry` check first, then increments the attempt counter only on the retryable path.</small>
   </div>
 
-  <div className="docs-decision-row">
-    <div className="docs-diagram-card">
+  <div class="docs-decision-row">
+    <div class="docs-diagram-card">
       <strong>`@DoNotRetry` on exception?</strong>
       <small>Checked first on the thrown exception and each exception in its cause chain.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--danger">
+    <div class="docs-diagram-card docs-diagram-card--danger">
       <strong>Yes</strong>
       <small>Move directly to DLQ.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>No</strong>
       <small>Continue to policy evaluation.</small>
     </div>
   </div>
 
-  <div className="docs-decision-row">
-    <div className="docs-diagram-card">
+  <div class="docs-decision-row">
+    <div class="docs-diagram-card">
       <strong>`RetryPolicy.shouldRetry()`?</strong>
       <small>Custom SPI can reject retries by exception type, attempt, or external state.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--danger">
+    <div class="docs-diagram-card docs-diagram-card--danger">
       <strong>No</strong>
       <small>Move to DLQ.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Yes</strong>
       <small>Check the job's retry budget.</small>
     </div>
   </div>
 
-  <div className="docs-decision-row">
-    <div className="docs-diagram-card">
+  <div class="docs-decision-row">
+    <div class="docs-diagram-card">
       <strong>`attempt <= maxRetries`?</strong>
       <small>The job's configured retry budget is the final gate.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--danger">
+    <div class="docs-diagram-card docs-diagram-card--danger">
       <strong>No</strong>
       <small>Move to DLQ.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--success">
+    <div class="docs-diagram-card docs-diagram-card--success">
       <strong>Yes</strong>
       <small>Calculate backoff and reschedule as PENDING.</small>
     </div>

--- a/website/docs/concepts/execution-model.md
+++ b/website/docs/concepts/execution-model.md
@@ -10,25 +10,25 @@ This page explains how Ratchet moves a job from "sitting in the database" to "ru
 
 ## Execution Pipeline
 
-<div className="docs-diagram" role="img" aria-label="Ratchet execution pipeline from the hot queue table through the Poller, coordinator, worker task, and post-processing.">
-  <div className="docs-diagram-flow">
-    <div className="docs-diagram-card docs-diagram-card--store">
+<div class="docs-diagram" role="img" aria-label="Ratchet execution pipeline from the hot queue table through the Poller, coordinator, worker task, and post-processing.">
+  <div class="docs-diagram-flow">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>Hot Queue</strong>
       <small>`scheduler_job_queue` stores live PENDING/RUNNING/PAUSED/WAITING state.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--primary">
+    <div class="docs-diagram-card docs-diagram-card--primary">
       <strong>Poller</strong>
       <small>Claims due PENDING rows with `FOR UPDATE SKIP LOCKED`.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>JobExecutionCoordinator</strong>
       <small>Dispatches lightweight claim DTOs to the configured executor.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>JobTask</strong>
       <small>Loads the full job, validates policy, executes, and records the outcome.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--muted">
+    <div class="docs-diagram-card docs-diagram-card--muted">
       <strong>Post-processing</strong>
       <small>Triggers chains, workflow branches, batch updates, events, and archival paths.</small>
     </div>
@@ -122,52 +122,52 @@ For efficiency, the Poller passes lightweight `JobClaimDto` objects (containing 
 
 ### Execution Steps
 
-<div className="docs-diagram docs-step-list" role="list" aria-label="JobTask execution steps">
-  <div className="docs-diagram-step" role="listitem">
+<div class="docs-diagram docs-step-list" role="list" aria-label="JobTask execution steps">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Setup MDC context</strong>
     <small>Adds job ID and node ID so logs can be correlated.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Load `JobEntity`</strong>
     <small>Loads the full entity lazily from the lightweight `JobClaimDto`.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Bind `JobContext`</strong>
     <small>Attaches logger, params, and any delivered signal payload to the worker thread.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Check cancellation</strong>
     <small>Re-reads status and exits cleanly if the job was canceled after claim.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Check circuit breaker</strong>
     <small>Asks `ResilienceStrategy` whether the target service is available.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Acquire resource permit</strong>
     <small>Reschedules without consuming a retry if the configured resource is saturated.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Validate class policy</strong>
     <small>Applies `ClassPolicy` before resolving the target invocation.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Resolve bean and method</strong>
     <small>Uses CDI lookup and reflection from the persisted payload.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Execute target</strong>
     <small>Runs through `ResilienceStrategy`, including circuit-breaker wrapping.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Handle result</strong>
     <small>Routes success to `handleSuccess()` or failure to `handleFailure()`.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Release resource permit</strong>
     <small>Frees capacity for other queued work.</small>
   </div>
-  <div className="docs-diagram-step" role="listitem">
+  <div class="docs-diagram-step" role="listitem">
     <strong>Clear MDC and context</strong>
     <small>Removes thread-local state before the worker returns to the pool.</small>
   </div>

--- a/website/docs/concepts/job-lifecycle.md
+++ b/website/docs/concepts/job-lifecycle.md
@@ -10,64 +10,64 @@ Every job in Ratchet follows a defined state machine from creation to terminal s
 
 ## State Machine
 
-<div className="docs-diagram" role="img" aria-label="Ratchet job state machine: PENDING jobs can run, pause, cancel, or retry; RUNNING jobs succeed, fail, or cancel; WAITING jobs unblock to PENDING when a signal arrives or fail on timeout.">
-  <div className="docs-diagram-row docs-diagram-row--tight">
-    <div className="docs-diagram-state docs-diagram-state--primary">
+<div class="docs-diagram" role="img" aria-label="Ratchet job state machine: PENDING jobs can run, pause, cancel, or retry; RUNNING jobs succeed, fail, or cancel; WAITING jobs unblock to PENDING when a signal arrives or fail on timeout.">
+  <div class="docs-diagram-row docs-diagram-row--tight">
+    <div class="docs-diagram-state docs-diagram-state--primary">
       <strong>PENDING</strong>
       <small>Queued and eligible when `scheduled_time <= now`.</small>
     </div>
-    <div className="docs-diagram-state docs-diagram-state--active">
+    <div class="docs-diagram-state docs-diagram-state--active">
       <strong>RUNNING</strong>
       <small>Claimed by one node and executing on a worker.</small>
     </div>
-    <div className="docs-diagram-state docs-diagram-state--warning">
+    <div class="docs-diagram-state docs-diagram-state--warning">
       <strong>WAITING</strong>
       <small>Blocked for an external signal; hidden from polling.</small>
     </div>
-    <div className="docs-diagram-state docs-diagram-state--muted">
+    <div class="docs-diagram-state docs-diagram-state--muted">
       <strong>PAUSED</strong>
       <small>Temporarily hidden; resumes to the stored previous state.</small>
     </div>
-    <div className="docs-diagram-state docs-diagram-state--success">
+    <div class="docs-diagram-state docs-diagram-state--success">
       <strong>SUCCEEDED</strong>
       <small>Terminal success; eligible for archival after retention.</small>
     </div>
-    <div className="docs-diagram-state docs-diagram-state--danger">
+    <div class="docs-diagram-state docs-diagram-state--danger">
       <strong>FAILED</strong>
       <small>Terminal when retries are exhausted; otherwise retried.</small>
     </div>
-    <div className="docs-diagram-state docs-diagram-state--danger">
+    <div class="docs-diagram-state docs-diagram-state--danger">
       <strong>CANCELED</strong>
       <small>Terminal cancellation from queued, running, paused, or waiting work.</small>
     </div>
   </div>
 
-  <div className="docs-diagram-connector">
+  <div class="docs-diagram-connector">
     <span>Main transitions</span>
   </div>
 
-  <div className="docs-diagram-row">
-    <div className="docs-diagram-card">
+  <div class="docs-diagram-row">
+    <div class="docs-diagram-card">
       <strong>PENDING -> RUNNING</strong>
       <small>Poller claims the row atomically with `SKIP LOCKED`.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>RUNNING -> SUCCEEDED</strong>
       <small>The task completes and result handling succeeds.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>RUNNING -> FAILED</strong>
       <small>The task throws, times out, or exhausts retry handling.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>FAILED -> PENDING</strong>
       <small>Automatic retry with backoff, or manual `retryJob()` reset.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>PENDING -> PAUSED</strong>
       <small>`pauseJob()` records `paused_from_status` for accurate resume.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>WAITING -> PENDING</strong>
       <small>`deliverSignal()` unblocks the job and attaches the signal payload.</small>
     </div>

--- a/website/docs/concepts/overview.md
+++ b/website/docs/concepts/overview.md
@@ -12,10 +12,10 @@ Ratchet is a portable, CDI-based job scheduler for Jakarta EE 10/11 applications
 
 In a typical Jakarta EE application, Ratchet sits between your business logic and the database. You inject `JobSchedulerService`, enqueue work using lambda expressions, and Ratchet handles persistence, polling, execution, retries, and lifecycle events.
 
-<div className="ratchet-fit-diagram" role="img" aria-label="Ratchet architecture: application code submits jobs through JobSchedulerService into the Ratchet engine, which persists through the JobStore SPI backed by MySQL, PostgreSQL, or MongoDB.">
-  <div className="fit-layer fit-layer-app">
+<div class="ratchet-fit-diagram" role="group" aria-label="Ratchet architecture: application code submits jobs through JobSchedulerService into the Ratchet engine, which persists through the JobStore SPI backed by MySQL, PostgreSQL, or MongoDB.">
+  <div class="fit-layer fit-layer-app">
     <div>
-      <span className="fit-kicker">Your Jakarta EE Application</span>
+      <span class="fit-kicker">Your Jakarta EE Application</span>
       <strong>Business services submit durable work</strong>
 
 ```java
@@ -25,53 +25,53 @@ scheduler.enqueue(() -> orderService.process(id)).withMaxRetries(3).submit();
 </div>
   </div>
 
-  <div className="fit-connector">
+  <div class="fit-connector">
     <span>JobSchedulerService</span>
   </div>
 
-  <div className="fit-layer fit-layer-engine">
-    <div className="fit-layer-header">
-      <span className="fit-kicker">Ratchet Engine</span>
+  <div class="fit-layer fit-layer-engine">
+    <div class="fit-layer-header">
+      <span class="fit-kicker">Ratchet Engine</span>
       <strong>Persist, claim, execute, retry, observe</strong>
     </div>
-    <div className="fit-engine-grid">
-      <div className="fit-node">
+    <div class="fit-engine-grid">
+      <div class="fit-node">
         <span>Poller</span>
         <small>Adaptive polling</small>
       </div>
-      <div className="fit-node">
+      <div class="fit-node">
         <span>JobTask</span>
         <small>Execution + retry</small>
       </div>
-      <div className="fit-node">
+      <div class="fit-node">
         <span>Workflow</span>
         <small>Chains + conditions</small>
       </div>
-      <div className="fit-node">
+      <div class="fit-node">
         <span>Batch</span>
         <small>Parent + child jobs</small>
       </div>
-      <div className="fit-node">
+      <div class="fit-node">
         <span>Events</span>
         <small>CDI + listeners</small>
       </div>
     </div>
   </div>
 
-  <div className="fit-connector">
+  <div class="fit-connector">
     <span>JobStore SPI</span>
   </div>
 
-  <div className="fit-store-grid">
-    <div className="fit-store">
+  <div class="fit-store-grid">
+    <div class="fit-store">
       <span>MySQL Store</span>
       <small>SKIP LOCKED claiming</small>
     </div>
-    <div className="fit-store">
+    <div class="fit-store">
       <span>PostgreSQL Store</span>
       <small>SKIP LOCKED claiming</small>
     </div>
-    <div className="fit-store">
+    <div class="fit-store">
       <span>MongoDB Store</span>
       <small>Atomic document updates</small>
     </div>
@@ -82,108 +82,108 @@ scheduler.enqueue(() -> orderService.process(id)).withMaxRetries(3).submit();
 
 Ratchet is organized into modules following the Jakarta EE API / RI / TCK pattern:
 
-<div className="module-inventory" role="list" aria-label="Ratchet Maven modules">
-  <section className="module-section module-section-api" role="listitem">
-    <div className="module-section-header">
-      <span className="fit-kicker">Public Contracts</span>
+<div class="module-inventory" role="list" aria-label="Ratchet Maven modules">
+  <section class="module-section module-section-api" role="listitem">
+    <div class="module-section-header">
+      <span class="fit-kicker">Public Contracts</span>
       <strong>Depend on this from applications and integrations</strong>
     </div>
-    <div className="module-chip-grid">
-      <div className="module-chip">
+    <div class="module-chip-grid">
+      <div class="module-chip">
         <code>ratchet-api</code>
         <p>Public API, SPIs, lifecycle events, annotations, and Jakarta EE-facing contracts.</p>
       </div>
     </div>
   </section>
 
-  <section className="module-section module-section-runtime" role="listitem">
-    <div className="module-section-header">
-      <span className="fit-kicker">Runtime</span>
+  <section class="module-section module-section-runtime" role="listitem">
+    <div class="module-section-header">
+      <span class="fit-kicker">Runtime</span>
       <strong>Engine and store implementations deployed at runtime</strong>
     </div>
-    <div className="module-chip-grid">
-      <div className="module-chip">
+    <div class="module-chip-grid">
+      <div class="module-chip">
         <code>ratchet</code>
         <p>Reference implementation, CDI integration, scheduler engine, poller, and executors.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-store-core</code>
         <p>Shared persistence entities and internal store support used by store adapters.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-store-mysql</code>
         <p>MySQL JobStore implementation and DDL.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-store-postgresql</code>
         <p>PostgreSQL JobStore implementation and DDL.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-store-mongodb</code>
         <p>MongoDB JobStore implementation with collection and index bootstrap.</p>
       </div>
     </div>
   </section>
 
-  <section className="module-section module-section-observability" role="listitem">
-    <div className="module-section-header">
-      <span className="fit-kicker">Observability</span>
+  <section class="module-section module-section-observability" role="listitem">
+    <div class="module-section-header">
+      <span class="fit-kicker">Observability</span>
       <strong>Optional adapters for metrics and traces</strong>
     </div>
-    <div className="module-chip-grid">
-      <div className="module-chip">
+    <div class="module-chip-grid">
+      <div class="module-chip">
         <code>ratchet-micrometer</code>
         <p>Micrometer metrics integration built on the public API.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-otel</code>
         <p>OpenTelemetry integration built on the public API.</p>
       </div>
     </div>
   </section>
 
-  <section className="module-section module-section-validation" role="listitem">
-    <div className="module-section-header">
-      <span className="fit-kicker">Validation</span>
+  <section class="module-section module-section-validation" role="listitem">
+    <div class="module-section-header">
+      <span class="fit-kicker">Validation</span>
       <strong>Conformance, integration, load, JPMS, and coverage modules</strong>
     </div>
-    <div className="module-chip-grid">
-      <div className="module-chip">
+    <div class="module-chip-grid">
+      <div class="module-chip">
         <code>ratchet-tck</code>
         <p>Technology Compatibility Kit aggregator.</p>
-        <div className="module-tags">
+        <div class="module-tags">
           <span>util</span>
           <span>store</span>
           <span>api</span>
           <span>jakarta</span>
         </div>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-testsuite</code>
         <p>Container and store integration tests.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-testsuite-jpms</code>
         <p>JPMS/module-system integration tests.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-loadtest</code>
         <p>Load and stress-test harness.</p>
       </div>
-      <div className="module-chip">
+      <div class="module-chip">
         <code>ratchet-coverage</code>
         <p>Aggregate coverage module for reactor reporting.</p>
       </div>
     </div>
   </section>
 
-  <section className="module-section module-section-distribution" role="listitem">
-    <div className="module-section-header">
-      <span className="fit-kicker">Distribution</span>
+  <section class="module-section module-section-distribution" role="listitem">
+    <div class="module-section-header">
+      <span class="fit-kicker">Distribution</span>
       <strong>Version alignment for consumers</strong>
     </div>
-    <div className="module-chip-grid">
-      <div className="module-chip">
+    <div class="module-chip-grid">
+      <div class="module-chip">
         <code>ratchet-bom</code>
         <p>Bill of Materials POM for importing consistent Ratchet dependency versions.</p>
       </div>
@@ -193,65 +193,65 @@ Ratchet is organized into modules following the Jakarta EE API / RI / TCK patter
 
 ### Module Dependency Graph
 
-<div className="module-dependency-diagram" role="img" aria-label="Ratchet module dependency graph. ratchet-api has only Jakarta EE API dependencies. The engine, store core, TCK, tests, observability modules, and BOM build on the API. Store implementations build on store core.">
-  <div className="dependency-layer">
-    <span className="dependency-layer-label">Public API</span>
-    <div className="dependency-node dependency-node-api">
+<div class="module-dependency-diagram" role="img" aria-label="Ratchet module dependency graph. ratchet-api has only Jakarta EE API dependencies. The engine, store core, TCK, tests, observability modules, and BOM build on the API. Store implementations build on store core.">
+  <div class="dependency-layer">
+    <span class="dependency-layer-label">Public API</span>
+    <div class="dependency-node dependency-node-api">
       <strong>ratchet-api</strong>
       <small>Jakarta EE APIs only</small>
     </div>
   </div>
 
-  <div className="dependency-bridge">
+  <div class="dependency-bridge">
     <span>runtime, observability, tests, and distribution build from the public contracts</span>
   </div>
 
-  <div className="dependency-layer">
-    <span className="dependency-layer-label">API Consumers</span>
-    <div className="dependency-node-grid">
-      <div className="dependency-node">
+  <div class="dependency-layer">
+    <span class="dependency-layer-label">API Consumers</span>
+    <div class="dependency-node-grid">
+      <div class="dependency-node">
         <strong>ratchet</strong>
         <small>Engine + CDI integration</small>
       </div>
-      <div className="dependency-node">
+      <div class="dependency-node">
         <strong>ratchet-store-core</strong>
         <small>Internal shared store layer</small>
       </div>
-      <div className="dependency-node">
+      <div class="dependency-node">
         <strong>ratchet-tck</strong>
         <small>Conformance modules</small>
       </div>
-      <div className="dependency-node">
+      <div class="dependency-node">
         <strong>ratchet-micrometer</strong>
         <small>Metrics adapter</small>
       </div>
-      <div className="dependency-node">
+      <div class="dependency-node">
         <strong>ratchet-otel</strong>
         <small>Tracing adapter</small>
       </div>
-      <div className="dependency-node">
+      <div class="dependency-node">
         <strong>ratchet-bom</strong>
         <small>Version alignment</small>
       </div>
     </div>
   </div>
 
-  <div className="dependency-bridge dependency-bridge-store">
+  <div class="dependency-bridge dependency-bridge-store">
     <span>store adapters share the internal store core</span>
   </div>
 
-  <div className="dependency-layer">
-    <span className="dependency-layer-label">Stores</span>
-    <div className="dependency-node-grid dependency-store-grid">
-      <div className="dependency-node dependency-node-store">
+  <div class="dependency-layer">
+    <span class="dependency-layer-label">Stores</span>
+    <div class="dependency-node-grid dependency-store-grid">
+      <div class="dependency-node dependency-node-store">
         <strong>ratchet-store-mysql</strong>
         <small>MySQL + DDL</small>
       </div>
-      <div className="dependency-node dependency-node-store">
+      <div class="dependency-node dependency-node-store">
         <strong>ratchet-store-postgresql</strong>
         <small>PostgreSQL + DDL</small>
       </div>
-      <div className="dependency-node dependency-node-store">
+      <div class="dependency-node dependency-node-store">
         <strong>ratchet-store-mongodb</strong>
         <small>MongoDB collections + indexes</small>
       </div>

--- a/website/docs/concepts/persistence.md
+++ b/website/docs/concepts/persistence.md
@@ -18,13 +18,13 @@ state. MongoDB maps the same logical model to collections. Supporting entities
 handle batches, executions, workflow conditions, locks, nodes, structured logs,
 resource limits, DLQ alerts, and archived jobs.
 
-<div className="docs-diagram persistence-model-diagram" role="img" aria-label="Ratchet persistence model with scheduler_job as cold metadata, scheduler_job_queue as hot live state, and supporting tables for tags, executions, batches, workflow conditions, locks, nodes, logs, resources, alerts, and archive rows.">
-  <div className="docs-diagram-table docs-diagram-card--primary">
-    <div className="docs-diagram-table-header">
+<div class="docs-diagram persistence-model-diagram" role="img" aria-label="Ratchet persistence model with scheduler_job as cold metadata, scheduler_job_queue as hot live state, and supporting tables for tags, executions, batches, workflow conditions, locks, nodes, logs, resources, alerts, and archive rows.">
+  <div class="docs-diagram-table docs-diagram-card--primary">
+    <div class="docs-diagram-table-header">
       <strong>scheduler_job</strong>
       <small>Cold metadata, immutable job shape, and terminal survivor fields.</small>
     </div>
-    <div className="docs-diagram-fields">
+    <div class="docs-diagram-fields">
       <span>job_id UUIDv7 PK</span>
       <span>priority + job_type</span>
       <span>payload + params</span>
@@ -40,16 +40,16 @@ resource limits, DLQ alerts, and archived jobs.
     </div>
   </div>
 
-  <div className="docs-diagram-connector">
+  <div class="docs-diagram-connector">
     <span>1:0/1 while live</span>
   </div>
 
-  <div className="docs-diagram-table docs-diagram-card--active">
-    <div className="docs-diagram-table-header">
+  <div class="docs-diagram-table docs-diagram-card--active">
+    <div class="docs-diagram-table-header">
       <strong>scheduler_job_queue</strong>
       <small>Hot claim/poll state. SQL claim, pickup, retry, pause, resume, and signal operations target this table.</small>
     </div>
-    <div className="docs-diagram-fields">
+    <div class="docs-diagram-fields">
       <span>job_id PK/FK</span>
       <span>status: PENDING, RUNNING, PAUSED, WAITING</span>
       <span>scheduled_time</span>
@@ -65,56 +65,56 @@ resource limits, DLQ alerts, and archived jobs.
     </div>
   </div>
 
-  <div className="docs-diagram-connector">
+  <div class="docs-diagram-connector">
     <span>Supporting tables</span>
   </div>
 
-  <div className="docs-diagram-row docs-diagram-row--tight">
-    <div className="docs-diagram-card">
+  <div class="docs-diagram-row docs-diagram-row--tight">
+    <div class="docs-diagram-card">
       <strong>scheduler_job_tag</strong>
       <small>Tags per job for search and affinity filters.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_job_execution</strong>
       <small>Execution attempts and history.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_batch</strong>
       <small>Batch parent metadata.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_batch_metrics</strong>
       <small>Batch progress counters.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_workflow_condition</strong>
       <small>Workflow branch predicates and conditions.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_lock</strong>
       <small>Store-backed leases for singleton operations.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_node</strong>
       <small>Node registration and heartbeats.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_job_log</strong>
       <small>Structured job logs.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_resource_limit / permit</strong>
       <small>Resource capacity and active permits.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_dlq_alerts</strong>
       <small>DLQ alert audit and deduplication.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_job_archive</strong>
       <small>Archived terminal jobs.</small>
     </div>
-    <div className="docs-diagram-card">
+    <div class="docs-diagram-card">
       <strong>scheduler_business_key_reservation</strong>
       <small>Active business-key uniqueness.</small>
     </div>
@@ -178,26 +178,26 @@ Ratchet uses **RFC 9562 §5.7 UUIDv7** for primary keys. UUIDs are 128-bit value
 
 ### Layout
 
-<div className="docs-diagram" role="img" aria-label="UUIDv7 layout: 48 bits timestamp, 4 bits version, 12 bits rand_a, 2 bits variant, and 62 bits rand_b.">
-  <span className="fit-kicker">128-bit UUIDv7 layout</span>
-  <div className="uuid-strip">
-    <div className="uuid-segment docs-diagram-card--primary">
+<div class="docs-diagram" role="img" aria-label="UUIDv7 layout: 48 bits timestamp, 4 bits version, 12 bits rand_a, 2 bits variant, and 62 bits rand_b.">
+  <span class="fit-kicker">128-bit UUIDv7 layout</span>
+  <div class="uuid-strip">
+    <div class="uuid-segment docs-diagram-card--primary">
       <strong>unix_ts_ms</strong>
       <small>48 bits</small>
     </div>
-    <div className="uuid-segment">
+    <div class="uuid-segment">
       <strong>ver</strong>
       <small>4 bits</small>
     </div>
-    <div className="uuid-segment docs-diagram-card--active">
+    <div class="uuid-segment docs-diagram-card--active">
       <strong>rand_a</strong>
       <small>12 bits</small>
     </div>
-    <div className="uuid-segment">
+    <div class="uuid-segment">
       <strong>var</strong>
       <small>2 bits</small>
     </div>
-    <div className="uuid-segment docs-diagram-card--store">
+    <div class="uuid-segment docs-diagram-card--store">
       <strong>rand_b</strong>
       <small>62 bits</small>
     </div>

--- a/website/docs/concepts/retry-strategies.md
+++ b/website/docs/concepts/retry-strategies.md
@@ -238,45 +238,45 @@ jobStore.scheduleJobRetry(job.getId(), errorMessage, newScheduledTime, attempt);
 
 The `@DoNotRetry` annotation is checked **before** the `RetryPolicy` SPI. If the exception class is annotated with `@DoNotRetry`, the job moves directly to the DLQ regardless of retry configuration or policy:
 
-<div className="docs-diagram docs-decision-grid" role="img" aria-label="Retry decision order: DoNotRetry first, maxRetries second, RetryPolicy third, then calculate delay and reschedule.">
-  <div className="docs-decision-row">
-    <div className="docs-diagram-card">
+<div class="docs-diagram docs-decision-grid" role="img" aria-label="Retry decision order: DoNotRetry first, maxRetries second, RetryPolicy third, then calculate delay and reschedule.">
+  <div class="docs-decision-row">
+    <div class="docs-diagram-card">
       <strong>1. `@DoNotRetry`?</strong>
       <small>Annotation wins over all retry settings.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--danger">
+    <div class="docs-diagram-card docs-diagram-card--danger">
       <strong>Yes</strong>
       <small>DLQ immediately.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>No</strong>
       <small>Check the job budget.</small>
     </div>
   </div>
-  <div className="docs-decision-row">
-    <div className="docs-diagram-card">
+  <div class="docs-decision-row">
+    <div class="docs-diagram-card">
       <strong>2. `attempt <= maxRetries`?</strong>
       <small>Per-job configuration is checked first.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--danger">
+    <div class="docs-diagram-card docs-diagram-card--danger">
       <strong>No</strong>
       <small>Move to DLQ.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Yes</strong>
       <small>Consult retry policy.</small>
     </div>
   </div>
-  <div className="docs-decision-row">
-    <div className="docs-diagram-card">
+  <div class="docs-decision-row">
+    <div class="docs-diagram-card">
       <strong>3. `RetryPolicy.shouldRetry()`?</strong>
       <small>Custom global rules can stop the retry early.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--danger">
+    <div class="docs-diagram-card docs-diagram-card--danger">
       <strong>No</strong>
       <small>Move to DLQ.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--success">
+    <div class="docs-diagram-card docs-diagram-card--success">
       <strong>Yes</strong>
       <small>Calculate delay and reschedule.</small>
     </div>

--- a/website/docs/concepts/scheduling.md
+++ b/website/docs/concepts/scheduling.md
@@ -230,21 +230,21 @@ The old job is marked as superseded (`superseded_by` column points to the new jo
 
 The engine doesn't poll at a fixed interval. The `PollingStrategy` dynamically adjusts the polling delay based on job availability patterns:
 
-<div className="docs-diagram" role="img" aria-label="Adaptive polling modes: wakeup signal enters burst mode, idle polls settle into normal mode, and sustained idleness enters deep idle until another wakeup signal.">
-  <div className="docs-diagram-flow">
-    <div className="docs-diagram-card docs-diagram-card--primary">
+<div class="docs-diagram" role="img" aria-label="Adaptive polling modes: wakeup signal enters burst mode, idle polls settle into normal mode, and sustained idleness enters deep idle until another wakeup signal.">
+  <div class="docs-diagram-flow">
+    <div class="docs-diagram-card docs-diagram-card--primary">
       <strong>Wakeup signal</strong>
       <small>Local submission or `ClusterCoordinator.notifyNewWork()` tells the poller to check immediately.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Burst mode</strong>
       <small>500ms delay, aggressive polling, exits after idle threshold.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--muted">
+    <div class="docs-diagram-card docs-diagram-card--muted">
       <strong>Normal mode</strong>
       <small>2-30 second adaptive delay based on rolling job counts and load.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--store">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>Deep idle</strong>
       <small>60 second delay after 5+ idle minutes; exits immediately on wakeup.</small>
     </div>

--- a/website/docs/concepts/workflows.md
+++ b/website/docs/concepts/workflows.md
@@ -24,21 +24,21 @@ scheduler.enqueue(() -> validateOrder(orderId))
 
 When you call `.then()`, the engine creates multiple jobs linked by `depends_on`:
 
-<div className="docs-diagram" role="img" aria-label="Chain dependency flow: all steps are persisted immediately, but downstream steps stay hidden until the prior step succeeds.">
-  <div className="docs-diagram-flow">
-    <div className="docs-diagram-card docs-diagram-card--primary">
+<div class="docs-diagram" role="img" aria-label="Chain dependency flow: all steps are persisted immediately, but downstream steps stay hidden until the prior step succeeds.">
+  <div class="docs-diagram-flow">
+    <div class="docs-diagram-card docs-diagram-card--primary">
       <strong>`validateOrder`</strong>
       <small>`scheduled_time = now`; visible to the Poller first.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--muted">
+    <div class="docs-diagram-card docs-diagram-card--muted">
       <strong>`chargePayment`</strong>
       <small>`depends_on = validateOrder`; hidden with the sentinel scheduled time.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--muted">
+    <div class="docs-diagram-card docs-diagram-card--muted">
       <strong>`fulfillOrder`</strong>
       <small>`depends_on = chargePayment`; released only after payment succeeds.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--muted">
+    <div class="docs-diagram-card docs-diagram-card--muted">
       <strong>`sendConfirmation`</strong>
       <small>Final dependent step in the chain.</small>
     </div>

--- a/website/docs/deployment/clustering.md
+++ b/website/docs/deployment/clustering.md
@@ -10,36 +10,36 @@ Ratchet can run on multiple nodes against the same store. Ordinary job claiming 
 
 ## Architecture
 
-<div className="docs-diagram" role="img" aria-label="Ratchet multi-node deployment: every node runs a local poller and worker pool, and all nodes coordinate through the shared store using SKIP LOCKED, node heartbeats, and scheduler locks.">
-  <div className="docs-diagram-row">
-    <div className="docs-diagram-card docs-diagram-card--active">
+<div class="docs-diagram" role="img" aria-label="Ratchet multi-node deployment: every node runs a local poller and worker pool, and all nodes coordinate through the shared store using SKIP LOCKED, node heartbeats, and scheduler locks.">
+  <div class="docs-diagram-row">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Node A</strong>
       <small>Local poller and worker pool.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Node B</strong>
       <small>Claims a different subset of work.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--active">
+    <div class="docs-diagram-card docs-diagram-card--active">
       <strong>Node C</strong>
       <small>No master/coordinator node required.</small>
     </div>
   </div>
 
-  <div className="docs-diagram-connector">
+  <div class="docs-diagram-connector">
     <span>`SKIP LOCKED` prevents duplicate claims while keeping nodes non-blocking</span>
   </div>
 
-  <div className="docs-diagram-row">
-    <div className="docs-diagram-card docs-diagram-card--store">
+  <div class="docs-diagram-row">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>scheduler_job_queue</strong>
       <small>Live claim state for pending, running, paused, and waiting jobs.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--store">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>scheduler_node</strong>
       <small>Heartbeats and failure detection.</small>
     </div>
-    <div className="docs-diagram-card docs-diagram-card--store">
+    <div class="docs-diagram-card docs-diagram-card--store">
       <strong>scheduler_lock</strong>
       <small>Store-backed leases for singleton maintenance paths.</small>
     </div>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,6 +8,8 @@
       "name": "website",
       "version": "0.0.0",
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
+        "playwright": "^1.61.0",
         "shiki": "^4.2.0",
         "vitepress": "^1.6.0"
       },
@@ -271,6 +273,19 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -1653,6 +1668,16 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/birpc": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -2112,6 +2137,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.15",

--- a/website/package.json
+++ b/website/package.json
@@ -8,9 +8,12 @@
     "start": "vitepress dev docs",
     "build": "vitepress build docs",
     "preview": "vitepress preview docs",
-    "serve": "vitepress preview docs"
+    "serve": "vitepress preview docs",
+    "a11y": "node a11y/scan.mjs"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
+    "playwright": "^1.61.0",
     "shiki": "^4.2.0",
     "vitepress": "^1.6.0"
   },


### PR DESCRIPTION
## What

Adds an automated accessibility gate over the documentation site and fixes every WCAG 2 A/AA violation it surfaced.

`website/a11y/scan.mjs` builds the site, serves it, and runs axe-core over every page in **both the light and dark themes** (run locally with `npm run a11y`). A new `a11y` job in `ci.yml` runs it on any change under `website/` and is wired into the `CI required` gate, so a regression blocks the merge. Scanning both themes is the point: the home page was clean in light but the dark theme hid real failures.

## Fixes the first run found

- **Brand amber** (`--vp-c-brand-1`) was 4.4:1 for links and inline code in light mode — darkened to amber-800 (~6.2:1).
- **Syntax highlighting**: a few `github-light` and `dracula` tokens fell just under 4.5:1. The specific colours are remapped at build time in `config.ts`; the themes are otherwise unchanged.
- **Comparison matrix**: dark-mode headers and status labels were unreadable (a global table-header rule was bleeding in), and the horizontal scroll had no keyboard access. Status colours now clear AA against their real blended backgrounds in both themes, and the scroll region is focusable. The matrix's *Spring Boot starter* row now reads **Unplanned**.
- **Hero trust strip**: the `×` separator used the most muted text colour (~2.5:1); it now uses a legible colour and is `aria-hidden`.

## Scope notes

- Generated Javadoc is excluded from the scan (third-party HTML we don't author).
- One finding is allowlisted with a documented reason: VitePress's own sidebar renders a collapsible group title as a `role="button"` wrapping its link. It's an upstream component, and the allowlist entry is the only one.
- `incomplete` axe results (e.g. nav text composited over a transparent header) are reported for manual review but don't fail the build. The nav case was pixel-verified at 10–13:1.

A separate commit fixes a Docusaurus port leftover: several diagram blocks used `className` instead of `class`, so their styles never applied.