### PR TITLE
Add a Star on GitHub CTA and fix the mobile hero

### DIFF
--- a/website/docs/.vitepress/theme/HeroCode.vue
+++ b/website/docs/.vitepress/theme/HeroCode.vue
@@ -53,7 +53,18 @@ html.dark .hero-code :deep(.shiki span) {
   color: var(--shiki-dark) !important;
 }
 
+/* Mobile is most of the traffic, so the snippet stays visible here instead of
+   being hidden. Shrink it to fit a phone and let long lines scroll. */
 @media (max-width: 640px) {
-  .hero-code { display: none; }
+  .hero-code {
+    max-width: 100%;
+  }
+  .hero-code :deep(.shiki) {
+    padding: 1rem;
+    font-size: 0.78rem;
+    line-height: 1.55;
+    border-radius: 10px;
+    box-shadow: 0 12px 32px rgba(31, 41, 51, 0.14);
+  }
 }
 </style>

--- a/website/docs/.vitepress/theme/HeroStarButton.vue
+++ b/website/docs/.vitepress/theme/HeroStarButton.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+// A GitHub-style call to action under the hero buttons. The homepage draws
+// traffic that does not always follow through to the repo, so this gives that
+// next step its own recognizable button. The umami data-attributes match the
+// trust strip and use-case band, so the click lands in analytics as a hero
+// cta-click with target=github-star.
+const repo = 'https://github.com/ratchet-run/ratchet'
+</script>
+
+<template>
+  <div class="hero-star">
+    <a
+      class="hero-star-btn"
+      :href="repo"
+      target="_blank"
+      rel="noopener"
+      data-umami-event="cta-click"
+      data-umami-event-location="hero"
+      data-umami-event-target="github-star"
+    >
+      <svg class="gh-mark" viewBox="0 0 16 16" width="18" height="18" aria-hidden="true">
+        <path
+          fill="currentColor"
+          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+        />
+      </svg>
+      <span>Star on GitHub</span>
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.hero-star {
+  margin-top: 16px;
+}
+
+/* Matches the VitePress medium hero button box (40px tall, 20px radius) so it
+   lines up with Get Started / API Reference, but in GitHub's own button color
+   rather than a site theme color, so it reads as "go to the repo". */
+.hero-star-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 20px;
+  border: 1px solid #24292f;
+  border-radius: 20px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1;
+  color: #ffffff;
+  background-color: #24292f;
+  transition:
+    color 0.25s,
+    background-color 0.25s,
+    border-color 0.25s;
+}
+
+.hero-star-btn:hover {
+  background-color: #32383f;
+  border-color: #32383f;
+}
+
+/* Pure black would disappear on the dark theme background, so invert it:
+   a white button with the dark mark. Both directions clear the AA contrast
+   floor the both-theme a11y scan enforces. */
+.dark .hero-star-btn {
+  color: #24292f;
+  background-color: #ffffff;
+  border-color: #ffffff;
+}
+
+.dark .hero-star-btn:hover {
+  background-color: #e6e8eb;
+  border-color: #e6e8eb;
+}
+
+.gh-mark {
+  flex-shrink: 0;
+}
+</style>

--- a/website/docs/.vitepress/theme/custom.css
+++ b/website/docs/.vitepress/theme/custom.css
@@ -216,6 +216,15 @@ html { color-scheme: light; }
   margin-top: 1.75rem !important;
 }
 
