### PR TITLE
Tidy comparison matrix spacing, hero code margin, and footer curtain

### DIFF
--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -74,7 +74,10 @@ export default defineConfig({
   // under `.wide-tables`; dropping the outline reclaims the column the wide
   // server x database tables need.
   transformPageData(pageData) {
-    if (pageData.relativePath.startsWith('conformance/')) {
+    if (
+      pageData.relativePath.startsWith('conformance/') ||
+      pageData.relativePath.startsWith('comparison/')
+    ) {
       pageData.frontmatter.pageClass = 'wide-tables'
       pageData.frontmatter.aside = false
     }

--- a/website/docs/.vitepress/theme/ComparisonMatrix.vue
+++ b/website/docs/.vitepress/theme/ComparisonMatrix.vue
@@ -283,14 +283,15 @@ const statusLabel = (s: Status) => ({
   min-width: 640px;
 }
 
-.cm-matrix th,
-.cm-matrix td { padding: 0; }
+/* No padding reset here: a `.cm-matrix td` reset outranks the per-cell classes
+   below and would flatten their padding to zero. The scoped cell classes
+   already out-specify VitePress's default table padding, so they can own it. */
 
 .cm-capability-header,
 .cm-product-header {
   text-align: center;
   font-weight: 600;
-  padding: 0.65rem 0.5rem;
+  padding: 0.75rem 0.5rem;
   background: var(--vp-c-default-soft);
   color: var(--vp-c-text-1);
   border-radius: 6px;
@@ -298,13 +299,13 @@ const statusLabel = (s: Status) => ({
 
 .cm-capability-header {
   text-align: left;
-  padding: 0.65rem 0.75rem;
+  padding: 0.75rem 0.75rem;
   white-space: nowrap;
 }
 
 .cm-ratchet-header {
   text-align: center;
-  padding: 0.65rem 0.5rem;
+  padding: 0.75rem 0.5rem;
   border-radius: 6px;
   background: var(--vp-c-brand-1);
   font-weight: 700;
@@ -315,7 +316,7 @@ const statusLabel = (s: Status) => ({
 .cm-capability {
   text-align: left;
   font-weight: 500;
-  padding: 0.75rem;
+  padding: 0.85rem 0.9rem;
   background: var(--vp-c-default-soft);
   color: var(--vp-c-text-1);
   border-radius: 6px;
@@ -325,7 +326,7 @@ const statusLabel = (s: Status) => ({
 .cm-cell {
   text-align: center;
   vertical-align: middle;
-  padding: 0.6rem 0.4rem;
+  padding: 0.85rem 0.7rem;
   border-radius: 6px;
   position: relative;
   font-weight: 600;

--- a/website/docs/.vitepress/theme/custom.css
+++ b/website/docs/.vitepress/theme/custom.css
@@ -368,6 +368,15 @@ html { color-scheme: light; }
   }
 }
 
+/* VitePress's aside outline ends in a `position: fixed` gradient ("curtain")
+   pinned to the viewport bottom to fade the TOC. It assumes the page background
+   continues below it, but our full-bleed dark footer does not, so when you
+   scroll to the bottom the pale curtain floats over the footer as a stray
+   shadow. The fade buys little, so drop it. */
+.aside-curtain {
+  display: none;
+}
+
 /* ------------------------------------------------------------------ */
 /* Docs-page customisations — ported from src/css/custom.css            */
 /* ------------------------------------------------------------------ */
@@ -1275,10 +1284,12 @@ html.dark .cm-ratchet-header { color: #0d1117; }
   }
 
   /* Lead with the product: the snippet sits right under the tagline, above
-     the CTAs, instead of below them. */
-  .hero-code-mobile {
+     the CTAs, instead of below them. The three-class selector outranks
+     HeroCode.vue's scoped `.hero-code { margin: 0 auto }`, which would
+     otherwise zero the top margin. */
+  .VPHero .main .hero-code-mobile {
     display: block;
-    margin: 1.5rem 0 0;
+    margin: 2.25rem 0 0;
   }
 
   /* Short tagline on phones; the full sentence is desktop-only. */


### PR DESCRIPTION
A handful of small layout fixes from a pass over the docs site.

## Comparison matrix
- **Cell padding was 0.** A `.cm-matrix td { padding: 0 }` reset outranked the per-cell padding classes (higher specificity), so every cell rendered with no padding and the status pills hugged their icons. Every cell already carries a padding class, so the reset is removed and the cells get a bit more room.
- **The table scrolled sideways and clipped its last column** inside the default content width. The conformance section already widens table-heavy pages (`pageClass: wide-tables` + `aside: false`) by path in `transformPageData`; the comparison section now gets the same treatment, so the full matrix fits with no horizontal scroll.

## Hero code (mobile)
- The inline mobile code snippet sat flush against the tagline. Its top margin was being overridden by `HeroCode.vue`'s scoped `margin: 0 auto`, so the rule now uses a more specific selector and the spacing actually applies.

## Footer curtain
- VitePress fades the bottom of the right-hand table of contents with a `position: fixed` gradient that assumes the page background continues beneath it. Over the full-bleed dark footer it surfaced as a stray "shadow" at the bottom of every aside page. Hidden, since the fade buys little.

## Checks
- `npm run build` passes.
- Both-theme a11y scan passes with no violations.
- Verified at 1280px (matrix full width, no scroll; no footer shadow) and 390px (hero code spacing).