### PR TITLE
Use a shorter hero snippet on mobile instead of a sideways scroll

### DIFF
--- a/website/docs/.vitepress/heroCodePlugin.ts
+++ b/website/docs/.vitepress/heroCodePlugin.ts
@@ -16,27 +16,44 @@ public void placeOrder(UUID orderId) {
         .submit();
 }`
 
-const VIRTUAL_ID = 'virtual:ratchet-hero-code'
-const RESOLVED_ID = '\0' + VIRTUAL_ID
+// A trimmed variant for phones. The full snippet's long lines force a
+// horizontal scroll on a narrow column, so this keeps the same story — inject
+// the service, submit a method reference, retry, done — in lines short enough
+// to read without scrolling or shrinking the type to a squint.
+const HERO_CODE_MOBILE = `@Inject
+JobSchedulerService scheduler;
 
-let cached: string | null = null
+scheduler
+    .enqueue(() -> ship(orderId))
+    .withMaxRetries(3)
+    .submit();`
+
+const SNIPPETS: Record<string, string> = {
+  'virtual:ratchet-hero-code': HERO_CODE,
+  'virtual:ratchet-hero-code-mobile': HERO_CODE_MOBILE,
+}
+
+const cache: Record<string, string> = {}
 
 export function heroCodePlugin(): Plugin {
   return {
     name: 'ratchet:hero-code',
     resolveId(id) {
-      if (id === VIRTUAL_ID) return RESOLVED_ID
+      if (id in SNIPPETS) return '\0' + id
     },
     async load(id) {
-      if (id !== RESOLVED_ID) return
-      if (cached === null) {
-        cached = await codeToHtml(HERO_CODE, {
+      if (!id.startsWith('\0')) return
+      const key = id.slice(1)
+      const code = SNIPPETS[key]
+      if (!code) return
+      if (cache[key] === undefined) {
+        cache[key] = await codeToHtml(code, {
           lang: 'java',
           themes: { light: 'github-light', dark: 'dracula' },
           defaultColor: false,
         })
       }
-      return `export default ${JSON.stringify(cached)}`
+      return `export default ${JSON.stringify(cache[key])}`
     },
   }
 }

--- a/website/docs/.vitepress/theme/HeroCode.vue
+++ b/website/docs/.vitepress/theme/HeroCode.vue
@@ -1,9 +1,15 @@
 <script setup lang="ts">
 // The HTML is pre-rendered through Shiki by heroCodePlugin.ts at build time
-// (see docs/.vitepress/heroCodePlugin.ts). Importing the virtual module here
+// (see docs/.vitepress/heroCodePlugin.ts). Importing the virtual modules here
 // keeps Shiki out of the client bundle and gives the hero code its final
 // markup during SSR so there is no flash of empty content on hydration.
-import html from 'virtual:ratchet-hero-code'
+import full from 'virtual:ratchet-hero-code'
+import compact from 'virtual:ratchet-hero-code-mobile'
+
+// `compact` renders the shorter snippet used inline on phones, where the full
+// snippet's long lines would otherwise scroll sideways.
+const props = defineProps<{ compact?: boolean }>()
+const html = props.compact ? compact : full
 </script>
 
 <template>
@@ -61,8 +67,8 @@ html.dark .hero-code :deep(.shiki span) {
   }
   .hero-code :deep(.shiki) {
     padding: 1rem;
-    font-size: 0.78rem;
-    line-height: 1.55;
+    font-size: 0.85rem;
+    line-height: 1.6;
     border-radius: 10px;
     box-shadow: 0 12px 32px rgba(31, 41, 51, 0.14);
   }

--- a/website/docs/.vitepress/theme/index.ts
+++ b/website/docs/.vitepress/theme/index.ts
@@ -19,7 +19,7 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'home-hero-info-before': () => h(HeroInfoTop),
       'home-hero-image': () => h(HeroCode),
-      'home-hero-info-after': () => h(HeroCode, { class: 'hero-code-mobile' }),
+      'home-hero-info-after': () => h(HeroCode, { compact: true, class: 'hero-code-mobile' }),
       'home-hero-actions-after': () => h(HeroStarButton),
       'home-hero-after': () => h(HeroTrustStrip),
       'home-features-after': () => [h(HomeUseCasesBand), h(HomeDocsBand)],

--- a/website/docs/.vitepress/virtual.d.ts
+++ b/website/docs/.vitepress/virtual.d.ts
@@ -4,3 +4,8 @@ declare module 'virtual:ratchet-hero-code' {
   const html: string
   export default html
 }
+
+declare module 'virtual:ratchet-hero-code-mobile' {
+  const html: string
+  export default html
+}


### PR DESCRIPTION
Follow-up to the mobile hero work. The inline mobile code snippet still inherited the full desktop snippet, whose long lines scroll sideways in a phone-width column. Shrinking the font enough to fit would push it below a comfortable reading size, so this gives the mobile instance its own shorter snippet instead.

The mobile snippet tells the same story in fewer characters: inject the service, submit a method reference, set retries, done. It fits the column with no horizontal scroll and reads at a normal size. The desktop snippet (with backoff and tags) is unchanged.

Mechanically, `heroCodePlugin.ts` now exposes a second pre-rendered virtual module for the compact snippet, and `HeroCode.vue` takes a `compact` prop to pick between them. The inline mobile instance passes `compact`; the desktop image column does not.

## Checks
- `npm run build` passes (no dead links).
- Both-theme a11y scan passes with no violations.
- Verified at 390px (no horizontal scroll, snippet above the fold) and 1280px (full snippet unchanged).