+/* Mobile-only hero pieces: the inline code snippet and the short tagline are
+   hidden on desktop and toggled on in the max-width:960px block below. */
+.hero-code-mobile {
+  display: none;
+}
+.tag-mobile {
+  display: none;
+}
+
 /* The "image" column is replaced by HeroCode.vue; suppress default bloom */
 .VPHero .image-bg,
 .VPHero .image-src {
@@ -1243,9 +1252,41 @@ html.dark .cm-ratchet-header { color: #0d1117; }
     justify-content: center;
   }
 
-  /* Hide the empty image column space on mobile */
+  /* Match the stacked CTAs: the GitHub button goes full width on mobile too. */
+  .hero-star {
+    width: 100%;
+  }
+  .hero-star-btn {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* The code renders inline below the tagline on mobile (see .hero-code-mobile),
+     so the desktop image column stays hidden at this width. */
   .VPHero .image {
     display: none !important;
+  }
+
+  /* VitePress reserves a fixed 640px container height for the desktop image.
+     On mobile that turns into a tall band of dead space above the fold, so
+     let the hero collapse to its actual content height. */
+  .VPHero .container {
+    min-height: auto !important;
+  }
+
+  /* Lead with the product: the snippet sits right under the tagline, above
+     the CTAs, instead of below them. */
+  .hero-code-mobile {
+    display: block;
+    margin: 1.5rem 0 0;
+  }
+
+  /* Short tagline on phones; the full sentence is desktop-only. */
+  .tag-full {
+    display: none;
+  }
+  .tag-mobile {
+    display: inline;
   }
 }
 

--- a/website/docs/.vitepress/theme/index.ts
+++ b/website/docs/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import DefaultTheme from 'vitepress/theme'
 import HeroCode from './HeroCode.vue'
 import HeroInfoTop from './HeroInfoTop.vue'
 import HeroTrustStrip from './HeroTrustStrip.vue'
+import HeroStarButton from './HeroStarButton.vue'
 import HomeUseCasesBand from './HomeUseCasesBand.vue'
 import HomeDocsBand from './HomeDocsBand.vue'
 import ComparisonMatrix from './ComparisonMatrix.vue'
@@ -18,6 +19,8 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'home-hero-info-before': () => h(HeroInfoTop),
       'home-hero-image': () => h(HeroCode),
+      'home-hero-info-after': () => h(HeroCode, { class: 'hero-code-mobile' }),
+      'home-hero-actions-after': () => h(HeroStarButton),
       'home-hero-after': () => h(HeroTrustStrip),
       'home-features-after': () => [h(HomeUseCasesBand), h(HomeDocsBand)],
       'layout-bottom': () => h(SiteFooter),

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: "Ratchet"
   text: "Inject one service. Submit a method reference."
-  tagline: Persistent, retrying background jobs on plain Jakarta EE. No proprietary dependencies, no message broker, and they run unchanged on whichever application server you already use.
+  tagline: "<span class='tag-full'>Persistent, retrying background jobs on plain Jakarta EE. No proprietary dependencies, no message broker, and they run unchanged on whichever application server you already use.</span><span class='tag-mobile'>Persistent, retrying background jobs on plain Jakarta EE. No broker, no proprietary deps.</span>"
   actions:
     - theme: brand
       text: Get Started


### PR DESCRIPTION
## Why

The homepage gets traffic that does not follow through to the repo, and most of that traffic is on phones, where the hero was working against us.

## Star on GitHub button

A third hero call to action: a GitHub-style black button linking to the repo. It inverts to a white button with the dark mark on the dark theme, so it stays visible and clears the both-theme accessibility scan. The click reports to analytics as a hero `cta-click` with `target=github-star`, so the repo follow-through is now measurable. No live star count (the number is small enough today that showing it would suppress clicks rather than drive them).

## Mobile hero

On phones the hero buried the product:

- The code snippet was hidden outright below 640px (it lives in the hero image column, which the theme also hides on small screens).
- VitePress reserves a fixed 640px container height for the desktop image, which became a band of dead space above the fold.
- The long tagline pushed everything down.

Now, on mobile only:

- The snippet renders inline right under the tagline and above the buttons, so the first thing a visitor sees is the actual API.
- The reserved image height collapses to the content, removing the dead gap.
- The tagline drops to a short version.
- All three CTAs (Get Started, API Reference, Star on GitHub) are full width and aligned.

Desktop is unchanged.

## Checks

- `npm run build` passes (no dead links).
- The both-theme a11y scan passes with no violations in light or dark.
- Verified at 390px and 1280px with screenshots.