### PR TITLE
Add a Use Cases section to the docs site

### DIFF
--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -104,6 +104,7 @@ apply "website/docs/getting-started/introduction.md" "prose-status" \
 VERIFIED_TIP_FILES=(
   "website/docs/use-cases/durable-llm-workflows.md"
   "website/docs/use-cases/scheduled-recurring-jobs.md"
+  "website/docs/use-cases/offload-after-request.md"
 )
 for f in "${VERIFIED_TIP_FILES[@]}"; do
   apply "$f" "verified-tip" \

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -105,6 +105,7 @@ VERIFIED_TIP_FILES=(
   "website/docs/use-cases/durable-llm-workflows.md"
   "website/docs/use-cases/scheduled-recurring-jobs.md"
   "website/docs/use-cases/offload-after-request.md"
+  "website/docs/use-cases/resilient-integrations.md"
 )
 for f in "${VERIFIED_TIP_FILES[@]}"; do
   apply "$f" "verified-tip" \

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -106,6 +106,8 @@ VERIFIED_TIP_FILES=(
   "website/docs/use-cases/scheduled-recurring-jobs.md"
   "website/docs/use-cases/offload-after-request.md"
   "website/docs/use-cases/resilient-integrations.md"
+  "website/docs/use-cases/bulk-batch-jobs.md"
+  "website/docs/use-cases/human-in-the-loop.md"
 )
 for f in "${VERIFIED_TIP_FILES[@]}"; do
   apply "$f" "verified-tip" \

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -71,6 +71,8 @@ MAVEN_FILES=(
   "website/docs/deployment/overview.md"            # ratchet-bom
   "website/docs/deployment/mongodb.md"             # ratchet-store-mongodb
   "website/docs/deployment/monitoring.md"          # ratchet-micrometer
+  "website/docs/use-cases/durable-llm-workflows.md"   # ratchet + ratchet-store-postgresql
+  "website/docs/use-cases/scheduled-recurring-jobs.md" # (no deps today; future-proofed)
 )
 for f in "${MAVEN_FILES[@]}"; do
   apply "$f" "maven-version" \
@@ -95,6 +97,18 @@ apply "README.md" "prose-status" \
   's{(Ratchet is in \*\*)$ENV{VER_RE}(\*\*)}{$1$ENV{VERSION}$2}g'
 apply "website/docs/getting-started/introduction.md" "prose-status" \
   's{(Ratchet is currently at version \*\*)$ENV{VER_RE}(\*\*)}{$1$ENV{VERSION}$2}g'
+
+# 3b. Use-case "Verified" tip blocks: the inline prose `ratchet-api` `VER` claim.
+#     Anchored on the backtick-wrapped artifact name so other code-span numbers
+#     (langchain4j versions, Java 17) are untouched.
+VERIFIED_TIP_FILES=(
+  "website/docs/use-cases/durable-llm-workflows.md"
+  "website/docs/use-cases/scheduled-recurring-jobs.md"
+)
+for f in "${VERIFIED_TIP_FILES[@]}"; do
+  apply "$f" "verified-tip" \
+    's{(`ratchet-api` `)$ENV{VER_RE}(`)}{$1$ENV{VERSION}$2}g'
+done
 
 # 4. Bug-report template placeholder. Anchored on the trailing " or a commit SHA".
 apply ".github/ISSUE_TEMPLATE/bug_report.yml" "issue-placeholder" \

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -126,6 +126,7 @@ export default defineConfig({
         {
           text: 'Use cases',
           items: [
+            { text: 'Scheduled & recurring jobs', link: '/use-cases/scheduled-recurring-jobs' },
             { text: 'Durable LLM & agent workflows', link: '/use-cases/durable-llm-workflows' },
           ],
         },

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
 
     nav: [
       { text: 'Getting Started', link: '/getting-started/introduction' },
-      { text: 'Use cases', link: '/use-cases/durable-llm-workflows' },
+      { text: 'Use Cases', link: '/use-cases/durable-llm-workflows' },
       { text: 'Compare', link: '/comparison/overview' },
       { text: 'Concepts', link: '/concepts/overview' },
       { text: 'API Reference', link: '/api-reference/overview' },
@@ -124,10 +124,10 @@ export default defineConfig({
     sidebar: {
       '/use-cases/': [
         {
-          text: 'Use cases',
+          text: 'Use Cases',
           items: [
-            { text: 'Scheduled & recurring jobs', link: '/use-cases/scheduled-recurring-jobs' },
-            { text: 'Durable LLM & agent workflows', link: '/use-cases/durable-llm-workflows' },
+            { text: 'Scheduled & Recurring Jobs', link: '/use-cases/scheduled-recurring-jobs' },
+            { text: 'Durable LLM & Agent Workflows', link: '/use-cases/durable-llm-workflows' },
           ],
         },
       ],

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -126,6 +126,7 @@ export default defineConfig({
         {
           text: 'Use Cases',
           items: [
+            { text: 'Offload Work After a Request', link: '/use-cases/offload-after-request' },
             { text: 'Scheduled & Recurring Jobs', link: '/use-cases/scheduled-recurring-jobs' },
             { text: 'Durable LLM & Agent Workflows', link: '/use-cases/durable-llm-workflows' },
           ],

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -130,6 +130,8 @@ export default defineConfig({
             { text: 'Scheduled & Recurring Jobs', link: '/use-cases/scheduled-recurring-jobs' },
             { text: 'Resilient Third-Party Integrations', link: '/use-cases/resilient-integrations' },
             { text: 'Durable LLM & Agent Workflows', link: '/use-cases/durable-llm-workflows' },
+            { text: 'Bulk & Batch Jobs', link: '/use-cases/bulk-batch-jobs' },
+            { text: 'Human-in-the-Loop Jobs', link: '/use-cases/human-in-the-loop' },
           ],
         },
       ],

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
 
     nav: [
       { text: 'Getting Started', link: '/getting-started/introduction' },
+      { text: 'Use cases', link: '/use-cases/durable-llm-workflows' },
       { text: 'Compare', link: '/comparison/overview' },
       { text: 'Concepts', link: '/concepts/overview' },
       { text: 'API Reference', link: '/api-reference/overview' },
@@ -121,6 +122,14 @@ export default defineConfig({
     ],
 
     sidebar: {
+      '/use-cases/': [
+        {
+          text: 'Use cases',
+          items: [
+            { text: 'Durable LLM & agent workflows', link: '/use-cases/durable-llm-workflows' },
+          ],
+        },
+      ],
       '/getting-started/': [
         {
           text: 'Getting Started',

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -128,6 +128,7 @@ export default defineConfig({
           items: [
             { text: 'Offload Work After a Request', link: '/use-cases/offload-after-request' },
             { text: 'Scheduled & Recurring Jobs', link: '/use-cases/scheduled-recurring-jobs' },
+            { text: 'Resilient Third-Party Integrations', link: '/use-cases/resilient-integrations' },
             { text: 'Durable LLM & Agent Workflows', link: '/use-cases/durable-llm-workflows' },
           ],
         },

--- a/website/docs/.vitepress/theme/HomeUseCasesBand.vue
+++ b/website/docs/.vitepress/theme/HomeUseCasesBand.vue
@@ -1,0 +1,149 @@
+<script setup lang="ts">
+const useCases = [
+  {
+    title: 'Offload work after a request',
+    href: '/use-cases/offload-after-request',
+    description:
+      'Persist follow-up work in the same commit as your business write, then return the response right away.',
+    event: 'offload-after-request',
+  },
+  {
+    title: 'Scheduled & recurring jobs',
+    href: '/use-cases/scheduled-recurring-jobs',
+    description:
+      'Cron and delayed jobs that survive a restart and fire on exactly one node. The Quartz replacement.',
+    event: 'scheduled-recurring-jobs',
+  },
+  {
+    title: 'Resilient third-party integrations',
+    href: '/use-cases/resilient-integrations',
+    description:
+      'Retry flaky external APIs with backoff, and trip a circuit breaker when a provider goes down.',
+    event: 'resilient-integrations',
+  },
+  {
+    title: 'Durable LLM & agent workflows',
+    href: '/use-cases/durable-llm-workflows',
+    description:
+      'Run model calls and multi-step agents as persisted, retrying jobs. Bring your own model client.',
+    event: 'durable-llm-workflows',
+  },
+]
+</script>
+
+<template>
+  <section class="usecase-band">
+    <div class="usecase-inner">
+      <div class="usecase-head">
+        <p class="eyebrow">Use cases</p>
+        <h2>Patterns Ratchet is built for.</h2>
+      </div>
+      <div class="usecase-grid">
+        <a
+          v-for="u in useCases"
+          :key="u.title"
+          :href="u.href"
+          class="usecase-link"
+          data-umami-event="cta-click"
+          data-umami-event-location="use-cases-grid"
+          :data-umami-event-target="u.event"
+        >
+          <span>{{ u.title }}</span>
+          <small>{{ u.description }}</small>
+        </a>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.usecase-band {
+  border-top: 1px solid var(--vp-c-divider);
+}
+
+.usecase-inner {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 3rem 0;
+}
+
+.usecase-head {
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: #0f766e;
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.dark .eyebrow {
+  color: #5eead4;
+}
+
+.usecase-head h2 {
+  margin: 0;
+  font-size: 2rem;
+  letter-spacing: 0;
+  border-top: 0;
+  padding-top: 0;
+  line-height: 1.15;
+}
+
+.usecase-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.usecase-link {
+  display: block;
+  min-height: 9rem;
+  padding: 1rem;
+  color: inherit;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  text-decoration: none;
+  transition: border-color 0.2s;
+}
+
+.usecase-link:hover {
+  text-decoration: none;
+  border-color: var(--vp-c-brand-1);
+}
+
+.usecase-link span {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--vp-c-text-1);
+  font-weight: 700;
+}
+
+.usecase-link small {
+  display: block;
+  color: var(--vp-c-text-2);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+@media (max-width: 996px) {
+  .usecase-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .usecase-head h2 {
+    font-size: 1.5rem;
+  }
+  .usecase-grid {
+    grid-template-columns: 1fr;
+  }
+  .usecase-link {
+    min-height: auto;
+  }
+}
+</style>

--- a/website/docs/.vitepress/theme/HomeUseCasesBand.vue
+++ b/website/docs/.vitepress/theme/HomeUseCasesBand.vue
@@ -28,6 +28,20 @@ const useCases = [
       'Run model calls and multi-step agents as persisted, retrying jobs. Bring your own model client.',
     event: 'durable-llm-workflows',
   },
+  {
+    title: 'Bulk & batch jobs',
+    href: '/use-cases/bulk-batch-jobs',
+    description:
+      'Fan thousands of items out as one tracked batch with aggregate progress, then branch on the result.',
+    event: 'bulk-batch-jobs',
+  },
+  {
+    title: 'Human-in-the-loop jobs',
+    href: '/use-cases/human-in-the-loop',
+    description:
+      'Park a job until a person approves it, then resume right where it left off. No thread held while it waits.',
+    event: 'human-in-the-loop',
+  },
 ]
 </script>
 
@@ -94,7 +108,7 @@ const useCases = [
 
 .usecase-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.75rem;
 }
 

--- a/website/docs/.vitepress/theme/custom.css
+++ b/website/docs/.vitepress/theme/custom.css
@@ -347,6 +347,18 @@ html { color-scheme: light; }
   }
 }
 
+/* The footer renders in VitePress's full-bleed `layout-bottom` slot, but on
+   docs pages the sidebar is `position: fixed` and runs the full viewport
+   height, so it overlays the left edge of the footer when you scroll to the
+   bottom. Reserve the sidebar gutter so the footer columns clear it, matching
+   how VitePress offsets `.VPContent.has-sidebar`. The home page has no sidebar,
+   so `:has(.VPSidebar)` leaves it full-bleed there. */
+@media (min-width: 960px) {
+  .Layout:has(.VPSidebar) .ratchet-site-footer {
+    padding-left: var(--vp-sidebar-width);
+  }
+}
+
 /* ------------------------------------------------------------------ */
 /* Docs-page customisations — ported from src/css/custom.css            */
 /* ------------------------------------------------------------------ */

--- a/website/docs/.vitepress/theme/index.ts
+++ b/website/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import DefaultTheme from 'vitepress/theme'
 import HeroCode from './HeroCode.vue'
 import HeroInfoTop from './HeroInfoTop.vue'
 import HeroTrustStrip from './HeroTrustStrip.vue'
+import HomeUseCasesBand from './HomeUseCasesBand.vue'
 import HomeDocsBand from './HomeDocsBand.vue'
 import ComparisonMatrix from './ComparisonMatrix.vue'
 import SiteFooter from './SiteFooter.vue'
@@ -18,7 +19,7 @@ export default {
       'home-hero-info-before': () => h(HeroInfoTop),
       'home-hero-image': () => h(HeroCode),
       'home-hero-after': () => h(HeroTrustStrip),
-      'home-features-after': () => h(HomeDocsBand),
+      'home-features-after': () => [h(HomeUseCasesBand), h(HomeDocsBand)],
       'layout-bottom': () => h(SiteFooter),
       'nav-bar-content-after': () => h(AppearanceToggle),
     })

--- a/website/docs/advanced/custom-logging.md
+++ b/website/docs/advanced/custom-logging.md
@@ -39,7 +39,7 @@ Each job execution receives its own `JobLogger` instance, bound to that job's ID
 
 ## Reference pattern: JBoss Logging implementation
 
-The default `JBossLoggingJobLogger` bridges job logs to JBoss Logging (which auto-detects the runtime backend — JBoss LogManager, SLF4J, Log4j 2, or JDK JUL) and publishes each log line as an internal `JobLogLine` event. The event is delivered to programmatic listeners and CDI observers; database persistence is not automatic unless your application observes the event and calls `JobAuditStore.appendLog(...)` or installs an equivalent integration.
+The default `JBossLoggingJobLogger` bridges job logs to JBoss Logging (which auto-detects the runtime backend: JBoss LogManager, SLF4J, Log4j 2, or JDK JUL) and publishes each log line as an internal `JobLogLine` event. The event is delivered to programmatic listeners and CDI observers; database persistence is not automatic unless your application observes the event and calls `JobAuditStore.appendLog(...)` or installs an equivalent integration.
 
 ```java
 public class JBossLoggingJobLogger implements JobLogger {
@@ -357,12 +357,12 @@ Ratchet writes four MDC keys via `org.jboss.logging.MDC` during job execution:
 
 These names are part of the public observability surface. Adding new keys is non-breaking; renaming or removing one of these four is a breaking change.
 
-**Whether application MDC entries unify with Ratchet's depends on the backend:**
+Whether application MDC entries unify with Ratchet's depends on the backend:
 
-- **Logback backend**: Application code calling `org.slf4j.MDC.put(...)` and Ratchet calling `org.jboss.logging.MDC.put(...)` write to the *same* thread-local map. Both sets of keys appear together in `%X{...}` output and JSON encoders. This is the recommended configuration for unified MDC.
-- **JBoss LogManager backend (WildFly)**: Both APIs delegate to the LogManager's MDC. Keys unify in container log patterns.
-- **Log4j 2 backend**: JBoss Logging delegates to Log4j 2's `ThreadContext`. Application code using `org.slf4j.MDC` (via `log4j-slf4j2-impl`) shares the same context map.
-- **JDK `java.util.logging` fallback**: JBoss Logging stores keys in its own per-thread map; stock JUL formatters do not render them. If application code uses `org.slf4j.MDC` via the `slf4j-jdk14` binding, the two MDC maps are *separate* and do not unify. For unified MDC in non-EE deployments, place Logback on the classpath instead of relying on the JUL fallback.
+- **Logback:** Application code calling `org.slf4j.MDC.put(...)` and Ratchet calling `org.jboss.logging.MDC.put(...)` write to the *same* thread-local map. Both sets of keys appear together in `%X{...}` output and JSON encoders. This is the recommended configuration for unified MDC.
+- **JBoss LogManager (WildFly):** Both APIs delegate to the LogManager's MDC. Keys unify in container log patterns.
+- **Log4j 2:** JBoss Logging delegates to Log4j 2's `ThreadContext`. Application code using `org.slf4j.MDC` (via `log4j-slf4j2-impl`) shares the same context map.
+- **JDK `java.util.logging` fallback:** JBoss Logging stores keys in its own per-thread map; stock JUL formatters do not render them. If application code uses `org.slf4j.MDC` via the `slf4j-jdk14` binding, the two MDC maps are *separate* and do not unify. For unified MDC in non-EE deployments, place Logback on the classpath instead of relying on the JUL fallback.
 
 To override auto-detection, set `-Dorg.jboss.logging.provider=slf4j` (or `jboss`, `log4j2`, `jdk`) on the JVM command line.
 

--- a/website/docs/advanced/customization-platform.md
+++ b/website/docs/advanced/customization-platform.md
@@ -52,7 +52,7 @@ No string-based implementation class names are loaded by Ratchet. This keeps the
 
 ## Configuration model
 
-Applications must produce an `@ApplicationScoped RatchetOptions` bean — Ratchet refuses to start otherwise. See [Configuration](/getting-started/configuration) for the canonical patterns.
+Applications must produce an `@ApplicationScoped RatchetOptions` bean; Ratchet refuses to start otherwise. See [Configuration](/getting-started/configuration) for the canonical patterns.
 
 `RatchetConfigSource` is an advanced overlay: produce it only when your platform already owns raw configuration and you want a producer that calls `RatchetOptionsFactory.fromEnvironment(yourSource)` to fold that platform on top of the ambient `RATCHET_*` / MicroProfile Config chain.
 

--- a/website/docs/advanced/metrics-collection.md
+++ b/website/docs/advanced/metrics-collection.md
@@ -324,12 +324,20 @@ Use the metrics to set up alerts for common operational issues:
 | No jobs started in 15 minutes (when expected) | Critical: scheduler may be stalled |
 | `ratchet.jobs.failed` with a specific `family` tag spikes | Investigate the failing exception family |
 
-## Best Practices
+## Best practices
 
-**Use tags for dimensionality, not metric names.** Prefer `ratchet.jobs.started{type=SINGLE}` over `ratchet.single_jobs.started`. Tags enable flexible aggregation and filtering in dashboards.
+### Use tags, not metric names, for dimensionality
 
-**Keep exception tags bounded.** The Micrometer adapter classifies failures into the bounded `ExceptionFamily` enum (`TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, `UNKNOWN`) for the `family` tag, so its cardinality stays fixed. If a custom collector instead tags by the exception's class name and your application throws many dynamically-generated exception types, this could create high-cardinality metrics. Consider normalizing exception names in that case.
+Prefer `ratchet.jobs.started{type=SINGLE}` over `ratchet.single_jobs.started`. Tags allow flexible aggregation and filtering in dashboards without multiplying metric names.
 
-**Monitor attempt counts.** A spike in `attempt > 1` failures indicates that retries are being consumed. Pair this with retry policy metrics to understand whether jobs are eventually succeeding or exhausting retries.
+### Keep exception tags bounded
 
-**Set baselines before alerting.** Run Ratchet for a few days with metrics collection enabled to establish baseline throughput, failure rates, and execution times. Set alert thresholds relative to these baselines rather than using absolute values.
+The Micrometer adapter classifies failures into the `ExceptionFamily` enum (`TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, `UNKNOWN`) for the `family` tag, so cardinality stays fixed. A custom collector that tags by exception class name can produce high-cardinality metrics if your application throws many dynamically-generated exception types. Normalize exception names in that case.
+
+### Monitor attempt counts
+
+A spike in `attempt > 1` failures means retries are being consumed. Pair this with retry policy metrics to understand whether jobs are eventually succeeding or exhausting their retry budget.
+
+### Set baselines before alerting
+
+Run Ratchet for a few days with metrics collection enabled to establish baseline throughput, failure rates, and execution times. Set alert thresholds relative to those baselines rather than using fixed absolute values.

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -11,7 +11,7 @@ Ratchet is designed around a set of Service Provider Interfaces (SPIs) that deco
 This guide covers the CDI wiring pattern, the complete SPI inventory, and Ratchet conformance tiers.
 The TCK is split into four submodules: `ratchet-tck-store` (store SPI), `ratchet-tck-api`
 (public-API, container-free), `ratchet-tck-jakarta` (Jakarta-EE conformance via Arquillian), and
-`ratchet-tck-util` (shared JUnit helpers). Each earns a distinct compatibility label — see the
+`ratchet-tck-util` (shared JUnit helpers). Each earns a distinct compatibility label; see the
 [README's tiered-conformance section](https://github.com/ratchet-run/ratchet#custom-store-implementation)
 for the full matrix.
 
@@ -651,14 +651,14 @@ public interface JobStore
 }
 ```
 
-A store opts into an optional capability by additionally implementing its interface. Callers never assume a capability is present — they probe for it, and the engine disables the dependent feature when it is absent:
+A store opts into an optional capability by additionally implementing its interface. Callers never assume a capability is present; they probe for it, and the engine disables the dependent feature when it is absent:
 
 ```java
 jobStore.capability(SignalStore.class)
     .ifPresent(signals -> signals.deliverSignalByKey(key, payload));
 ```
 
-Ratchet ships MySQL, PostgreSQL, and MongoDB implementations, all of which advertise every capability. To implement a custom store (for example DynamoDB, Redis, or an in-memory test backend), implement the core `JobStore` — plus any optional capabilities your backend can support — and validate it against the TCK.
+Ratchet ships MySQL, PostgreSQL, and MongoDB implementations, all of which advertise every capability. To implement a custom store (for example DynamoDB, Redis, or an in-memory test backend), implement the core `JobStore`, plus any optional capabilities your backend can support, and validate it against the TCK.
 
 ### Core Store Interfaces (mandatory)
 

--- a/website/docs/api-reference/annotations.md
+++ b/website/docs/api-reference/annotations.md
@@ -48,7 +48,7 @@ Marks a method for cron-scheduled recurring execution. Annotated methods are aut
 | `timeoutSeconds` | `long` | `3600` | No | Maximum execution time in seconds (default: 1 hour). |
 | `tags` | `String[]` | `{}` | No | Tags for filtering and categorization. |
 
-### Cron Expression Format
+### Cron expression format
 
 Uses Quartz cron format with 6-7 fields:
 
@@ -64,7 +64,7 @@ second minute hour day-of-month month day-of-week [year]
 | `0 0 0 1 * ?` | First day of every month at midnight |
 | `0 30 8 ? * MON-FRI` | Weekdays at 8:30 AM |
 
-### Method Requirements
+### Method requirements
 
 - Must be `public`
 - Must have **no parameters** or a single [`JobContext`](./job-context) parameter
@@ -265,7 +265,7 @@ public interface ResilienceStrategy {
 
 Currently `@Incubating` SPIs include the scheduler extension contracts in `run.ratchet.spi`, including `RatchetConfigSource`, `JobInvocationResolver`, `ResultPersistenceStrategy`, `ExecutionTuningProvider`, `PollingStrategyProvider`, `JobLoggerFactory`, `ResilienceStrategy`, `ClassPolicy`, `ErrorSanitizer`, `ExecutorProvider`, `BeanResolver`, `MetricsCollector`, `JobLogger`, `ClusterCoordinator`, `StartupCoordinator`, and `NodeIdentityProvider`.
 
-## See Also
+## See also
 
 - [Job Options and Enums](./job-options)
 - [SPI Interfaces](./spi-interfaces)

--- a/website/docs/api-reference/batch-builder.md
+++ b/website/docs/api-reference/batch-builder.md
@@ -324,7 +324,7 @@ scheduler.<Long>streamingBatch("Process Stream")
     // ...
 ```
 
-### Workflow Methods
+### Workflow methods
 
 `StreamingBatchBuilder` supports the same workflow methods as `BatchBuilder`:
 
@@ -370,7 +370,7 @@ JobHandle handle = scheduler.<Long>streamingBatch("Full Migration")
 | Best for | Small-medium collections | Large datasets, database cursors |
 | Submit method | `submit()` | `start()` |
 
-## See Also
+## See also
 
 - [BatchContext Reference](./batch-context)
 - [WorkflowCondition Reference](./workflow-condition)

--- a/website/docs/api-reference/batch-context.md
+++ b/website/docs/api-reference/batch-context.md
@@ -26,7 +26,7 @@ public record BatchContext(
 )
 ```
 
-### Record Components
+### Record components
 
 | Component | Type | Description |
 |---|---|---|
@@ -35,7 +35,7 @@ public record BatchContext(
 | `completedItems` | `int` | Number of child jobs completed successfully |
 | `failedItems` | `int` | Number of child jobs that have failed |
 
-### Computed Methods
+### Computed methods
 
 #### isComplete
 
@@ -82,7 +82,7 @@ if (ctx.successRate() < 0.9) {
 }
 ```
 
-### Usage in Progress Hooks
+### Usage in progress hooks
 
 ```java
 scheduler.enqueueBatch("Process Orders")
@@ -102,7 +102,7 @@ scheduler.enqueueBatch("Process Orders")
     .submit();
 ```
 
-### Usage in Workflow Conditions
+### Usage in workflow conditions
 
 ```java
 public final class ImportBatchConditions {
@@ -145,7 +145,7 @@ public record StreamingBatchContext(
 )
 ```
 
-### Record Components
+### Record components
 
 | Component | Type | Description |
 |---|---|---|
@@ -203,7 +203,7 @@ scheduler.<Long>streamingBatch("Full Pipeline")
     .start();
 ```
 
-## See Also
+## See also
 
 - [BatchBuilder Reference](./batch-builder)
 - [WorkflowCondition Reference](./workflow-condition)

--- a/website/docs/api-reference/event-system.md
+++ b/website/docs/api-reference/event-system.md
@@ -8,9 +8,9 @@ description: Complete reference for job lifecycle events, batch events, chain ev
 
 Observing and reacting to job lifecycle events. Ratchet publishes events at every state transition. Use them for monitoring, alerting, and custom integrations.
 
-## Listening to Events
+## Listening to events
 
-### CDI Observers
+### CDI observers
 
 Use CDI `@Observes` for type-safe event handling:
 
@@ -34,7 +34,7 @@ public class JobMonitor {
 }
 ```
 
-### Programmatic Listeners
+### Programmatic listeners
 
 Register listeners via [`JobSchedulerService.addEventListener()`](./job-scheduler-service#addeventlistener):
 
@@ -49,7 +49,7 @@ scheduler.addEventListener(event -> {
 });
 ```
 
-## Event Base Class
+## Event base class
 
 All job lifecycle events extend `AbstractJobSchedulerEvent`:
 
@@ -73,7 +73,7 @@ public abstract class AbstractJobSchedulerEvent implements Serializable {
 | `getNodeId()` | `String` | Identifier of the cluster node that processed this job |
 | `getTimestamp()` | `Instant` | When this event was created |
 
-## Job Lifecycle Events
+## Job lifecycle events
 
 ### JobStartedEvent
 
@@ -283,7 +283,7 @@ public void onCallbackFailed(@Observes JobCallbackFailedEvent event) {
 }
 ```
 
-## Batch Events
+## Batch events
 
 ### BatchCompletingEvent
 
@@ -339,7 +339,7 @@ public void onBatchCompleted(@Observes BatchCompletedEvent event) {
 }
 ```
 
-## Chain Event Types {#chainevent-types}
+## Chain event types {#chainevent-types}
 
 ### ChainStartedEvent
 
@@ -383,7 +383,7 @@ public void onChainFailed(@Observes ChainFailedEvent event) {
 }
 ```
 
-## Workflow Events
+## Workflow events
 
 ### WorkflowBranchTriggeredEvent
 
@@ -403,7 +403,7 @@ public UUID getNextJobId()
 | `getBranchCondition()` | `String` | Description of the branch condition that matched |
 | `getNextJobId()` | `UUID` | Child job ID scheduled for the branch |
 
-## Signal Events
+## Signal events
 
 These events accompany the [signal-waiting job](./job-scheduler-service) lifecycle (`WAITING` status and `deliverSignal()`).
 
@@ -483,11 +483,11 @@ public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
 | `getSignalKey()` | `String` | Signal key the job was waiting on |
 | `getSignalTimeout()` | `Duration` | Configured maximum wait duration that elapsed (never null) |
 
-## System Metrics
+## System metrics
 
 Ratchet does not publish aggregate system-metrics through the event listener API. For per-job metrics (start, completion, failure, retry timings), implement the [`MetricsCollector`](./spi-interfaces#metricscollector) SPI and wire it to your monitoring backend (Micrometer, StatsD, Prometheus, etc.).
 
-## Example: Comprehensive Monitoring
+## Example: comprehensive monitoring
 
 ```java
 @ApplicationScoped
@@ -532,7 +532,7 @@ public class SchedulerMonitoring {
 }
 ```
 
-## See Also
+## See also
 
 - [JobSchedulerService Event Methods](./job-scheduler-service#event-listener-management)
 - [Job Lifecycle](/concepts/job-lifecycle)

--- a/website/docs/api-reference/functional-interfaces.md
+++ b/website/docs/api-reference/functional-interfaces.md
@@ -10,7 +10,7 @@ Ratchet defines six serializable functional interfaces for job tasks, callbacks,
 
 **Package:** `run.ratchet.api`
 
-## Why Serializable?
+## Why serializable?
 
 Ratchet persists job definitions in a database. When you write:
 
@@ -39,7 +39,7 @@ public interface SerializableCheckedRunnable extends Serializable {
 
 **Used in:** `JobSchedulerService.enqueue()`, `schedule()`, `enqueueNow()`, `JobBuilder.then()`, all workflow branch tasks.
 
-### Correct Usage
+### Correct usage
 
 ```java
 // Method reference
@@ -55,7 +55,7 @@ scheduler.enqueue(() -> myService.process(userId)).submit();
 scheduler.enqueue(() -> reportService.generate(userId, reportType, startDate)).submit();
 ```
 
-### Incorrect Usage
+### Incorrect usage
 
 ```java
 // WRONG -- multi-statement lambda
@@ -71,7 +71,7 @@ scheduler.enqueue(() -> {
 }).submit();  // throws IllegalArgumentException
 ```
 
-### Workaround for Complex Logic
+### Workaround for complex logic
 
 Wrap multi-step logic in a single method on a CDI bean:
 
@@ -92,7 +92,7 @@ public class UserWorkflow {
 scheduler.enqueue(() -> userWorkflow.processAndNotify(userId)).submit();
 ```
 
-### Exception Handling
+### Exception handling
 
 Exceptions thrown from `run()` are caught by the executor and trigger:
 1. Retry attempts based on job configuration
@@ -330,7 +330,7 @@ scheduler.<Long>streamingBatch("Migrate Users")
 | Checked exceptions | No | Yes |
 | Primary use | Callbacks, progress hooks | Streaming batch processing |
 
-## See Also
+## See also
 
 - [JobBuilder Reference](./job-builder)
 - [BatchBuilder Reference](./batch-builder)

--- a/website/docs/api-reference/job-builder.md
+++ b/website/docs/api-reference/job-builder.md
@@ -11,7 +11,7 @@ Fluent builder API for creating and configuring individual jobs. `JobBuilder` is
 **Package:** `run.ratchet.api`
 **Type:** Interface
 
-## Basic Usage
+## Basic usage
 
 ```java
 JobHandle handle = scheduler.enqueue(() -> orderService.process(orderId))
@@ -26,7 +26,7 @@ JobHandle handle = scheduler.enqueue(() -> orderService.process(orderId))
     .submit();
 ```
 
-## Configuration Methods
+## Configuration methods
 
 ### withPriority
 
@@ -298,7 +298,7 @@ scheduler.enqueue(() -> billingService.charge(cardToken))
 
 See the [Payload Encryption](../advanced/payload-encryption) guide for setup, engine choice, and key rotation.
 
-## Callback Methods
+## Callback methods
 
 ### onSuccess
 
@@ -336,7 +336,7 @@ scheduler.enqueue(() -> riskyService.execute())
     .submit();
 ```
 
-## Workflow Methods
+## Workflow methods
 
 ### then
 
@@ -538,7 +538,7 @@ JobHandle handle = scheduler.enqueue(() -> processData())
 log.info("Submitted job {}", handle.id());
 ```
 
-## Accessor Methods
+## Accessor methods
 
 These methods allow reading the configured state of a builder. They are primarily used internally by the scheduler but are part of the public interface.
 
@@ -553,7 +553,7 @@ These methods allow reading the configured state of a builder. They are primaril
 | `isImmediate()` | `boolean` | Whether immediate wakeup is requested |
 | `onSuccess()` | `SerializableConsumer<JobContext>` | Success callback, or null |
 
-## Example: Complete Configuration
+## Example: complete configuration
 
 ```java
 JobHandle handle = scheduler.enqueue(() -> paymentService.charge(orderId, amount))
@@ -582,7 +582,7 @@ JobHandle handle = scheduler.enqueue(() -> paymentService.charge(orderId, amount
     .submit();
 ```
 
-## See Also
+## See also
 
 - [JobSchedulerService Reference](./job-scheduler-service)
 - [JobOptions Reference](./job-options)

--- a/website/docs/api-reference/job-context.md
+++ b/website/docs/api-reference/job-context.md
@@ -25,7 +25,7 @@ void processOrder(long orderId) {
 }
 ```
 
-## Static Methods
+## Static methods
 
 ### current
 
@@ -127,7 +127,7 @@ try {
 }
 ```
 
-## Instance Methods
+## Instance methods
 
 ### jobId
 
@@ -240,7 +240,7 @@ For simple payloads delivered with `deliverSignal(jobId, payload)`, request the 
 String reviewer = JobContext.current().signalPayload(String.class);
 ```
 
-## Thread-Local Lifecycle
+## Thread-local lifecycle
 
 `JobContext` uses `ThreadLocal` storage. The lifecycle is:
 
@@ -254,7 +254,7 @@ Each thread has its own isolated context, preventing cross-contamination when mu
 `JobContext.current()` only works inside a Ratchet-managed job execution. Calling it from other threads, background tasks, or outside a job throws `IllegalStateException`.
 :::
 
-## Example: Multi-Step Job with Parameters
+## Example: multi-step job with parameters
 
 ```java
 @ApplicationScoped
@@ -296,7 +296,7 @@ scheduler.enqueue(() -> orderProcessor.processOrder(orderId))
     .submit();
 ```
 
-## Example: Unit Testing with JobContext
+## Example: unit testing with JobContext
 
 ```java
 @Test
@@ -316,7 +316,7 @@ void testJobUsesParameters() {
 }
 ```
 
-## See Also
+## See also
 
 - [JobBuilder Parameters](./job-builder#withparam)
 - [Signal-Waiting Jobs](./job-builder#awaitsignal)

--- a/website/docs/api-reference/job-result.md
+++ b/website/docs/api-reference/job-result.md
@@ -39,7 +39,7 @@ scheduler.enqueue(() -> analyzeData())
     .submit();
 ```
 
-## Factory Methods
+## Factory methods
 
 ### success
 
@@ -116,7 +116,7 @@ JobResult<String> result = JobResult.of(
     Map.of("recordsProcessed", 500));
 ```
 
-## Status Methods
+## Status methods
 
 ### isSuccess
 
@@ -174,7 +174,7 @@ if (result.hasError()) {
 }
 ```
 
-## Value Access
+## Value access
 
 ### getValue
 
@@ -221,7 +221,7 @@ if (cause instanceof TimeoutException) {
 }
 ```
 
-## Timing Methods
+## Timing methods
 
 ### getStartTime
 
@@ -275,7 +275,7 @@ long duration = result.getExecutionTimeMsOrZero();
 metrics.record("job.duration", duration);
 ```
 
-## Metadata Methods
+## Metadata methods
 
 ### getMetadata (map)
 
@@ -327,11 +327,11 @@ String status = result.getMetadata("status", "unknown");
 Double rate = result.getMetadata("successRate", 1.0);
 ```
 
-## Using in Workflow Conditions
+## Using in workflow conditions
 
 `JobResult` is the primary input for workflow branching decisions:
 
-### Success/Failure Branching
+### Success/failure branching
 
 ```java
 scheduler.enqueue(() -> processPayment(orderId))
@@ -340,7 +340,7 @@ scheduler.enqueue(() -> processPayment(orderId))
     .submit();
 ```
 
-### Value-Based Branching
+### Value-based branching
 
 ```java
 public final class StockConditions {
@@ -359,7 +359,7 @@ scheduler.enqueue(() -> inventoryService.checkStock(itemId))
     .submit();
 ```
 
-### Complex Condition Branching
+### Complex condition branching
 
 ```java
 public final class AnalysisConditions {
@@ -386,7 +386,7 @@ scheduler.enqueue(() -> analyzeData())
 
 `JobResult` implements `Serializable`. During serialization, non-serializable `Throwable` instances in the `exception` field are automatically converted to a safe `RuntimeException` that preserves the original class name, message, and stack trace. This is transparent -- in-memory access via `getException()` returns the original `Throwable`.
 
-## See Also
+## See also
 
 - [WorkflowCondition Reference](./workflow-condition)
 - [JobBuilder Workflow Methods](./job-builder#workflow-methods)

--- a/website/docs/api-reference/job-scheduler-service.md
+++ b/website/docs/api-reference/job-scheduler-service.md
@@ -16,7 +16,7 @@ JobSchedulerService scheduler;
 **Package:** `run.ratchet.api`
 **Type:** Interface
 
-## Scheduling Methods
+## Scheduling methods
 
 ### enqueue
 
@@ -114,7 +114,7 @@ scheduler.scheduleRecurring(
     .submit();
 ```
 
-## Batch Methods
+## Batch methods
 
 ### enqueueBatch
 
@@ -167,7 +167,7 @@ scheduler.<Long>streamingBatch("Migrate Users")
     .start();
 ```
 
-## Job Replacement
+## Job replacement
 
 ### replace
 
@@ -195,7 +195,7 @@ JobHandle replacement = scheduler.replace(
     JobOptions.defaults().withPriority(JobPriority.HIGH));
 ```
 
-## Job Control Methods
+## Job control methods
 
 ### cancelJob
 
@@ -292,7 +292,7 @@ if (retried) {
 }
 ```
 
-## Signal Delivery Methods
+## Signal delivery methods
 
 Signal-waiting jobs are created through [`JobBuilder.awaitSignal()`](./job-builder#awaitsignal). They remain in `WAITING` status until a matching signal is delivered, or until their signal timeout fails the job.
 
@@ -345,7 +345,7 @@ if (decision != null && decision.isRejected()) {
 }
 ```
 
-## Recurring Job Management
+## Recurring job management
 
 ### cancelRecurringJobsByTag
 
@@ -387,7 +387,7 @@ scheduler.scheduleRecurring("0 0 10 * * ?", ZoneId.of("UTC"),
     .submit();
 ```
 
-## Event Listener Management
+## Event listener management
 
 ### addEventListener
 
@@ -489,7 +489,7 @@ JobHandle submit()
 
 Finalizes configuration and submits the recurring job to the scheduler.
 
-## See Also
+## See also
 
 - [JobBuilder Reference](./job-builder)
 - [BatchBuilder Reference](./batch-builder)

--- a/website/docs/api-reference/overview.md
+++ b/website/docs/api-reference/overview.md
@@ -10,7 +10,7 @@ Ratchet's public API is organized into two packages: `run.ratchet.api` for the u
 
 ## Package Structure
 
-### `run.ratchet.api` — User-Facing API
+### `run.ratchet.api`: User-Facing API
 
 Classes and interfaces you use directly when scheduling jobs, building workflows, and observing events.
 
@@ -39,7 +39,7 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`JobType`](./job-options#jobtype) | Enum | Job categories: SINGLE, RECURRING, BATCH, CHAIN, WORKFLOW, SYSTEM |
 | [`CircuitBreakerProfile`](./annotations#circuitbreakerprotected) | Enum | Pre-configured circuit breaker profiles: DEFAULT, FAST, CRITICAL, EXTERNAL_API, CLAIM_PATH |
 
-### `run.ratchet.api` — Annotations
+### `run.ratchet.api`: Annotations
 
 | Annotation | Target | Purpose |
 |---|---|---|
@@ -48,7 +48,7 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`@DoNotRetry`](./annotations#donotretry) | Type | Marks exception classes that should never be retried |
 | [`@Incubating`](./annotations#incubating) | Any | Marks experimental APIs that may change without deprecation |
 
-### `run.ratchet.api` — Functional Interfaces
+### `run.ratchet.api`: Functional Interfaces
 
 | Interface | Signature | Purpose |
 |---|---|---|
@@ -59,7 +59,7 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`SerializablePredicate<T>`](./functional-interfaces#serializablepredicatet) | `boolean test(T t)` | Custom workflow conditions |
 | [`SerializableCheckedConsumer<T>`](./functional-interfaces#serializablecheckedconsumert) | `void accept(T t) throws Exception` | Streaming batch item processing |
 
-### `run.ratchet.api.event` — Event Types
+### `run.ratchet.api.event`: Event Types
 
 | Event | Fires When |
 |---|---|
@@ -81,7 +81,7 @@ Classes and interfaces you use directly when scheduling jobs, building workflows
 | [`ChainFailedEvent`](./event-system#chainevent-types) | Workflow chain fails |
 | [`WorkflowBranchTriggeredEvent`](./event-system#workflowbranchtriggeredevent) | A workflow condition matches |
 
-### `run.ratchet.spi` — Extension Points
+### `run.ratchet.spi`: Extension Points
 
 | Interface | Purpose |
 |---|---|

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -8,7 +8,7 @@ description: Extension points for customizing Ratchet behavior including retry, 
 
 Extension points for customizing Ratchet behavior. All SPI interfaces live in the `run.ratchet.spi` package. To provide a custom implementation, create a CDI bean annotated with `@Alternative @Priority(APPLICATION)`.
 
-## Registering an SPI Implementation
+## Registering an SPI implementation
 
 ```java
 @Alternative
@@ -278,7 +278,7 @@ See the [Payload Encryption](/advanced/payload-encryption) guide for setup and t
 
 ## KeyProvider
 
-Owns key storage, the active write key, lookup by id, and the rotation lifecycle. This is the seam a deployment replaces to back encryption with a static key, an environment variable, a JCA `KeyStore`, or an external key service such as AWS KMS, GCP KMS, or HashiCorp Vault. `currentKey()` answers "which key do I write with now?", and `keyById()` resolves a recorded key id; a provider must keep old keys resolvable until every row written under them has been rewritten or deleted. `SecretKeyProvider` in `ratchet-encryption` is a ready-made static-key implementation, and `WrappedKeyProvider` (in `run.ratchet.spi`) is a `KeyProvider` sub-interface, the seam an external key service implements for KMS-wrapped data keys.
+Owns key storage, the active write key, lookup by id, and the rotation lifecycle. Replace this seam to back encryption with a static key, an environment variable, a JCA `KeyStore`, or an external service such as AWS KMS, GCP KMS, or HashiCorp Vault. `currentKey()` answers "which key do I write with now?"; `keyById()` resolves a recorded key id. A provider must keep old keys resolvable until every row written under them has been rewritten or deleted. `SecretKeyProvider` in `ratchet-encryption` is a ready-made static-key implementation. `WrappedKeyProvider` (in `run.ratchet.spi`) is a sub-interface for KMS-wrapped data keys.
 
 ```java
 @Incubating
@@ -839,7 +839,7 @@ public class AsmLambdaAnalyzer implements LambdaAnalyzer {
 }
 ```
 
-## See Also
+## See also
 
 - [Annotations Reference](./annotations)
 - [Event System](./event-system)

--- a/website/docs/api-reference/workflow-condition.md
+++ b/website/docs/api-reference/workflow-condition.md
@@ -361,7 +361,7 @@ List<WorkflowBranch> branches = builder.workflowBranches();
 
 ## Predicate Serialization Contract
 
-Custom predicates (`CUSTOM`, `BATCH_CUSTOM`, `RESULT_VALUE`) are stored in the database as `JobPayload` JSON — the same Class/Method/Args format used for job task lambdas. The predicate is analyzed at **scheduling time** using ASM bytecode inspection and must resolve to a **single public method call**.
+Custom predicates (`CUSTOM`, `BATCH_CUSTOM`, `RESULT_VALUE`) are stored in the database as `JobPayload` JSON, using the same Class/Method/Args format as job task lambdas. The predicate is analyzed at **scheduling time** using ASM bytecode inspection and must resolve to a **single public method call**.
 
 ### Supported shapes
 

--- a/website/docs/concepts/batches.md
+++ b/website/docs/concepts/batches.md
@@ -163,7 +163,7 @@ scheduler.<User>streamingBatch("Process All Users")
 4. Streaming continues until the stream is exhausted
 5. Child jobs execute in parallel as they're created (no need to wait for streaming to finish)
 
-This means a million-row result set never needs to be held in memory -- it's processed in 100-item chunks.
+This means a million-row result set is never held in memory; it's processed in 100-item chunks.
 
 ### Streaming Progress
 

--- a/website/docs/concepts/clustering.md
+++ b/website/docs/concepts/clustering.md
@@ -46,7 +46,7 @@ Ratchet is designed to run on multiple nodes without additional coordination inf
   </div>
 </div>
 
-Each node runs its own Poller, claims its own subset of jobs, and executes them independently. No node is special -- there is no "master" or "coordinator" node. The database is the single source of truth.
+Each node runs its own Poller, claims its own subset of jobs, and executes them independently. No node is special: there is no "master" or "coordinator" node. The database is the single source of truth.
 
 ## How SKIP LOCKED Provides Cluster Safety
 
@@ -65,7 +65,7 @@ LIMIT 50;
 -- Node B gets a disjoint set of jobs
 ```
 
-SQL stores use `SKIP LOCKED`, and the MongoDB store uses atomic document updates. These are the foundation of Ratchet's multi-node execution -- no external coordination service is required for ordinary job claiming.
+SQL stores use `SKIP LOCKED`, and the MongoDB store uses atomic document updates. These are the foundation of Ratchet's multi-node execution; no external coordination service is required for ordinary job claiming.
 
 ## StartupCoordinator
 
@@ -105,7 +105,7 @@ public interface ClusterCoordinator extends AutoCloseable {
 
 ### Default: NoOpClusterCoordinator
 
-The default implementation does nothing -- wakeup notifications are only delivered locally. This is correct for single-node deployments and acceptable for multi-node deployments where sub-second latency isn't critical.
+The default implementation does nothing; wakeup notifications are only delivered locally. This is correct for single-node deployments and acceptable for multi-node deployments where sub-second latency isn't critical.
 
 With the no-op coordinator, jobs submitted on Node A will be picked up by Node B at the next natural poll cycle. The adaptive polling algorithm ensures this happens within seconds during active periods, or up to 60 seconds during deep idle.
 
@@ -153,7 +153,7 @@ public class InfinispanClusterCoordinator implements ClusterCoordinator {
 }
 ```
 
-The SPI is intentionally minimal -- `notifyNewWork`, `registerWakeupListener`, and `close` -- so it can be implemented over any pub/sub mechanism.
+The SPI is intentionally minimal (`notifyNewWork`, `registerWakeupListener`, and `close`), so it can be implemented over any pub/sub mechanism.
 
 ## Node Identity
 

--- a/website/docs/concepts/error-handling.md
+++ b/website/docs/concepts/error-handling.md
@@ -140,7 +140,7 @@ public class CustomErrorSanitizer implements ErrorSanitizer {
 
 ## Dead Letter Queue (DLQ)
 
-When a job permanently fails (exhausts retries, `@DoNotRetry`, or `RetryPolicy` rejects), it moves to the DLQ. The DLQ is not a separate table -- it's the set of jobs with `status = FAILED` and no remaining retries.
+When a job permanently fails (exhausts retries, `@DoNotRetry`, or `RetryPolicy` rejects), it moves to the DLQ. The DLQ is not a separate table; it's the set of jobs with `status = FAILED` and no remaining retries.
 
 ### What Happens on DLQ Entry
 
@@ -222,7 +222,7 @@ If the circuit breaker for `payment-gateway` is OPEN, jobs targeting `PaymentSer
 
 ## Timeout as Failure
 
-When a job exceeds its configured timeout, the worker thread is interrupted. The resulting `InterruptedException` flows through the normal failure pipeline -- `@DoNotRetry` check, `RetryPolicy` consultation, retry scheduling, or DLQ routing.
+When a job exceeds its configured timeout, the worker thread is interrupted. The resulting `InterruptedException` flows through the normal failure pipeline: `@DoNotRetry` check, `RetryPolicy` consultation, retry scheduling, or DLQ routing.
 
 ```java
 scheduler.enqueue(() -> longRunningService.process(data))

--- a/website/docs/concepts/execution-model.md
+++ b/website/docs/concepts/execution-model.md
@@ -189,7 +189,7 @@ The `ResilienceStrategy` SPI is consulted to check if the target service is avai
 
 **6. Resource Permit**
 
-If the job specifies a `resourceName`, the `ResourcePermitService` attempts to acquire a permit. If the resource is at capacity, the job is rescheduled with a configurable delay. This is not a failure -- no retry is consumed.
+If the job specifies a `resourceName`, the `ResourcePermitService` attempts to acquire a permit. If the resource is at capacity, the job is rescheduled with a configurable delay. This is not a failure; no retry is consumed.
 
 **7. Security Validation**
 
@@ -224,7 +224,7 @@ The executor checks `wasJobCanceledDuringExecution()` both before starting work 
 
 ## Transactions and Database Connections
 
-`JobTask.call()` does **not** run inside a transaction. This is a deliberate design decision -- holding a database connection for the entire duration of a potentially long-running job would exhaust connection pools.
+`JobTask.call()` does **not** run inside a transaction. This is deliberate: holding a database connection open for the entire duration of a long-running job would exhaust connection pools.
 
 Instead, each database operation (status update, retry scheduling, success marking) is a separate short transaction. The `@Transactional` annotation is on the individual service methods (`PostExecutionHandler`, `DeadLetterService`, etc.), not on `JobTask` itself.
 

--- a/website/docs/concepts/job-types.md
+++ b/website/docs/concepts/job-types.md
@@ -86,7 +86,7 @@ public class MaintenanceService {
 }
 ```
 
-At startup, the `RecurringJobProcessor` CDI bean scans for `@Recurring` methods, validates them, and registers them with the scheduler. The annotation's `id` (or auto-generated fully-qualified method name) serves as the business key, ensuring exactly one active master per annotation.
+At startup, the `RecurringJobProcessor` CDI bean scans for `@Recurring` methods, validates them, and registers them with the scheduler. The annotation's `id` (or auto-generated fully-qualified method name) is the business key, ensuring exactly one active master per annotation.
 
 ### Programmatic API
 

--- a/website/docs/concepts/overview.md
+++ b/website/docs/concepts/overview.md
@@ -298,7 +298,7 @@ Ratchet separates API contracts from implementation through Service Provider Int
 | `JobStore` | Persistence backend | MySQL / PostgreSQL / MongoDB modules |
 | `JobInvocationResolver` | Callback-to-method invocation resolution | ASM bytecode analysis |
 | `ResultPersistenceStrategy` | Job return-value persistence | JSON metadata with size cap |
-| `RatchetOptions` | Typed runtime options | Required CDI producer — see [Configuration](/getting-started/configuration) |
+| `RatchetOptions` | Typed runtime options | Required CDI producer; see [Configuration](/getting-started/configuration) |
 | `RetryPolicy` | Custom retry decisions | Passthrough (uses job config) |
 | `ClassPolicy` | Security allowlist | Empty package allowlist; startup fails fast until you provide one |
 | `MetricsCollector` | Observability hooks | No-op |

--- a/website/docs/concepts/persistence.md
+++ b/website/docs/concepts/persistence.md
@@ -214,7 +214,7 @@ Ratchet uses **RFC 9562 §5.7 UUIDv7** for primary keys. UUIDs are 128-bit value
 
 ### Properties
 
-- **Time-ordered:** The 48-bit timestamp prefix preserves B-tree locality — inserts cluster at the right edge, range scans by time work directly.
+- **Time-ordered:** The 48-bit timestamp prefix preserves B-tree locality: inserts cluster at the right edge, and range scans by time work directly.
 - **Monotonic within a millisecond:** `rand_a` is used as a per-ms counter; on overflow inside a single ms, generation busy-spins via `Thread.onSpinWait` until the wall clock advances (RFC 9562 §6.2 wait-for-tick). The timestamp is never advanced past wall-clock time.
 - **Coordination-free:** 62 bits of randomness in `rand_b` make collisions vanishingly unlikely without inter-node coordination.
 - **128-bit `java.util.UUID`:** Standard Java type, no special storage adapter on PostgreSQL (native `uuid`). MySQL stores as `BINARY(16)` and uses the MySQL store's `META-INF/orm-mysql.xml` mapping plus `UuidByteArrayConverter` so non-Hibernate JPA providers bind UUID fields as 16 bytes. MongoDB stores BSON UUID subtype 4 (`UuidRepresentation.STANDARD`).

--- a/website/docs/conformance/index.md
+++ b/website/docs/conformance/index.md
@@ -7,7 +7,7 @@ sidebar_label: TCK Conformance
 # TCK Conformance
 
 Ratchet defines three conformance tiers. Each tier is independently verifiable by third-party
-implementors — a store author does not need to satisfy Jakarta Runtime contracts to claim Store
+implementors. A store author does not need to satisfy Jakarta Runtime contracts to claim Store
 compatibility.
 
 ## Conformance Tiers
@@ -40,8 +40,8 @@ Results are published for all 15 server × database combinations (WildFly, WildF
 Open Liberty, GlassFish × MySQL, PostgreSQL, MongoDB) and regenerated after each successful CI run
 on `main`.
 
-- [API Conformance Matrix](./api/) — Tier 2 results across all runtimes
-- [Jakarta Runtime Conformance Matrix](./jakarta/) — Tier 3 results across all runtimes
+- [API Conformance Matrix](./api/) -- Tier 2 results across all runtimes
+- [Jakarta Runtime Conformance Matrix](./jakarta/) -- Tier 3 results across all runtimes
 
 ## Running Conformance Tests Locally
 

--- a/website/docs/deployment/cluster-configuration.md
+++ b/website/docs/deployment/cluster-configuration.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: Cluster Configuration
-description: Running Ratchet across multiple nodes — ClusterCoordinator, NodeIdentityProvider, recurring job deduplication, and distributed locking.
+description: Running Ratchet across multiple nodes: ClusterCoordinator, NodeIdentityProvider, recurring job deduplication, and distributed locking.
 ---
 
 # Cluster Configuration
@@ -12,11 +12,11 @@ Ratchet supports multi-node deployments where multiple application instances sha
 
 In a clustered Ratchet deployment:
 
-1. **Job claiming is safe by default** — The database handles concurrency via row-level locking (`SELECT ... FOR UPDATE SKIP LOCKED` on PostgreSQL, InnoDB row locks on MySQL, atomic updates on MongoDB). No additional configuration is needed for one-shot jobs.
+1. **Job claiming is safe by default.** The database handles concurrency via row-level locking (`SELECT ... FOR UPDATE SKIP LOCKED` on PostgreSQL, InnoDB row locks on MySQL, atomic updates on MongoDB). No additional configuration is needed for one-shot jobs.
 
-2. **Recurring execution and startup coordination are separate concerns** — runtime recurring execution uses `scheduler_lock` so only one node advances the recurring scheduler at a time, and destructive startup cleanup is gated by the built-in `StartupCoordinator`, which also uses store-backed leases.
+2. **Recurring execution and startup coordination are separate concerns.** Runtime recurring execution uses `scheduler_lock` so only one node advances the recurring scheduler at a time, and destructive startup cleanup is gated by the built-in `StartupCoordinator`, which also uses store-backed leases.
 
-3. **Node identity is tracked** — Each node registers itself in the `scheduler_node` table with a heartbeat. This enables distributed locking and stale-node detection.
+3. **Node identity is tracked.** Each node registers itself in the `scheduler_node` table with a heartbeat. This enables distributed locking and stale-node detection.
 
 ## Enabling cluster mode
 
@@ -85,7 +85,7 @@ If you do not provide a `ClusterCoordinator`, Ratchet still coordinates one-shot
 
 ### First-party coordinator modules
 
-You usually do not implement this SPI yourself. Ratchet ships four coordinator modules — PostgreSQL `LISTEN`/`NOTIFY`, JMS, Hazelcast, and Infinispan — that you enable by adding a dependency, with no `beans.xml` change. See [Cluster Coordinators](/deployment/cluster-coordinators) for setup, configuration, delivery guarantees, failure behavior, and metrics. The examples below show how to build a custom transport when none of the shipped modules fit.
+You usually do not implement this SPI yourself. Ratchet ships four coordinator modules (PostgreSQL `LISTEN`/`NOTIFY`, JMS, Hazelcast, and Infinispan) that you enable by adding a dependency, with no `beans.xml` change. See [Cluster Coordinators](/deployment/cluster-coordinators) for setup, configuration, delivery guarantees, failure behavior, and metrics. The examples below show how to build a custom transport when none of the shipped modules fit.
 
 ## StartupCoordinator
 
@@ -308,8 +308,8 @@ ORDER BY locked_at;
 
 ## See also
 
-- [Deployment Overview](/deployment/overview) — General deployment guidance
-- [Kubernetes Deployment](/deployment/kubernetes) — StatefulSet and pod configuration
-- [Performance Tuning](/deployment/performance-tuning) — Tuning polling and thread pools
-- [Clustering & Distributed Execution](/deployment/clustering) — Conceptual overview of clustering
-- [Monitoring & Observability](/deployment/monitoring) — Metrics and health checks
+- [Deployment Overview](/deployment/overview) -- General deployment guidance
+- [Kubernetes Deployment](/deployment/kubernetes) -- StatefulSet and pod configuration
+- [Performance Tuning](/deployment/performance-tuning) -- Tuning polling and thread pools
+- [Clustering & Distributed Execution](/deployment/clustering) -- Conceptual overview of clustering
+- [Monitoring & Observability](/deployment/monitoring) -- Metrics and health checks

--- a/website/docs/deployment/cluster-configuration.md
+++ b/website/docs/deployment/cluster-configuration.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 title: Cluster Configuration
-description: Running Ratchet across multiple nodes: ClusterCoordinator, NodeIdentityProvider, recurring job deduplication, and distributed locking.
+description: "Running Ratchet across multiple nodes: ClusterCoordinator, NodeIdentityProvider, recurring job deduplication, and distributed locking."
 ---
 
 # Cluster Configuration

--- a/website/docs/deployment/cluster-coordinators.md
+++ b/website/docs/deployment/cluster-coordinators.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 9
 title: Cluster Coordinators
-description: First-party push-based cross-node wakeup modules: delivery guarantees, configuration, failure behavior, metrics, and the polling fallback floor
+description: "First-party push-based cross-node wakeup modules: delivery guarantees, configuration, failure behavior, metrics, and the polling fallback floor"
 ---
 
 # Cluster Coordinators

--- a/website/docs/deployment/cluster-coordinators.md
+++ b/website/docs/deployment/cluster-coordinators.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 9
 title: Cluster Coordinators
-description: First-party push-based cross-node wakeup modules — delivery guarantees, configuration, failure behavior, metrics, and the polling fallback floor
+description: First-party push-based cross-node wakeup modules: delivery guarantees, configuration, failure behavior, metrics, and the polling fallback floor
 ---
 
 # Cluster Coordinators
@@ -15,8 +15,8 @@ Coordinators are a **latency optimization, never a correctness mechanism**.
 Claim correctness always comes from the store (`FOR UPDATE SKIP LOCKED` on SQL,
 the equivalent guarded find-and-modify on MongoDB). A coordinator only shortens
 the gap between "work submitted on node A" and "node B notices." If you can
-tolerate poll-interval latency for cross-node wakeups, you do not need one — see
-[When you need a coordinator](#when-you-need-a-coordinator).
+tolerate poll-interval latency for cross-node wakeups, you do not need one (see
+[When you need a coordinator](#when-you-need-a-coordinator)).
 
 ## When you need a coordinator
 
@@ -44,7 +44,7 @@ quickly). Normal and low-priority jobs wait for the next poll regardless.
 
 | Module | Transport | Best fit |
 | --- | --- | --- |
-| `ratchet-coordinator-postgresql` | PostgreSQL `LISTEN`/`NOTIFY` | A PostgreSQL-backed deployment — no extra infrastructure |
+| `ratchet-coordinator-postgresql` | PostgreSQL `LISTEN`/`NOTIFY` | A PostgreSQL-backed deployment (no extra infrastructure) |
 | `ratchet-coordinator-jms` | Jakarta Messaging topic | You already run a broker (ActiveMQ Artemis, IBM MQ, …) or want an EE-native transport |
 | `ratchet-coordinator-hazelcast` | Hazelcast `ITopic` | Payara (bundles Hazelcast), or any deployment already using Hazelcast |
 | `ratchet-coordinator-infinispan` | Infinispan / JGroups | WildFly, or a stack already running Infinispan + JGroups |
@@ -56,7 +56,7 @@ same delivery, self-suppression, failure, and metrics contracts described below.
 
 Pick the transport you already operate. If you have no preference, the
 PostgreSQL coordinator is the lowest-friction option for a PostgreSQL store: it
-needs no broker, no cache grid, and no extra ports — just the database you are
+needs no broker, no cache grid, and no extra ports: just the database you are
 already connected to.
 
 ## Enabling a coordinator
@@ -137,7 +137,7 @@ The publish path borrows short-lived connections from your configured
 | --- | --- | --- |
 | `connectionFactoryJndi` | `java:comp/DefaultJMSConnectionFactory` | Connection factory lookup name |
 | `topicJndi` | `java:comp/Ratchet/Wakeup` | Wakeup topic lookup name |
-| `cellId` | _(none)_ | Operator hygiene only — JMS cell isolation needs separate physical topics |
+| `cellId` | _(none)_ | Operator hygiene only; JMS cell isolation needs separate physical topics |
 | `brokerSideSelfFilter` | `true` | Add a JMS selector so the broker drops a node's own messages (receive-side filtering is always on regardless) |
 | `reconnectBackoffInitialMs` | `200` | Reconnect delay after the `ExceptionListener` fires; doubles per retry |
 | `reconnectBackoffMaxMs` | `30000` | Cap on the doubled reconnect delay |
@@ -186,7 +186,7 @@ execution-target label.
 
 The execution target is **informational only**. A receiving node wakes its
 poller unconditionally; the claim-side filter on each node then decides which
-pool actually drains. A wakeup never routes a job to a particular node — it only
+pool actually drains. A wakeup never routes a job to a particular node: it only
 prompts nodes to look.
 
 Publishing never blocks the scheduler and never throws into it. A transport
@@ -204,12 +204,12 @@ This is the guarantee that lets you treat coordinators as optional:
 
 Concretely, the scheduler behaves correctly in every degraded case:
 
-- **Push delivery fails** (broker down, channel error, connection lost) — the
-  hint is dropped; each node's adaptive poll loop still drains the queue at
+- **Push delivery fails** (broker down, channel error, connection lost): the
+  hint is dropped, and each node's adaptive poll loop still drains the queue at
   poll-interval latency.
-- **A node is not subscribed yet** (still starting, mid-reconnect) — it misses
+- **A node is not subscribed yet** (still starting, mid-reconnect): it misses
   hints during that window and falls back to polling until it re-subscribes.
-- **The coordinator is removed entirely** — the deployment reverts to the
+- **The coordinator is removed entirely**: the deployment reverts to the
   `NoOp` behavior with no correctness change, only higher wakeup latency.
 
 No coordinator implementation may break this contract. The `ClusterCoordinator`
@@ -239,7 +239,7 @@ depth.
   own cluster membership and reconnection; the coordinator does not.
 - **Back-pressure** is bounded. The listener dispatch pool has a fixed queue
   capacity and a discard-oldest policy, so a sustained wakeup storm drops the
-  oldest hints rather than exhausting memory — losing a hint only costs latency.
+  oldest hints rather than exhausting memory. Losing a hint only costs latency.
 - **Shutdown** is clean and idempotent. `close()` can be called twice safely,
   loop threads are interrupt-aware, and the coordinator waits up to
   `shutdownGraceMs` for threads and the dispatch pool to drain.
@@ -253,8 +253,8 @@ back to unmanaged threads.
 
 Coordinators emit two counters through the `MetricsCollector` SPI:
 
-- `clusterWakeupPublished(transport, outcome)` — one per publish attempt.
-- `clusterWakeupReceived(transport, outcome)` — one per inbound wakeup.
+- `clusterWakeupPublished(transport, outcome)` -- one per publish attempt.
+- `clusterWakeupReceived(transport, outcome)` -- one per inbound wakeup.
 
 The `transport` label is the coordinator kind: `postgresql`, `jms`,
 `infinispan`, or `hazelcast`. The `outcome` label is bounded:
@@ -264,8 +264,8 @@ The `transport` label is the coordinator kind: `postgresql`, `jms`,
 | Published | `success`, `failure` |
 | Received | `delivered`, `ignored_self`, `parse_failure`, `transport_failure`, `pre_registration_overflow`, `listener_failure` |
 
-Node identity, job ids, and workflow ids are deliberately **never** metric
-labels — they are unbounded and would blow up cardinality. Watch
+Node identity, job ids, and workflow ids are deliberately excluded from metric
+labels because they are unbounded and would blow up cardinality. Watch
 `ignored_self` to confirm self-suppression is working, and `transport_failure` /
 `failure` to spot a degraded transport (the scheduler keeps working through the
 polling floor while you investigate).
@@ -285,10 +285,10 @@ JNDI bindings per cell.
 
 ## See also
 
-- [Clustering](/deployment/clustering) — claim-based execution, heartbeats, and
+- [Clustering](/deployment/clustering) -- claim-based execution, heartbeats, and
   where wakeup notifications fit
-- [Cluster Configuration](/deployment/cluster-configuration) — node identity,
+- [Cluster Configuration](/deployment/cluster-configuration) -- node identity,
   distributed locks, and Kubernetes patterns
-- [Monitoring](/deployment/monitoring) — wiring up the `MetricsCollector`
-- [Clustering concepts](/concepts/clustering) — the `ClusterCoordinator` SPI and
+- [Monitoring](/deployment/monitoring) -- wiring up the `MetricsCollector`
+- [Clustering concepts](/concepts/clustering) -- the `ClusterCoordinator` SPI and
   how to implement a custom transport

--- a/website/docs/deployment/clustering.md
+++ b/website/docs/deployment/clustering.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 title: Clustering
-description: Running Ratchet across multiple nodes — claim-based execution, node heartbeats, wakeup coordination, and failure detection
+description: Running Ratchet across multiple nodes: claim-based execution, node heartbeats, wakeup coordination, and failure detection
 ---
 
 # Clustering
@@ -46,7 +46,7 @@ Ratchet can run on multiple nodes against the same store. Ordinary job claiming 
   </div>
 </div>
 
-Every node runs its own poller and workers. For ordinary job claiming, no node is special — the database is the single source of truth.
+Every node runs its own poller and workers. For ordinary job claiming, no node is special: the database is the single source of truth.
 
 ## How Job Claiming Works
 
@@ -66,7 +66,7 @@ LIMIT :batchSize;
 - **`FOR UPDATE`** locks the selected rows
 - **`SKIP LOCKED`** skips rows already locked by another node's in-flight claim
 
-This means each node gets a disjoint set of jobs — no duplicate execution, no distributed lock manager, no coordination protocol. The database handles it.
+This means each node gets a disjoint set of jobs with no duplicate execution and no distributed lock manager needed. The database handles it.
 
 ### Optimized Claiming
 
@@ -116,7 +116,7 @@ List<NodeEntity> dead = nodeStore.findInactiveNodesSince(
 nodeStore.deleteInactiveNodesSince(cutoff);
 ```
 
-Jobs that were claimed by a dead node (status `RUNNING`, `picked_by` set to the dead node) can be reclaimed after the timeout expires — the poller will pick them up on the next cycle.
+Jobs that were claimed by a dead node (status `RUNNING`, `picked_by` set to the dead node) can be reclaimed after the timeout expires. The poller will pick them up on the next cycle.
 
 ### Clock Skew
 
@@ -157,9 +157,9 @@ Out of the box, Ratchet uses `NoOpClusterCoordinator`. That is fine for any depl
 
 ### First-party coordinator modules
 
-To enable push-based wakeups, add one of the first-party coordinator modules — PostgreSQL `LISTEN`/`NOTIFY`, JMS, Hazelcast, or Infinispan/JGroups. They are opt-in by dependency (no `beans.xml` change) and share a common delivery, self-suppression, failure, and metrics contract. See [Cluster Coordinators](/deployment/cluster-coordinators) for setup, configuration, delivery guarantees, and the polling fallback floor.
+To enable push-based wakeups, add one of the first-party coordinator modules: PostgreSQL `LISTEN`/`NOTIFY`, JMS, Hazelcast, or Infinispan/JGroups. They are opt-in by dependency (no `beans.xml` change) and share a common delivery, self-suppression, failure, and metrics contract. See [Cluster Coordinators](/deployment/cluster-coordinators) for setup, configuration, delivery guarantees, and the polling fallback floor.
 
-To build your own transport instead, implement the `ClusterCoordinator` SPI — see [Clustering concepts](/concepts/clustering).
+To build your own transport instead, implement the `ClusterCoordinator` SPI. See [Clustering concepts](/concepts/clustering).
 
 ## Priority Boosting
 
@@ -176,7 +176,7 @@ The `scheduler_lock` table provides advisory locks for operations that must be c
 | `lock_name` | Unique lock identifier |
 | `owner_node` | Node that holds the lock |
 | `locked_at` | When the lock was acquired |
-| `expires_at` | TTL — lock auto-expires for crash safety |
+| `expires_at` | TTL; lock auto-expires for crash safety |
 
 For MongoDB, the lock collection uses a TTL index on `expires_at`, so expired locks are garbage-collected automatically.
 
@@ -191,8 +191,8 @@ For MongoDB, the lock collection uses a TTL index on `expires_at`, so expired lo
 
 The key tradeoff: shorter poll intervals mean lower latency but more database load. `ClusterCoordinator` lets you keep a longer default interval while still responding immediately to urgent work.
 
-## See Also
+## See also
 
-- [Cluster Configuration](./cluster-configuration.md) — Tuning poll intervals, thread pools, and batch sizes
-- [Performance Tuning](./performance-tuning.md) — Database indexing and query optimization
-- [Concepts: Clustering](../concepts/clustering.md) — Architectural deep-dive into the clustering model
+- [Cluster Configuration](./cluster-configuration.md) -- Tuning poll intervals, thread pools, and batch sizes
+- [Performance Tuning](./performance-tuning.md) -- Database indexing and query optimization
+- [Concepts: Clustering](../concepts/clustering.md) -- Architectural deep-dive into the clustering model

--- a/website/docs/deployment/clustering.md
+++ b/website/docs/deployment/clustering.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 title: Clustering
-description: Running Ratchet across multiple nodes: claim-based execution, node heartbeats, wakeup coordination, and failure detection
+description: "Running Ratchet across multiple nodes: claim-based execution, node heartbeats, wakeup coordination, and failure detection"
 ---
 
 # Clustering

--- a/website/docs/deployment/configuration.md
+++ b/website/docs/deployment/configuration.md
@@ -8,7 +8,7 @@ Tuning Ratchet for your deployment.
 
 Ratchet's Jakarta EE configuration model is CDI-first:
 
-- Produce exactly one `@ApplicationScoped RatchetOptions` bean — **required**. If absent, CDI fails deployment with `UnsatisfiedResolutionException` and the scheduler never starts.
+- Produce exactly one `@ApplicationScoped RatchetOptions` bean (**required**). If absent, CDI fails deployment with `UnsatisfiedResolutionException` and the scheduler never starts.
 - Produce store resources, such as `EntityManager`, `MongoDatabase`, and managed executors, as normal CDI resources.
 - Replace behavioral extension points with CDI `@Alternative` beans.
 
@@ -91,7 +91,7 @@ public class OrdersRatchetEntityManagerProvider implements RatchetEntityManagerP
 
 A job picks its pool with `.virtual()` or `.platform()` on the builder; calling neither inherits `default-threading-mode`. The label selects a configured executor, not a guaranteed thread type. Set `ratchet.worker.virtual-executor-jndi` to a second managed executor to enable the virtual pool. When it is unset, a `.virtual()` job runs on platform instead, recorded with a one-time log warning and the `ratchet.execution.target.fallback` metric. The metric increments for each affected job occurrence; the warning is emitted once per distinct requested target.
 
-Whether the virtual pool's threads are actually virtual is the container's decision. Pointing `virtual-executor-jndi` at an `@ManagedExecutorDefinition(virtual = true)` is a request the runtime may ignore: GlassFish 8 honors it, while WildFly 40 binds the executor but still runs jobs on platform threads. Jakarta exposes no API to check this at runtime, so Ratchet can neither warn about it nor guarantee it — confirm against your container's documentation.
+Whether the virtual pool's threads are actually virtual is the container's decision. Pointing `virtual-executor-jndi` at an `@ManagedExecutorDefinition(virtual = true)` is a request the runtime may ignore: GlassFish 8 honors it, while WildFly 40 binds the executor but still runs jobs on platform threads. Jakarta exposes no API to check this at runtime, so Ratchet can neither warn about it nor guarantee it. Confirm against your container's documentation.
 
 `ratchet.worker.use-virtual-threads` was removed. It only switched backpressure accounting and never selected an executor; a stale value is ignored with a startup warning. Use `default-threading-mode` and `virtual-executor-jndi` instead.
 
@@ -151,7 +151,7 @@ Security and behavior extension points are CDI beans, not class names in propert
 | `ExecutorProvider` | Jakarta Concurrency managed executors | Custom managed executors or standalone tests |
 | `ResilienceStrategy` | Built-in circuit breaker | External resilience library |
 
-## See Also
+## See also
 
 - [Getting Started configuration](/getting-started/configuration)
 - [Installation](/deployment/installation)

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -1,14 +1,14 @@
 ---
 sidebar_position: 4
 title: Database Setup
-description: Setting up MySQL, PostgreSQL, or MongoDB for Ratchet — schema application, DataSource configuration, and connection pooling.
+description: Setting up MySQL, PostgreSQL, or MongoDB for Ratchet: schema application, DataSource configuration, and connection pooling.
 ---
 
 # Database Setup
 
 Ratchet requires a database to persist jobs, execution history, and scheduling metadata. This guide covers setup for all three supported stores.
 
-SQL stores ship DDL as plain SQL files bundled inside each SQL store module JAR. There is no Flyway or Liquibase dependency — you apply the schema using whatever mechanism your team prefers, **or** opt in to Ratchet's built-in startup migrator (see [Auto-migration](#auto-migration) below). MongoDB initializes collections and indexes at startup unconditionally — its named indexes are referenced by claim queries, so initialization is correctness-critical, not optional.
+SQL stores ship DDL as plain SQL files bundled inside each SQL store module JAR. There is no Flyway or Liquibase dependency: apply the schema using whatever mechanism your team prefers, **or** opt in to Ratchet's built-in startup migrator (see [Auto-migration](#auto-migration) below). MongoDB initializes collections and indexes at startup unconditionally; its named indexes are referenced by claim queries, so initialization is correctness-critical, not optional.
 
 ## PostgreSQL
 
@@ -246,7 +246,7 @@ db.createUser({
 
 ### Initialize Collections and Indexes
 
-MongoDB does not require a DDL file — the store module creates collections and indexes automatically on startup. However, you can pre-create the same collections and indexes for faster initial startup:
+MongoDB does not require a DDL file; the store module creates collections and indexes automatically on startup. You can pre-create the same collections and indexes for faster initial startup:
 
 ```javascript
 // mongosh
@@ -351,7 +351,7 @@ max_connections = 200
 
 ## Schema Upgrades
 
-Ratchet uses `CREATE TABLE IF NOT EXISTS` in its DDL on both MySQL and PostgreSQL. On PostgreSQL it also uses `CREATE INDEX IF NOT EXISTS`; on MySQL indexes are declared inline within `CREATE TABLE IF NOT EXISTS` (MySQL has no partial indexes), so MySQL re-run safety relies on `CREATE TABLE IF NOT EXISTS` across the 18 tables. This means you can safely re-run the schema file against an existing database — it will create any missing tables or indexes without modifying existing ones.
+Ratchet uses `CREATE TABLE IF NOT EXISTS` in its DDL on both MySQL and PostgreSQL. On PostgreSQL it also uses `CREATE INDEX IF NOT EXISTS`; on MySQL indexes are declared inline within `CREATE TABLE IF NOT EXISTS` (MySQL has no partial indexes), so MySQL re-run safety relies on `CREATE TABLE IF NOT EXISTS` across the 18 tables. This means you can safely re-run the schema file against an existing database, and it will create any missing tables or indexes without modifying existing ones.
 
 For schema changes between Ratchet versions:
 
@@ -378,7 +378,7 @@ Or via configuration:
 ratchet.schema.auto-migrate=true
 ```
 
-When enabled, `SchemaMigrationLifecycleHook` runs during scheduler startup (before the poller is initialized), acquires an advisory lock (`GET_LOCK` on MySQL, `pg_advisory_lock` on PostgreSQL), records each applied script in `ratchet_schema_version`, and verifies SHA-256 checksums on subsequent runs. Concurrent startups converge — exactly one node applies migrations while the others wait on the lock.
+When enabled, `SchemaMigrationLifecycleHook` runs during scheduler startup (before the poller is initialized), acquires an advisory lock (`GET_LOCK` on MySQL, `pg_advisory_lock` on PostgreSQL), records each applied script in `ratchet_schema_version`, and verifies SHA-256 checksums on subsequent runs. Concurrent startups converge: exactly one node applies migrations while the others wait on the lock.
 
 ### DataSource binding
 
@@ -413,15 +413,15 @@ The dialect is auto-detected from `DatabaseMetaData.getDatabaseProductName()`. L
 
 ### Enabling auto-migrate on a database that already has the schema
 
-The bundled migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), so `auto-migrate=true` is safe to enable against a database whose `scheduler_*` tables already exist — for example, one provisioned directly from the consolidated `*-schema.sql`. On the first run the migrator re-applies each script as a no-op and records it in `ratchet_schema_version`; every subsequent run skips by checksum. If you would rather manage the schema entirely through external tooling, keep `auto-migrate=false`.
+The bundled migrations are idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), so `auto-migrate=true` is safe to enable against a database whose `scheduler_*` tables already exist (for example, one provisioned directly from the consolidated `*-schema.sql`). On the first run the migrator re-applies each script as a no-op and records it in `ratchet_schema_version`; every subsequent run skips by checksum. If you would rather manage the schema entirely through external tooling, keep `auto-migrate=false`.
 
 ### `CREATE INDEX CONCURRENTLY`
 
-PostgreSQL rejects `CREATE INDEX CONCURRENTLY` inside a transaction block, and the auto-migrator wraps each script in a JDBC transaction. The bundled migrations therefore use plain `CREATE INDEX`. Operators who need to avoid the brief table lock during a large-table reindex can apply the migration script manually with `CONCURRENTLY` before flipping `auto-migrate=true` — `ratchet_schema_version` records the version regardless of how the DDL ran.
+PostgreSQL rejects `CREATE INDEX CONCURRENTLY` inside a transaction block, and the auto-migrator wraps each script in a JDBC transaction. The bundled migrations therefore use plain `CREATE INDEX`. Operators who need to avoid the brief table lock during a large-table reindex can apply the migration script manually with `CONCURRENTLY` before flipping `auto-migrate=true`; `ratchet_schema_version` records the version regardless of how the DDL ran.
 
 ### MongoDB
 
-MongoDB does not participate in `auto-migrate` — its collections and named indexes are created unconditionally during store startup. The `auto-migrate` flag is JDBC-only by contract.
+MongoDB does not participate in `auto-migrate`; its collections and named indexes are created unconditionally during store startup. The `auto-migrate` flag is JDBC-only by contract.
 
 ## Backup Strategy
 
@@ -459,7 +459,7 @@ For all databases, schedule regular backups and test restoration periodically. I
 
 ## See Also
 
-- [PostgreSQL Deployment](/deployment/postgresql) — PostgreSQL-specific tuning and monitoring
-- [MySQL Deployment](/deployment/mysql) — MySQL-specific tuning and monitoring
-- [Configuration](/deployment/configuration) — Full configuration reference
-- [Deployment Overview](/deployment/overview) — General deployment guidance
+- [PostgreSQL Deployment](/deployment/postgresql) -- PostgreSQL-specific tuning and monitoring
+- [MySQL Deployment](/deployment/mysql) -- MySQL-specific tuning and monitoring
+- [Configuration](/deployment/configuration) -- Full configuration reference
+- [Deployment Overview](/deployment/overview) -- General deployment guidance

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: Database Setup
-description: Setting up MySQL, PostgreSQL, or MongoDB for Ratchet: schema application, DataSource configuration, and connection pooling.
+description: "Setting up MySQL, PostgreSQL, or MongoDB for Ratchet: schema application, DataSource configuration, and connection pooling."
 ---
 
 # Database Setup

--- a/website/docs/deployment/docker.md
+++ b/website/docs/deployment/docker.md
@@ -390,7 +390,7 @@ docker compose exec postgres psql -U ratchet -c "\dt scheduler_*"
 
 ## See also
 
-- [Kubernetes Deployment](/deployment/kubernetes) — Orchestrated container deployments
-- [Database Setup](/deployment/database-setup) — Schema application details
-- [Configuration](/deployment/configuration) — All Ratchet configuration properties
-- [Cluster Configuration](/deployment/cluster-configuration) — Multi-node coordination
+- [Kubernetes Deployment](/deployment/kubernetes) -- Orchestrated container deployments
+- [Database Setup](/deployment/database-setup) -- Schema application details
+- [Configuration](/deployment/configuration) -- All Ratchet configuration properties
+- [Cluster Configuration](/deployment/cluster-configuration) -- Multi-node coordination

--- a/website/docs/deployment/installation.md
+++ b/website/docs/deployment/installation.md
@@ -140,7 +140,7 @@ public class MyService {
 
 ## Step 5: Configuration (required)
 
-Produce a single `@ApplicationScoped RatchetOptions` bean — the scheduler refuses to start without it. The smallest viable producer reads `RATCHET_*` environment variables and MicroProfile Config:
+Produce a single `@ApplicationScoped RatchetOptions` bean; the scheduler refuses to start without it. The smallest viable producer reads `RATCHET_*` environment variables and MicroProfile Config:
 
 ```java
 @ApplicationScoped

--- a/website/docs/deployment/kubernetes.md
+++ b/website/docs/deployment/kubernetes.md
@@ -461,7 +461,7 @@ spec:
 
 ## See also
 
-- [Docker Deployment](/deployment/docker) — Building container images
-- [Cluster Configuration](/deployment/cluster-configuration) — ClusterCoordinator and node identity
-- [Performance Tuning](/deployment/performance-tuning) — Tuning for high throughput
-- [Configuration](/deployment/configuration) — Full configuration reference
+- [Docker Deployment](/deployment/docker) -- Building container images
+- [Cluster Configuration](/deployment/cluster-configuration) -- ClusterCoordinator and node identity
+- [Performance Tuning](/deployment/performance-tuning) -- Tuning for high throughput
+- [Configuration](/deployment/configuration) -- Full configuration reference

--- a/website/docs/deployment/mongodb.md
+++ b/website/docs/deployment/mongodb.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 title: MongoDB
-description: Setting up the MongoDB store: collections, indexes, configuration, and migration from SQL stores
+description: "Setting up the MongoDB store: collections, indexes, configuration, and migration from SQL stores"
 ---
 
 # MongoDB Deployment

--- a/website/docs/deployment/mongodb.md
+++ b/website/docs/deployment/mongodb.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 title: MongoDB
-description: Setting up the MongoDB store — collections, indexes, configuration, and migration from SQL stores
+description: Setting up the MongoDB store: collections, indexes, configuration, and migration from SQL stores
 ---
 
 # MongoDB Deployment
@@ -28,7 +28,7 @@ availability.
 </dependency>
 ```
 
-This pulls in the MongoDB sync driver. No ODM (Morphia, Spring Data) is required — the store uses the driver directly.
+This pulls in the MongoDB sync driver. No ODM (Morphia, Spring Data) is required; the store uses the driver directly.
 
 ## Collection Setup
 
@@ -40,12 +40,12 @@ operation is idempotent and safe to run on every boot.
 
 | Collection | Purpose |
 |-----------|---------|
-| `scheduler_job` | Main job store — status, payload, scheduling, priority |
+| `scheduler_job` | Main job store: status, payload, scheduling, priority |
 | `scheduler_recurring_job` | Recurring job master records (cron/interval definitions) |
 | `scheduler_recurring_job_archive` | Archived recurring job definitions |
 | `scheduler_batch` | Batch parent records and progress state |
 | `scheduler_batch_metrics` | Batch-level runtime metrics |
-| `scheduler_job_execution` | Execution history — start/end times, node, outcome |
+| `scheduler_job_execution` | Execution history: start/end times, node, outcome |
 | `scheduler_job_log` | Optional per-job log storage if your application persists `JobLogLine` events |
 | `scheduler_job_archive` | Archived completed/failed jobs |
 | `scheduler_lock` | Distributed advisory locks with TTL |
@@ -65,8 +65,8 @@ The initializer creates these indexes for query performance:
 |-------|--------|-------|
 | `idx_job_claim_exec` | `status`, `job_type`, `priority` DESC, `scheduled_time`, `_id` | Executable claim candidate filtering |
 | `idx_job_poll_composite` | `status`, `priority` DESC, `scheduled_time` | General due-job lookup |
-| `idx_job_idempotency_key` | `idempotency_key` | **Unique** — global dedup |
-| `idx_job_active_business_key` | `business_key` | **Unique partial** — only for PENDING/RUNNING/PAUSED/WAITING |
+| `idx_job_idempotency_key` | `idempotency_key` | **Unique** (global dedup) |
+| `idx_job_active_business_key` | `business_key` | **Unique partial** (PENDING/RUNNING/PAUSED/WAITING only) |
 | `idx_job_tags` | `tags` | Multikey index for tag-based queries |
 | `idx_job_picked_by` | `picked_by` | Find jobs claimed by a specific node |
 
@@ -74,7 +74,7 @@ The initializer creates these indexes for query performance:
 
 | Index | Fields | Notes |
 |-------|--------|-------|
-| `idx_lock_ttl` | `expires_at` | **TTL index** — MongoDB auto-deletes expired locks |
+| `idx_lock_ttl` | `expires_at` | **TTL index** (MongoDB auto-deletes expired locks) |
 
 ### scheduler_job_execution
 
@@ -96,7 +96,7 @@ db.scheduler_job.findOneAndUpdate(
 )
 ```
 
-This provides the same guarantee — no two nodes claim the same job — through MongoDB's document-level write lock rather than row-level `SKIP LOCKED`.
+This gives the same guarantee (no two nodes claim the same job) through MongoDB's document-level write lock rather than row-level `SKIP LOCKED`.
 
 ### UUIDv7 Identifiers
 
@@ -104,7 +104,7 @@ Ratchet uses the same RFC 9562 §5.7 UUIDv7 identifiers on MongoDB as it does fo
 
 ### Tags
 
-In SQL stores, tags use a separate `scheduler_job_tag` join table. In MongoDB, tags are embedded as an array field on the job document with a multikey index — more natural for document storage and eliminates the join.
+In SQL stores, tags use a separate `scheduler_job_tag` join table. In MongoDB, tags are embedded as an array field on the job document with a multikey index, which is more natural for document storage and eliminates the join.
 
 ## Configuration
 
@@ -180,6 +180,6 @@ Key metrics to watch:
 
 ## See Also
 
-- [Database Setup](./database-setup.md) — General database preparation
-- [Clustering](./clustering.md) — Multi-node deployment patterns
-- [Performance Tuning](./performance-tuning.md) — Query optimization and index maintenance
+- [Database Setup](./database-setup.md) -- General database preparation
+- [Clustering](./clustering.md) -- Multi-node deployment patterns
+- [Performance Tuning](./performance-tuning.md) -- Query optimization and index maintenance

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -6,7 +6,7 @@ description: Micrometer metrics, event-based monitoring, health checks, and aler
 
 # Monitoring
 
-Ratchet provides two monitoring channels: **Micrometer metrics** for quantitative dashboards and alerts, and the **event system** for real-time programmatic observation.
+Ratchet provides two monitoring channels: Micrometer metrics for quantitative dashboards and alerts, and the event system for real-time programmatic observation.
 
 ## Micrometer integration
 
@@ -45,7 +45,7 @@ The `MicrometerMetricsCollector` is annotated `@Alternative @Priority(1000)`, so
 | `ratchet.jobs.failed` | Counter | `type`, `family` | Jobs that failed (exception-family classification as tag) |
 | `ratchet.jobs.duration` | Timer | `type` | Execution time per job |
 
-The `type` tag corresponds to `JobType` (`SINGLE`, `RECURRING`, `BATCH`, `CHAIN`, `WORKFLOW`, `SYSTEM`). The `priority` tag corresponds to `JobPriority` (`LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL`). The `family` tag corresponds to `ExceptionFamily` — a coarse classification of the failure cause rather than the raw exception class name.
+The `type` tag corresponds to `JobType` (`SINGLE`, `RECURRING`, `BATCH`, `CHAIN`, `WORKFLOW`, `SYSTEM`). The `priority` tag corresponds to `JobPriority` (`LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL`). The `family` tag corresponds to `ExceptionFamily`, a coarse classification of the failure cause rather than the raw exception class name.
 
 ### Grafana dashboard queries
 
@@ -72,7 +72,7 @@ topk(5, sum by (family) (rate(ratchet_jobs_failed_total[5m])))
 
 ### Custom `MetricsCollector`
 
-If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. The SPI declares several callbacks beyond the three core job-lifecycle hooks (`jobStarted`, `jobCompleted`, `jobFailed`) — including `successFinalizationRetried`/`successFinalizationMinimal`/`successFinalizationStuck`, `claimTransientFailure`, `jobsClaimed`, `gateRejected`, and `localWakeup`, plus default no-op hooks for cluster wakeup, callback failures, signal events, store operations, and poller circuit-breaker state. The simplest approach is to extend `NoOpMetricsCollector` and override only the callbacks you emit:
+If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. Beyond the three core job-lifecycle hooks (`jobStarted`, `jobCompleted`, `jobFailed`), the SPI also declares `successFinalizationRetried`/`successFinalizationMinimal`/`successFinalizationStuck`, `claimTransientFailure`, `jobsClaimed`, `gateRejected`, and `localWakeup`, plus default no-op hooks for cluster wakeup, callback failures, signal events, store operations, and poller circuit-breaker state. The simplest approach is to extend `NoOpMetricsCollector` and override only the callbacks you need:
 
 ```java
 public class MyMetricsCollector extends NoOpMetricsCollector {
@@ -140,7 +140,7 @@ scheduler.addEventListener(event -> {
 });
 ```
 
-For aggregate poll-cycle and throughput metrics, use the `MetricsCollector` SPI (or the Micrometer module) rather than the event system — events carry per-job context, not cycle-level summaries.
+For aggregate poll-cycle and throughput metrics, use the `MetricsCollector` SPI (or the Micrometer module) rather than the event system. Events carry per-job context, not cycle-level summaries.
 
 ### Event types
 
@@ -207,7 +207,7 @@ Jobs in the dead-letter queue need human attention:
 SELECT COUNT(*) FROM scheduler_dlq_alerts;
 ```
 
-Wire this into your alerting system — a non-zero DLQ count means something failed permanently.
+Wire this into your alerting system. A non-zero DLQ count means something failed permanently.
 
 ## Alerting recommendations
 
@@ -216,12 +216,12 @@ Wire this into your alerting system — a non-zero DLQ count means something fai
 | DLQ count > 0 | **Critical** | Investigate and retry or archive |
 | Failure rate > 5% (5min window) | **Warning** | Check logs for systematic errors |
 | P95 duration > 2x normal | **Warning** | Check for resource contention or slow dependencies |
-| Node heartbeat stale > 2min | **Critical** | Node may be down — check process health |
+| Node heartbeat stale > 2min | **Critical** | Node may be down; check process health |
 | Pending CRITICAL jobs > 30s | **Critical** | Cluster may be overloaded |
 | Pending queue depth growing | **Warning** | Scale up nodes or increase thread pool |
 
 ## See also
 
-- [Event System](../api-reference/event-system.md) — Complete event type reference
-- [Metrics Collection](../advanced/metrics-collection.md) — Advanced custom metrics patterns
-- [Troubleshooting](./troubleshooting.md) — Diagnosing common deployment issues
+- [Event System](../api-reference/event-system.md) -- Complete event type reference
+- [Metrics Collection](../advanced/metrics-collection.md) -- Advanced custom metrics patterns
+- [Troubleshooting](./troubleshooting.md) -- Diagnosing common deployment issues

--- a/website/docs/deployment/multi-cell.md
+++ b/website/docs/deployment/multi-cell.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 12
 title: Multi-Cell Deployment
-description: Running several independent Ratchet cells side by side — one store per cell — for tenant isolation or throughput beyond a single shared store.
+description: Running several independent Ratchet cells side by side (one store per cell) for tenant isolation or throughput beyond a single shared store.
 ---
 
 # Multi-Cell Deployment
@@ -10,7 +10,7 @@ A **cell** is one self-contained Ratchet deployment: its own application
 instances, its own datasource, and its own schema. Running several cells
 side by side gives you isolation or aggregate throughput that a single
 shared store cannot, and it needs no special code. Ratchet already scopes
-every uniqueness guarantee — job IDs, idempotency keys, business keys — to a
+every uniqueness guarantee (job IDs, idempotency keys, business keys) to a
 single store, so N stores are N independent schedulers that happen to run the
 same engine.
 
@@ -44,7 +44,7 @@ need. Most deployments never do.
 
 - One database can hold and serve your whole job population.
 - You want different node groups to handle different work. Worker tag
-  affinity routes jobs to eligible nodes *within one store* — tag a job with
+  affinity routes jobs to eligible nodes *within one store*: tag a job with
   `withTags(...)` and constrain a node's claims with a
   [`NodeTagAffinityProvider`](/api-reference/spi-interfaces#nodetagaffinityprovider). No second store
   is required for workload routing.
@@ -56,7 +56,7 @@ need. Most deployments never do.
   data, retention policy, and schema evolution are physically independent,
   and one tenant's load cannot starve another's claims.
 - **You have outgrown one store's write throughput.** A single store has a
-  commit-throughput ceiling — under sustained enqueue load the bottleneck is
+  commit-throughput ceiling. Under sustained enqueue load the bottleneck is
   transaction commit, not worker count, so adding nodes does not help past a
   point. Splitting the workload across cells multiplies the number of
   independent commit pipelines. See [Performance
@@ -69,7 +69,7 @@ the wrong unit of isolation or throughput.
 
 ## Pattern 1: Cell per tenant
 
-Each tenant gets its own cell — its own schema, and usually its own
+Each tenant gets its own cell: its own schema, and usually its own
 connection pool.
 
 ```
@@ -80,11 +80,11 @@ Tenant C  ->  Ratchet cell C  ->  schema_c
 
 Use it for:
 
-- **Compliance and data residency** — a tenant's jobs, payloads, and history
+- Compliance and data residency: a tenant's jobs, payloads, and history
   never share a table with another tenant's.
-- **A billing or quota boundary** — per-cell metrics attribute load directly
+- Billing or quota boundaries: per-cell metrics attribute load directly
   to a tenant.
-- **Independent schema evolution** — migrate or pause one tenant's cell
+- Independent schema evolution: migrate or pause one tenant's cell
   without touching the others.
 
 The cost is operational: more schemas to provision, migrate, and monitor.
@@ -105,12 +105,12 @@ User-facing notifications       ->  cell "notify"
 
 Use it for:
 
-- **Protecting latency-sensitive work from bulk work** — a reporting batch
+- Protecting latency-sensitive work from bulk work: a reporting batch
   that saturates its own store's commit pipeline cannot slow down
   notification jobs in a different cell.
-- **Tuning each store independently** — poll interval, batch size, retention,
+- Tuning each store independently: poll interval, batch size, retention,
   and pool sizing per domain.
-- **Independent scaling** — grow the reconciliation cell's node count without
+- Independent scaling: grow the reconciliation cell's node count without
   touching the reporting cell.
 
 This is the throughput-and-isolation pattern. When one shared store would
@@ -146,13 +146,13 @@ code, not with a Ratchet chain.
 
 Because there is no cross-cell layer, routing is the application's
 responsibility: choose the cell, then submit to that cell's
-`JobSchedulerService`. The job never moves between cells afterward — it is
+`JobSchedulerService`. The job never moves between cells afterward. It is
 claimed, executed, retried, and archived entirely within the cell it was
 created in.
 
 Keep the routing key stable and outside the job payload. For cell-per-tenant
 the key is the tenant ID; for cell-per-domain it is the workload class. A job
-submitted to the wrong cell is not an error Ratchet can detect — it will run
+submitted to the wrong cell is not an error Ratchet can detect. It will run
 in that cell against that cell's data.
 
 ## Sizing reference
@@ -170,7 +170,7 @@ and throughput pull toward cells; everything else favors a single store.
 
 Throughput planning starts with a single cell, because the ceiling is a
 property of one store. Establish what one cell sustains for your workload and
-hardware (the limiting factor is transaction commit, not worker count — see
+hardware (the limiting factor is transaction commit, not worker count; see
 [Performance Tuning](/deployment/performance-tuning)), then add cells when
 your aggregate target or isolation requirement exceeds it. Each cell is
 sized like any single deployment: see [Cluster
@@ -179,8 +179,8 @@ and polling tuning.
 
 ## See also
 
-- [Deployment Overview](/deployment/overview) — application server, database, and module requirements
-- [Clustering](/deployment/clustering) — scaling one store across nodes with `SKIP LOCKED`
-- [Cluster Configuration](/deployment/cluster-configuration) — per-cell node, pool, and polling tuning
-- [Performance Tuning](/deployment/performance-tuning) — the single-store commit-throughput ceiling
-- [SPI Reference: `NodeTagAffinityProvider`](/api-reference/spi-interfaces#nodetagaffinityprovider) — in-store workload routing
+- [Deployment Overview](/deployment/overview) -- Application server, database, and module requirements
+- [Clustering](/deployment/clustering) -- Scaling one store across nodes with `SKIP LOCKED`
+- [Cluster Configuration](/deployment/cluster-configuration) -- Per-cell node, pool, and polling tuning
+- [Performance Tuning](/deployment/performance-tuning) -- The single-store commit-throughput ceiling
+- [SPI Reference: `NodeTagAffinityProvider`](/api-reference/spi-interfaces#nodetagaffinityprovider) -- In-store workload routing

--- a/website/docs/deployment/mysql.md
+++ b/website/docs/deployment/mysql.md
@@ -89,7 +89,7 @@ The `mapping-file` line is required for non-Hibernate providers (EclipseLink,
 OpenJPA, etc.). MySQL stores UUIDv7 IDs as `BINARY(16)`, and the mapping file
 applies the store-local `UuidByteArrayConverter` so those providers bind UUID
 fields as 16 bytes. Hibernate maps UUID to `BINARY(16)` natively on MySQL, and
-Hibernate 6+ rejects an `AttributeConverter` on an `@Id` attribute — omit the
+Hibernate 6+ rejects an `AttributeConverter` on an `@Id` attribute; omit the
 `<mapping-file>` line entirely when using Hibernate. PostgreSQL does not use
 this mapping file.
 
@@ -130,10 +130,10 @@ Or via WildFly CLI:
 :::caution MySQL Isolation Level
 MySQL defaults to `REPEATABLE READ`, which acquires gap locks on `SELECT ... FOR UPDATE` that block concurrent inserts into the same table. This causes lock wait timeouts under production job scheduling load. **Always** configure `READ COMMITTED` isolation via one of:
 
-- **WildFly DataSource**: `transaction-isolation=TRANSACTION_READ_COMMITTED`
-- **JDBC URL**: `?sessionVariables=transaction_isolation='READ-COMMITTED'`
-- **persistence.xml**: `<property name="hibernate.connection.isolation" value="2"/>`
-- **WildFly -ds.xml**: `<transaction-isolation>TRANSACTION_READ_COMMITTED</transaction-isolation>`
+- WildFly DataSource: `transaction-isolation=TRANSACTION_READ_COMMITTED`
+- JDBC URL: `?sessionVariables=transaction_isolation='READ-COMMITTED'`
+- persistence.xml: `<property name="hibernate.connection.isolation" value="2"/>`
+- WildFly -ds.xml: `<transaction-isolation>TRANSACTION_READ_COMMITTED</transaction-isolation>`
 
 Ratchet checks this at startup and fails by default when the active session is not
 `READ COMMITTED`. Use `RatchetOptions.builder().store(s -> s.isolationCheckMode(RatchetOptions.IsolationCheckMode.WARN))`
@@ -165,12 +165,12 @@ Ratchet does not expose MySQL-only tuning flags. Use the shared scheduler settin
 
 The MySQL schema uses several MySQL-specific features:
 
-- **ENUM types** for `status`, `job_type`, `backoff_policy`, and `level` columns
-- **BINARY(16) UUIDv7 identifiers** for every primary and foreign key that refers to a job, batch, execution, log, archive, resource permit, or workflow row
-- **JSON columns** for `payload`, `params`, `job_result`, and `mdc`
-- **GENERATED ALWAYS AS ... STORED** columns to extract `target_class` and `method_name` from payload JSON
-- **Reservation table** for active business-key uniqueness without keeping terminal rows hot
-- **Optional operator views** in `ddl/views/vw_jobs.sql` that expose binary UUIDs as hyphenated strings via `BIN_TO_UUID(col)` without MySQL's UUIDv1 swap flag
+- ENUM types for `status`, `job_type`, `backoff_policy`, and `level` columns
+- BINARY(16) UUIDv7 identifiers for every primary and foreign key that refers to a job, batch, execution, log, archive, resource permit, or workflow row
+- JSON columns for `payload`, `params`, `job_result`, and `mdc`
+- `GENERATED ALWAYS AS ... STORED` columns to extract `target_class` and `method_name` from payload JSON
+- A reservation table for active business-key uniqueness without keeping terminal rows hot
+- Optional operator views in `ddl/views/vw_jobs.sql` that expose binary UUIDs as hyphenated strings via `BIN_TO_UUID(col)` without MySQL's UUIDv1 swap flag
 
 ### Key Indexes
 

--- a/website/docs/deployment/overview.md
+++ b/website/docs/deployment/overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Deployment Overview
-description: What you need to deploy Ratchet: application server, database, modules, and configuration.
+description: "What you need to deploy Ratchet: application server, database, modules, and configuration."
 ---
 
 # Deployment Overview

--- a/website/docs/deployment/overview.md
+++ b/website/docs/deployment/overview.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 title: Deployment Overview
-description: What you need to deploy Ratchet — application server, database, modules, and configuration.
+description: What you need to deploy Ratchet: application server, database, modules, and configuration.
 ---
 
 # Deployment Overview
@@ -77,7 +77,7 @@ See [Docker Deployment](/deployment/docker) and [Kubernetes Deployment](/deploym
 
 ## Database schema
 
-Ratchet ships SQL DDL as plain files — no Flyway or Liquibase dependency is required. The schema files are bundled inside each SQL store module JAR at `ddl/`:
+Ratchet ships SQL DDL as plain files. No Flyway or Liquibase dependency is required. The schema files are bundled inside each SQL store module JAR at `ddl/`:
 
 - `ratchet-store-mysql` contains `ddl/mysql-schema.sql`
 - `ratchet-store-postgresql` contains `ddl/postgresql-schema.sql`
@@ -112,7 +112,7 @@ The SQL schema creates these primary tables. MongoDB uses analogous collections 
 
 ## Configuration
 
-Ratchet **requires** a CDI-produced `RatchetOptions` bean. If no producer is found, CDI fails deployment with `UnsatisfiedResolutionException` and the scheduler never starts — a first-class kill-switch for any deployment that includes `ratchet` without wanting it active.
+Ratchet **requires** a CDI-produced `RatchetOptions` bean. If no producer is found, CDI fails deployment with `UnsatisfiedResolutionException` and the scheduler never starts. This acts as a first-class kill-switch for any deployment that includes `ratchet` without wanting it active.
 
 The producer may build options programmatically or read `RATCHET_*` environment variables and MicroProfile Config via `RatchetOptionsFactory.fromEnvironment()`. See [Configuration](/getting-started/configuration) for both patterns.
 
@@ -132,10 +132,10 @@ See [Configuration](/deployment/configuration) for the full reference.
 
 Ratchet provides multiple monitoring integration points:
 
-- **Event system** — CDI events for job lifecycle (started, completed, failed, DLQ)
-- **MetricsCollector SPI** — Plug in Micrometer or any custom metrics backend
-- **MicroProfile Health** — Implement health checks against the job store
-- **Store queries** — Direct SQL queries or MongoDB queries against Ratchet storage for dashboards
+- **Event system:** CDI events for job lifecycle (started, completed, failed, DLQ)
+- **MetricsCollector SPI:** plug in Micrometer or any custom metrics backend
+- **MicroProfile Health:** implement health checks against the job store
+- **Store queries:** direct SQL queries or MongoDB queries against Ratchet storage for dashboards
 
 See [Monitoring & Observability](/deployment/monitoring) for integration guides.
 
@@ -143,19 +143,19 @@ See [Monitoring & Observability](/deployment/monitoring) for integration guides.
 
 Before going to production:
 
-1. **Apply or initialize storage** — Run schema SQL for MySQL/PostgreSQL; let MongoDB initialize collections and indexes at startup
-2. **Configure the store resource** — JNDI-bound, JTA-managed `DataSource` for SQL stores, or a CDI-produced `MongoDatabase` for MongoDB
-3. **Set isolation level for SQL stores** — MySQL requires `READ COMMITTED` (not the default `REPEATABLE READ`)
-4. **Tune polling** — Adjust `polling.minDelayMs`, `polling.maxDelayMs`, and `polling.batchSize` for your workload
-5. **Set up retention** — Configure `maintenance.jobRetentionDays`, `maintenance.dlqPurgeDays`, and `maintenance.logRetentionDays` to prevent unbounded table growth
-6. **Enable metrics** — Wire `MetricsCollector` to your monitoring stack
-7. **Configure wakeups if needed** — If running multiple nodes and you want faster cross-node responsiveness, implement `ClusterCoordinator`
-8. **Test failover** — Verify jobs recover when a node goes down
+1. **Apply or initialize storage:** run schema SQL for MySQL/PostgreSQL; let MongoDB initialize collections and indexes at startup
+2. **Configure the store resource:** JNDI-bound, JTA-managed `DataSource` for SQL stores, or a CDI-produced `MongoDatabase` for MongoDB
+3. **Set isolation level for SQL stores:** MySQL requires `READ COMMITTED` (not the default `REPEATABLE READ`)
+4. **Tune polling:** adjust `polling.minDelayMs`, `polling.maxDelayMs`, and `polling.batchSize` for your workload
+5. **Set up retention:** configure `maintenance.jobRetentionDays`, `maintenance.dlqPurgeDays`, and `maintenance.logRetentionDays` to prevent unbounded table growth
+6. **Enable metrics:** wire `MetricsCollector` to your monitoring stack
+7. **Configure wakeups if needed:** if running multiple nodes and you want faster cross-node responsiveness, implement `ClusterCoordinator`
+8. **Test failover:** verify jobs recover when a node goes down
 
 ## Next steps
 
-- [Installation & Setup](/deployment/installation) — Step-by-step getting started
-- [Database Setup](/deployment/database-setup) — Schema application for all stores
-- [Configuration](/deployment/configuration) — Full configuration reference
-- [Docker Deployment](/deployment/docker) — Containerized deployments
-- [Kubernetes Deployment](/deployment/kubernetes) — Orchestrated deployments
+- [Installation & Setup](/deployment/installation) -- Step-by-step getting started
+- [Database Setup](/deployment/database-setup) -- Schema application for all stores
+- [Configuration](/deployment/configuration) -- Full configuration reference
+- [Docker Deployment](/deployment/docker) -- Containerized deployments
+- [Kubernetes Deployment](/deployment/kubernetes) -- Orchestrated deployments

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -6,7 +6,7 @@ description: Tuning Ratchet's polling intervals, thread pools, batch sizes, time
 
 # Performance Tuning
 
-Ratchet's performance depends on the interplay between polling frequency, thread pool sizing, batch sizes, database tuning, and the nature of your jobs. This guide covers how to tune each parameter for your workload.
+Ratchet's performance depends on polling frequency, thread pool sizing, batch sizes, database tuning, and the nature of your jobs. This guide covers how to tune each parameter for your workload.
 
 ## Polling configuration
 
@@ -28,7 +28,7 @@ Ratchet uses adaptive polling, so the minimum and maximum delay matter more than
 | 3000ms | ~3 seconds | 20 | High-throughput production workloads |
 | 10000ms | ~10 seconds | 6 | Light workloads, reduce DB pressure |
 
-Lowering the minimum below 1 second is not recommended — the overhead of frequent queries usually outweighs the latency benefit.
+Lowering the minimum below 1 second is not recommended: the overhead of frequent queries usually outweighs the latency benefit.
 
 ### Batch size
 
@@ -103,14 +103,14 @@ RATCHET_WORKER_VIRTUAL_EXECUTOR_JNDI=java:app/concurrent/MyVirtualExecutor
 Virtual threads (Project Loom) eliminate the need to size thread pools for I/O-bound workloads. With the default threading mode set to virtual and a virtual-backed managed executor wired in, Ratchet routes jobs to the virtual pool, and the JVM multiplexes them across platform threads.
 
 Benefits:
-- No thread pool sizing needed — virtual threads are cheap to create
+- No thread pool sizing needed (virtual threads are cheap to create)
 - Blocking I/O no longer wastes platform threads
 - Scales to thousands of concurrent jobs without tuning
 
 Considerations:
 - Requires Java 21 or later
 - CPU-bound jobs do not benefit (still limited by platform thread count)
-- `synchronized` blocks can pin virtual threads — prefer `ReentrantLock` in job code
+- `synchronized` blocks can pin virtual threads; prefer `ReentrantLock` in job code
 
 ### Custom `ExecutorProvider`
 
@@ -207,22 +207,22 @@ Recommended timeouts by job type:
 
 ### PostgreSQL tuning
 
-**Shared buffers** — Set to 25% of available RAM:
+**Shared buffers:** set to 25% of available RAM:
 ```sql
 ALTER SYSTEM SET shared_buffers = '4GB';
 ```
 
-**Work memory** — Increase for complex queries:
+**Work memory:** increase for complex queries:
 ```sql
 ALTER SYSTEM SET work_mem = '256MB';
 ```
 
-**Effective cache size** — Set to 75% of available RAM:
+**Effective cache size:** set to 75% of available RAM:
 ```sql
 ALTER SYSTEM SET effective_cache_size = '12GB';
 ```
 
-**Autovacuum** — Ratchet performs frequent updates and deletes on the hot queue table. Tune autovacuum to keep up:
+**Autovacuum:** Ratchet performs frequent updates and deletes on the hot queue table. Tune autovacuum to keep up:
 ```sql
 ALTER TABLE scheduler_job_queue SET (
   autovacuum_vacuum_scale_factor = 0.05,  -- vacuum after 5% of rows change
@@ -230,7 +230,7 @@ ALTER TABLE scheduler_job_queue SET (
 );
 ```
 
-**Connection pooling** — Use PgBouncer in transaction mode:
+**Connection pooling:** use PgBouncer in transaction mode:
 ```ini
 [pgbouncer]
 pool_mode = transaction
@@ -240,20 +240,20 @@ default_pool_size = 25
 
 ### MySQL tuning
 
-**InnoDB buffer pool** — Set to 70-80% of available RAM:
+**InnoDB buffer pool:** set to 70-80% of available RAM:
 ```ini
 [mysqld]
 innodb_buffer_pool_size = 8G
 innodb_buffer_pool_instances = 8
 ```
 
-**Log file size** — Larger redo logs improve write performance:
+**Log file size:** larger redo logs improve write performance:
 ```ini
 [mysqld]
 innodb_log_file_size = 1G
 ```
 
-**Isolation level** — Required for Ratchet:
+**Isolation level:** required for Ratchet:
 ```ini
 [mysqld]
 transaction_isolation = READ-COMMITTED
@@ -289,7 +289,7 @@ LIMIT 100
 FOR UPDATE SKIP LOCKED;
 ```
 
-The query should use `idx_claim_executable` on `scheduler_job_queue` on both PostgreSQL and MySQL — it is the hot-path claim index. On PostgreSQL it is partial on `status = 'PENDING'`; on MySQL it is a plain index with `status` as the leading column (MySQL has no partial indexes). A sort on computed effective priority is expected; a full scan of the pending queue is not. If you see a sequential scan, check that statistics are up to date:
+The query should use `idx_claim_executable` on `scheduler_job_queue` on both PostgreSQL and MySQL: it is the hot-path claim index. On PostgreSQL it is partial on `status = 'PENDING'`; on MySQL it is a plain index with `status` as the leading column (MySQL has no partial indexes). A sort on computed effective priority is expected; a full scan of the pending queue is not. If you see a sequential scan, check that statistics are up to date:
 
 ```sql
 -- PostgreSQL
@@ -411,17 +411,17 @@ WHERE status = 'PENDING'
 
 ## Tuning checklist
 
-1. **Start with defaults** — Ratchet's defaults work well for most workloads
-2. **Measure first** — Enable metrics before changing anything
-3. **Tune one parameter at a time** — Change one setting, measure the impact, then move on
-4. **Watch the database** — Most performance issues are database-related (missing indexes, insufficient memory, too many connections)
-5. **Set timeouts** — Every job should have a timeout to prevent resource leaks
-6. **Configure retention** — Keep the active job table small for fast polling
-7. **Scale horizontally** — Add nodes before over-tuning a single instance
+1. **Start with defaults:** Ratchet's defaults work well for most workloads
+2. **Measure first:** enable metrics before changing anything
+3. **Tune one parameter at a time:** change one setting, measure the impact, then move on
+4. **Watch the database:** most performance issues are database-related (missing indexes, insufficient memory, too many connections)
+5. **Set timeouts:** every job should have a timeout to prevent resource leaks
+6. **Configure retention:** keep the active job table small for fast polling
+7. **Scale horizontally:** add nodes before over-tuning a single instance
 
 ## See also
 
-- [Configuration](/deployment/configuration) — Full configuration reference
-- [Monitoring & Observability](/deployment/monitoring) — Metrics and alerting
-- [Cluster Configuration](/deployment/cluster-configuration) — Multi-node tuning
-- [Troubleshooting](/deployment/troubleshooting) — Diagnosing performance issues
+- [Configuration](/deployment/configuration) -- Full configuration reference
+- [Monitoring & Observability](/deployment/monitoring) -- Metrics and alerting
+- [Cluster Configuration](/deployment/cluster-configuration) -- Multi-node tuning
+- [Troubleshooting](/deployment/troubleshooting) -- Diagnosing performance issues

--- a/website/docs/deployment/troubleshooting.md
+++ b/website/docs/deployment/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 14
 title: Deployment Troubleshooting
-description: Diagnosing and fixing common deployment problems — schema issues, connection failures, clustering problems, and performance bottlenecks
+description: Diagnosing and fixing common deployment problems: schema issues, connection failures, clustering problems, and performance bottlenecks
 ---
 
 # Deployment Troubleshooting
@@ -57,7 +57,7 @@ WHERE status = 'PENDING';
 
 **Symptom:** Column not found errors or constraint violations after upgrading Ratchet.
 
-**Fix:** Compare your applied schema against the latest DDL in the new version. Ratchet does not auto-migrate — you must diff and apply changes manually or through your migration tool.
+**Fix:** Compare your applied schema against the latest DDL in the new version. Ratchet does not auto-migrate, so you must diff and apply changes manually or through your migration tool.
 
 ## Connection Issues
 
@@ -114,9 +114,9 @@ mongosh --eval 'rs.initiate()'
 **Symptom:** The same job runs on two nodes simultaneously.
 
 **Possible causes:**
-1. **Missing `SKIP LOCKED` support** — You're on a database version that doesn't support it (MySQL < 8.0, PostgreSQL < 9.5)
-2. **Job timeout too short** — The job takes longer than its timeout, so the poller reclaims it while it's still running on another node
-3. **Clock skew** — Nodes have significantly different system clocks
+1. **Missing `SKIP LOCKED` support:** you're on a database version that doesn't support it (MySQL < 8.0, PostgreSQL < 9.5)
+2. **Job timeout too short:** the job takes longer than its timeout, so the poller reclaims it while it's still running on another node
+3. **Clock skew:** nodes have significantly different system clocks
 
 **Fix:**
 1. Upgrade to a supported database version
@@ -180,7 +180,7 @@ FOR UPDATE SKIP LOCKED LIMIT 10;
 
 **Fixes:**
 1. Ensure the composite index exists (see [Missing indexes](#missing-indexes))
-2. Reduce batch size — claiming fewer jobs per cycle reduces lock contention
+2. Reduce batch size: claiming fewer jobs per cycle reduces lock contention
 3. Archive completed jobs to keep the table lean
 
 ### Queue growing despite available capacity
@@ -188,9 +188,9 @@ FOR UPDATE SKIP LOCKED LIMIT 10;
 **Symptom:** Pending job count increases while worker threads are idle.
 
 **Possible causes:**
-1. **Scheduling mismatch** — Jobs have `scheduled_time` in the future
-2. **Resource permits** — Jobs require a resource permit that's exhausted
-3. **Paused jobs** — Jobs are in `PAUSED` status
+1. **Scheduling mismatch:** jobs have `scheduled_time` in the future
+2. **Resource permits:** jobs require a resource permit that's exhausted
+3. **Paused jobs:** jobs are in `PAUSED` status
 
 **Diagnosis:**
 ```sql
@@ -224,13 +224,13 @@ WHERE status = 'PENDING' AND scheduled_time > NOW();
 
 ### Multiple store implementations on classpath
 
-**Symptom:** `Ambiguous dependency for type JobStore` — CDI found two store beans.
+**Symptom:** `Ambiguous dependency for type JobStore`. CDI found two store beans.
 
 **Fix:** Include only one store module in your deployment. If you need both (e.g., for migration), mark one as `@Alternative` and don't enable it.
 
 ## See Also
 
-- [Troubleshooting Overview](../troubleshooting/overview.md) — General debugging techniques
-- [Common Issues](../troubleshooting/common-issues.md) — Frequently encountered problems
-- [Clustering](./clustering.md) — Multi-node architecture and failure modes
-- [Performance Tuning](./performance-tuning.md) — Optimizing for throughput
+- [Troubleshooting Overview](../troubleshooting/overview.md) -- General debugging techniques
+- [Common Issues](../troubleshooting/common-issues.md) -- Frequently encountered problems
+- [Clustering](./clustering.md) -- Multi-node architecture and failure modes
+- [Performance Tuning](./performance-tuning.md) -- Optimizing for throughput

--- a/website/docs/deployment/troubleshooting.md
+++ b/website/docs/deployment/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 14
 title: Deployment Troubleshooting
-description: Diagnosing and fixing common deployment problems: schema issues, connection failures, clustering problems, and performance bottlenecks
+description: "Diagnosing and fixing common deployment problems: schema issues, connection failures, clustering problems, and performance bottlenecks"
 ---
 
 # Deployment Troubleshooting

--- a/website/docs/getting-started/basic-concepts.md
+++ b/website/docs/getting-started/basic-concepts.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 title: Basic Concepts
-description: Core Ratchet terminology — jobs, schedules, stores, builders, contexts, and the CDI programming model
+description: Core Ratchet terminology: jobs, schedules, stores, builders, contexts, and the CDI programming model
 ---
 
 # Basic Concepts
@@ -10,7 +10,7 @@ Understanding the core building blocks helps before reading the API. Ratchet has
 
 ## Jobs
 
-A **job** is a unit of work that Ratchet persists and executes. A job is a serialized lambda — a method reference stored in the database and invoked later by a worker thread.
+A **job** is a unit of work that Ratchet persists and executes. Concretely, it is a serialized lambda: a method reference stored in the database and invoked later by a worker thread.
 
 ```java
 // This lambda IS the job
@@ -23,7 +23,7 @@ Every job has:
 |----------|-------------|
 | **ID** | Auto-assigned UUIDv7 identifier |
 | **Status** | Current lifecycle state (`PENDING`, `RUNNING`, `SUCCEEDED`, `FAILED`, `CANCELED`, `PAUSED`, `WAITING`) |
-| **Priority** | Execution ordering — `LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL` |
+| **Priority** | Execution ordering: `LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL` |
 | **Payload** | The serialized lambda or method reference |
 | **Parameters** | Key-value pairs available at execution time via `JobContext` |
 | **Tags** | Labels for grouping and bulk operations |
@@ -34,11 +34,11 @@ Jobs progress through a [lifecycle](../concepts/job-lifecycle.md) from creation 
 
 Ratchet supports several execution patterns:
 
-- **Single** — Execute once, right now or after a delay
-- **Recurring** — Execute on a cron schedule, creating child instances each time
-- **Batch parent** — Coordinate parallel execution of child jobs
-- **Batch child** — Individual items within a batch
-- **Chained** — Execute after another job completes (success, failure, or conditional)
+- **Single:** execute once, right now or after a delay
+- **Recurring:** execute on a cron schedule, creating child instances each time
+- **Batch parent:** coordinate parallel execution of child jobs
+- **Batch child:** individual items within a batch
+- **Chained:** execute after another job completes (success, failure, or conditional)
 
 See [Job Types](../concepts/job-types.md) for details on each pattern.
 
@@ -122,7 +122,7 @@ JobResult.success(invoiceTotal);
 JobResult.failure("Payment declined", exception);
 ```
 
-Results drive [workflow branching](../concepts/workflows.md) — downstream jobs can inspect the parent result and conditionally execute.
+Results drive [workflow branching](../concepts/workflows.md): downstream jobs can inspect the parent result and conditionally execute.
 
 ## Stores
 
@@ -213,6 +213,6 @@ See the [Event System](../api-reference/event-system.md) for all event types.
 
 Now that you know the vocabulary, the best way to learn is to build something:
 
-- **[Your First Job](./first-job.md)** — Build a complete job with retries, callbacks, and monitoring
-- **[Configuration](./configuration.md)** — Tune polling intervals, thread pools, and timeouts
-- **[Job Lifecycle](../concepts/job-lifecycle.md)** — Understand every state transition in detail
+- **[Your First Job](./first-job.md)** -- Build a complete job with retries, callbacks, and monitoring
+- **[Configuration](./configuration.md)** -- Tune polling intervals, thread pools, and timeouts
+- **[Job Lifecycle](../concepts/job-lifecycle.md)** -- Understand every state transition in detail

--- a/website/docs/getting-started/basic-concepts.md
+++ b/website/docs/getting-started/basic-concepts.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 title: Basic Concepts
-description: Core Ratchet terminology: jobs, schedules, stores, builders, contexts, and the CDI programming model
+description: "Core Ratchet terminology: jobs, schedules, stores, builders, contexts, and the CDI programming model"
 ---
 
 # Basic Concepts

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -9,7 +9,7 @@ description: CDI producer setup, beans.xml requirements, and the required Ratche
 Ratchet is designed to run in Jakarta EE without static global configuration. CDI owns the runtime objects, Ratchet consumes one immutable `RatchetOptions` bean that your application produces, and store-specific resources remain normal CDI resources.
 
 :::important Required producer
-Your application **must** produce exactly one `@ApplicationScoped RatchetOptions` bean. If no producer is found, CDI fails deployment with `UnsatisfiedResolutionException` and the scheduler never starts — this is the intended kill-switch for deployments that pull `ratchet` onto the classpath without wanting it active. There is no automatic fallback chain.
+Your application **must** produce exactly one `@ApplicationScoped RatchetOptions` bean. If no producer is found, CDI fails deployment with `UnsatisfiedResolutionException` and the scheduler never starts. This is the intended kill-switch for deployments that pull `ratchet` onto the classpath without wanting it active. There is no automatic fallback chain.
 :::
 
 ## How Ratchet bootstraps
@@ -155,7 +155,7 @@ clock (`NOW(3)` / `CURRENT_TIMESTAMP`). If the JDBC connection writes those colu
 zone than the server evaluates the comparison in, due jobs are claimed late (or early) by the
 offset between the two zones.
 
-Most providers avoid this automatically — Hibernate, for example, negotiates `connectionTimeZone=UTC`
+Most providers avoid this automatically. Hibernate, for example, negotiates `connectionTimeZone=UTC`
 with MySQL Connector/J. Others (notably EclipseLink) bind `java.sql.Timestamp` values in the JVM's
 default zone, so a non-UTC application JVM against a UTC database silently skews claim timing. To
 stay correct on any provider:
@@ -253,7 +253,7 @@ When you call `RatchetOptionsFactory.fromEnvironment(...)` from inside your prod
 3. Environment variables (canonical `RATCHET_*` names)
 4. Built-in defaults
 
-This is not a runtime fallback — Ratchet only reads it when your producer explicitly asks it to. If you use Option B (programmatic) your producer skips the chain entirely.
+This is not a runtime fallback. Ratchet only reads it when your producer explicitly asks it to. If you use Option B (programmatic), your producer skips the chain entirely.
 
 To overlay a platform-specific config source on top of env + MP Config, pass it as a vararg:
 

--- a/website/docs/getting-started/first-job.md
+++ b/website/docs/getting-started/first-job.md
@@ -9,7 +9,7 @@ description: A complete walkthrough of creating a job with retries, backoff, par
 The [Quick Start](./quickstart.md) showed the fire-and-forget pattern. This guide builds a complete, production-quality job with retry handling, exponential backoff, parameters, success/failure callbacks, and event monitoring. By the end, you'll understand every option on the `JobBuilder` fluent API.
 
 :::note Prerequisite
-This guide assumes you've already produced a `@ApplicationScoped RatchetOptions` bean. If you haven't, see [Configuration](./configuration.md) — the scheduler won't start without one.
+This guide assumes you've already produced a `@ApplicationScoped RatchetOptions` bean. If you haven't, see [Configuration](./configuration.md). The scheduler won't start without one.
 :::
 
 ## The Scenario

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -16,7 +16,7 @@ Before starting, make sure you have:
 2. A database (PostgreSQL, MySQL, or MongoDB) accessible from your application
 3. Ratchet dependencies added to your `pom.xml` (see [Installation](./installation.md))
 4. The Ratchet schema applied to your database
-5. A `@Produces RatchetOptions` CDI bean — required; no automatic fallback
+5. A `@Produces RatchetOptions` CDI bean (required; no automatic fallback)
 6. A `ClassPolicy` CDI alternative that allows your application's packages
 
 If you haven't done steps 3 and 4 yet, here's the minimum `pom.xml` setup:

--- a/website/docs/troubleshooting/faq.md
+++ b/website/docs/troubleshooting/faq.md
@@ -33,7 +33,7 @@ Ratchet ships with three store modules:
 
 The SQL modules provide DDL scripts (`src/main/resources/ddl/`) as plain SQL files. Apply them however you manage your schema (Flyway, Liquibase, manual scripts, etc.). The MongoDB module initializes its collections and indexes at startup.
 
-**Adding a new database:** Implement the composed `JobStore` SPI and provide the corresponding schema/bootstrap logic for your backend. The `ratchet-tck-store` submodule contains contract tests that validate any store implementation against the expected behavior — passing them earns the "Ratchet Store Compatible" label.
+**Adding a new database:** Implement the composed `JobStore` SPI and provide the corresponding schema/bootstrap logic for your backend. The `ratchet-tck-store` submodule contains contract tests that validate any store implementation against the expected behavior; passing them earns the "Ratchet Store Compatible" label.
 
 ## How does retry work?
 
@@ -81,7 +81,7 @@ Yes. Ratchet supports multi-node deployment. Each node runs its own poller that 
 
 Ratchet supports worker tag affinity: tag jobs with `withTags(...)` and constrain which jobs a node claims by providing a `NodeTagAffinityProvider` (the default is `DefaultNodeTagAffinityProvider`, consumed by the poller). For fully custom routing or cross-node wakeups, implement the `ClusterCoordinator` SPI.
 
-**Key multi-node settings:**
+**Multi-node settings:**
 
 | Variable | Default | Purpose |
 |---|---|---|
@@ -111,7 +111,7 @@ When a node crashes while jobs are RUNNING:
 
 Ratchet and Quartz have different architectures. Quartz uses trigger-based scheduling with XML or programmatic job definitions. Ratchet uses lambda serialization and a pull-based poller.
 
-**Key differences to address:**
+**Differences to address:**
 
 | Quartz Concept | Ratchet Equivalent |
 |---|---|
@@ -162,7 +162,7 @@ The circuit breaker is resolved per job by inspecting the `@CircuitBreakerProtec
 
 Yes, on a Jakarta EE 11 container. Virtual-thread support has two parts:
 
-1. **Where jobs run.** Ratchet runs each job on the `ManagedExecutorService` resolved from `ratchet.worker.job-executor-jndi` (default `java:comp/DefaultManagedExecutorService`). Point that at a virtual-thread-backed managed executor and jobs run on virtual threads — with the container's context propagation (CDI, transaction, security) intact, which a hand-rolled `Thread.ofVirtual()` executor would lose.
+1. **Where jobs run.** Ratchet runs each job on the `ManagedExecutorService` resolved from `ratchet.worker.job-executor-jndi` (default `java:comp/DefaultManagedExecutorService`). Point that at a virtual-thread-backed managed executor and jobs run on virtual threads, with the container's context propagation (CDI, transaction, security) intact. A hand-rolled `Thread.ofVirtual()` executor would lose that context.
 2. **Backpressure accounting.** `execution.virtualCounterAccounting(true)` swaps the semaphore-based concurrency limits for `AtomicInteger` counters, since virtual threads are cheap and a fixed pool no longer bounds concurrency. Each job type keeps a configurable limit (default 1000) to prevent unbounded growth.
 
 Ratchet does not ship its own executor definition (resource-definition scanning of library jars is container-specific, so a bundled definition would not bind portably). Declare one in your application on EE 11 (Jakarta Concurrency 3.1) and point Ratchet at it:
@@ -193,9 +193,9 @@ RatchetOptions.builder()
 ```
 
 **Requirements:**
-- A Jakarta EE 11 container whose Jakarta Concurrency 3.1 implementation honors `virtual = true`, on Java 21+. Verified on Eclipse GlassFish 8 (the EE 11 reference implementation). Note: WildFly 40.0.0.Final accepts the definition and runs jobs on the configured executor, but does not yet create virtual threads for managed executors — jobs run on platform threads there until a later release implements it.
+- A Jakarta EE 11 container whose Jakarta Concurrency 3.1 implementation honors `virtual = true`, on Java 21+. Verified on Eclipse GlassFish 8 (the EE 11 reference implementation). Note: WildFly 40.0.0.Final accepts the definition and runs jobs on the configured executor, but does not yet create virtual threads for managed executors; jobs run on platform threads there until a later release implements it.
 - Jakarta EE 10 (Jakarta Concurrency 3.0) has no standard `virtual = true` attribute on `@ManagedExecutorDefinition`, so an application cannot portably declare a virtual-thread executor. `virtualCounterAccounting(true)` still switches the backpressure model, but jobs run on virtual threads only if you point the JNDI name at an executor the container itself configures as virtual through a vendor-specific mechanism.
-- Your jobs must not hold long `synchronized` blocks or call native methods that pin the carrier thread — prefer `ReentrantLock`.
+- Your jobs must not hold long `synchronized` blocks or call native methods that pin the carrier thread. Prefer `ReentrantLock`.
 
 **When to use virtual threads:** They are most useful when jobs spend most of their time waiting on I/O (database queries, HTTP calls, file operations). For CPU-bound workloads, platform threads with appropriate pool sizes are usually sufficient.
 

--- a/website/docs/troubleshooting/overview.md
+++ b/website/docs/troubleshooting/overview.md
@@ -149,7 +149,7 @@ Add to `server.xml`:
 <logging traceSpecification="run.ratchet.*=fine"/>
 ```
 
-### Key Logger Categories
+### Logger categories
 
 | Logger | What It Logs |
 |---|---|
@@ -179,9 +179,9 @@ These MDC values are available in your log format patterns for correlation:
 
 ## Configuration Reference
 
-Ratchet requires a CDI-produced `RatchetOptions` bean — deployment fails with `UnsatisfiedResolutionException` otherwise. Applications may write a programmatic producer or read env vars + MicroProfile Config inside a producer via `RatchetOptionsFactory.fromEnvironment()`. See [Configuration](/getting-started/configuration).
+Ratchet requires a CDI-produced `RatchetOptions` bean. Deployment fails with `UnsatisfiedResolutionException` if one is not present. Applications may write a programmatic producer or read env vars + MicroProfile Config inside a producer via `RatchetOptionsFactory.fromEnvironment()`. See [Configuration](/getting-started/configuration).
 
-Key diagnostic-related settings:
+Diagnostic-related settings:
 
 | Option | Default | Purpose |
 |---|---|---|

--- a/website/docs/use-cases/bulk-batch-jobs.md
+++ b/website/docs/use-cases/bulk-batch-jobs.md
@@ -1,0 +1,128 @@
+---
+title: Bulk & Batch Jobs
+description: Fan thousands of items out as one tracked batch, watch aggregate progress as it runs, and branch on the success rate when it finishes -- without writing the bookkeeping yourself.
+---
+
+# Bulk & Batch Jobs
+
+Someone uploads an album of four thousand photos. Every one of them needs the same treatment: a resized copy, a thumbnail, a virus scan. The work is embarrassingly parallel and none of it should hold up the upload response, so it belongs in the background. The hard part was never running four thousand jobs. It is knowing, at any moment, how many finished, how many failed, and what to do when the album is done.
+
+Roll that yourself and you end up writing the same ledger every time. A counter row. A careful increment after each item so two workers do not clobber each other. A check after every update for "are we there yet." A separate pass to decide whether 4,000-of-4,000 is a success or whether the 60 corrupt files mean someone should look before the album goes live. It is all plumbing, and it is the kind of plumbing that leaks under concurrency.
+
+A batch is Ratchet's name for that ledger. You hand it the items and the work; it enqueues one child job each, counts completions and failures as they land, and hands every progress hook an immutable snapshot. When the batch finishes, you branch on what actually happened.
+
+::: tip Verified
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `BatchStore` capability.
+:::
+
+## Fan out, track progress, branch on the result
+
+```java
+import java.util.List;
+import java.util.UUID;
+
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobSchedulerService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class ImageSetService {
+
+  @Inject JobSchedulerService scheduler;
+
+  @Inject AlbumProgress progress;
+
+  @Transactional
+  public JobHandle process(UUID albumId, List<String> imageKeys) {
+    return scheduler
+        .enqueueBatch("album-" + albumId)
+        .forEach(imageKeys, key -> renderDerivatives(key))
+        .onProgress(ctx -> progress.record(albumId, ctx))
+        .thenWhenFailureCount(25, () -> quarantineAlbum(albumId))
+        .thenWhenSuccessRate(1.0, () -> publishAlbum(albumId))
+        .submit();
+  }
+
+  void renderDerivatives(String imageKey) { /* resize, thumbnail, virus-scan */ }
+
+  void quarantineAlbum(UUID albumId) { /* too many bad files; hold for review */ }
+
+  void publishAlbum(UUID albumId) { /* flip the album to visible */ }
+}
+```
+
+`forEach` enqueues one child job per key. Each runs `renderDerivatives` on a worker, independently, with the store's retry rules behind it. The parent job is the batch itself: it does no image work, it owns the count.
+
+The two `thenWhen` lines are the part you would otherwise hand-roll. `thenWhenFailureCount(25, ...)` schedules `quarantineAlbum` if twenty-five children fail, so a bad upload stops short of publishing. `thenWhenSuccessRate(1.0, ...)` runs `publishAlbum` only when every child succeeded. They are conditions on the final tally, evaluated once, by the batch, not by you polling a counter.
+
+As with every Ratchet job, the lambdas are method references on this CDI bean: only the argument (`albumId`, an image key) is serialized, and the bean is resolved again from CDI when the child runs.
+
+## The progress snapshot
+
+The `onProgress` hook fires after each child completes, and it receives a `BatchContext`: a small immutable record of where the batch stands.
+
+```java
+import java.util.UUID;
+
+import run.ratchet.api.BatchContext;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class AlbumProgress {
+
+  // Persist a row the UI can poll: "3818 of 4000 done, 60 failed".
+  public void record(UUID albumId, BatchContext ctx) {
+    int pct = ctx.percentDone();        // 0..100, rounds down
+    int ok = ctx.completedItems();
+    int failed = ctx.failedItems();
+    int total = ctx.totalItems();
+    boolean done = ctx.isComplete();    // completed + failed >= total
+    double rate = ctx.successRate();    // completed / processed, 0.0..1.0
+    // ... write that row somewhere the album page can read it.
+  }
+}
+```
+
+`BatchContext` is computed, not stored by you: `percentDone`, `successRate`, and `isComplete` are derived from the three counts the batch maintains. The hook is where you turn those numbers into something a user can see, a progress bar, a "182 left" badge, a metric, without ever touching the counter that produced them.
+
+## Streaming the items instead of listing them
+
+`forEach` takes a `Collection`, which means the whole list of keys sits in memory at submit time. Four thousand keys is fine. Four million is not. For a dataset too large to hold at once, `streamingBatch` consumes a `Stream` in chunks and persists chunk boundaries as it goes, so a restart picks up where it left off instead of starting over.
+
+```java
+public JobHandle reindex(UUID albumId, java.util.stream.Stream<String> imageKeys) {
+  return scheduler
+      .<String>streamingBatch("reindex-" + albumId)
+      .fromStream(imageKeys)
+      .process(key -> renderDerivatives(key))
+      .withChunkSize(500)
+      .onBatchProgress(ctx -> progress.record(albumId, ctx))
+      .thenOnBatchSuccess(() -> publishAlbum(albumId))
+      .start();
+}
+```
+
+Same counting, same completion branches; the difference is that the items arrive 500 at a time off a stream you never fully materialize. Note the two progress hooks a streaming batch offers: `onProgress` watches the stream drain locally and is not persisted, while `onBatchProgress` reports execution progress and survives handoff to another node. Reach for `onBatchProgress` when the number has to be right after a restart.
+
+## Honest scope
+
+- Batches are an **optional store capability**. A store that does not advertise `BatchStore` throws `UnsupportedOperationException` from `enqueueBatch` and `streamingBatch`, by design: it refuses to persist a parent job whose children it cannot track, rather than silently dropping the count. The bundled MySQL, PostgreSQL, and MongoDB stores all advertise it.
+- The items and the per-item action must be `Serializable`; the action is stored and replayed, so capture ids and keys, not live service handles.
+- Children are independent and run in whatever order workers claim them. A batch counts completions and failures; it does not sequence one item after another. If item B depends on item A, that is a [workflow](../concepts/workflows.md), not a batch.
+- `submit()` runs with the Jakarta transaction attribute `REQUIRED`, so the batch is created inside the caller's transaction. The children become eligible when that transaction commits, then run on the next poll, not the same instant.
+
+## Why reach for a batch
+
+The work was always going to be a few thousand background jobs. What a batch saves you is the ledger around them: the concurrency-safe counting, the "is it finished" check, and the decision about what a partial result means. Those land as `completedItems` and `failedItems` on a snapshot, `isComplete` instead of a polling loop, and `thenWhenSuccessRate` instead of an after-the-fact audit. You describe the items, the work, and the finish conditions; the count is the store's problem.
+
+## Next steps
+
+- [Batches](../concepts/batches.md) -- the model behind parent jobs, child jobs, and aggregate state
+- [Workflows](../concepts/workflows.md) -- when items must run in order, or a batch must lead into the next step
+- [BatchBuilder](../api-reference/batch-builder.md) -- every builder method, including the `thenWhen` conditions
+- [BatchContext](../api-reference/batch-context.md) -- the progress record and its derived accessors
+- [Quickstart](../getting-started/quickstart.md) -- get a first job running

--- a/website/docs/use-cases/durable-llm-workflows.md
+++ b/website/docs/use-cases/durable-llm-workflows.md
@@ -10,7 +10,7 @@ Calling a language model from a request thread is a trap. The call is slow, it f
 This is the problem durable execution solves, and it is what Ratchet already does for any other background work. Ratchet is not an AI framework and ships no model client. It is the layer underneath: it persists the call before it runs, retries it with backoff, trips a circuit breaker when the provider is down, and resumes a half-finished multi-step workflow after a crash. You bring the model client. On Jakarta EE the natural choice is [langchain4j-cdi](https://github.com/langchain4j/langchain4j-cdi), which exposes a [LangChain4j](https://docs.langchain4j.dev) AI service as an injectable CDI bean, the same programming model Ratchet uses.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. It is not a full runnable application — wiring it up needs a Jakarta EE server and AWS credentials — but the API usage is real, not illustrative pseudocode.
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. It is not a full runnable application (wiring it up needs a Jakarta EE server and AWS credentials), but the API usage is real, not illustrative pseudocode.
 :::
 
 ## What you wire together
@@ -35,7 +35,7 @@ The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`, `langchai
   <version>1.3.3</version>
 </dependency>
 
-<!-- A model provider — Amazon Bedrock here; any LangChain4j provider works -->
+<!-- A model provider; Amazon Bedrock here, but any LangChain4j provider works -->
 <dependency>
   <groupId>dev.langchain4j</groupId>
   <artifactId>langchain4j-bedrock</artifactId>
@@ -45,7 +45,7 @@ The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`, `langchai
 
 ## Define the AI service
 
-A LangChain4j AI service is a plain interface. The `@RegisterAIService` annotation makes langchain4j-cdi register it as a CDI bean you can inject anywhere — including inside a Ratchet job.
+A LangChain4j AI service is a plain interface. The `@RegisterAIService` annotation makes langchain4j-cdi register it as a CDI bean you can inject anywhere, including inside a Ratchet job.
 
 ```java
 import dev.langchain4j.cdi.spi.RegisterAIService;
@@ -86,7 +86,7 @@ public class ChatModelProducer {
 }
 ```
 
-`BedrockChatModel` uses the default AWS credential chain and region resolution, so the same code runs against any model on Bedrock by changing the `modelId`. If you would rather configure the model with properties than code, langchain4j-cdi can build it from MicroProfile Config instead — see the [langchain4j-cdi docs](https://github.com/langchain4j/langchain4j-cdi).
+`BedrockChatModel` uses the default AWS credential chain and region resolution, so the same code runs against any model on Bedrock by changing the `modelId`. If you would rather configure the model with properties than code, langchain4j-cdi can build it from MicroProfile Config instead. See the [langchain4j-cdi docs](https://github.com/langchain4j/langchain4j-cdi).
 
 ## Run the model call as a durable job
 
@@ -158,7 +158,7 @@ You could call the model inline, or stand up a separate durable-execution servic
 
 ## Next steps
 
-- [Retry strategies](../concepts/retry-strategies.md) — tune backoff and max attempts per job
-- [Workflows](../concepts/workflows.md) — chaining, branching, and signal-waiting in depth
-- [Circuit breakers](../advanced/circuit-breakers.md) — trip out a model provider that is down
-- [Quickstart](../getting-started/quickstart.md) — get a first job running
+- [Retry strategies](../concepts/retry-strategies.md) -- tune backoff and max attempts per job
+- [Workflows](../concepts/workflows.md) -- chaining, branching, and signal-waiting in depth
+- [Circuit breakers](../advanced/circuit-breakers.md) -- trip out a model provider that is down
+- [Quickstart](../getting-started/quickstart.md) -- get a first job running

--- a/website/docs/use-cases/durable-llm-workflows.md
+++ b/website/docs/use-cases/durable-llm-workflows.md
@@ -1,9 +1,9 @@
 ---
-title: Durable LLM & agent workflows
+title: Durable LLM & Agent Workflows
 description: Run LLM calls and multi-step agent workflows as persisted, retrying Ratchet jobs in a Jakarta EE app, with langchain4j-cdi supplying the model client.
 ---
 
-# Durable LLM & agent workflows
+# Durable LLM & Agent Workflows
 
 Calling a language model from a request thread is a trap. The call is slow, it fails in ways ordinary code does not (a 429 from the provider, a socket timeout, a model that is briefly overloaded), and an agent rarely makes just one call: it retrieves context, calls the model, runs a tool, calls the model again. Do that inline and a single restart loses everything in flight, and a provider hiccup surfaces as a failed HTTP request to your user.
 

--- a/website/docs/use-cases/durable-llm-workflows.md
+++ b/website/docs/use-cases/durable-llm-workflows.md
@@ -1,0 +1,164 @@
+---
+title: Durable LLM & agent workflows
+description: Run LLM calls and multi-step agent workflows as persisted, retrying Ratchet jobs in a Jakarta EE app, with langchain4j-cdi supplying the model client.
+---
+
+# Durable LLM & agent workflows
+
+Calling a language model from a request thread is a trap. The call is slow, it fails in ways ordinary code does not (a 429 from the provider, a socket timeout, a model that is briefly overloaded), and an agent rarely makes just one call: it retrieves context, calls the model, runs a tool, calls the model again. Do that inline and a single restart loses everything in flight, and a provider hiccup surfaces as a failed HTTP request to your user.
+
+This is the problem durable execution solves, and it is what Ratchet already does for any other background work. Ratchet is not an AI framework and ships no model client. It is the layer underneath: it persists the call before it runs, retries it with backoff, trips a circuit breaker when the provider is down, and resumes a half-finished multi-step workflow after a crash. You bring the model client. On Jakarta EE the natural choice is [langchain4j-cdi](https://github.com/langchain4j/langchain4j-cdi), which exposes a [LangChain4j](https://docs.langchain4j.dev) AI service as an injectable CDI bean, the same programming model Ratchet uses.
+
+::: tip Verified
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. It is not a full runnable application — wiring it up needs a Jakarta EE server and AWS credentials — but the API usage is real, not illustrative pseudocode.
+:::
+
+## What you wire together
+
+```xml
+<!-- Ratchet: the durable execution engine + a store -->
+<dependency>
+  <groupId>run.ratchet</groupId>
+  <artifactId>ratchet</artifactId>
+  <version>0.1.1-SNAPSHOT</version>
+</dependency>
+<dependency>
+  <groupId>run.ratchet</groupId>
+  <artifactId>ratchet-store-postgresql</artifactId>
+  <version>0.1.1-SNAPSHOT</version>
+</dependency>
+
+<!-- langchain4j-cdi: AI services as CDI beans on WildFly, Liberty, Payara, GlassFish -->
+<dependency>
+  <groupId>dev.langchain4j.cdi</groupId>
+  <artifactId>langchain4j-cdi-portable-ext</artifactId>
+  <version>1.3.3</version>
+</dependency>
+
+<!-- A model provider — Amazon Bedrock here; any LangChain4j provider works -->
+<dependency>
+  <groupId>dev.langchain4j</groupId>
+  <artifactId>langchain4j-bedrock</artifactId>
+  <version>1.0.0-beta5</version>
+</dependency>
+```
+
+## Define the AI service
+
+A LangChain4j AI service is a plain interface. The `@RegisterAIService` annotation makes langchain4j-cdi register it as a CDI bean you can inject anywhere — including inside a Ratchet job.
+
+```java
+import dev.langchain4j.cdi.spi.RegisterAIService;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@RegisterAIService(chatModelName = "doc-assistant")
+public interface DocAssistant {
+
+  @SystemMessage("You are a precise technical summarizer. Answer in {{language}}.")
+  String summarize(@UserMessage String document, @V("language") String language);
+}
+```
+
+## Provide the model
+
+`chatModelName` points at a CDI bean that produces the `ChatModel`. Build it once and let the container manage it:
+
+```java
+import dev.langchain4j.model.bedrock.BedrockChatModel;
+import dev.langchain4j.model.chat.ChatModel;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+
+@ApplicationScoped
+public class ChatModelProducer {
+
+  @Produces
+  @Named("doc-assistant")
+  @ApplicationScoped
+  public ChatModel docAssistantModel() {
+    return BedrockChatModel.builder()
+        .modelId("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+        .build();
+  }
+}
+```
+
+`BedrockChatModel` uses the default AWS credential chain and region resolution, so the same code runs against any model on Bedrock by changing the `modelId`. If you would rather configure the model with properties than code, langchain4j-cdi can build it from MicroProfile Config instead — see the [langchain4j-cdi docs](https://github.com/langchain4j/langchain4j-cdi).
+
+## Run the model call as a durable job
+
+Here is the part Ratchet exists for. The request thread enqueues the work and returns; the model call runs on a worker, persisted, with retries and a timeout. A 429 or a dropped connection no longer fails the user's request. It just retries with backoff.
+
+```java
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobSchedulerService;
+
+@ApplicationScoped
+public class DocumentIntake {
+
+  @Inject JobSchedulerService scheduler;
+
+  @Inject DocAssistant assistant;
+
+  /** The request thread returns immediately; the model call runs as a persisted, retrying job. */
+  public JobHandle enqueueSummary(UUID documentId) {
+    return scheduler
+        .enqueue(() -> summarize(documentId))
+        .withMaxRetries(5)
+        .withBackoff(BackoffPolicy.EXPONENTIAL, Duration.ofSeconds(2))
+        .withTimeout(Duration.ofMinutes(2))
+        .withTags("llm", "summarize")
+        .submit();
+  }
+
+  /** Runs inside the job. Ratchet resolves this bean from CDI; only documentId is serialized. */
+  public void summarize(UUID documentId) {
+    String text = loadDocument(documentId);
+    String summary = assistant.summarize(text, "English");
+    storeSummary(documentId, summary);
+  }
+}
+```
+
+The lambda passed to `enqueue` is a method call on a CDI bean. Ratchet serializes only the arguments (`documentId`) and resolves the bean again from CDI when the job runs, so the injected `DocAssistant` is live at execution time, not captured at submission. Exhaust the retries and the job lands in the dead-letter queue with its error, instead of vanishing.
+
+Exponential backoff is the right default for a model provider: rate limits and brief overloads clear on their own, and backing off is what they are asking you to do.
+
+## Chain the steps of an agent workflow
+
+Agents are multi-step, and the steps fail independently. Model each step as its own job and chain them. A failure in step three does not discard the results of steps one and two, which are already persisted.
+
+```java
+scheduler.enqueue(() -> retrieveContext(queryId))
+    .thenOnSuccess(() -> answerWithModel(queryId))
+    .thenOnSuccess(() -> indexAnswer(queryId))
+    .thenOnFailure(() -> flagForReview(queryId))
+    .submit();
+```
+
+Each step is a separate persisted job with its own retry budget. If `answerWithModel` keeps failing, Ratchet retries that step alone and the retrieved context is not thrown away and re-fetched.
+
+## Pause for a human, then resume
+
+Some agent actions should not happen without sign-off: sending the email it drafted, filing the ticket, running the refund. Ratchet has a waiting state for exactly this: a job can wait for a signal, and an approval (from a UI, a webhook, a Slack action) delivers that signal to resume it. The job holds no thread while it waits. See [Workflows](../concepts/workflows.md) and the signal APIs on [`JobSchedulerService`](../api-reference/job-scheduler-service.md) for the delivery contract.
+
+## Why run it through Ratchet
+
+You could call the model inline, or stand up a separate durable-execution service. Ratchet's argument is the same one it makes everywhere else: it lives inside the Jakarta EE server you already run. No second orchestrator to operate, no extra datastore, no separate programming model. The model client is a CDI bean, the job is a CDI bean, and the work survives a restart because it was written to your database before it ran.
+
+## Next steps
+
+- [Retry strategies](../concepts/retry-strategies.md) — tune backoff and max attempts per job
+- [Workflows](../concepts/workflows.md) — chaining, branching, and signal-waiting in depth
+- [Circuit breakers](../advanced/circuit-breakers.md) — trip out a model provider that is down
+- [Quickstart](../getting-started/quickstart.md) — get a first job running

--- a/website/docs/use-cases/human-in-the-loop.md
+++ b/website/docs/use-cases/human-in-the-loop.md
@@ -1,0 +1,113 @@
+---
+title: Human-in-the-Loop Jobs
+description: Park a job in a waiting state until a person approves it, then resume exactly where it left off -- holding no thread, surviving restarts, and timing out on its own if nobody answers.
+---
+
+# Human-in-the-Loop Jobs
+
+A refund over five hundred dollars should not go out until a person says so. The logic is ready the moment the request arrives: look up the order, check the amount, move the money. What is missing is a decision, and that decision might come in ten seconds or two days, from a button in an admin console, a reply in Slack, or a callback from a finance system.
+
+The clumsy way to wait is to not wait at all: write a `refund_pending` row, drop the in-progress work on the floor, and rebuild it later when the approval shows up. Now the logic lives in two places, the "resume" path drifts from the "start" path, and a half-decided refund is a row somebody has to reconcile by hand. The other clumsy way is to actually block a thread for two days, which is a thread you do not get back.
+
+Ratchet gives the job a waiting state instead. It parks in `WAITING`, holds no thread, and survives a restart as a row in the database. An approval delivers a signal that moves it back to runnable, and the same job body that was about to run the refund now runs it, reading the approver's decision as it goes.
+
+The [durable LLM workflows](./durable-llm-workflows.md#pause-for-a-human-then-resume) page reaches for this same mechanism to gate an agent's actions. This page is the mechanism itself: how a job waits, how a decision reaches it, and what happens when nobody decides.
+
+::: tip Verified
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `SignalStore` capability.
+:::
+
+## Park, decide, resume
+
+```java
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.UUID;
+
+import run.ratchet.api.JobContext;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobSchedulerService;
+import run.ratchet.api.SignalDecision;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class RefundApproval {
+
+  @Inject JobSchedulerService scheduler;
+
+  @Inject RefundStore refunds;
+
+  // 1. The refund job is created already waiting. It will not run until signaled.
+  @Transactional
+  public UUID requestRefund(UUID refundId) {
+    JobHandle handle =
+        scheduler
+            .enqueue(() -> settleRefund(refundId))
+            .awaitSignal("refund-" + refundId, Duration.ofDays(2))
+            .submit();
+    refunds.recordPendingApproval(refundId, handle.id());
+    return handle.id();
+  }
+
+  // 2. The approver's action delivers a structured decision to that exact job.
+  public boolean approve(UUID jobId, String approver) {
+    return scheduler.deliverSignal(jobId, SignalDecision.approved(approver)) == 1;
+  }
+
+  public boolean reject(UUID jobId, String reason) {
+    return scheduler.deliverSignal(jobId, SignalDecision.rejected(null, reason)) == 1;
+  }
+
+  // 3. Once unblocked, the job body reads the decision and acts on it.
+  void settleRefund(UUID refundId) {
+    SignalDecision decision = JobContext.current().signalPayload(SignalDecision.class);
+    if (decision == null || decision.isRejected()) {
+      String why = decision == null ? "approval timed out" : decision.rejectionReason();
+      refunds.markDenied(refundId, why);
+      return;
+    }
+    String approver = decision.payload(String.class);
+    BigDecimal amount = refunds.amountOf(refundId);
+    refunds.payOut(refundId, amount, approver);
+  }
+}
+```
+
+`awaitSignal(signalKey, timeout)` is what marks the builder, so `submit()` persists the job in `WAITING` rather than `PENDING`. No worker claims it. It is a durable row holding a place in line, costing nothing but the row, until something wakes it.
+
+What wakes it is a decision, and the decision is structured. `SignalDecision.approved(approver)` and `SignalDecision.rejected(null, reason)` both carry an outcome the scheduler records: a rejection has to include a reason, an approval must not. The job reads that decision back with `signalPayload(SignalDecision.class)`, and the `outcome` and `rejectionReason` come through typed, exactly as sent. The inner payload is the soft spot. The `approver` string survives only in its JSON-native form, so you ask for `String.class`, not for some class of your own. Note too that delivering a decision unblocks the job whichever way it points; paying out an approval or recording a denial is the job body's job, which is why all of it sits in one method.
+
+Delivery is also idempotent, which matters more than it sounds. `deliverSignal(jobId, decision)` returns `1` when it moved a waiting job and `0` when it didn't, so a double-clicked Approve button does no harm: the first call unblocks the job, the second finds it already gone from `WAITING` and reports `0`. The broadcast form, `deliverSignal(signalKey, decision)`, wakes every job waiting on that key and tells you how many it moved. Reach for the `jobId` form to approve one thing and the `signalKey` form to release a whole group at once.
+
+## When nobody decides
+
+A wait cannot be open-ended, which is why `awaitSignal` requires a timeout. A scanner running on the poll tick looks for waiting jobs whose deadline has passed and resolves them so they never sit forever.
+
+What "resolve" means depends on the job's retry budget:
+
+- **No retries (the default).** The wait times out into a permanent failure. The job moves to `FAILED` with a `SignalTimeoutException`, fires a `JobSignalTimedOutEvent`, and travels the normal failure path, including the dead-letter queue, so a refund nobody approved becomes a visible, inspectable failure rather than a silent stall.
+- **Retries configured.** A timeout reschedules the job to actually run, without a delivered decision. That is the case the `decision == null` branch above is written for: the body wakes with no approval and denies the refund rather than paying it out. Treat `null` as "no one said yes."
+
+Either way the timeout is the job's own concern. You do not run a reaper, and a process restart mid-wait changes nothing, because the deadline lives on the row, not in memory.
+
+## Honest scope
+
+- Signals are an **optional store capability**. A store that does not advertise `SignalStore` throws `UnsupportedOperationException` from the submission path, refusing to create a `WAITING` job it could neither signal nor time out, rather than stranding it forever. The bundled MySQL, PostgreSQL, and MongoDB stores all advertise it.
+- A signal payload is **not a typed-bean carrier**. It round-trips as JSON, so it returns as a `String`, a `Number` (a `BigDecimal` under the default serializer), a `Boolean`, a `List`, or a `Map`. Pass an id or an amount and look the rest up; do not try to ship a domain object through the signal and get the same class back.
+- `awaitSignal` waits for *a* signal, not a conversation. For multi-step back-and-forth (approve, then later confirm shipment), model each wait as its own job in a [workflow](../concepts/workflows.md), chained on the previous one's result.
+- The decision's outcome is **scheduler-visible metadata for audit and events, not enforcement**. An approved decision still just unblocks the job; nothing pays out until your body decides to. Approval and rejection are signals to your code, not actions the scheduler takes on your behalf.
+
+## Why park it in Ratchet
+
+The alternative is two code paths and a reconciliation problem: one path that starts the refund, a `pending` row that throws away the in-progress work, and a second path that has to reconstruct it when approval lands, kept in sync with the first by hand. A waiting job collapses that into one. The work pauses in place and resumes in the same method, the decision arrives as data the body reads, and the case nobody wants to handle, the approval that never comes, is handled by the timeout you were required to set. One method, one row, and a deadline that cannot be forgotten.
+
+## Next steps
+
+- [Job lifecycle](../concepts/job-lifecycle.md) -- where `WAITING` sits among a job's states
+- [Workflows](../concepts/workflows.md) -- chaining waits for multi-step approvals
+- [JobBuilder](../api-reference/job-builder.md) -- `awaitSignal` and the rest of the builder
+- [JobSchedulerService](../api-reference/job-scheduler-service.md) -- the `deliverSignal` delivery contract
+- [Durable LLM & agent workflows](./durable-llm-workflows.md) -- the same pause-for-a-human, applied to agents

--- a/website/docs/use-cases/offload-after-request.md
+++ b/website/docs/use-cases/offload-after-request.md
@@ -78,7 +78,7 @@ The lambdas are method references on this CDI bean. Ratchet serializes only the 
 
 The reason this is safe and a thread pool is not comes down to one line in the API contract: `submit()` runs with the Jakarta transaction attribute `REQUIRED`. It persists the job inside whatever transaction is already open — here, the one `@Transactional` started on `placeOrder`.
 
-So the order row and the three job rows are a single commit. Two outcomes, no third:
+So the order row and the three job rows are a single commit, with only two ways it can land:
 
 - The transaction commits. The order is saved **and** all three jobs are guaranteed to run.
 - Something rolls back — a constraint violation, a thrown exception, a crash mid-method. The order is not saved **and** no jobs exist. Nothing was half-done.
@@ -102,7 +102,7 @@ Key the job on something stable from the request — an order id, a payment inte
 
 ## What happens when the work fails
 
-A worker runs the job, not the request thread, so failure has somewhere to go that is not the customer's screen. `reserveInventory` above gets five attempts with exponential backoff. If the inventory service is briefly down, the retries ride it out. If it stays down past the retry budget, the job lands in the dead-letter queue with its final error attached, where you can inspect it and replay it. It does not vanish, and it does not take the order down with it.
+A worker runs the job, not the request thread, so failure has somewhere to go that is not the customer's screen. `reserveInventory` above gets five attempts with exponential backoff. If the inventory service is briefly down, the retries ride it out. If it stays down past the retry budget, the job lands in the dead-letter queue with its final error attached, ready to inspect and replay. The order was committed and answered long before any of this, so a stuck side effect stays a side effect.
 
 ## Honest scope
 

--- a/website/docs/use-cases/offload-after-request.md
+++ b/website/docs/use-cases/offload-after-request.md
@@ -1,18 +1,18 @@
 ---
 title: Offload Work After a Request
-description: Persist follow-up work in the same transaction as your business write, return the response immediately, and let Ratchet run the side effects on a worker — durably, with retries.
+description: Persist follow-up work in the same transaction as your business write, return the response immediately, and let Ratchet run the side effects on a worker, durably and with retries.
 ---
 
 # Offload Work After a Request
 
-A checkout request has one job: take the order and say yes. The receipt email, the inventory hold, the nudge to the warehouse — none of that has to finish before the customer sees a confirmation. Do it inline anyway and you have tied the success of the order to the mood of your SMTP provider. The email times out, the whole request 500s, and the customer is left wondering whether they just bought anything.
+A checkout request has one job: take the order and say yes. The receipt email, the inventory hold, the nudge to the warehouse: none of that has to finish before the customer sees a confirmation. Do it inline anyway and you have tied the success of the order to the mood of your SMTP provider. The email times out, the whole request 500s, and the customer is left wondering whether they just bought anything.
 
 The usual escape hatch is a thread pool, or a `@Async` method, or handing the work to a message broker. The thread pool loses everything in flight when the process restarts. The broker is a second system to run, and now you have the dual-write problem: you saved the order to your database and published a message to the broker, and there is a window where one happened and the other did not.
 
-Ratchet closes that window. You enqueue the follow-up work inside the same transaction that writes the order, so the job and the order row commit together. The request returns as soon as the row is durable. The work runs later, on a worker, with retries — and it cannot get lost, because it was written to the same database as the thing it follows up on.
+Ratchet closes that window. You enqueue the follow-up work inside the same transaction that writes the order, so the job and the order row commit together. The request returns as soon as the row is durable. The work runs later, on a worker, with retries, and it cannot get lost, because it was written to the same database as the thing it follows up on.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode — the running app needs a Jakarta EE server and a configured store.
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
 :::
 
 ## Enqueue inside the transaction, return now
@@ -76,18 +76,18 @@ The lambdas are method references on this CDI bean. Ratchet serializes only the 
 
 ## Why "before returning" is a real guarantee
 
-The reason this is safe and a thread pool is not comes down to one line in the API contract: `submit()` runs with the Jakarta transaction attribute `REQUIRED`. It persists the job inside whatever transaction is already open — here, the one `@Transactional` started on `placeOrder`.
+The reason this is safe and a thread pool is not comes down to one line in the API contract: `submit()` runs with the Jakarta transaction attribute `REQUIRED`. It persists the job inside whatever transaction is already open: here, the one `@Transactional` started on `placeOrder`.
 
 So the order row and the three job rows are a single commit, with only two ways it can land:
 
 - The transaction commits. The order is saved **and** all three jobs are guaranteed to run.
-- Something rolls back — a constraint violation, a thrown exception, a crash mid-method. The order is not saved **and** no jobs exist. Nothing was half-done.
+- Something rolls back: a constraint violation, a thrown exception, a crash mid-method. The order is not saved **and** no jobs exist. Nothing was half-done.
 
 There is no moment where the order persisted but the receipt job evaporated, and none where a job is queued for an order that was rolled back. That is the dual-write problem, and Ratchet sidesteps it by making the queue part of your database instead of a system beside it.
 
 ## Idempotency: the double-submit problem
 
-Users double-click. Load balancers retry. A flaky network makes the browser resend a POST that actually succeeded. Without a guard, each of those creates a second order — and a second receipt.
+Users double-click. Load balancers retry. A flaky network makes the browser resend a POST that actually succeeded. Without a guard, each of those creates a second order, and a second receipt.
 
 `withIdempotencyKey` is the guard. The key is unique forever, enforced by a database constraint. Submit a job with a key that already exists and the duplicate is silently dropped, not run again.
 
@@ -98,7 +98,7 @@ scheduler
     .submit();
 ```
 
-Key the job on something stable from the request — an order id, a payment intent id, a webhook delivery id. Now "send the receipt for order 8412" can be attempted any number of times and the email goes out once.
+Key the job on something stable from the request: an order id, a payment intent id, a webhook delivery id. Now "send the receipt for order 8412" can be attempted any number of times and the email goes out once.
 
 ## What happens when the work fails
 
@@ -106,7 +106,7 @@ A worker runs the job, not the request thread, so failure has somewhere to go th
 
 ## Honest scope
 
-- The work runs **after** the response, not during it. If the caller needs the result to answer the request — a computed total, a validation verdict — that is synchronous work and belongs inline, not in a job.
+- The work runs **after** the response, not during it. If the caller needs the result to answer the request, like a computed total or a validation verdict, that is synchronous work and belongs inline, not in a job.
 - The three jobs here are independent and run in whatever order workers pick them up. If step B must follow step A, chain them with `then` / `thenOnSuccess` or model it as a [workflow](../concepts/workflows.md); do not rely on submission order.
 - Jobs become eligible the instant the transaction commits, but they run on the next poll cycle, not the same millisecond. This is fast background work, not an inline call.
 
@@ -116,8 +116,8 @@ A thread pool is simpler until the process restarts and the in-flight work is go
 
 ## Next steps
 
-- [Job lifecycle](../concepts/job-lifecycle.md) — how a submitted job moves to running, succeeded, or dead-lettered
-- [Persistence](../concepts/persistence.md) — why the job and your data share one commit
-- [Retry strategies](../concepts/retry-strategies.md) — tune backoff and attempts per job
-- [JobBuilder](../api-reference/job-builder.md) — every option on the builder, including idempotency and tags
-- [Quickstart](../getting-started/quickstart.md) — get a first job running
+- [Job lifecycle](../concepts/job-lifecycle.md) -- how a submitted job moves to running, succeeded, or dead-lettered
+- [Persistence](../concepts/persistence.md) -- why the job and your data share one commit
+- [Retry strategies](../concepts/retry-strategies.md) -- tune backoff and attempts per job
+- [JobBuilder](../api-reference/job-builder.md) -- every option on the builder, including idempotency and tags
+- [Quickstart](../getting-started/quickstart.md) -- get a first job running

--- a/website/docs/use-cases/offload-after-request.md
+++ b/website/docs/use-cases/offload-after-request.md
@@ -1,0 +1,123 @@
+---
+title: Offload Work After a Request
+description: Persist follow-up work in the same transaction as your business write, return the response immediately, and let Ratchet run the side effects on a worker — durably, with retries.
+---
+
+# Offload Work After a Request
+
+A checkout request has one job: take the order and say yes. The receipt email, the inventory hold, the nudge to the warehouse — none of that has to finish before the customer sees a confirmation. Do it inline anyway and you have tied the success of the order to the mood of your SMTP provider. The email times out, the whole request 500s, and the customer is left wondering whether they just bought anything.
+
+The usual escape hatch is a thread pool, or a `@Async` method, or handing the work to a message broker. The thread pool loses everything in flight when the process restarts. The broker is a second system to run, and now you have the dual-write problem: you saved the order to your database and published a message to the broker, and there is a window where one happened and the other did not.
+
+Ratchet closes that window. You enqueue the follow-up work inside the same transaction that writes the order, so the job and the order row commit together. The request returns as soon as the row is durable. The work runs later, on a worker, with retries — and it cannot get lost, because it was written to the same database as the thing it follows up on.
+
+::: tip Verified
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode — the running app needs a Jakarta EE server and a configured store.
+:::
+
+## Enqueue inside the transaction, return now
+
+```java
+import java.time.Duration;
+import java.util.UUID;
+
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobSchedulerService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+@ApplicationScoped
+public class CheckoutService {
+
+  @Inject JobSchedulerService scheduler;
+
+  @Inject OrderRepository orders;
+
+  @Transactional
+  public OrderConfirmation placeOrder(Cart cart) {
+    Order order = orders.save(Order.from(cart));
+
+    scheduler
+        .enqueue(() -> sendReceipt(order.id()))
+        .withIdempotencyKey("receipt-" + order.id())
+        .withTags("email", "receipt")
+        .submit();
+
+    scheduler
+        .enqueue(() -> reserveInventory(order.id()))
+        .withMaxRetries(5)
+        .withBackoff(BackoffPolicy.EXPONENTIAL, Duration.ofSeconds(2))
+        .withTags("inventory")
+        .submit();
+
+    scheduler
+        .enqueue(() -> notifyFulfillment(order.id()))
+        .withPriority(JobPriority.HIGH)
+        .withTags("fulfillment")
+        .submit();
+
+    return OrderConfirmation.accepted(order.id());
+  }
+
+  void sendReceipt(UUID orderId) { /* render and send the email */ }
+
+  void reserveInventory(UUID orderId) { /* decrement stock, place the hold */ }
+
+  void notifyFulfillment(UUID orderId) { /* hand off to the warehouse */ }
+}
+```
+
+The handler returns `OrderConfirmation` the moment the order row is committed. Three jobs are now sitting in the database, due immediately, and a worker picks them up on the next poll. The customer never waited on any of them.
+
+The lambdas are method references on this CDI bean. Ratchet serializes only the argument (`order.id()`) and resolves the bean again from CDI when the job runs, so anything injected into `CheckoutService` is live at execution time, not captured at submission.
+
+## Why "before returning" is a real guarantee
+
+The reason this is safe and a thread pool is not comes down to one line in the API contract: `submit()` runs with the Jakarta transaction attribute `REQUIRED`. It persists the job inside whatever transaction is already open — here, the one `@Transactional` started on `placeOrder`.
+
+So the order row and the three job rows are a single commit. Two outcomes, no third:
+
+- The transaction commits. The order is saved **and** all three jobs are guaranteed to run.
+- Something rolls back — a constraint violation, a thrown exception, a crash mid-method. The order is not saved **and** no jobs exist. Nothing was half-done.
+
+There is no moment where the order persisted but the receipt job evaporated, and none where a job is queued for an order that was rolled back. That is the dual-write problem, and Ratchet sidesteps it by making the queue part of your database instead of a system beside it.
+
+## Idempotency: the double-submit problem
+
+Users double-click. Load balancers retry. A flaky network makes the browser resend a POST that actually succeeded. Without a guard, each of those creates a second order — and a second receipt.
+
+`withIdempotencyKey` is the guard. The key is unique forever, enforced by a database constraint. Submit a job with a key that already exists and the duplicate is silently dropped, not run again.
+
+```java
+scheduler
+    .enqueue(() -> sendReceipt(orderId))
+    .withIdempotencyKey("receipt-" + orderId)
+    .submit();
+```
+
+Key the job on something stable from the request — an order id, a payment intent id, a webhook delivery id. Now "send the receipt for order 8412" can be attempted any number of times and the email goes out once.
+
+## What happens when the work fails
+
+A worker runs the job, not the request thread, so failure has somewhere to go that is not the customer's screen. `reserveInventory` above gets five attempts with exponential backoff. If the inventory service is briefly down, the retries ride it out. If it stays down past the retry budget, the job lands in the dead-letter queue with its final error attached, where you can inspect it and replay it. It does not vanish, and it does not take the order down with it.
+
+## Honest scope
+
+- The work runs **after** the response, not during it. If the caller needs the result to answer the request — a computed total, a validation verdict — that is synchronous work and belongs inline, not in a job.
+- The three jobs here are independent and run in whatever order workers pick them up. If step B must follow step A, chain them with `then` / `thenOnSuccess` or model it as a [workflow](../concepts/workflows.md); do not rely on submission order.
+- Jobs become eligible the instant the transaction commits, but they run on the next poll cycle, not the same millisecond. This is fast background work, not an inline call.
+
+## Why run it through Ratchet
+
+A thread pool is simpler until the process restarts and the in-flight work is gone. A broker is durable but it is a second datastore to run, secure, and keep in sync with your database. Ratchet's pitch is the boring middle: the durability of a persisted queue with none of the dual-write risk, because the queue lives in the database you already committed the order to. The follow-up work is a CDI bean, enqueued in the same transaction, and it survives a restart because it was written down before the response was sent.
+
+## Next steps
+
+- [Job lifecycle](../concepts/job-lifecycle.md) — how a submitted job moves to running, succeeded, or dead-lettered
+- [Persistence](../concepts/persistence.md) — why the job and your data share one commit
+- [Retry strategies](../concepts/retry-strategies.md) — tune backoff and attempts per job
+- [JobBuilder](../api-reference/job-builder.md) — every option on the builder, including idempotency and tags
+- [Quickstart](../getting-started/quickstart.md) — get a first job running

--- a/website/docs/use-cases/resilient-integrations.md
+++ b/website/docs/use-cases/resilient-integrations.md
@@ -1,0 +1,123 @@
+---
+title: Resilient Third-Party Integrations
+description: Call flaky external APIs from durable jobs that retry transient failures with backoff and trip a circuit breaker during an outage, so a downstream provider going down does not take your work with it.
+---
+
+# Resilient Third-Party Integrations
+
+Sooner or later your code has to call someone else's: a payment gateway, a shipping carrier, an email provider, a partner's REST API. Those calls fail in two different ways, and the two need different answers. Sometimes it is a blip, a 503 or a dropped connection that works on the next try. Sometimes the provider is genuinely down, and every call you make for the next ten minutes is going to fail no matter what.
+
+Retrying handles the blip. It is the wrong tool for the outage: a hundred queued jobs each retrying a dead API eight times is four hundred doomed calls and a thundering herd on a service that is already struggling. A circuit breaker handles the outage. It notices the failure rate, stops sending calls for a while, and lets the provider recover.
+
+Ratchet gives you both, and they stay out of each other's way. The retry budget rides out transient errors. The breaker rides out outages without spending that budget. The external call lives in a durable job, so none of this happens on the request thread, and a provider's bad afternoon never reaches your user as a failed request.
+
+::: tip Verified
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store. The `@CircuitBreakerProtected` annotation is marked `@Incubating` and may change.
+:::
+
+## Layer one: the call as a retrying job
+
+Put the external call in a job, give it a retry budget, and back off between attempts. A transient failure now costs the customer nothing.
+
+```java
+import java.time.Duration;
+import java.util.UUID;
+
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobSchedulerService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class FulfillmentJobs {
+
+  @Inject JobSchedulerService scheduler;
+
+  @Inject CarrierApi carrier;
+
+  @Inject ShipmentRepository shipments;
+
+  public JobHandle requestLabel(UUID orderId) {
+    return scheduler
+        .enqueue(() -> bookLabel(orderId))
+        .withMaxRetries(8)
+        .withBackoff(BackoffPolicy.EXPONENTIAL, Duration.ofSeconds(5))
+        .withTimeout(Duration.ofSeconds(30))
+        .withIdempotencyKey("label-" + orderId)
+        .withTags("shipping", "external")
+        .submit();
+  }
+
+  public void bookLabel(UUID orderId) {
+    String tracking = carrier.createLabel(orderId);
+    shipments.attachTracking(orderId, tracking);
+  }
+}
+```
+
+Eight attempts with exponential backoff starting at five seconds spreads the retries out instead of slamming the carrier the instant it stutters. The timeout caps how long a single hung call can sit there. If every attempt fails, the job dead-letters with its last error, ready to inspect and replay.
+
+## Layer two: wrap the client in a circuit breaker
+
+The retry budget is for failures that clear on their own. It does nothing for a carrier that is flat-out down, where retrying is just noise. That is the breaker's job. Annotate the client bean with `@CircuitBreakerProtected` and pick the `EXTERNAL_API` profile, which is tuned for third-party services.
+
+```java
+import java.util.UUID;
+
+import run.ratchet.api.CircuitBreakerProfile;
+import run.ratchet.api.CircuitBreakerProtected;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@CircuitBreakerProtected(service = "carrier-api", profile = CircuitBreakerProfile.EXTERNAL_API)
+public class CarrierApi {
+
+  public String createLabel(UUID orderId) {
+    // POST to the carrier; throws on a non-2xx response or a timeout.
+    return doHttpCreateLabel(orderId);
+  }
+
+  private String doHttpCreateLabel(UUID orderId) { /* the real HTTP client */ }
+}
+```
+
+A CDI interceptor wraps every call to a method on this bean in a breaker keyed by `service`. The `EXTERNAL_API` profile opens the circuit once 60% of a 50-call sliding window has failed, holds it open for 60 seconds, then lets three trial calls through to test recovery. The `service` name is the unit of sharing: every bean and method that names `"carrier-api"` draws on the same breaker, so failures seen by one method protect all the others.
+
+## How the two layers stay out of each other's way
+
+This is the part that makes the combination work rather than fight. When the breaker is open, a call to `createLabel` does not run and does not fail in the ordinary sense. It throws `CircuitBreakerOpenException`, and Ratchet treats that differently from a normal job failure: the job is **rescheduled, not retried**. It goes back to pending with a delay set to whatever time is left on the breaker's open window, and its attempt counter is left untouched.
+
+So the two budgets never cannibalize each other:
+
+- A real failure from the carrier (a 500, a timeout) consumes one of the eight attempts and backs off. That is the retry budget doing its job.
+- An open circuit costs zero attempts. The job parks until the breaker is ready to test recovery, then tries for real.
+
+A ten-minute carrier outage no longer burns through a job's retries and dead-letters it while the carrier is still down. The breaker absorbs the outage; the retry budget is still there, intact, for the genuine attempt once the carrier is back. And because the breaker fails fast while open, a backlog of queued label jobs stops hammering the carrier within a single sliding window instead of grinding against it for as long as it stays down.
+
+## Retries need idempotency
+
+A retried `POST` is only safe if calling it twice does no harm. The first attempt might have reached the carrier and created the label before the response timed out, so attempt two could book a second shipment. Two defenses, used together:
+
+- `withIdempotencyKey` on the Ratchet job (above) stops a double submission of the same logical work from creating two jobs.
+- An idempotency key on the outbound request, derived from the order, lets the carrier collapse a duplicated call into the original. Most payment and shipping APIs support one; use it.
+
+## Honest scope
+
+- `@CircuitBreakerProtected` is `@Incubating`. The behavior is stable but the annotation's shape may change before it is finalized.
+- The breaker is in-process. Each node keeps its own failure window and trips its own circuit, so on a five-node cluster the provider sees up to five independent breakers, not one shared verdict. That is usually fine, since each node only stops sending its own doomed traffic.
+- The profile thresholds are defaults. If `EXTERNAL_API` is too eager or too patient for a particular provider, override the profile per deployment through `RatchetOptions` rather than reaching for a custom annotation.
+
+## Why run it through Ratchet
+
+You could wire up Resilience4j and a thread pool yourself and get to roughly the same place. Folding it into Ratchet means the retrying, the breaker, and the durable record of the work are one mechanism instead of three you have to integrate. The external call is a CDI bean, the breaker is an annotation on it, and the job that drives the call survives a restart because it was persisted before the first attempt. The flaky integration becomes a job like any other, with the failure handling already attached.
+
+## Next steps
+
+- [Circuit breakers](../advanced/circuit-breakers.md) -- profiles, state machine, and configuration overrides in depth
+- [Retry strategies](../concepts/retry-strategies.md) -- backoff policies and attempt budgets
+- [Error handling](../concepts/error-handling.md) -- how failures move through retries to the dead-letter queue
+- [Annotations](../api-reference/annotations.md) -- the full `@CircuitBreakerProtected` reference
+- [Quickstart](../getting-started/quickstart.md) -- get a first job running

--- a/website/docs/use-cases/scheduled-recurring-jobs.md
+++ b/website/docs/use-cases/scheduled-recurring-jobs.md
@@ -1,9 +1,9 @@
 ---
-title: Scheduled & recurring jobs
+title: Scheduled & Recurring Jobs
 description: Cron and delayed jobs that survive restarts and never double-fire across a cluster, run inside the Jakarta EE server you already operate — no separate scheduler.
 ---
 
-# Scheduled & recurring jobs
+# Scheduled & Recurring Jobs
 
 Every application grows a list of things that have to happen on a clock. Purge expired sessions at 2 AM. Send the weekly digest on Monday morning. Retry the failed exports an hour later. Poll a partner's API every fifteen minutes during business hours.
 

--- a/website/docs/use-cases/scheduled-recurring-jobs.md
+++ b/website/docs/use-cases/scheduled-recurring-jobs.md
@@ -106,15 +106,13 @@ The delay is computed once, at submission: the job is persisted now and stays in
 
 ## Honest scope
 
-A few things worth saying plainly:
-
 - Cron is **Quartz syntax** (6–7 fields with `?` and `L`/`W` support), not the 5-field Unix crontab. `0 0 2 * * ?` is daily at 2 AM, and the leading field is seconds.
 - Schedules default to **UTC**. Set `zone` per job when a schedule has to track a wall clock through DST.
 - A recurring job is regular, not real-time. Fire times are honored at the resolution of the poll cycle, so a 15-minute schedule is reliable; a "run at exactly 14:30:00.000" guarantee is not what this is.
 
 ## Why run it through Ratchet
 
-You could keep Quartz, or a `@Scheduled` bean, or a crontab. The argument for folding the schedule into Ratchet is the same one it makes everywhere else: the run is durable because it was written to your database before it happened, and it is cluster-safe because one row can only be claimed once. The scheduler is not a separate service with its own tables and its own failure modes. It is the job engine you already run, plus a cron string.
+You could keep Quartz, or a `@Scheduled` bean, or a crontab. Folding the schedule into Ratchet instead buys you the two things those make you build by hand: the run is durable because it was written to your database before it fired, and it is cluster-safe because one row can only be claimed once. The scheduler stops being a separate service with its own tables and its own failure modes. It is the job engine you already run, with a cron string on top.
 
 ## Next steps
 

--- a/website/docs/use-cases/scheduled-recurring-jobs.md
+++ b/website/docs/use-cases/scheduled-recurring-jobs.md
@@ -1,0 +1,125 @@
+---
+title: Scheduled & recurring jobs
+description: Cron and delayed jobs that survive restarts and never double-fire across a cluster, run inside the Jakarta EE server you already operate — no separate scheduler.
+---
+
+# Scheduled & recurring jobs
+
+Every application grows a list of things that have to happen on a clock. Purge expired sessions at 2 AM. Send the weekly digest on Monday morning. Retry the failed exports an hour later. Poll a partner's API every fifteen minutes during business hours.
+
+The usual answer is Quartz, or a `@Scheduled` method, or a cron line on one box. Each one has the same two holes. The schedule lives outside your database, so a restart in the wrong second drops a run on the floor. And the moment you run more than one node, the cron fires on all of them at once, and now three servers are sending the same digest.
+
+Ratchet treats a scheduled run as what it already is: a job. It gets written to your database before it runs, claimed by exactly one node, retried on failure, and picked up again after a crash. The schedule is a row, not a thread on a single machine. If you already run Ratchet for background work, recurring work is the same engine with a cron string attached.
+
+::: tip Verified
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode — the running app needs a Jakarta EE server and a configured store.
+:::
+
+## The declarative path: `@Recurring`
+
+For schedules you know at build time, annotate a method on any CDI bean. At startup Ratchet scans your beans, validates each annotated method, and registers it. No XML, no scheduler factory, no trigger objects.
+
+```java
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobContext;
+import run.ratchet.api.Recurring;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MaintenanceService {
+
+  @Recurring(cron = "0 0 2 * * ?", name = "Nightly cleanup")
+  public void purgeExpiredSessions() {
+    // Runs at 02:00 every day, in UTC.
+  }
+
+  @Recurring(
+      cron = "0 */15 9-17 ? * MON-FRI",
+      zone = "America/New_York",
+      name = "Business-hours health check",
+      priority = 8,
+      maxRetries = 5,
+      backoffPolicy = BackoffPolicy.EXPONENTIAL,
+      tags = {"health", "monitoring"})
+  public void healthCheck(JobContext context) {
+    context.logger().info("health check running");
+  }
+}
+```
+
+The method has to be `public`, live on a CDI bean, and take either nothing or a single `JobContext`. The return value is ignored. The cron string is a Quartz expression — six or seven fields, `second minute hour day-of-month month day-of-week [year]` — and it is evaluated in the `zone` you name, which matters the two days a year that daylight saving moves the clock. Leave `zone` off and you get UTC.
+
+The second method shows the knobs you would otherwise wire up by hand: a priority, a retry budget, exponential backoff, and tags you can filter on later. They are annotation attributes, not a separate configuration file.
+
+## Why it does not double-fire
+
+This is the part a single-node cron cannot give you. Each `@Recurring` method gets an identity — its `id`, which defaults to the fully qualified class and method name. Ratchet uses that identity as a **business key**, and business keys are unique among active jobs. So no matter how many nodes boot the same code, only one recurring master can exist for that method. The cron ticks once, on one node, and the resulting work is claimed by one worker.
+
+You get exactly-once registration from the same constraint that stops two business-key jobs from running at once. There is no second distributed lock to operate, and nothing extra to configure when you scale from one node to five.
+
+## The programmatic path: `scheduleRecurring`
+
+Some schedules are not known until runtime — a per-tenant report whose cron a customer picks in a settings screen. Build those with the fluent API instead of an annotation.
+
+```java
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.List;
+
+import run.ratchet.api.JobOptions;
+import run.ratchet.api.JobSchedulerService;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class ReportScheduler {
+
+  @Inject JobSchedulerService scheduler;
+
+  /** A schedule the operator defines at runtime, not at compile time. */
+  public void scheduleHourlyReport(String tenantId, String cron) {
+    scheduler
+        .scheduleRecurring(cron, ZoneId.of("UTC"), () -> generateReport(tenantId))
+        .withOptions(JobOptions.defaults()
+            .withMaxRetries(3)
+            .withTimeout(Duration.ofMinutes(10)))
+        .withTags(List.of("reports", "tenant:" + tenantId))
+        .withBusinessKey("hourly-report-" + tenantId)
+        .submit();
+  }
+}
+```
+
+The `withBusinessKey` here is doing real work. It scopes the recurring master per tenant, so re-running this method for the same tenant does not stack up a second schedule. The lambda is a method reference on a CDI bean — Ratchet serializes only the arguments (`tenantId`) and resolves the bean from CDI when the job runs, so injected dependencies are live at execution time, not captured at submission.
+
+## One-shot, deferred
+
+Not every timed job repeats. "Send a reminder in 30 minutes" is a single run at a future instant, and `schedule` takes a `Duration`:
+
+```java
+scheduler.schedule(Duration.ofMinutes(30), () -> sendReminder(userId)).submit();
+```
+
+The delay is computed once, at submission: the job is persisted now and stays invisible to the poller until the clock passes `now + 30m`. Survive a restart in between and the reminder still fires, because the due time is a column, not a timer in memory.
+
+## Honest scope
+
+A few things worth saying plainly:
+
+- Cron is **Quartz syntax** (6–7 fields with `?` and `L`/`W` support), not the 5-field Unix crontab. `0 0 2 * * ?` is daily at 2 AM, and the leading field is seconds.
+- Schedules default to **UTC**. Set `zone` per job when a schedule has to track a wall clock through DST.
+- A recurring job is regular, not real-time. Fire times are honored at the resolution of the poll cycle, so a 15-minute schedule is reliable; a "run at exactly 14:30:00.000" guarantee is not what this is.
+
+## Why run it through Ratchet
+
+You could keep Quartz, or a `@Scheduled` bean, or a crontab. The argument for folding the schedule into Ratchet is the same one it makes everywhere else: the run is durable because it was written to your database before it happened, and it is cluster-safe because one row can only be claimed once. The scheduler is not a separate service with its own tables and its own failure modes. It is the job engine you already run, plus a cron string.
+
+## Next steps
+
+- [Scheduling](../concepts/scheduling.md) — every mode, cron grammar, and timezone behavior in depth
+- [Clustering](../concepts/clustering.md) — how one row gets claimed by exactly one node
+- [Retry strategies](../concepts/retry-strategies.md) — tune backoff and attempts per schedule
+- [Annotations](../api-reference/annotations.md) — the full `@Recurring` attribute reference
+- [Quickstart](../getting-started/quickstart.md) — get a first job running

--- a/website/docs/use-cases/scheduled-recurring-jobs.md
+++ b/website/docs/use-cases/scheduled-recurring-jobs.md
@@ -1,6 +1,6 @@
 ---
 title: Scheduled & Recurring Jobs
-description: Cron and delayed jobs that survive restarts and never double-fire across a cluster, run inside the Jakarta EE server you already operate — no separate scheduler.
+description: Cron and delayed jobs that survive restarts and never double-fire across a cluster, run inside the Jakarta EE server you already operate, with no separate scheduler.
 ---
 
 # Scheduled & Recurring Jobs
@@ -12,7 +12,7 @@ The usual answer is Quartz, or a `@Scheduled` method, or a cron line on one box.
 Ratchet treats a scheduled run as what it already is: a job. It gets written to your database before it runs, claimed by exactly one node, retried on failure, and picked up again after a crash. The schedule is a row, not a thread on a single machine. If you already run Ratchet for background work, recurring work is the same engine with a cron string attached.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode — the running app needs a Jakarta EE server and a configured store.
+The Java on this page compiles against `ratchet-api` `0.1.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
 :::
 
 ## The declarative path: `@Recurring`
@@ -48,19 +48,19 @@ public class MaintenanceService {
 }
 ```
 
-The method has to be `public`, live on a CDI bean, and take either nothing or a single `JobContext`. The return value is ignored. The cron string is a Quartz expression — six or seven fields, `second minute hour day-of-month month day-of-week [year]` — and it is evaluated in the `zone` you name, which matters the two days a year that daylight saving moves the clock. Leave `zone` off and you get UTC.
+The method has to be `public`, live on a CDI bean, and take either nothing or a single `JobContext`. The return value is ignored. The cron string is a Quartz expression of six or seven fields (`second minute hour day-of-month month day-of-week [year]`), evaluated in the `zone` you name. That matters the two days a year that daylight saving moves the clock. Leave `zone` off and you get UTC.
 
 The second method shows the knobs you would otherwise wire up by hand: a priority, a retry budget, exponential backoff, and tags you can filter on later. They are annotation attributes, not a separate configuration file.
 
 ## Why it does not double-fire
 
-This is the part a single-node cron cannot give you. Each `@Recurring` method gets an identity — its `id`, which defaults to the fully qualified class and method name. Ratchet uses that identity as a **business key**, and business keys are unique among active jobs. So no matter how many nodes boot the same code, only one recurring master can exist for that method. The cron ticks once, on one node, and the resulting work is claimed by one worker.
+This is the part a single-node cron cannot give you. Each `@Recurring` method gets an identity: its `id`, which defaults to the fully qualified class and method name. Ratchet uses that identity as a **business key**, and business keys are unique among active jobs. So no matter how many nodes boot the same code, only one recurring master can exist for that method. The cron ticks once, on one node, and the resulting work is claimed by one worker.
 
 You get exactly-once registration from the same constraint that stops two business-key jobs from running at once. There is no second distributed lock to operate, and nothing extra to configure when you scale from one node to five.
 
 ## The programmatic path: `scheduleRecurring`
 
-Some schedules are not known until runtime — a per-tenant report whose cron a customer picks in a settings screen. Build those with the fluent API instead of an annotation.
+Some schedules are not known until runtime, like a per-tenant report whose cron a customer picks in a settings screen. Build those with the fluent API instead of an annotation.
 
 ```java
 import java.time.Duration;
@@ -92,7 +92,7 @@ public class ReportScheduler {
 }
 ```
 
-The `withBusinessKey` here is doing real work. It scopes the recurring master per tenant, so re-running this method for the same tenant does not stack up a second schedule. The lambda is a method reference on a CDI bean — Ratchet serializes only the arguments (`tenantId`) and resolves the bean from CDI when the job runs, so injected dependencies are live at execution time, not captured at submission.
+The `withBusinessKey` here is doing real work. It scopes the recurring master per tenant, so re-running this method for the same tenant does not stack up a second schedule. The lambda is a method reference on a CDI bean. Ratchet serializes only the arguments (`tenantId`) and resolves the bean from CDI when the job runs, so injected dependencies are live at execution time, not captured at submission.
 
 ## One-shot, deferred
 
@@ -116,8 +116,8 @@ You could keep Quartz, or a `@Scheduled` bean, or a crontab. Folding the schedul
 
 ## Next steps
 
-- [Scheduling](../concepts/scheduling.md) — every mode, cron grammar, and timezone behavior in depth
-- [Clustering](../concepts/clustering.md) — how one row gets claimed by exactly one node
-- [Retry strategies](../concepts/retry-strategies.md) — tune backoff and attempts per schedule
-- [Annotations](../api-reference/annotations.md) — the full `@Recurring` attribute reference
-- [Quickstart](../getting-started/quickstart.md) — get a first job running
+- [Scheduling](../concepts/scheduling.md) -- every mode, cron grammar, and timezone behavior in depth
+- [Clustering](../concepts/clustering.md) -- how one row gets claimed by exactly one node
+- [Retry strategies](../concepts/retry-strategies.md) -- tune backoff and attempts per schedule
+- [Annotations](../api-reference/annotations.md) -- the full `@Recurring` attribute reference
+- [Quickstart](../getting-started/quickstart.md) -- get a first job running


### PR DESCRIPTION
Adds a Use Cases section to the documentation site: six task-shaped pages that each take one pattern Ratchet is built for and walk it end to end, plus a homepage band that links into them.

## Pages

- **Offload Work After a Request** -- enqueue follow-up work in the same transaction as the business write, return right away.
- **Scheduled & Recurring Jobs** -- cron and delayed jobs that survive a restart and fire on one node.
- **Resilient Third-Party Integrations** -- retry flaky external APIs with backoff and trip a circuit breaker.
- **Durable LLM & Agent Workflows** -- model calls and multi-step agents as persisted, retrying jobs; bring your own model client.
- **Bulk & Batch Jobs** -- fan thousands of items out as one tracked batch, read aggregate progress, branch on the result.
- **Human-in-the-Loop Jobs** -- a job parks in WAITING until an approval delivers a signal, holding no thread while it waits.

## How the pages were built

- Every Java sample compiles against `ratchet-api` `0.1.1-SNAPSHOT`. The snippets are real API usage, not pseudocode.
- Behavioral claims were checked against the engine source, not just the existing docs (batch completion counting, the signal timeout scanner, the default no-retry path).
- Each page ran through a humanizer pass to match the measured prose conventions of the rest of the site (near-zero em dashes, sentence-case subheadings, two-hyphen list glosses).

## Wiring

- Use Cases nav entry and sidebar listing all six pages.
- Homepage band of six cards in a 3x2 grid, each linking into a page.
- The version-sync script's verified-tip file list covers all six pages, so the pinned `ratchet-api` version stays in step on a release bump.

`npm run build` passes with no dead links.