### PR TITLE
Extract a SchemaMigrationDialect SPI and move per-dialect SQL into the stores

### DIFF
--- a/.github/workflows/owasp-depcheck.yml
+++ b/.github/workflows/owasp-depcheck.yml
@@ -50,6 +50,11 @@ jobs:
           path: '.'
           format: 'HTML'
           out: 'target'
+          # The Central Analyzer recovers jar coordinates by SHA-1 lookup against the legacy
+          # search.maven.org Solr endpoint, which read-times-out and 403s under load. Maven-built
+          # jars already carry their GAV in META-INF/maven/**/pom.properties, so --disableCentral
+          # drops that flaky network call without losing identification (the NVD data is preloaded
+          # in the action image, so CVE matching is unaffected).
           args: >
             --format SARIF
             --failOnCVSS 7
@@ -63,6 +68,7 @@ jobs:
             --disablePnpmAudit
             --disableRetireJs
             --disableOssIndex
+            --disableCentral
             --suppression /github/workspace/owasp-suppressions.xml
 
       - name: Upload Dependency-Check report

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -53,11 +53,12 @@
         snappy-compressed body and over-allocates heap, a DoS fixed in Prometheus
         server 3.5.3 and 3.11.3. micrometer-registry-prometheus is the io.micrometer
         client library that only emits metrics (write-only scrape()); it has no
-        remote-read endpoint and is not the Prometheus server. The CPE rule above
-        strips the Prometheus server CPE identifier, but the CVE is also attached
-        directly via the NVD CVE analyzer, so suppress that record by CVE id.
+        remote-read endpoint and is not the Prometheus server. Matched by file path,
+        not packageUrl: this scan reaches the jar nested inside the WARs (WEB-INF/lib),
+        where Dependency-Check assigns the server CPE from the name but no Maven PURL,
+        so packageUrl/cpe rules never match (mirrors the protobuf-java entry).
         ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus@.*$</packageUrl>
+        <filePath regex="true">.*/micrometer-registry-prometheus-[^/]+\.jar$</filePath>
         <cve>CVE-2026-42154</cve>
     </suppress>
 

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -48,6 +48,21 @@
 
     <suppress>
         <notes><![CDATA[
+        False positive: CVE-2026-42154 is a Prometheus SERVER vulnerability — the
+        remote-read endpoint (/api/v1/read) under-validates the declared length of a
+        snappy-compressed body and over-allocates heap, a DoS fixed in Prometheus
+        server 3.5.3 and 3.11.3. micrometer-registry-prometheus is the io.micrometer
+        client library that only emits metrics (write-only scrape()); it has no
+        remote-read endpoint and is not the Prometheus server. The CPE rule above
+        strips the Prometheus server CPE identifier, but the CVE is also attached
+        directly via the NVD CVE analyzer, so suppress that record by CVE id.
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.micrometer/micrometer-registry-prometheus@.*$</packageUrl>
+        <cve>CVE-2026-42154</cve>
+    </suppress>
+
+    <suppress>
+        <notes><![CDATA[
         False positive: this package is the Prometheus Java client library
         (metrics emission), not the Prometheus server binary. Dependency-Check
         attaches the Prometheus server CPE because the artifact name contains

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationDialect.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationDialect.java
@@ -37,18 +37,22 @@ public interface SchemaMigrationDialect {
   /**
    * Canonical dialect id, lower-case ({@code "mysql"}, {@code "postgresql"}, {@code "oracle"}).
    *
-   * <p>Used to select a dialect from a configured or auto-detected dialect string.
+   * <p>The schema-migration lifecycle hook matches this id against {@code
+   * RATCHET_SCHEMA_MIGRATION_DIALECT} to choose one dialect when several store modules are
+   * deployed; the engine no longer infers a dialect from JDBC product metadata.
    *
    * @return the canonical id; never {@code null} or blank
    */
   String id();
 
   /**
-   * Returns the {@code CREATE TABLE IF NOT EXISTS ratchet_schema_version} statement for this
-   * dialect. The table must expose {@code version}, {@code applied_at}, {@code description}, and a
-   * nullable {@code checksum} column with {@code version} as the primary key.
+   * Returns a single executable statement that creates {@code ratchet_schema_version} if it does
+   * not already exist — the engine runs it before every migration and does not catch already-exists
+   * errors, so the statement must be idempotent on its own. The table must expose {@code version},
+   * {@code applied_at}, {@code description}, and a nullable {@code checksum} column with {@code
+   * version} as the primary key.
    *
-   * @return a single executable DDL statement
+   * @return a single executable statement
    */
   String createVersionTableSql();
 

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationDialect.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationDialect.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.migration;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import run.ratchet.api.Incubating;
+
+/**
+ * Per-vendor strategy for the dialect-specific parts of {@link SchemaMigrator}.
+ *
+ * <p>The migrator engine owns everything portable — classpath script discovery, checksum
+ * validation, statement splitting, the apply loop, and the {@code ratchet_schema_version} ledger.
+ * Everything that differs by database lives behind this interface: the migration lock, the version
+ * ledger DDL, and the version-record upsert. A store that wants to participate in Ratchet schema
+ * auto-migration supplies one implementation; the engine never switches on a database product name.
+ *
+ * @apiNote This is a store-implementor SPI, not an application-facing API. Implementations may be
+ *     stateless and are used from a single migration thread at a time per connection.
+ */
+@Incubating
+public interface SchemaMigrationDialect {
+
+  /**
+   * Canonical dialect id, lower-case ({@code "mysql"}, {@code "postgresql"}, {@code "oracle"}).
+   *
+   * <p>Used to select a dialect from a configured or auto-detected dialect string.
+   *
+   * @return the canonical id; never {@code null} or blank
+   */
+  String id();
+
+  /**
+   * Returns the {@code CREATE TABLE IF NOT EXISTS ratchet_schema_version} statement for this
+   * dialect. The table must expose {@code version}, {@code applied_at}, {@code description}, and a
+   * nullable {@code checksum} column with {@code version} as the primary key.
+   *
+   * @return a single executable DDL statement
+   */
+  String createVersionTableSql();
+
+  /**
+   * Returns the parameterized upsert that records an applied migration in {@code
+   * ratchet_schema_version}. The three positional parameters are, in order, {@code version}, {@code
+   * description}, and {@code checksum}; an existing row for the same version must have its
+   * description and checksum overwritten.
+   *
+   * @return a single executable SQL statement with three positional parameters
+   */
+  String recordVersionSql();
+
+  /**
+   * Whether the migration lock must be held on a dedicated connection separate from the one that
+   * runs the migration DDL.
+   *
+   * <p>Most dialects hold a session-level advisory lock on the migration connection itself. A
+   * dialect whose DDL auto-commits (which would drop a transactional lock) returns {@code true},
+   * and the engine opens a second connection that runs no DDL to hold the lock for the migration
+   * window.
+   *
+   * @return {@code true} to lock on a dedicated connection, {@code false} to lock on the migration
+   *     connection
+   */
+  boolean usesDedicatedLockConnection();
+
+  /**
+   * Acquires the cluster-wide migration lock on the supplied connection, blocking until it is held
+   * or failing loudly when the dialect's wait window elapses.
+   *
+   * @param connection the connection that holds the lock — the dedicated lock connection when
+   *     {@link #usesDedicatedLockConnection()} is {@code true}, otherwise the migration connection
+   * @throws SQLException if the lock cannot be acquired
+   */
+  void acquireLock(Connection connection) throws SQLException;
+
+  /**
+   * Releases the migration lock previously acquired on the supplied connection.
+   *
+   * @param connection the same connection passed to {@link #acquireLock(Connection)}
+   * @throws SQLException if the lock cannot be released
+   */
+  void releaseLock(Connection connection) throws SQLException;
+}

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationLifecycleHook.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrationLifecycleHook.java
@@ -20,8 +20,11 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.interceptor.Interceptor;
-import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import javax.sql.DataSource;
 import org.jboss.logging.Logger;
@@ -37,6 +40,9 @@ import run.ratchet.spi.SchedulerLifecycleHook;
  * Setting {@code RATCHET_SCHEMA_AUTO_MIGRATE=true} flips on a Quartz/Spring-Batch-dev style
  * "just-works" bootstrap suitable for development, CI, and embedded deployments.
  *
+ * <p>The dialect is supplied by the deployed store, never inferred by this hook: each SQL store
+ * publishes a {@link SchemaMigrationDialect} CDI bean, and the hook consumes whatever is present.
+ *
  * <p>Resolution rules:
  *
  * <ul>
@@ -44,16 +50,16 @@ import run.ratchet.spi.SchedulerLifecycleHook;
  *   <li>Enabled with no {@link DataSource} CDI bean: throws {@link SchemaInitializationException}
  *       (deployment fails fast). Application must produce a {@code DataSource} via
  *       {@code @Resource} or {@code @Produces}.
- *   <li>Enabled with no explicit dialect: probes {@code DatabaseMetaData#getDatabaseProductName}
- *       through {@link SchemaMigrator#dialectFromMetadata(Connection)} — only MySQL, MariaDB,
- *       PostgreSQL, and Oracle are accepted; everything else (including CockroachDB) requires
- *       {@code RATCHET_SCHEMA_MIGRATION_DIALECT}. Oracle holds its migration lock on a second
- *       pooled connection, so the DataSource pool maximum must be at least 2.
+ *   <li>Enabled with no {@link SchemaMigrationDialect} bean: throws — the deployed store does not
+ *       support managed migration.
+ *   <li>Enabled with exactly one dialect bean: uses it.
+ *   <li>Enabled with several dialect beans: requires {@code RATCHET_SCHEMA_MIGRATION_DIALECT} to
+ *       select one by {@link SchemaMigrationDialect#id() id}.
  * </ul>
  *
  * <p>Scope is JDBC-only by contract. MongoDB initializes its collections and indexes
  * unconditionally inside {@code MongoJobStoreImpl} because named indexes are referenced by claim
- * queries (correctness-critical, not operational).
+ * queries (correctness-critical, not operational), and ships no {@link SchemaMigrationDialect}.
  */
 @ApplicationScoped
 @Priority(Interceptor.Priority.LIBRARY_BEFORE)
@@ -63,17 +69,22 @@ public class SchemaMigrationLifecycleHook implements SchedulerLifecycleHook {
 
   private final RatchetOptions options;
   private final Instance<DataSource> dataSourceLookup;
+  private final Instance<SchemaMigrationDialect> dialectLookup;
 
   protected SchemaMigrationLifecycleHook() {
     this.options = null;
     this.dataSourceLookup = null;
+    this.dialectLookup = null;
   }
 
   @Inject
   public SchemaMigrationLifecycleHook(
-      RatchetOptions options, Instance<DataSource> dataSourceLookup) {
+      RatchetOptions options,
+      Instance<DataSource> dataSourceLookup,
+      Instance<SchemaMigrationDialect> dialectLookup) {
     this.options = options;
     this.dataSourceLookup = dataSourceLookup;
+    this.dialectLookup = dialectLookup;
   }
 
   @Override
@@ -101,12 +112,12 @@ public class SchemaMigrationLifecycleHook implements SchedulerLifecycleHook {
     }
 
     DataSource dataSource = dataSourceLookup.get();
-    String dialect = resolveDialect(dataSource, schemaOptions);
+    SchemaMigrationDialect dialect = resolveDialect(schemaOptions);
     String prefix = schemaOptions.migrationPrefix();
     log.infof(
         "Ratchet schema auto-migration enabled (dialect=%s, prefix=%s); applying pending"
             + " migrations.",
-        dialect, prefix);
+        dialect.id(), prefix);
     try {
       SchemaMigrator.MigrationResult result =
           new SchemaMigrator(dataSource, dialect, prefix).migrate();
@@ -129,19 +140,53 @@ public class SchemaMigrationLifecycleHook implements SchedulerLifecycleHook {
     return e.getClass().getSimpleName() + ": " + message;
   }
 
-  private String resolveDialect(DataSource dataSource, RatchetOptions.SchemaOptions schemaOptions) {
+  /**
+   * Selects the {@link SchemaMigrationDialect} for the deployed store. The store declares it; the
+   * hook never infers a dialect from the JDBC product name.
+   */
+  private SchemaMigrationDialect resolveDialect(RatchetOptions.SchemaOptions schemaOptions) {
+    if (dialectLookup == null || dialectLookup.isUnsatisfied()) {
+      throw new SchemaInitializationException(
+          "ratchet.schema.auto-migrate=true but the deployed store provides no"
+              + " SchemaMigrationDialect. Managed migration is JDBC-only and requires a SQL store"
+              + " module (MySQL, PostgreSQL, or Oracle). Apply the bundled DDL externally and set"
+              + " ratchet.schema.auto-migrate=false if the deployed store does not support managed"
+              + " migration.");
+    }
+
     String configured = schemaOptions.migrationDialect();
     if (configured != null && !configured.isBlank()) {
-      return configured.trim();
-    }
-    try (Connection connection = dataSource.getConnection()) {
-      return SchemaMigrator.dialectFromMetadata(connection);
-    } catch (SQLException e) {
+      String wanted = configured.trim().toLowerCase(Locale.ROOT);
+      for (SchemaMigrationDialect candidate : dialectLookup) {
+        if (candidate.id().equals(wanted)) {
+          return candidate;
+        }
+      }
       throw new SchemaInitializationException(
-          "Could not probe DataSource metadata to resolve migration dialect; set"
-              + " ratchet.schema.migration-dialect explicitly. Cause: "
-              + exceptionSummary(e),
-          e);
+          "ratchet.schema.migration-dialect="
+              + configured
+              + " but no deployed SchemaMigrationDialect advertises that id. Available: "
+              + availableIds()
+              + ".");
     }
+
+    if (dialectLookup.isAmbiguous()) {
+      throw new SchemaInitializationException(
+          "Multiple SchemaMigrationDialect beans are available ("
+              + availableIds()
+              + "); set ratchet.schema.migration-dialect (RATCHET_SCHEMA_MIGRATION_DIALECT) to"
+              + " select one.");
+    }
+
+    return dialectLookup.get();
+  }
+
+  private String availableIds() {
+    List<String> ids = new ArrayList<>();
+    for (SchemaMigrationDialect candidate : dialectLookup) {
+      ids.add(candidate.id());
+    }
+    Collections.sort(ids);
+    return String.join(", ", ids);
   }
 }

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrator.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/migration/SchemaMigrator.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -38,7 +37,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -60,79 +58,35 @@ public final class SchemaMigrator {
   public static final String DEFAULT_MIGRATION_PREFIX = "ddl/migrations";
 
   private static final Pattern SCRIPT_NAME = Pattern.compile("V(\\d+)__(.+)\\.sql");
-  private static final String LOCK_NAME = "ratchet_schema_migration";
-  private static final long POSTGRESQL_LOCK_KEY = 0x52617463686574L;
-  // Oracle has no grant-free session-level advisory lock and its DDL auto-commits, so the lock is
-  // held as an EXCLUSIVE table lock on a dedicated connection (see acquireLock/migrate). WAIT N is
-  // in seconds; a second migrator that cannot acquire the lock within this window fails loudly.
-  private static final int ORACLE_LOCK_WAIT_SECONDS = 120;
-  private static final int ORA_NAME_ALREADY_USED = 955;
-  private static final int ORA_RESOURCE_BUSY = 54;
 
   private final DataSource dataSource;
-  private final Dialect dialect;
+  private final SchemaMigrationDialect dialect;
   private final String classpathPrefix;
   private final ClassLoader classLoader;
 
-  public SchemaMigrator(DataSource dataSource, String dialect) {
+  public SchemaMigrator(DataSource dataSource, SchemaMigrationDialect dialect) {
     this(dataSource, dialect, DEFAULT_MIGRATION_PREFIX);
   }
 
-  public SchemaMigrator(DataSource dataSource, String dialect, String classpathPrefix) {
-    this(
-        dataSource,
-        dialect,
-        classpathPrefix,
-        Thread.currentThread().getContextClassLoader() != null
-            ? Thread.currentThread().getContextClassLoader()
-            : SchemaMigrator.class.getClassLoader());
+  public SchemaMigrator(
+      DataSource dataSource, SchemaMigrationDialect dialect, String classpathPrefix) {
+    this(dataSource, dialect, classpathPrefix, defaultClassLoader());
   }
 
   SchemaMigrator(
-      DataSource dataSource, String dialect, String classpathPrefix, ClassLoader classLoader) {
+      DataSource dataSource,
+      SchemaMigrationDialect dialect,
+      String classpathPrefix,
+      ClassLoader classLoader) {
     this.dataSource = Objects.requireNonNull(dataSource, "dataSource");
-    this.dialect = Dialect.from(dialect);
+    this.dialect = Objects.requireNonNull(dialect, "dialect");
     this.classpathPrefix = normalizePrefix(classpathPrefix);
     this.classLoader = Objects.requireNonNull(classLoader, "classLoader");
   }
 
-  /**
-   * Resolves the migration dialect string ({@code "mysql"}, {@code "postgresql"}, or {@code
-   * "oracle"}) from a JDBC connection's product name.
-   *
-   * <p>Whitelist only — auto-detection is intentionally narrow because look-alike products such as
-   * CockroachDB report a PostgreSQL wire protocol but lack {@code pg_advisory_lock}, and MariaDB
-   * variants beyond the explicit allow-list have not been verified. Operators running on an
-   * unsupported product must set {@code RATCHET_SCHEMA_MIGRATION_DIALECT} explicitly.
-   *
-   * @throws SchemaInitializationException if the product is not on the whitelist
-   */
-  public static String dialectFromMetadata(Connection connection) throws SQLException {
-    DatabaseMetaData metaData = connection.getMetaData();
-    String product = metaData.getDatabaseProductName();
-    if (product == null) {
-      throw new SchemaInitializationException(
-          "JDBC driver did not report a database product name; set the migration dialect"
-              + " explicitly via ratchet.schema.migration-dialect"
-              + " (RATCHET_SCHEMA_MIGRATION_DIALECT)");
-    }
-    String normalized = product.trim().toLowerCase(Locale.ROOT);
-    if (normalized.equals("mysql") || normalized.equals("mariadb")) {
-      return "mysql";
-    }
-    if (normalized.equals("postgresql")) {
-      return "postgresql";
-    }
-    if (normalized.equals("oracle")) {
-      return "oracle";
-    }
-    throw new SchemaInitializationException(
-        "Unsupported database product '"
-            + product
-            + "' for Ratchet schema auto-migration. Supported: MySQL, MariaDB, PostgreSQL, Oracle."
-            + " Override via ratchet.schema.migration-dialect"
-            + " (RATCHET_SCHEMA_MIGRATION_DIALECT) if your driver reports a non-standard name,"
-            + " or apply the bundled DDL externally and leave ratchet.schema.auto-migrate=false.");
+  private static ClassLoader defaultClassLoader() {
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    return contextClassLoader != null ? contextClassLoader : SchemaMigrator.class.getClassLoader();
   }
 
   private static String normalizePrefix(String prefix) {
@@ -251,13 +205,13 @@ public final class SchemaMigrator {
     List<MigrationScript> skipped = new ArrayList<>();
 
     try (Connection connection = dataSource.getConnection()) {
-      // Most dialects hold a session-level advisory lock on the migration connection itself.
-      // Oracle cannot: its DDL auto-commits (which would drop a transactional lock) and DBMS_LOCK
-      // needs an EXECUTE grant managed users often lack, so it locks on a second connection.
+      // Most dialects hold a session-level advisory lock on the migration connection itself; a
+      // dialect whose DDL auto-commits asks for a dedicated lock connection instead so the lock
+      // survives the per-script commits.
       Connection lockConnection =
           dialect.usesDedicatedLockConnection() ? openLockConnection() : connection;
       try {
-        acquireLock(lockConnection);
+        dialect.acquireLock(lockConnection);
         Throwable migrationFailure = null;
         try {
           ensureSchemaVersionTable(connection);
@@ -333,104 +287,16 @@ public final class SchemaMigrator {
       return dataSource.getConnection();
     } catch (SQLException e) {
       throw new SchemaMigrationException(
-          "Oracle schema migration needs a second JDBC connection to hold its advisory lock, but"
-              + " the DataSource could not supply one. Configure a connection pool maximum of at"
-              + " least 2 (one connection runs the migration, the other holds the lock).",
+          "This dialect holds its migration lock on a dedicated JDBC connection, but the DataSource"
+              + " could not supply a second one. Configure a connection pool maximum of at least 2"
+              + " (one connection runs the migration, the other holds the lock).",
           e);
-    }
-  }
-
-  private void acquireLock(Connection connection) throws SQLException {
-    if (dialect == Dialect.ORACLE) {
-      acquireOracleLock(connection);
-      return;
-    }
-    try (Statement statement = connection.createStatement()) {
-      switch (dialect) {
-        case MYSQL -> {
-          try (ResultSet resultSet =
-              statement.executeQuery("SELECT GET_LOCK('" + LOCK_NAME + "', 30)")) {
-            if (!resultSet.next() || resultSet.getInt(1) != 1) {
-              throw new SchemaMigrationException("Timed out acquiring MySQL schema migration lock");
-            }
-          }
-        }
-        case POSTGRESQL ->
-            statement.execute("SELECT pg_advisory_lock(" + POSTGRESQL_LOCK_KEY + ")");
-        default -> {
-          // Oracle is handled above; no other dialect reaches here.
-        }
-      }
-    }
-  }
-
-  /**
-   * Acquires the Oracle migration lock on a dedicated connection.
-   *
-   * <p>Oracle DDL auto-commits, which would release any transactional lock held on the migration
-   * connection itself, and {@code DBMS_LOCK} requires an EXECUTE grant that managed users often
-   * lack. Instead a tiny dedicated {@code ratchet_schema_lock} table is locked {@code IN EXCLUSIVE
-   * MODE} on a second connection that never runs DDL, so the lock survives the migration's
-   * per-script commits. The lock table is separate from {@code ratchet_schema_version} on purpose:
-   * an EXCLUSIVE lock on the ledger would block the migration connection's own ledger writes.
-   */
-  private void acquireOracleLock(Connection connection) throws SQLException {
-    try (Statement statement = connection.createStatement()) {
-      statement.execute(
-          "CREATE TABLE IF NOT EXISTS ratchet_schema_lock (lock_name VARCHAR2(128) NOT NULL,"
-              + " CONSTRAINT pk_ratchet_schema_lock PRIMARY KEY (lock_name))");
-    } catch (SQLException e) {
-      // ORA-00955: a concurrent migrator created the lock table first. Any other error is fatal.
-      if (e.getErrorCode() != ORA_NAME_ALREADY_USED) {
-        throw e;
-      }
-    }
-    connection.setAutoCommit(false);
-    try (Statement statement = connection.createStatement()) {
-      statement.execute(
-          "LOCK TABLE ratchet_schema_lock IN EXCLUSIVE MODE WAIT " + ORACLE_LOCK_WAIT_SECONDS);
-    } catch (SQLException e) {
-      if (e.getErrorCode() == ORA_RESOURCE_BUSY) {
-        throw new SchemaMigrationException(
-            "Timed out after "
-                + ORACLE_LOCK_WAIT_SECONDS
-                + "s acquiring the Oracle schema migration lock; another migrator held it longer"
-                + " than the wait window.",
-            e);
-      }
-      throw e;
-    }
-  }
-
-  private void releaseLock(Connection connection) throws SQLException {
-    if (dialect == Dialect.ORACLE) {
-      // Commit releases the EXCLUSIVE table lock; the dedicated lock connection is closed by the
-      // caller immediately afterward.
-      connection.commit();
-      return;
-    }
-    try (Statement statement = connection.createStatement()) {
-      switch (dialect) {
-        case MYSQL -> {
-          try (ResultSet resultSet =
-              statement.executeQuery("SELECT RELEASE_LOCK('" + LOCK_NAME + "')")) {
-            if (!resultSet.next() || resultSet.getInt(1) != 1) {
-              throw new SQLException("Failed to release MySQL schema migration lock");
-            }
-          }
-        }
-        case POSTGRESQL ->
-            statement.execute("SELECT pg_advisory_unlock(" + POSTGRESQL_LOCK_KEY + ")");
-        default -> {
-          // Oracle is handled above; no other dialect reaches here.
-        }
-      }
     }
   }
 
   private void releaseLock(Connection connection, Throwable primaryFailure) throws SQLException {
     try {
-      releaseLock(connection);
+      dialect.releaseLock(connection);
     } catch (SQLException e) {
       if (primaryFailure != null) {
         primaryFailure.addSuppressed(e);
@@ -568,90 +434,6 @@ public final class SchemaMigrator {
       String sql = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
       return new MigrationScript(
           matcher.group(1), matcher.group(2).replace('_', ' '), resourceName, sha256(sql), sql);
-    }
-  }
-
-  private enum Dialect {
-    MYSQL,
-    POSTGRESQL,
-    ORACLE;
-
-    private static Dialect from(String value) {
-      if (value == null || value.isBlank()) {
-        throw new IllegalArgumentException("Ratchet schema migration dialect is required");
-      }
-      return switch (value.trim().toLowerCase(Locale.ROOT)) {
-        case "mysql" -> MYSQL;
-        case "postgres", "postgresql", "pg" -> POSTGRESQL;
-        case "oracle" -> ORACLE;
-        default ->
-            throw new IllegalArgumentException("Unsupported Ratchet schema dialect: " + value);
-      };
-    }
-
-    private boolean usesDedicatedLockConnection() {
-      return this == ORACLE;
-    }
-
-    private String createVersionTableSql() {
-      return switch (this) {
-        case MYSQL ->
-            """
-            CREATE TABLE IF NOT EXISTS ratchet_schema_version
-            (
-                version     VARCHAR(20)  NOT NULL,
-                applied_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-                description VARCHAR(200) NOT NULL,
-                checksum    VARCHAR(64)  NULL,
-                PRIMARY KEY (version)
-            ) ENGINE = InnoDB
-              DEFAULT CHARSET = utf8mb4
-              COLLATE = utf8mb4_unicode_ci\
-            """;
-        case POSTGRESQL ->
-            """
-            CREATE TABLE IF NOT EXISTS ratchet_schema_version
-            (
-                version VARCHAR(20) NOT NULL,
-                applied_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-                description VARCHAR(200) NOT NULL,
-                checksum VARCHAR(64),
-                CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
-            )\
-            """;
-        case ORACLE ->
-            """
-            CREATE TABLE IF NOT EXISTS ratchet_schema_version
-            (
-                version     VARCHAR2(20)  NOT NULL,
-                applied_at  TIMESTAMP(6)  DEFAULT SYSTIMESTAMP NOT NULL,
-                description VARCHAR2(200) NOT NULL,
-                checksum    VARCHAR2(64),
-                CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
-            )\
-            """;
-      };
-    }
-
-    private String recordVersionSql() {
-      return switch (this) {
-        case MYSQL ->
-            "INSERT INTO ratchet_schema_version (version, description, checksum) VALUES (?, ?, ?)"
-                + " ON DUPLICATE KEY UPDATE description = VALUES(description),"
-                + " checksum = VALUES(checksum)";
-        case POSTGRESQL ->
-            "INSERT INTO ratchet_schema_version (version, description, checksum) VALUES (?, ?, ?)"
-                + " ON CONFLICT (version) DO UPDATE SET description = EXCLUDED.description,"
-                + " checksum = EXCLUDED.checksum";
-        case ORACLE ->
-            "MERGE INTO ratchet_schema_version t"
-                + " USING (SELECT ? AS version, ? AS description, ? AS checksum FROM dual) s"
-                + " ON (t.version = s.version)"
-                + " WHEN MATCHED THEN UPDATE SET t.description = s.description,"
-                + " t.checksum = s.checksum"
-                + " WHEN NOT MATCHED THEN INSERT (version, description, checksum)"
-                + " VALUES (s.version, s.description, s.checksum)";
-      };
     }
   }
 

--- a/stores/ratchet-store-core/src/test/java/run/ratchet/store/migration/SchemaMigratorTest.java
+++ b/stores/ratchet-store-core/src/test/java/run/ratchet/store/migration/SchemaMigratorTest.java
@@ -30,9 +30,9 @@ import static org.mockito.Mockito.when;
 
 import jakarta.enterprise.inject.Instance;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import javax.sql.DataSource;
@@ -41,6 +41,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import run.ratchet.api.RatchetOptions;
 
+/**
+ * Exercises the dialect-agnostic {@link SchemaMigrator} engine — discovery, checksum validation,
+ * the apply loop, and lock orchestration — against a {@link RecordingDialect} stub.
+ * Dialect-specific SQL (lock statements, version DDL, upserts) is covered by each store's own
+ * dialect test.
+ */
 class SchemaMigratorTest {
 
   private DataSource dataSource;
@@ -48,8 +54,7 @@ class SchemaMigratorTest {
   private Statement statement;
   private PreparedStatement selectVersion;
   private PreparedStatement insertVersion;
-  private ResultSet mysqlLock;
-  private ResultSet mysqlRelease;
+  private RecordingDialect dialect;
 
   private static ResultSet missingVersion() throws Exception {
     ResultSet resultSet = mock(ResultSet.class);
@@ -74,7 +79,7 @@ class SchemaMigratorTest {
   }
 
   private SchemaMigrator migrator(String classpathPrefix) {
-    return new SchemaMigrator(dataSource, "mysql", classpathPrefix);
+    return new SchemaMigrator(dataSource, dialect, classpathPrefix);
   }
 
   @BeforeEach
@@ -84,8 +89,7 @@ class SchemaMigratorTest {
     statement = mock(Statement.class);
     selectVersion = mock(PreparedStatement.class);
     insertVersion = mock(PreparedStatement.class);
-    mysqlLock = mock(ResultSet.class);
-    mysqlRelease = mock(ResultSet.class);
+    dialect = new RecordingDialect();
 
     when(dataSource.getConnection()).thenReturn(connection);
     when(connection.createStatement()).thenReturn(statement);
@@ -93,14 +97,6 @@ class SchemaMigratorTest {
     when(connection.prepareStatement(startsWith("SELECT checksum"))).thenReturn(selectVersion);
     when(connection.prepareStatement(startsWith("INSERT INTO ratchet_schema_version")))
         .thenReturn(insertVersion);
-    when(statement.executeQuery("SELECT GET_LOCK('ratchet_schema_migration', 30)"))
-        .thenReturn(mysqlLock);
-    when(statement.executeQuery("SELECT RELEASE_LOCK('ratchet_schema_migration')"))
-        .thenReturn(mysqlRelease);
-    when(mysqlLock.next()).thenReturn(true);
-    when(mysqlLock.getInt(1)).thenReturn(1);
-    when(mysqlRelease.next()).thenReturn(true);
-    when(mysqlRelease.getInt(1)).thenReturn(1);
   }
 
   @Test
@@ -129,6 +125,8 @@ class SchemaMigratorTest {
 
     verify(insertVersion, times(2)).executeUpdate();
     verify(connection, times(2)).commit();
+    assertEquals(1, dialect.acquireCount());
+    assertEquals(1, dialect.releaseCount());
   }
 
   @Test
@@ -172,26 +170,16 @@ class SchemaMigratorTest {
   }
 
   @Test
-  void failsWhenMysqlAdvisoryLockCannotBeAcquired() throws Exception {
-    when(mysqlLock.getInt(1)).thenReturn(0);
+  void failsWhenAdvisoryLockCannotBeAcquired() throws Exception {
+    dialect.failAcquireWith(
+        new SchemaMigrationException("Timed out acquiring schema migration lock"));
 
     SchemaMigrationException ex =
         assertThrows(SchemaMigrationException.class, () -> migrator("schema-migrator").migrate());
 
-    assertTrue(ex.getMessage().contains("Timed out acquiring MySQL schema migration lock"));
+    assertTrue(ex.getMessage().contains("Timed out acquiring schema migration lock"));
     verify(statement, never()).execute(startsWith("CREATE TABLE IF NOT EXISTS"));
-    verify(statement, never()).executeQuery("SELECT RELEASE_LOCK('ratchet_schema_migration')");
-  }
-
-  @Test
-  void postgresqlDialectUsesAdvisoryLock() throws Exception {
-    SchemaMigrator.MigrationResult result =
-        new SchemaMigrator(dataSource, "postgresql", "schema-migrator-empty").migrate();
-
-    assertEquals(0, result.appliedCount());
-    assertEquals(0, result.skippedCount());
-    verify(statement).execute(startsWith("SELECT pg_advisory_lock("));
-    verify(statement).execute(startsWith("SELECT pg_advisory_unlock("));
+    assertEquals(0, dialect.releaseCount());
   }
 
   @Test
@@ -209,7 +197,7 @@ class SchemaMigratorTest {
     verify(connection).rollback();
     verify(connection).setAutoCommit(true);
     verify(insertVersion, never()).executeUpdate();
-    verify(statement).executeQuery("SELECT RELEASE_LOCK('ratchet_schema_migration')");
+    assertEquals(1, dialect.releaseCount());
   }
 
   @Test
@@ -230,75 +218,32 @@ class SchemaMigratorTest {
   }
 
   @Test
-  void surfacesMysqlReleaseLockFailureAfterMigrationWorkCompletes() throws Exception {
-    when(mysqlRelease.getInt(1)).thenReturn(0);
+  void surfacesReleaseLockFailureAfterMigrationWorkCompletes() {
+    dialect.failReleaseWith(new java.sql.SQLException("Failed to release schema migration lock"));
 
     java.sql.SQLException ex =
         assertThrows(
             java.sql.SQLException.class, () -> migrator("schema-migrator-empty").migrate());
 
-    assertTrue(ex.getMessage().contains("Failed to release MySQL schema migration lock"));
-    verify(statement).executeQuery("SELECT RELEASE_LOCK('ratchet_schema_migration')");
+    assertTrue(ex.getMessage().contains("Failed to release schema migration lock"));
+    assertEquals(1, dialect.releaseCount());
   }
 
   @Test
-  void keepsMigrationFailureWhenMysqlReleaseLockAlsoFails() throws Exception {
+  void keepsMigrationFailureWhenReleaseLockAlsoFails() throws Exception {
     ResultSet firstMissingVersion = missingVersion();
     when(selectVersion.executeQuery()).thenReturn(firstMissingVersion);
     when(statement.execute(contains("CREATE TABLE ratchet_test_order")))
         .thenThrow(new java.sql.SQLException("migration failed"));
-    when(mysqlRelease.getInt(1)).thenReturn(0);
+    dialect.failReleaseWith(new java.sql.SQLException("Failed to release schema migration lock"));
 
     java.sql.SQLException ex =
         assertThrows(java.sql.SQLException.class, () -> migrator("schema-migrator").migrate());
 
     assertEquals("migration failed", ex.getMessage());
     assertEquals(1, ex.getSuppressed().length);
-    assertTrue(ex.getSuppressed()[0].getMessage().contains("Failed to release MySQL"));
+    assertTrue(ex.getSuppressed()[0].getMessage().contains("Failed to release"));
     verify(connection).rollback();
-    verify(statement).executeQuery("SELECT RELEASE_LOCK('ratchet_schema_migration')");
-  }
-
-  @Test
-  void dialectFromMetadataMapsKnownProducts() throws Exception {
-    DatabaseMetaData mysqlMeta = mock(DatabaseMetaData.class);
-    when(mysqlMeta.getDatabaseProductName()).thenReturn("MySQL");
-    Connection mysqlConn = mock(Connection.class);
-    when(mysqlConn.getMetaData()).thenReturn(mysqlMeta);
-    assertEquals("mysql", SchemaMigrator.dialectFromMetadata(mysqlConn));
-
-    DatabaseMetaData mariaMeta = mock(DatabaseMetaData.class);
-    when(mariaMeta.getDatabaseProductName()).thenReturn("MariaDB");
-    Connection mariaConn = mock(Connection.class);
-    when(mariaConn.getMetaData()).thenReturn(mariaMeta);
-    assertEquals("mysql", SchemaMigrator.dialectFromMetadata(mariaConn));
-
-    DatabaseMetaData pgMeta = mock(DatabaseMetaData.class);
-    when(pgMeta.getDatabaseProductName()).thenReturn("PostgreSQL");
-    Connection pgConn = mock(Connection.class);
-    when(pgConn.getMetaData()).thenReturn(pgMeta);
-    assertEquals("postgresql", SchemaMigrator.dialectFromMetadata(pgConn));
-
-    DatabaseMetaData oracleMeta = mock(DatabaseMetaData.class);
-    when(oracleMeta.getDatabaseProductName()).thenReturn("Oracle");
-    Connection oracleConn = mock(Connection.class);
-    when(oracleConn.getMetaData()).thenReturn(oracleMeta);
-    assertEquals("oracle", SchemaMigrator.dialectFromMetadata(oracleConn));
-  }
-
-  @Test
-  void dialectFromMetadataRejectsLookalikes() throws Exception {
-    DatabaseMetaData crdbMeta = mock(DatabaseMetaData.class);
-    when(crdbMeta.getDatabaseProductName()).thenReturn("CockroachDB");
-    Connection crdbConn = mock(Connection.class);
-    when(crdbConn.getMetaData()).thenReturn(crdbMeta);
-
-    SchemaInitializationException ex =
-        assertThrows(
-            SchemaInitializationException.class,
-            () -> SchemaMigrator.dialectFromMetadata(crdbConn));
-    assertTrue(ex.getMessage().contains("CockroachDB"));
-    assertTrue(ex.getMessage().contains("Supported"));
   }
 
   @Test
@@ -311,6 +256,13 @@ class SchemaMigratorTest {
     when(dataSources.get()).thenReturn(failingDataSource);
     when(failingDataSource.getConnection()).thenThrow(new java.sql.SQLException());
 
+    SchemaMigrationDialect mysqlDialect = mock(SchemaMigrationDialect.class);
+    when(mysqlDialect.id()).thenReturn("mysql");
+    @SuppressWarnings("unchecked")
+    Instance<SchemaMigrationDialect> dialects = mock(Instance.class);
+    when(dialects.isUnsatisfied()).thenReturn(false);
+    when(dialects.iterator()).thenReturn(List.of(mysqlDialect).iterator());
+
     RatchetOptions options =
         RatchetOptions.builder()
             .schema(
@@ -320,11 +272,76 @@ class SchemaMigratorTest {
                         .migrationDialect("mysql")
                         .migrationPrefix("schema-migrator-empty"))
             .build();
-    SchemaMigrationLifecycleHook hook = new SchemaMigrationLifecycleHook(options, dataSources);
+    SchemaMigrationLifecycleHook hook =
+        new SchemaMigrationLifecycleHook(options, dataSources, dialects);
 
     SchemaInitializationException ex =
         assertThrows(SchemaInitializationException.class, hook::beforeStart);
 
     assertEquals("Ratchet schema auto-migration failed: SQLException", ex.getMessage());
+  }
+
+  /**
+   * Minimal {@link SchemaMigrationDialect} for engine tests: returns predictable SQL and records
+   * (or fails) lock calls so the engine's orchestration can be asserted without a real database.
+   */
+  private static final class RecordingDialect implements SchemaMigrationDialect {
+
+    private RuntimeException acquireFailure;
+    private SQLException releaseFailure;
+    private int acquireCount;
+    private int releaseCount;
+
+    void failAcquireWith(RuntimeException failure) {
+      this.acquireFailure = failure;
+    }
+
+    void failReleaseWith(SQLException failure) {
+      this.releaseFailure = failure;
+    }
+
+    int acquireCount() {
+      return acquireCount;
+    }
+
+    int releaseCount() {
+      return releaseCount;
+    }
+
+    @Override
+    public String id() {
+      return "stub";
+    }
+
+    @Override
+    public String createVersionTableSql() {
+      return "CREATE TABLE IF NOT EXISTS ratchet_schema_version (version VARCHAR(20) NOT NULL)";
+    }
+
+    @Override
+    public String recordVersionSql() {
+      return "INSERT INTO ratchet_schema_version (version, description, checksum) VALUES (?, ?, ?)";
+    }
+
+    @Override
+    public boolean usesDedicatedLockConnection() {
+      return false;
+    }
+
+    @Override
+    public void acquireLock(Connection connection) {
+      acquireCount++;
+      if (acquireFailure != null) {
+        throw acquireFailure;
+      }
+    }
+
+    @Override
+    public void releaseLock(Connection connection) throws SQLException {
+      releaseCount++;
+      if (releaseFailure != null) {
+        throw releaseFailure;
+      }
+    }
   }
 }

--- a/stores/ratchet-store-mysql/pom.xml
+++ b/stores/ratchet-store-mysql/pom.xml
@@ -142,6 +142,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Publishes a test-jar so the integration testsuite can ServiceLoad this store's
+                 SqlDialectTestSupport implementation into the deployment WAR. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/stores/ratchet-store-mysql/pom.xml
+++ b/stores/ratchet-store-mysql/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>run.ratchet</groupId>

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSchemaMigrationDialect.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlSchemaMigrationDialect.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mysql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import run.ratchet.store.migration.SchemaMigrationDialect;
+import run.ratchet.store.migration.SchemaMigrationException;
+
+/** MySQL/MariaDB schema migration dialect: session-level {@code GET_LOCK} advisory lock. */
+@ApplicationScoped
+public class MysqlSchemaMigrationDialect implements SchemaMigrationDialect {
+
+  private static final String LOCK_NAME = "ratchet_schema_migration";
+
+  @Override
+  public String id() {
+    return "mysql";
+  }
+
+  @Override
+  public String createVersionTableSql() {
+    return """
+        CREATE TABLE IF NOT EXISTS ratchet_schema_version
+        (
+            version     VARCHAR(20)  NOT NULL,
+            applied_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+            description VARCHAR(200) NOT NULL,
+            checksum    VARCHAR(64)  NULL,
+            PRIMARY KEY (version)
+        ) ENGINE = InnoDB
+          DEFAULT CHARSET = utf8mb4
+          COLLATE = utf8mb4_unicode_ci\
+        """;
+  }
+
+  @Override
+  public String recordVersionSql() {
+    return "INSERT INTO ratchet_schema_version (version, description, checksum) VALUES (?, ?, ?)"
+        + " ON DUPLICATE KEY UPDATE description = VALUES(description),"
+        + " checksum = VALUES(checksum)";
+  }
+
+  @Override
+  public boolean usesDedicatedLockConnection() {
+    return false;
+  }
+
+  @Override
+  public void acquireLock(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT GET_LOCK('" + LOCK_NAME + "', 30)")) {
+      if (!resultSet.next() || resultSet.getInt(1) != 1) {
+        throw new SchemaMigrationException("Timed out acquiring MySQL schema migration lock");
+      }
+    }
+  }
+
+  @Override
+  public void releaseLock(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet = statement.executeQuery("SELECT RELEASE_LOCK('" + LOCK_NAME + "')")) {
+      if (!resultSet.next() || resultSet.getInt(1) != 1) {
+        throw new SQLException("Failed to release MySQL schema migration lock");
+      }
+    }
+  }
+}

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlDialectTestSupport.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlDialectTestSupport.java
@@ -50,32 +50,31 @@ public final class MysqlDialectTestSupport implements SqlDialectTestSupport {
   }
 
   @Override
-  public void insertBackgroundChunk(
-      EntityManager em, int batchCount, int offset, String keyPrefix) {
-    // job_id is BINARY(16); UUID_TO_BIN(UUID(), 1) produces a time-ordered 16-byte value.
-    // language=MySQL
-    String setDepthSql = "SET @@cte_max_recursion_depth = " + (batchCount + 1);
-    em.createNativeQuery(setDepthSql).executeUpdate();
+  public void insertTerminalChunk(EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Cold archive rows: terminal_status='SUCCEEDED', no queue row. job_id is BINARY(16);
+    // UUID_TO_BIN(UUID(), 1) produces a time-ordered 16-byte value (random is fine here — these
+    // rows are never correlated to a queue row).
+    setRecursionDepth(em, batchCount);
     // language=MySQL
     String sql =
         """
         INSERT INTO scheduler_job
-          (job_id, status, scheduled_time, job_type, payload, idempotency_key,
-           business_key, execution_start_time, execution_end_time,
-           created_at, updated_at)
+          (job_id, job_type, payload, idempotency_key, business_key,
+           created_at, terminal_status, terminated_at,
+           execution_start_time, execution_end_time, queue_wait_ms)
         WITH RECURSIVE seq(n) AS (
           SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %d
         )
-        SELECT UUID_TO_BIN(UUID(), 1),
-               'SUCCEEDED', NOW() - INTERVAL 1 HOUR, 'SINGLE',
+        SELECT UUID_TO_BIN(UUID(), 1), 'SINGLE',
                JSON_OBJECT('target','run.ratchet.testsuite.app.TimingJob',
                            'method','execute','descriptor','()V','isStatic',true,
                            'args',JSON_ARRAY()),
                UUID(),
                CONCAT('%s-', n + %d),
+               NOW(), 'SUCCEEDED', NOW() - INTERVAL 1 HOUR,
                NOW() - INTERVAL 1 HOUR,
                DATE_ADD(NOW() - INTERVAL 1 HOUR, INTERVAL 10000 MICROSECOND),
-               NOW(), NOW()
+               10
         FROM seq
         """
             .formatted(batchCount, keyPrefix, offset);
@@ -83,15 +82,63 @@ public final class MysqlDialectTestSupport implements SqlDialectTestSupport {
   }
 
   @Override
-  public void analyzeSchedulerJob(EntityManager em) {
+  public void insertPendingQueueChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Live PENDING jobs: a cold parent plus a far-future hot queue row. Deterministic BINARY(16)
+    // ids — UNHEX(LPAD(HEX(n), 32, '0')) — let both inserts agree on job_id without an anti-join.
+    setRecursionDepth(em, batchCount);
     // language=MySQL
-    String mysqlAnalyze = "ANALYZE TABLE scheduler_job";
+    String coldSql =
+        """
+        INSERT INTO scheduler_job
+          (job_id, job_type, payload, idempotency_key, business_key, created_at)
+        WITH RECURSIVE seq(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %1$d
+        )
+        SELECT UNHEX(LPAD(HEX(n + %2$d), 32, '0')), 'SINGLE',
+               JSON_OBJECT('target','run.ratchet.testsuite.app.TimingJob',
+                           'method','execute','descriptor','()V','isStatic',true,
+                           'args',JSON_ARRAY()),
+               CONCAT('%3$s-key-', n + %2$d),
+               CONCAT('%3$s-', n + %2$d),
+               NOW()
+        FROM seq
+        """
+            .formatted(batchCount, offset, keyPrefix);
+    em.createNativeQuery(coldSql).executeUpdate();
+
+    // language=MySQL
+    String hotSql =
+        """
+        INSERT INTO scheduler_job_queue
+          (job_id, status, job_type, scheduled_time, updated_at)
+        WITH RECURSIVE seq(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %1$d
+        )
+        SELECT UNHEX(LPAD(HEX(n + %2$d), 32, '0')), 'PENDING', 'SINGLE',
+               NOW() + INTERVAL 365 DAY, NOW()
+        FROM seq
+        """
+            .formatted(batchCount, offset);
+    em.createNativeQuery(hotSql).executeUpdate();
+  }
+
+  private void setRecursionDepth(EntityManager em, int batchCount) {
+    // language=MySQL
+    String setDepthSql = "SET @@cte_max_recursion_depth = " + (batchCount + 1);
+    em.createNativeQuery(setDepthSql).executeUpdate();
+  }
+
+  @Override
+  public void analyzeTable(EntityManager em, String table) {
+    // language=MySQL
+    String mysqlAnalyze = "ANALYZE TABLE " + table;
     em.createNativeQuery(mysqlAnalyze).getResultList();
   }
 
   @Override
   public void assertNoFullScan(
-      EntityManager em, UserTransaction utx, String label, Runnable storeOperation)
+      EntityManager em, UserTransaction utx, String table, String label, Runnable storeOperation)
       throws Exception {
     // MySQL: Select_scan is session-wide (all tables), not per-table like PostgreSQL's
     // pg_stat_user_tables. Log for informational purposes only.
@@ -106,8 +153,8 @@ public final class MysqlDialectTestSupport implements SqlDialectTestSupport {
 
     log.info(
         String.format(
-            "Scan stats [%s]: MySQL — per-table scan metrics not available, "
+            "Scan stats [%s] on %s: MySQL — per-table scan metrics not available, "
                 + "relying on index definitions and EXPLAIN plans for verification",
-            label));
+            label, table));
   }
 }

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlDialectTestSupport.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlDialectTestSupport.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mysql;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+import java.util.UUID;
+import java.util.logging.Logger;
+import run.ratchet.tck.store.SqlDialectTestSupport;
+
+/** MySQL {@link SqlDialectTestSupport}: BINARY(16) ids, foreign-key toggling, and TRUNCATE. */
+public final class MysqlDialectTestSupport implements SqlDialectTestSupport {
+
+  private static final Logger log = Logger.getLogger(MysqlDialectTestSupport.class.getName());
+
+  /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
+  public MysqlDialectTestSupport() {}
+
+  @Override
+  public void disableForeignKeyChecks(EntityManager em) {
+    em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
+  }
+
+  @Override
+  public void enableForeignKeyChecks(EntityManager em) {
+    em.createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
+  }
+
+  @Override
+  public void clearTable(EntityManager em, String table) {
+    em.createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
+  }
+
+  @Override
+  public Object jobIdParam(UUID jobId) {
+    return SqlDialectTestSupport.uuidToBigEndianBytes(jobId);
+  }
+
+  @Override
+  public void insertBackgroundChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // job_id is BINARY(16); UUID_TO_BIN(UUID(), 1) produces a time-ordered 16-byte value.
+    // language=MySQL
+    String setDepthSql = "SET @@cte_max_recursion_depth = " + (batchCount + 1);
+    em.createNativeQuery(setDepthSql).executeUpdate();
+    // language=MySQL
+    String sql =
+        """
+        INSERT INTO scheduler_job
+          (job_id, status, scheduled_time, job_type, payload, idempotency_key,
+           business_key, execution_start_time, execution_end_time,
+           created_at, updated_at)
+        WITH RECURSIVE seq(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %d
+        )
+        SELECT UUID_TO_BIN(UUID(), 1),
+               'SUCCEEDED', NOW() - INTERVAL 1 HOUR, 'SINGLE',
+               JSON_OBJECT('target','run.ratchet.testsuite.app.TimingJob',
+                           'method','execute','descriptor','()V','isStatic',true,
+                           'args',JSON_ARRAY()),
+               UUID(),
+               CONCAT('%s-', n + %d),
+               NOW() - INTERVAL 1 HOUR,
+               DATE_ADD(NOW() - INTERVAL 1 HOUR, INTERVAL 10000 MICROSECOND),
+               NOW(), NOW()
+        FROM seq
+        """
+            .formatted(batchCount, keyPrefix, offset);
+    em.createNativeQuery(sql).executeUpdate();
+  }
+
+  @Override
+  public void analyzeSchedulerJob(EntityManager em) {
+    // language=MySQL
+    String mysqlAnalyze = "ANALYZE TABLE scheduler_job";
+    em.createNativeQuery(mysqlAnalyze).getResultList();
+  }
+
+  @Override
+  public void assertNoFullScan(
+      EntityManager em, UserTransaction utx, String label, Runnable storeOperation)
+      throws Exception {
+    // MySQL: Select_scan is session-wide (all tables), not per-table like PostgreSQL's
+    // pg_stat_user_tables. Log for informational purposes only.
+    utx.begin();
+    try {
+      storeOperation.run();
+      utx.commit();
+    } catch (RuntimeException e) {
+      rollbackQuietly(utx);
+      throw e;
+    }
+
+    log.info(
+        String.format(
+            "Scan stats [%s]: MySQL — per-table scan metrics not available, "
+                + "relying on index definitions and EXPLAIN plans for verification",
+            label));
+  }
+}

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigrationDialectTest.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigrationDialectTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mysql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.migration.SchemaMigrationException;
+
+class MysqlSchemaMigrationDialectTest {
+
+  private static final String GET_LOCK = "SELECT GET_LOCK('ratchet_schema_migration', 30)";
+  private static final String RELEASE_LOCK = "SELECT RELEASE_LOCK('ratchet_schema_migration')";
+
+  private final MysqlSchemaMigrationDialect dialect = new MysqlSchemaMigrationDialect();
+  private Connection connection;
+  private Statement statement;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection = mock(Connection.class);
+    statement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(statement);
+  }
+
+  private void stubLockQuery(String sql, int result) throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(statement.executeQuery(sql)).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(true);
+    when(resultSet.getInt(1)).thenReturn(result);
+  }
+
+  @Test
+  void advertisesMysqlIdentityOnSharedConnection() {
+    assertEquals("mysql", dialect.id());
+    assertFalse(dialect.usesDedicatedLockConnection());
+  }
+
+  @Test
+  void acquiresAdvisoryLockViaGetLock() throws Exception {
+    stubLockQuery(GET_LOCK, 1);
+
+    dialect.acquireLock(connection);
+
+    verify(statement).executeQuery(GET_LOCK);
+  }
+
+  @Test
+  void failsWhenGetLockDoesNotReturnOne() throws Exception {
+    stubLockQuery(GET_LOCK, 0);
+
+    SchemaMigrationException ex =
+        assertThrows(SchemaMigrationException.class, () -> dialect.acquireLock(connection));
+
+    assertTrue(ex.getMessage().contains("Timed out acquiring MySQL schema migration lock"));
+  }
+
+  @Test
+  void releasesAdvisoryLock() throws Exception {
+    stubLockQuery(RELEASE_LOCK, 1);
+
+    dialect.releaseLock(connection);
+
+    verify(statement).executeQuery(RELEASE_LOCK);
+  }
+
+  @Test
+  void failsWhenReleaseLockDoesNotReturnOne() throws Exception {
+    stubLockQuery(RELEASE_LOCK, 0);
+
+    SQLException ex = assertThrows(SQLException.class, () -> dialect.releaseLock(connection));
+
+    assertTrue(ex.getMessage().contains("Failed to release MySQL schema migration lock"));
+  }
+
+  @Test
+  void versionLedgerSqlIsMysqlFlavored() {
+    assertTrue(dialect.createVersionTableSql().contains("ENGINE = InnoDB"));
+    assertTrue(dialect.recordVersionSql().startsWith("INSERT INTO ratchet_schema_version"));
+    assertTrue(dialect.recordVersionSql().contains("ON DUPLICATE KEY UPDATE"));
+  }
+}

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigratorIT.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigratorIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.mysql.MySQLContainer;
+import run.ratchet.store.migration.SchemaMigrationDialect;
 import run.ratchet.store.migration.SchemaMigrationException;
 import run.ratchet.store.migration.SchemaMigrator;
 import run.ratchet.tck.store.AbstractSchemaMigratorContract;
@@ -66,8 +67,8 @@ class MysqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
   }
 
   @Override
-  protected String dialect() {
-    return "mysql";
+  protected SchemaMigrationDialect dialect() {
+    return new MysqlSchemaMigrationDialect();
   }
 
   private void corruptRecordedChecksum(String version) throws SQLException {
@@ -100,7 +101,8 @@ class MysqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
   void rejectsPreviouslyAppliedMigrationWithDifferentChecksum() throws Exception {
     resetDatabase();
 
-    SchemaMigrator.MigrationResult first = new SchemaMigrator(dataSource(), "mysql").migrate();
+    SchemaMigrator.MigrationResult first =
+        new SchemaMigrator(dataSource(), new MysqlSchemaMigrationDialect()).migrate();
     assertTrue(first.appliedCount() > 0, "expected at least one migration applied");
 
     String firstVersion = first.applied().get(0).version();
@@ -109,7 +111,7 @@ class MysqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
     SchemaMigrationException ex =
         assertThrows(
             SchemaMigrationException.class,
-            () -> new SchemaMigrator(dataSource(), "mysql").migrate());
+            () -> new SchemaMigrator(dataSource(), new MysqlSchemaMigrationDialect()).migrate());
     assertTrue(ex.getMessage().contains("Checksum mismatch"), () -> "got: " + ex.getMessage());
     assertTrue(ex.getMessage().contains(firstVersion), () -> "got: " + ex.getMessage());
   }

--- a/stores/ratchet-store-mysql/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
+++ b/stores/ratchet-store-mysql/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
@@ -1,0 +1,1 @@
+run.ratchet.store.mysql.MysqlDialectTestSupport

--- a/stores/ratchet-store-oracle/pom.xml
+++ b/stores/ratchet-store-oracle/pom.xml
@@ -137,6 +137,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Publishes a test-jar so the integration testsuite can ServiceLoad this store's
+                 SqlDialectTestSupport implementation into the deployment WAR. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleSchemaMigrationDialect.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleSchemaMigrationDialect.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.oracle;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import run.ratchet.store.migration.SchemaMigrationDialect;
+import run.ratchet.store.migration.SchemaMigrationException;
+
+/**
+ * Oracle schema migration dialect.
+ *
+ * <p>Oracle has no grant-free session-level advisory lock and its DDL auto-commits, so the
+ * migration lock is held as an {@code EXCLUSIVE} table lock on a dedicated connection (see {@link
+ * #usesDedicatedLockConnection()}). The version-record upsert is a {@code MERGE}.
+ */
+@ApplicationScoped
+public class OracleSchemaMigrationDialect implements SchemaMigrationDialect {
+
+  // WAIT N is in seconds; a second migrator that cannot acquire the lock within this window fails
+  // loudly.
+  private static final int LOCK_WAIT_SECONDS = 120;
+  private static final int ORA_NAME_ALREADY_USED = 955;
+  private static final int ORA_RESOURCE_BUSY = 54;
+
+  @Override
+  public String id() {
+    return "oracle";
+  }
+
+  @Override
+  public String createVersionTableSql() {
+    return """
+        CREATE TABLE IF NOT EXISTS ratchet_schema_version
+        (
+            version     VARCHAR2(20)  NOT NULL,
+            applied_at  TIMESTAMP(6)  DEFAULT SYSTIMESTAMP NOT NULL,
+            description VARCHAR2(200) NOT NULL,
+            checksum    VARCHAR2(64),
+            CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
+        )\
+        """;
+  }
+
+  @Override
+  public String recordVersionSql() {
+    return "MERGE INTO ratchet_schema_version t"
+        + " USING (SELECT ? AS version, ? AS description, ? AS checksum FROM dual) s"
+        + " ON (t.version = s.version)"
+        + " WHEN MATCHED THEN UPDATE SET t.description = s.description,"
+        + " t.checksum = s.checksum"
+        + " WHEN NOT MATCHED THEN INSERT (version, description, checksum)"
+        + " VALUES (s.version, s.description, s.checksum)";
+  }
+
+  @Override
+  public boolean usesDedicatedLockConnection() {
+    return true;
+  }
+
+  /**
+   * Acquires the Oracle migration lock on a dedicated connection.
+   *
+   * <p>Oracle DDL auto-commits, which would release any transactional lock held on the migration
+   * connection itself, and {@code DBMS_LOCK} requires an EXECUTE grant that managed users often
+   * lack. Instead a tiny dedicated {@code ratchet_schema_lock} table is locked {@code IN EXCLUSIVE
+   * MODE} on a second connection that never runs DDL, so the lock survives the migration's
+   * per-script commits. The lock table is separate from {@code ratchet_schema_version} on purpose:
+   * an EXCLUSIVE lock on the ledger would block the migration connection's own ledger writes.
+   */
+  @Override
+  public void acquireLock(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "CREATE TABLE IF NOT EXISTS ratchet_schema_lock (lock_name VARCHAR2(128) NOT NULL,"
+              + " CONSTRAINT pk_ratchet_schema_lock PRIMARY KEY (lock_name))");
+    } catch (SQLException e) {
+      // ORA-00955: a concurrent migrator created the lock table first. Any other error is fatal.
+      if (e.getErrorCode() != ORA_NAME_ALREADY_USED) {
+        throw e;
+      }
+    }
+    connection.setAutoCommit(false);
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "LOCK TABLE ratchet_schema_lock IN EXCLUSIVE MODE WAIT " + LOCK_WAIT_SECONDS);
+    } catch (SQLException e) {
+      if (e.getErrorCode() == ORA_RESOURCE_BUSY) {
+        throw new SchemaMigrationException(
+            "Timed out after "
+                + LOCK_WAIT_SECONDS
+                + "s acquiring the Oracle schema migration lock; another migrator held it longer"
+                + " than the wait window.",
+            e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public void releaseLock(Connection connection) throws SQLException {
+    // Commit releases the EXCLUSIVE table lock; the dedicated lock connection is closed by the
+    // engine immediately afterward.
+    connection.commit();
+  }
+}

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleSchemaMigrationDialect.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleSchemaMigrationDialect.java
@@ -45,15 +45,26 @@ public class OracleSchemaMigrationDialect implements SchemaMigrationDialect {
 
   @Override
   public String createVersionTableSql() {
+    // Oracle's CREATE TABLE IF NOT EXISTS is 23ai-only, and the engine runs this statement without
+    // catching already-exists errors, so wrap a plain CREATE TABLE in a PL/SQL block that swallows
+    // ORA-00955 (name already used). That keeps re-runs idempotent across Oracle versions. The
+    // statement runs under the migration lock, so there is no concurrent-create race to handle.
     return """
-        CREATE TABLE IF NOT EXISTS ratchet_schema_version
-        (
-            version     VARCHAR2(20)  NOT NULL,
-            applied_at  TIMESTAMP(6)  DEFAULT SYSTIMESTAMP NOT NULL,
-            description VARCHAR2(200) NOT NULL,
-            checksum    VARCHAR2(64),
-            CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
-        )\
+        BEGIN
+          EXECUTE IMMEDIATE 'CREATE TABLE ratchet_schema_version
+          (
+              version     VARCHAR2(20)  NOT NULL,
+              applied_at  TIMESTAMP(6)  DEFAULT SYSTIMESTAMP NOT NULL,
+              description VARCHAR2(200) NOT NULL,
+              checksum    VARCHAR2(64),
+              CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
+          )';
+        EXCEPTION
+          WHEN OTHERS THEN
+            IF SQLCODE != -955 THEN
+              RAISE;
+            END IF;
+        END;\
         """;
   }
 
@@ -86,8 +97,11 @@ public class OracleSchemaMigrationDialect implements SchemaMigrationDialect {
   @Override
   public void acquireLock(Connection connection) throws SQLException {
     try (Statement statement = connection.createStatement()) {
+      // Plain CREATE TABLE rather than IF NOT EXISTS (which is 23ai-only): the lock table is
+      // created before the lock is held, so two migrators can race here. The ORA-00955 catch below
+      // handles the loser of that race and keeps this portable across Oracle versions.
       statement.execute(
-          "CREATE TABLE IF NOT EXISTS ratchet_schema_lock (lock_name VARCHAR2(128) NOT NULL,"
+          "CREATE TABLE ratchet_schema_lock (lock_name VARCHAR2(128) NOT NULL,"
               + " CONSTRAINT pk_ratchet_schema_lock PRIMARY KEY (lock_name))");
     } catch (SQLException e) {
       // ORA-00955: a concurrent migrator created the lock table first. Any other error is fatal.

--- a/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleDialectTestSupport.java
+++ b/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleDialectTestSupport.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.oracle;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+import java.util.UUID;
+import run.ratchet.tck.store.SqlDialectTestSupport;
+
+/**
+ * Oracle {@link SqlDialectTestSupport}: RAW(16) ids, no foreign-key toggling, and row-level DELETE.
+ *
+ * <p>The performance methods throw {@link UnsupportedOperationException}: the perf helper's bulk
+ * insert and scan checks still target the pre-hot/cold-split {@code scheduler_job} columns and run
+ * only on MySQL and PostgreSQL today. Oracle's perf SQL arrives with the perf suite's hot/cold
+ * migration; the cleanup and id-binding paths used by every functional IT are fully supported here.
+ */
+public final class OracleDialectTestSupport implements SqlDialectTestSupport {
+
+  private static final String PERF_PENDING =
+      "Oracle performance SQL lands with the perf suite's hot/cold-schema migration";
+
+  /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
+  public OracleDialectTestSupport() {}
+
+  @Override
+  public void disableForeignKeyChecks(EntityManager em) {
+    // Oracle has no session-level foreign-key toggle; DELETE respects the child-before-parent
+    // ordering the caller iterates in.
+  }
+
+  @Override
+  public void enableForeignKeyChecks(EntityManager em) {
+    // No-op — see disableForeignKeyChecks.
+  }
+
+  @Override
+  public void clearTable(EntityManager em, String table) {
+    // A concurrent TRUNCATE both fails outright on tables that enabled foreign keys reference
+    // (ORA-02266) and resets a table's data-object number, so any in-flight poller query against it
+    // dies with ORA-08103. Row-level DELETE is MVCC-friendly and coexists with the live poller.
+    em.createNativeQuery("DELETE FROM " + table).executeUpdate();
+  }
+
+  @Override
+  public Object jobIdParam(UUID jobId) {
+    return SqlDialectTestSupport.uuidToBigEndianBytes(jobId);
+  }
+
+  @Override
+  public void insertBackgroundChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    throw new UnsupportedOperationException(PERF_PENDING);
+  }
+
+  @Override
+  public void analyzeSchedulerJob(EntityManager em) {
+    throw new UnsupportedOperationException(PERF_PENDING);
+  }
+
+  @Override
+  public void assertNoFullScan(
+      EntityManager em, UserTransaction utx, String label, Runnable storeOperation) {
+    throw new UnsupportedOperationException(PERF_PENDING);
+  }
+}

--- a/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleDialectTestSupport.java
+++ b/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleDialectTestSupport.java
@@ -17,21 +17,17 @@ package run.ratchet.store.oracle;
 
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.UserTransaction;
+import java.util.Locale;
 import java.util.UUID;
+import java.util.logging.Logger;
 import run.ratchet.tck.store.SqlDialectTestSupport;
 
 /**
  * Oracle {@link SqlDialectTestSupport}: RAW(16) ids, no foreign-key toggling, and row-level DELETE.
- *
- * <p>The performance methods throw {@link UnsupportedOperationException}: the perf helper's bulk
- * insert and scan checks still target the pre-hot/cold-split {@code scheduler_job} columns and run
- * only on MySQL and PostgreSQL today. Oracle's perf SQL arrives with the perf suite's hot/cold
- * migration; the cleanup and id-binding paths used by every functional IT are fully supported here.
  */
 public final class OracleDialectTestSupport implements SqlDialectTestSupport {
 
-  private static final String PERF_PENDING =
-      "Oracle performance SQL lands with the perf suite's hot/cold-schema migration";
+  private static final Logger log = Logger.getLogger(OracleDialectTestSupport.class.getName());
 
   /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
   public OracleDialectTestSupport() {}
@@ -61,19 +57,100 @@ public final class OracleDialectTestSupport implements SqlDialectTestSupport {
   }
 
   @Override
-  public void insertBackgroundChunk(
-      EntityManager em, int batchCount, int offset, String keyPrefix) {
-    throw new UnsupportedOperationException(PERF_PENDING);
+  public void insertTerminalChunk(EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Cold archive rows: terminal_status='SUCCEEDED', no queue row. CONNECT BY LEVEL generates the
+    // chunk; SYS_GUID() is a fresh RAW(16) per row (random is fine — never correlated to a queue
+    // row). The payload literal is implicitly stored into the CLOB column.
+    // language=Oracle
+    String sql =
+        """
+        INSERT INTO scheduler_job
+          (job_id, job_type, payload, idempotency_key, business_key,
+           created_at, terminal_status, terminated_at,
+           execution_start_time, execution_end_time, queue_wait_ms)
+        SELECT SYS_GUID(), 'SINGLE',
+               '{"target":"run.ratchet.testsuite.app.TimingJob",\
+        "method":"execute","descriptor":"()V",\
+        "isStatic":true,"args":[]}',
+               RAWTOHEX(SYS_GUID()),
+               '%2$s-' || (LEVEL + %1$d),
+               SYSTIMESTAMP, 'SUCCEEDED', SYSTIMESTAMP - INTERVAL '1' HOUR,
+               SYSTIMESTAMP - INTERVAL '1' HOUR,
+               SYSTIMESTAMP - INTERVAL '1' HOUR + INTERVAL '0.01' SECOND,
+               10
+        FROM dual CONNECT BY LEVEL <= %3$d
+        """
+            .formatted(offset, keyPrefix, batchCount);
+    em.createNativeQuery(sql).executeUpdate();
   }
 
   @Override
-  public void analyzeSchedulerJob(EntityManager em) {
-    throw new UnsupportedOperationException(PERF_PENDING);
+  public void insertPendingQueueChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Live PENDING jobs: a cold parent plus a far-future hot queue row. Deterministic RAW(16) ids —
+    // HEXTORAW(LPAD(TO_CHAR(n, 'FMXXXX...'), 32, '0')) — let both inserts agree on job_id without
+    // an
+    // anti-join.
+    // language=Oracle
+    String coldSql =
+        """
+        INSERT INTO scheduler_job
+          (job_id, job_type, payload, idempotency_key, business_key, created_at)
+        SELECT HEXTORAW(LPAD(TO_CHAR(LEVEL + %1$d, 'FMXXXXXXXXXXXXXXXX'), 32, '0')), 'SINGLE',
+               '{"target":"run.ratchet.testsuite.app.TimingJob",\
+        "method":"execute","descriptor":"()V",\
+        "isStatic":true,"args":[]}',
+               '%2$s-key-' || (LEVEL + %1$d),
+               '%2$s-' || (LEVEL + %1$d),
+               SYSTIMESTAMP
+        FROM dual CONNECT BY LEVEL <= %3$d
+        """
+            .formatted(offset, keyPrefix, batchCount);
+    em.createNativeQuery(coldSql).executeUpdate();
+
+    // language=Oracle
+    String hotSql =
+        """
+        INSERT INTO scheduler_job_queue
+          (job_id, status, job_type, scheduled_time, updated_at)
+        SELECT HEXTORAW(LPAD(TO_CHAR(LEVEL + %1$d, 'FMXXXXXXXXXXXXXXXX'), 32, '0')),
+               'PENDING', 'SINGLE', SYSTIMESTAMP + INTERVAL '365' DAY(3), SYSTIMESTAMP
+        FROM dual CONNECT BY LEVEL <= %2$d
+        """
+            .formatted(offset, batchCount);
+    em.createNativeQuery(hotSql).executeUpdate();
+  }
+
+  @Override
+  public void analyzeTable(EntityManager em, String table) {
+    // Oracle gathers optimizer statistics via DBMS_STATS; the table name is upper-cased to match
+    // the data-dictionary identifier. Runs in its own committed transaction (the caller commits the
+    // insert chunks first), so it does not deadlock against uncommitted DML.
+    String block =
+        "BEGIN DBMS_STATS.GATHER_TABLE_STATS(USER, '" + table.toUpperCase(Locale.ROOT) + "'); END;";
+    em.createNativeQuery(block).executeUpdate();
   }
 
   @Override
   public void assertNoFullScan(
-      EntityManager em, UserTransaction utx, String label, Runnable storeOperation) {
-    throw new UnsupportedOperationException(PERF_PENDING);
+      EntityManager em, UserTransaction utx, String table, String label, Runnable storeOperation)
+      throws Exception {
+    // Oracle has no cheap per-table sequential-scan counter (v$ views are instance-wide and require
+    // privileges Testcontainers does not grant), so the claim path's index usage is verified by the
+    // schema-conformance TCK and EXPLAIN plans instead. Log for informational purposes only.
+    utx.begin();
+    try {
+      storeOperation.run();
+      utx.commit();
+    } catch (RuntimeException e) {
+      rollbackQuietly(utx);
+      throw e;
+    }
+
+    log.info(
+        String.format(
+            "Scan stats [%s] on %s: Oracle — per-table scan metrics not available, "
+                + "relying on index definitions and EXPLAIN plans for verification",
+            label, table));
   }
 }

--- a/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleSchemaMigratorIT.java
+++ b/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleSchemaMigratorIT.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.oracle.OracleContainer;
+import run.ratchet.store.migration.SchemaMigrationDialect;
 import run.ratchet.store.migration.SchemaMigrationException;
 import run.ratchet.store.migration.SchemaMigrator;
 import run.ratchet.tck.store.AbstractSchemaMigratorContract;
@@ -74,8 +75,8 @@ class OracleSchemaMigratorIT extends AbstractSchemaMigratorContract {
   }
 
   @Override
-  protected String dialect() {
-    return "oracle";
+  protected SchemaMigrationDialect dialect() {
+    return new OracleSchemaMigrationDialect();
   }
 
   @Override
@@ -138,7 +139,8 @@ class OracleSchemaMigratorIT extends AbstractSchemaMigratorContract {
   void rejectsPreviouslyAppliedMigrationWithDifferentChecksum() throws Exception {
     resetDatabase();
 
-    SchemaMigrator.MigrationResult first = new SchemaMigrator(dataSource(), "oracle").migrate();
+    SchemaMigrator.MigrationResult first =
+        new SchemaMigrator(dataSource(), new OracleSchemaMigrationDialect()).migrate();
     assertTrue(first.appliedCount() > 0, "expected at least one migration applied");
 
     String firstVersion = first.applied().get(0).version();
@@ -147,7 +149,7 @@ class OracleSchemaMigratorIT extends AbstractSchemaMigratorContract {
     SchemaMigrationException ex =
         assertThrows(
             SchemaMigrationException.class,
-            () -> new SchemaMigrator(dataSource(), "oracle").migrate());
+            () -> new SchemaMigrator(dataSource(), new OracleSchemaMigrationDialect()).migrate());
     assertTrue(ex.getMessage().contains("Checksum mismatch"), () -> "got: " + ex.getMessage());
     assertTrue(ex.getMessage().contains(firstVersion), () -> "got: " + ex.getMessage());
   }

--- a/stores/ratchet-store-oracle/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
+++ b/stores/ratchet-store-oracle/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
@@ -1,0 +1,1 @@
+run.ratchet.store.oracle.OracleDialectTestSupport

--- a/stores/ratchet-store-postgresql/pom.xml
+++ b/stores/ratchet-store-postgresql/pom.xml
@@ -138,6 +138,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Publishes a test-jar so the integration testsuite can ServiceLoad this store's
+                 SqlDialectTestSupport implementation into the deployment WAR. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/stores/ratchet-store-postgresql/pom.xml
+++ b/stores/ratchet-store-postgresql/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>run.ratchet</groupId>

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSchemaMigrationDialect.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlSchemaMigrationDialect.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.postgresql;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import run.ratchet.store.migration.SchemaMigrationDialect;
+
+/** PostgreSQL schema migration dialect: session-level {@code pg_advisory_lock}. */
+@ApplicationScoped
+public class PostgresqlSchemaMigrationDialect implements SchemaMigrationDialect {
+
+  private static final long LOCK_KEY = 0x52617463686574L;
+
+  @Override
+  public String id() {
+    return "postgresql";
+  }
+
+  @Override
+  public String createVersionTableSql() {
+    return """
+        CREATE TABLE IF NOT EXISTS ratchet_schema_version
+        (
+            version VARCHAR(20) NOT NULL,
+            applied_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            description VARCHAR(200) NOT NULL,
+            checksum VARCHAR(64),
+            CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
+        )\
+        """;
+  }
+
+  @Override
+  public String recordVersionSql() {
+    return "INSERT INTO ratchet_schema_version (version, description, checksum) VALUES (?, ?, ?)"
+        + " ON CONFLICT (version) DO UPDATE SET description = EXCLUDED.description,"
+        + " checksum = EXCLUDED.checksum";
+  }
+
+  @Override
+  public boolean usesDedicatedLockConnection() {
+    return false;
+  }
+
+  @Override
+  public void acquireLock(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("SELECT pg_advisory_lock(" + LOCK_KEY + ")");
+    }
+  }
+
+  @Override
+  public void releaseLock(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute("SELECT pg_advisory_unlock(" + LOCK_KEY + ")");
+    }
+  }
+}

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlDialectTestSupport.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlDialectTestSupport.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.postgresql;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+import java.util.UUID;
+import java.util.logging.Logger;
+import run.ratchet.tck.store.SqlDialectTestSupport;
+
+/**
+ * PostgreSQL {@link SqlDialectTestSupport}: native {@code uuid} ids, no foreign-key toggling, and
+ * row-level DELETE. PostgreSQL is the only dialect that can attribute a sequential scan to a
+ * specific table via {@code pg_stat_user_tables}, so it carries the only enforcing scan check.
+ */
+public final class PostgresqlDialectTestSupport implements SqlDialectTestSupport {
+
+  private static final Logger log = Logger.getLogger(PostgresqlDialectTestSupport.class.getName());
+
+  /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
+  public PostgresqlDialectTestSupport() {}
+
+  @Override
+  public void disableForeignKeyChecks(EntityManager em) {
+    // PostgreSQL has no session-level foreign-key toggle; DELETE respects the child-before-parent
+    // ordering the caller iterates in.
+  }
+
+  @Override
+  public void enableForeignKeyChecks(EntityManager em) {
+    // No-op — see disableForeignKeyChecks.
+  }
+
+  @Override
+  public void clearTable(EntityManager em, String table) {
+    em.createNativeQuery("DELETE FROM " + table).executeUpdate();
+  }
+
+  @Override
+  public Object jobIdParam(UUID jobId) {
+    // PostgreSQL's native uuid column type accepts the UUID directly.
+    return jobId;
+  }
+
+  @Override
+  public void insertBackgroundChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // job_id is native uuid; gen_random_uuid() returns a fresh v4 per row.
+    // language=PostgreSQL
+    String sql =
+        """
+        INSERT INTO scheduler_job
+          (job_id, status, scheduled_time, job_type, payload, idempotency_key,
+           business_key, execution_start_time, execution_end_time,
+           created_at, updated_at)
+        SELECT gen_random_uuid(),
+               'SUCCEEDED', NOW() - INTERVAL '1 hour', 'SINGLE',
+               '{"target":"run.ratchet.testsuite.app.TimingJob",\
+        "method":"execute","descriptor":"()V",\
+        "isStatic":true,"args":[]}'::jsonb,
+               gen_random_uuid()::text,
+               '%s-' || (g + %d),
+               NOW() - INTERVAL '1 hour',
+               NOW() - INTERVAL '1 hour' + INTERVAL '10 milliseconds',
+               NOW(), NOW()
+        FROM generate_series(1, %d) AS g
+        """
+            .formatted(keyPrefix, offset, batchCount);
+    em.createNativeQuery(sql).executeUpdate();
+  }
+
+  @Override
+  public void analyzeSchedulerJob(EntityManager em) {
+    // language=PostgreSQL
+    String pgAnalyze = "ANALYZE scheduler_job";
+    em.createNativeQuery(pgAnalyze).executeUpdate();
+  }
+
+  @Override
+  public void assertNoFullScan(
+      EntityManager em, UserTransaction utx, String label, Runnable storeOperation)
+      throws Exception {
+    // language=PostgreSQL
+    String statSql =
+        """
+        SELECT seq_scan, idx_scan FROM pg_stat_user_tables
+        WHERE relname = 'scheduler_job'
+        """;
+    ScanCounts before = readScanCounts(em, utx, statSql);
+
+    utx.begin();
+    try {
+      storeOperation.run();
+      utx.commit();
+    } catch (RuntimeException e) {
+      rollbackQuietly(utx);
+      throw e;
+    }
+
+    ScanCounts after = readScanCounts(em, utx, statSql);
+    long seqDelta = after.seqScan() - before.seqScan();
+    long idxDelta = after.idxScan() - before.idxScan();
+
+    log.info(
+        String.format(
+            "Scan stats [%s]: seq_scan delta=%d, idx_scan delta=%d", label, seqDelta, idxDelta));
+
+    if (seqDelta != 0) {
+      throw new AssertionError(
+          label + ": sequential scan detected on scheduler_job (seq_scan delta=" + seqDelta + ")");
+    }
+  }
+
+  private ScanCounts readScanCounts(EntityManager em, UserTransaction utx, String statSql)
+      throws Exception {
+    utx.begin();
+    Object result;
+    try {
+      result = em.createNativeQuery(statSql).getSingleResult();
+      utx.commit();
+    } catch (RuntimeException e) {
+      rollbackQuietly(utx);
+      throw e;
+    }
+
+    if (!(result instanceof Object[] row) || row.length < 2) {
+      throw new IllegalStateException("Unexpected PostgreSQL scan stats row: " + result);
+    }
+    return new ScanCounts(numberAt(row, 0, "seq_scan"), numberAt(row, 1, "idx_scan"));
+  }
+
+  private long numberAt(Object[] row, int index, String columnName) {
+    if (!(row[index] instanceof Number value)) {
+      throw new IllegalStateException("PostgreSQL scan stat " + columnName + " was " + row[index]);
+    }
+    return value.longValue();
+  }
+
+  private record ScanCounts(long seqScan, long idxScan) {}
+}

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlDialectTestSupport.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlDialectTestSupport.java
@@ -154,7 +154,7 @@ public final class PostgresqlDialectTestSupport implements SqlDialectTestSupport
 
     if (seqDelta != 0) {
       throw new AssertionError(
-          label + ": sequential scan detected on scheduler_job (seq_scan delta=" + seqDelta + ")");
+          label + ": sequential scan detected on " + table + " (seq_scan delta=" + seqDelta + ")");
     }
   }
 

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlDialectTestSupport.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlDialectTestSupport.java
@@ -56,26 +56,27 @@ public final class PostgresqlDialectTestSupport implements SqlDialectTestSupport
   }
 
   @Override
-  public void insertBackgroundChunk(
-      EntityManager em, int batchCount, int offset, String keyPrefix) {
-    // job_id is native uuid; gen_random_uuid() returns a fresh v4 per row.
+  public void insertTerminalChunk(EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Cold archive rows: terminal_status='SUCCEEDED', no queue row. job_id is native uuid;
+    // gen_random_uuid() returns a fresh v4 per row (random is fine — never correlated to a queue
+    // row).
     // language=PostgreSQL
     String sql =
         """
         INSERT INTO scheduler_job
-          (job_id, status, scheduled_time, job_type, payload, idempotency_key,
-           business_key, execution_start_time, execution_end_time,
-           created_at, updated_at)
-        SELECT gen_random_uuid(),
-               'SUCCEEDED', NOW() - INTERVAL '1 hour', 'SINGLE',
+          (job_id, job_type, payload, idempotency_key, business_key,
+           created_at, terminal_status, terminated_at,
+           execution_start_time, execution_end_time, queue_wait_ms)
+        SELECT gen_random_uuid(), 'SINGLE',
                '{"target":"run.ratchet.testsuite.app.TimingJob",\
         "method":"execute","descriptor":"()V",\
         "isStatic":true,"args":[]}'::jsonb,
                gen_random_uuid()::text,
                '%s-' || (g + %d),
+               NOW(), 'SUCCEEDED', NOW() - INTERVAL '1 hour',
                NOW() - INTERVAL '1 hour',
                NOW() - INTERVAL '1 hour' + INTERVAL '10 milliseconds',
-               NOW(), NOW()
+               10
         FROM generate_series(1, %d) AS g
         """
             .formatted(keyPrefix, offset, batchCount);
@@ -83,22 +84,55 @@ public final class PostgresqlDialectTestSupport implements SqlDialectTestSupport
   }
 
   @Override
-  public void analyzeSchedulerJob(EntityManager em) {
+  public void insertPendingQueueChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Live PENDING jobs: a cold parent plus a far-future hot queue row. Deterministic uuids —
+    // '00000000-0000-0000-0000-' || lpad(to_hex(n), 12, '0') — let both inserts agree on job_id
+    // without an anti-join.
     // language=PostgreSQL
-    String pgAnalyze = "ANALYZE scheduler_job";
+    String coldSql =
+        """
+        INSERT INTO scheduler_job
+          (job_id, job_type, payload, idempotency_key, business_key, created_at)
+        SELECT ('00000000-0000-0000-0000-' || lpad(to_hex(g + %2$d), 12, '0'))::uuid, 'SINGLE',
+               '{"target":"run.ratchet.testsuite.app.TimingJob",\
+        "method":"execute","descriptor":"()V",\
+        "isStatic":true,"args":[]}'::jsonb,
+               '%3$s-key-' || (g + %2$d),
+               '%3$s-' || (g + %2$d),
+               NOW()
+        FROM generate_series(1, %1$d) AS g
+        """
+            .formatted(batchCount, offset, keyPrefix);
+    em.createNativeQuery(coldSql).executeUpdate();
+
+    // language=PostgreSQL
+    String hotSql =
+        """
+        INSERT INTO scheduler_job_queue
+          (job_id, status, job_type, scheduled_time, updated_at)
+        SELECT ('00000000-0000-0000-0000-' || lpad(to_hex(g + %2$d), 12, '0'))::uuid,
+               'PENDING', 'SINGLE', NOW() + INTERVAL '365 days', NOW()
+        FROM generate_series(1, %1$d) AS g
+        """
+            .formatted(batchCount, offset);
+    em.createNativeQuery(hotSql).executeUpdate();
+  }
+
+  @Override
+  public void analyzeTable(EntityManager em, String table) {
+    // language=PostgreSQL
+    String pgAnalyze = "ANALYZE " + table;
     em.createNativeQuery(pgAnalyze).executeUpdate();
   }
 
   @Override
   public void assertNoFullScan(
-      EntityManager em, UserTransaction utx, String label, Runnable storeOperation)
+      EntityManager em, UserTransaction utx, String table, String label, Runnable storeOperation)
       throws Exception {
     // language=PostgreSQL
     String statSql =
-        """
-        SELECT seq_scan, idx_scan FROM pg_stat_user_tables
-        WHERE relname = 'scheduler_job'
-        """;
+        "SELECT seq_scan, idx_scan FROM pg_stat_user_tables WHERE relname = '" + table + "'";
     ScanCounts before = readScanCounts(em, utx, statSql);
 
     utx.begin();

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigrationDialectTest.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigrationDialectTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.postgresql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PostgresqlSchemaMigrationDialectTest {
+
+  private final PostgresqlSchemaMigrationDialect dialect = new PostgresqlSchemaMigrationDialect();
+  private Connection connection;
+  private Statement statement;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection = mock(Connection.class);
+    statement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(statement);
+  }
+
+  @Test
+  void advertisesPostgresqlIdentityOnSharedConnection() {
+    assertEquals("postgresql", dialect.id());
+    assertFalse(dialect.usesDedicatedLockConnection());
+  }
+
+  @Test
+  void acquiresSessionAdvisoryLock() throws Exception {
+    dialect.acquireLock(connection);
+
+    verify(statement).execute(startsWith("SELECT pg_advisory_lock("));
+  }
+
+  @Test
+  void releasesSessionAdvisoryLock() throws Exception {
+    dialect.releaseLock(connection);
+
+    verify(statement).execute(startsWith("SELECT pg_advisory_unlock("));
+  }
+
+  @Test
+  void versionLedgerSqlIsPostgresqlFlavored() {
+    assertTrue(dialect.createVersionTableSql().contains("TIMESTAMPTZ"));
+    assertTrue(dialect.recordVersionSql().startsWith("INSERT INTO ratchet_schema_version"));
+    assertTrue(dialect.recordVersionSql().contains("ON CONFLICT (version) DO UPDATE"));
+  }
+}

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigratorIT.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigratorIT.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import run.ratchet.store.migration.SchemaMigrationDialect;
 import run.ratchet.store.migration.SchemaMigrator;
 import run.ratchet.tck.store.AbstractSchemaMigratorContract;
 import run.ratchet.tck.store.JdbcDriverDataSource;
@@ -59,8 +60,8 @@ class PostgresqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
   }
 
   @Override
-  protected String dialect() {
-    return "postgresql";
+  protected SchemaMigrationDialect dialect() {
+    return new PostgresqlSchemaMigrationDialect();
   }
 
   @Override

--- a/stores/ratchet-store-postgresql/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
+++ b/stores/ratchet-store-postgresql/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
@@ -1,0 +1,1 @@
+run.ratchet.store.postgresql.PostgresqlDialectTestSupport

--- a/testing/ratchet-showcase/src/main/java/run/ratchet/showcase/config/ShowcaseSchemaMigrator.java
+++ b/testing/ratchet-showcase/src/main/java/run/ratchet/showcase/config/ShowcaseSchemaMigrator.java
@@ -23,6 +23,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Locale;
 import java.util.logging.Logger;
 import javax.sql.DataSource;
+import run.ratchet.store.migration.SchemaMigrationDialect;
 import run.ratchet.store.migration.SchemaMigrator;
 
 public final class ShowcaseSchemaMigrator {
@@ -40,21 +41,34 @@ public final class ShowcaseSchemaMigrator {
     String user = args[2];
     String password = args[3];
 
-    loadDriver(dialect);
+    SchemaMigrationDialect migrationDialect = dialectFor(dialect);
     SchemaMigrator.MigrationResult result =
-        new SchemaMigrator(new DriverManagerDataSource(jdbcUrl, user, password), dialect).migrate();
+        new SchemaMigrator(new DriverManagerDataSource(jdbcUrl, user, password), migrationDialect)
+            .migrate();
     System.out.printf(
         "Ratchet schema migration complete: applied=%d skipped=%d%n",
         result.appliedCount(), result.skippedCount());
   }
 
-  private static void loadDriver(String dialect) throws ClassNotFoundException {
-    switch (dialect) {
-      case "postgresql" -> Class.forName("org.postgresql.Driver");
-      case "mysql" -> Class.forName("com.mysql.cj.jdbc.Driver");
-      default ->
-          throw new IllegalArgumentException("Unsupported SQL showcase database: " + dialect);
-    }
+  private static SchemaMigrationDialect dialectFor(String dialect)
+      throws ReflectiveOperationException {
+    // The active Maven profile bundles exactly one SQL store, so resolve its dialect reflectively
+    // rather than statically referencing a store module that may not be on the classpath.
+    String dialectClass =
+        switch (dialect) {
+          case "postgresql" -> {
+            Class.forName("org.postgresql.Driver");
+            yield "run.ratchet.store.postgresql.PostgresqlSchemaMigrationDialect";
+          }
+          case "mysql" -> {
+            Class.forName("com.mysql.cj.jdbc.Driver");
+            yield "run.ratchet.store.mysql.MysqlSchemaMigrationDialect";
+          }
+          default ->
+              throw new IllegalArgumentException("Unsupported SQL showcase database: " + dialect);
+        };
+    return (SchemaMigrationDialect)
+        Class.forName(dialectClass).getDeclaredConstructor().newInstance();
   }
 
   private static final class DriverManagerDataSource implements DataSource {

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSchemaMigratorContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSchemaMigratorContract.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
+import run.ratchet.store.migration.SchemaMigrationDialect;
 import run.ratchet.store.migration.SchemaMigrator;
 
 /**
@@ -44,7 +45,7 @@ public abstract class AbstractSchemaMigratorContract {
 
   protected abstract DataSource dataSource();
 
-  protected abstract String dialect();
+  protected abstract SchemaMigrationDialect dialect();
 
   protected abstract void resetDatabase() throws Exception;
 

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/SqlDialectTestSupport.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/SqlDialectTestSupport.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.store;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+/**
+ * Per-dialect behavior for the integration testsuite's JPA helpers. Each SQL store owns one
+ * implementation in its own test sources — next to its {@code DialectTypeMapper} — so the dialect
+ * differences the helpers would otherwise branch on (foreign-key toggling, TRUNCATE vs DELETE, UUID
+ * binding, the performance bulk insert and scan check) live with the store rather than in the
+ * testsuite.
+ *
+ * <p>Implementations are discovered through {@link java.util.ServiceLoader}: each store registers
+ * its implementation under {@code META-INF/services}, and exactly one store is on the classpath of
+ * any deployment. Implementations therefore need a public no-argument constructor and must be
+ * stateless.
+ */
+public interface SqlDialectTestSupport {
+
+  // --- cleanup ---
+
+  /** Suspends foreign key enforcement for the cleanup transaction. No-op where unsupported. */
+  void disableForeignKeyChecks(EntityManager em);
+
+  /** Restores foreign key enforcement after cleanup. No-op where unsupported. */
+  void enableForeignKeyChecks(EntityManager em);
+
+  /**
+   * Empties one scheduler table. MySQL uses {@code TRUNCATE}; PostgreSQL and Oracle delete rows
+   * instead. The scheduler poller keeps ticking through cleanup, and a row-level {@code DELETE} is
+   * MVCC-friendly and respects the child-before-parent ordering the caller iterates in, so it
+   * coexists with the live poller where {@code TRUNCATE} would not.
+   */
+  void clearTable(EntityManager em, String table);
+
+  // --- data manipulation ---
+
+  /**
+   * Native-query parameter binding for a UUID id column. MySQL {@code BINARY(16)} and Oracle {@code
+   * RAW(16)} both store the 16 big-endian bytes of the UUID, and a native query does not run the
+   * entity's AttributeConverter. Hibernate happens to coerce a bare {@link UUID} parameter into
+   * those bytes, but EclipseLink binds it verbatim and the predicate then matches nothing, so MySQL
+   * and Oracle pre-convert. PostgreSQL is the exception: its native {@code uuid} column type
+   * accepts the {@link UUID} directly.
+   */
+  Object jobIdParam(UUID jobId);
+
+  // --- performance ---
+  // MySQL and PostgreSQL carry the live implementations. Oracle's perf SQL lands with the perf
+  // suite's hot/cold-schema migration; until then the Oracle implementation throws.
+
+  /**
+   * Inserts one chunk of background {@code scheduler_job} rows using a dialect-native bulk insert.
+   */
+  void insertBackgroundChunk(EntityManager em, int batchCount, int offset, String keyPrefix);
+
+  /** Refreshes {@code scheduler_job} table statistics for accurate query-planner estimates. */
+  void analyzeSchedulerJob(EntityManager em);
+
+  /**
+   * Runs {@code storeOperation} and asserts it triggered no sequential scan on {@code
+   * scheduler_job}. The transaction boundaries are themselves dialect-specific — PostgreSQL reads
+   * {@code pg_stat_user_tables} in separately committed transactions on either side of the
+   * operation, while MySQL can only log — so each implementation owns (and rolls back) the
+   * transactions it opens.
+   */
+  void assertNoFullScan(
+      EntityManager em, UserTransaction utx, String label, Runnable storeOperation)
+      throws Exception;
+
+  /**
+   * Big-endian byte encoding shared by the MySQL {@code BINARY(16)} and Oracle {@code RAW(16)} ids.
+   */
+  static byte[] uuidToBigEndianBytes(UUID jobId) {
+    ByteBuffer buf = ByteBuffer.allocate(16);
+    buf.putLong(jobId.getMostSignificantBits());
+    buf.putLong(jobId.getLeastSignificantBits());
+    return buf.array();
+  }
+
+  /** Best-effort rollback for implementations that open their own transactions. */
+  default void rollbackQuietly(UserTransaction utx) {
+    try {
+      utx.rollback();
+    } catch (Exception ignored) {
+      // best-effort rollback
+    }
+  }
+}

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/SqlDialectTestSupport.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/SqlDialectTestSupport.java
@@ -63,26 +63,40 @@ public interface SqlDialectTestSupport {
   Object jobIdParam(UUID jobId);
 
   // --- performance ---
-  // MySQL and PostgreSQL carry the live implementations. Oracle's perf SQL lands with the perf
-  // suite's hot/cold-schema migration; until then the Oracle implementation throws.
+  // The schema splits completed jobs (cold {@code scheduler_job}) from live, claimable jobs
+  // (hot {@code scheduler_job_queue}). The two perf ITs grow different tables: table-growth grows
+  // the cold archive, claim-degradation grows the hot queue. Each store owns the dialect-native
+  // bulk insert and the (dialect-specific) scan diagnostics for both.
 
   /**
-   * Inserts one chunk of background {@code scheduler_job} rows using a dialect-native bulk insert.
+   * Inserts one chunk of terminal (completed) {@code scheduler_job} rows — {@code
+   * terminal_status='SUCCEEDED'}, no queue row — so they grow the cold archive without becoming
+   * claimable. Used by the table-growth IT. Random ids; {@code offset} keeps {@code business_key}
+   * and {@code idempotency_key} unique across chunks.
    */
-  void insertBackgroundChunk(EntityManager em, int batchCount, int offset, String keyPrefix);
-
-  /** Refreshes {@code scheduler_job} table statistics for accurate query-planner estimates. */
-  void analyzeSchedulerJob(EntityManager em);
+  void insertTerminalChunk(EntityManager em, int batchCount, int offset, String keyPrefix);
 
   /**
-   * Runs {@code storeOperation} and asserts it triggered no sequential scan on {@code
-   * scheduler_job}. The transaction boundaries are themselves dialect-specific — PostgreSQL reads
-   * {@code pg_stat_user_tables} in separately committed transactions on either side of the
-   * operation, while MySQL can only log — so each implementation owns (and rolls back) the
+   * Inserts one chunk of live, PENDING jobs: a cold {@code scheduler_job} parent plus a hot {@code
+   * scheduler_job_queue} row referencing it (the queue's foreign key requires the parent). The
+   * queue rows are far-future {@code scheduled_time} so the running poller never claims or drains
+   * them mid-measurement. Used by the claim-degradation IT. Ids are derived deterministically from
+   * {@code offset + row} so the cold and hot inserts agree on {@code job_id} without an anti-join.
+   */
+  void insertPendingQueueChunk(EntityManager em, int batchCount, int offset, String keyPrefix);
+
+  /** Refreshes one table's statistics for accurate query-planner estimates. */
+  void analyzeTable(EntityManager em, String table);
+
+  /**
+   * Runs {@code storeOperation} and asserts it triggered no sequential scan on {@code table}. The
+   * transaction boundaries are themselves dialect-specific — PostgreSQL reads {@code
+   * pg_stat_user_tables} in separately committed transactions on either side of the operation,
+   * while MySQL and Oracle can only log — so each implementation owns (and rolls back) the
    * transactions it opens.
    */
   void assertNoFullScan(
-      EntityManager em, UserTransaction utx, String label, Runnable storeOperation)
+      EntityManager em, UserTransaction utx, String table, String label, Runnable storeOperation)
       throws Exception;
 
   /**

--- a/testing/ratchet-testsuite/pom.xml
+++ b/testing/ratchet-testsuite/pom.xml
@@ -88,6 +88,18 @@
       <artifactId>ratchet-tck-jakarta</artifactId>
       <scope>test</scope>
     </dependency>
+    <!--
+      The Jpa* test helpers (src/main) reference the SqlDialectTestSupport interface, which lives in
+      ratchet-tck-store next to DialectTypeMapper. provided keeps tck-store (and its JUnit deps) off
+      the WAR; RatchetArchiveBuilder bundles just the interface plus the active store's ServiceLoader
+      implementation. The per-store implementations are pulled in via the test-jar dependencies under
+      each db profile below.
+    -->
+    <dependency>
+      <groupId>run.ratchet</groupId>
+      <artifactId>ratchet-tck-store</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-micrometer</artifactId>
@@ -1116,6 +1128,14 @@
           <groupId>run.ratchet</groupId>
           <artifactId>ratchet-store-mysql</artifactId>
         </dependency>
+        <!-- Test-jar carries MysqlDialectTestSupport (ServiceLoader-discovered by the testsuite). -->
+        <dependency>
+          <groupId>run.ratchet</groupId>
+          <artifactId>ratchet-store-mysql</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
         <dependency>
           <groupId>com.mysql</groupId>
           <artifactId>mysql-connector-j</artifactId>
@@ -1139,6 +1159,14 @@
           <groupId>run.ratchet</groupId>
           <artifactId>ratchet-store-postgresql</artifactId>
         </dependency>
+        <!-- Test-jar carries PostgresqlDialectTestSupport (ServiceLoader-discovered by the testsuite). -->
+        <dependency>
+          <groupId>run.ratchet</groupId>
+          <artifactId>ratchet-store-postgresql</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
         <dependency>
           <groupId>org.postgresql</groupId>
           <artifactId>postgresql</artifactId>
@@ -1161,6 +1189,14 @@
         <dependency>
           <groupId>run.ratchet</groupId>
           <artifactId>ratchet-store-oracle</artifactId>
+        </dependency>
+        <!-- Test-jar carries OracleDialectTestSupport (ServiceLoader-discovered by the testsuite). -->
+        <dependency>
+          <groupId>run.ratchet</groupId>
+          <artifactId>ratchet-store-oracle</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
         </dependency>
         <!--
           Oracle's JDBC driver is published under the Free Use Terms and Conditions (not an

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DocumentStorePerformanceTestHelper.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/DocumentStorePerformanceTestHelper.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -47,11 +48,30 @@ public class DocumentStorePerformanceTestHelper implements PerformanceTestHelper
   @Inject private Clock clock;
 
   @Override
-  public void insertBackgroundRows(int count, String keyPrefix) {
+  public void insertTerminalBackgroundRows(int count, int baseOffset, String keyPrefix) {
+    // MongoDB keeps one scheduler_job collection (no hot/cold split): terminal docs are SUCCEEDED
+    // and past-due, so countReadyJobs (PENDING-only) never counts them and the poller never claims
+    // them.
+    insertBackgroundRows(
+        count, baseOffset, keyPrefix, "SUCCEEDED", clock.instant().minusSeconds(3600));
+  }
+
+  @Override
+  public void insertPendingBackgroundRows(int count, int baseOffset, String keyPrefix) {
+    // PENDING but far-future so a running poller never claims them mid-measurement, mirroring the
+    // SQL hot-queue background rows.
+    insertBackgroundRows(
+        count, baseOffset, keyPrefix, "PENDING", clock.instant().plus(365, ChronoUnit.DAYS));
+  }
+
+  private void insertBackgroundRows(
+      int count, int baseOffset, String keyPrefix, String status, Instant scheduledTime) {
     int chunkSize = 10_000;
 
     for (int offset = 0; offset < count; offset += chunkSize) {
       int batchCount = Math.min(chunkSize, count - offset);
+      // Number documents from the cumulative base so business keys stay unique across growth calls.
+      int rowOffset = baseOffset + offset;
 
       List<Document> docs = new ArrayList<>(batchCount);
       Instant now = clock.instant();
@@ -59,8 +79,8 @@ public class DocumentStorePerformanceTestHelper implements PerformanceTestHelper
       for (int i = 0; i < batchCount; i++) {
         docs.add(
             new Document()
-                .append("status", "SUCCEEDED")
-                .append("scheduled_time", Date.from(past))
+                .append("status", status)
+                .append("scheduled_time", Date.from(scheduledTime))
                 .append("job_type", "SINGLE")
                 .append(
                     "payload",
@@ -71,7 +91,7 @@ public class DocumentStorePerformanceTestHelper implements PerformanceTestHelper
                         .append("isStatic", true)
                         .append("args", List.of()))
                 .append("idempotency_key", UUID.randomUUID().toString())
-                .append("business_key", keyPrefix + "-" + (offset + i + 1))
+                .append("business_key", keyPrefix + "-" + (rowOffset + i + 1))
                 .append("execution_start_time", Date.from(past))
                 .append("execution_end_time", Date.from(past.plusMillis(10)))
                 .append("created_at", Date.from(now))
@@ -116,16 +136,16 @@ public class DocumentStorePerformanceTestHelper implements PerformanceTestHelper
   }
 
   @Override
-  public void assertNoFullScan(String label, Runnable storeOperation) {
+  public void assertNoFullScan(String table, String label, Runnable storeOperation) {
     // MongoDB: collStats provides scan diagnostics, but collection-level scan counters
-    // are not as straightforward as PostgreSQL's pg_stat_user_tables. Execute the operation
-    // and log for informational purposes.
+    // are not as straightforward as PostgreSQL's pg_stat_user_tables. The table argument is
+    // irrelevant here (one collection holds every job). Execute the operation and log only.
     storeOperation.run();
 
     log.info(
         String.format(
-            "Scan stats [%s]: MongoDB — per-collection scan metrics not directly available, "
+            "Scan stats [%s] on %s: MongoDB — per-collection scan metrics not directly available, "
                 + "relying on index definitions and explain plans for verification",
-            label));
+            label, table));
   }
 }

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaPerformanceTestHelper.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaPerformanceTestHelper.java
@@ -22,6 +22,7 @@ import jakarta.transaction.UserTransaction;
 import java.util.List;
 import java.util.logging.Logger;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
+import run.ratchet.tck.store.SqlDialectTestSupport;
 
 /** JPA implementation using native bulk inserts. */
 @ApplicationScoped
@@ -35,7 +36,7 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
 
   @Override
   public void insertBackgroundRows(int count, String keyPrefix) {
-    String dbType = TestRuntimeConfig.dbType();
+    SqlDialectTestSupport dialect = SqlDialectTestSupportProvider.get();
     int chunkSize = 100_000;
 
     try {
@@ -43,11 +44,7 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
         int batchCount = Math.min(chunkSize, count - offset);
 
         utx.begin();
-        if ("postgresql".equals(dbType)) {
-          insertPostgresqlChunk(batchCount, offset, keyPrefix);
-        } else {
-          insertMysqlChunk(batchCount, offset, keyPrefix);
-        }
+        dialect.insertBackgroundChunk(em(), batchCount, offset, keyPrefix);
         utx.commit();
 
         if (count > chunkSize) {
@@ -58,15 +55,7 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
 
       // Refresh table statistics for accurate query planner estimates
       utx.begin();
-      if ("postgresql".equals(dbType)) {
-        // language=PostgreSQL
-        String pgAnalyze = "ANALYZE scheduler_job";
-        em().createNativeQuery(pgAnalyze).executeUpdate();
-      } else {
-        // language=MySQL
-        String mysqlAnalyze = "ANALYZE TABLE scheduler_job";
-        em().createNativeQuery(mysqlAnalyze).getResultList();
-      }
+      dialect.analyzeSchedulerJob(em());
       utx.commit();
     } catch (RuntimeException e) {
       rollbackQuietly();
@@ -108,134 +97,13 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
 
   @Override
   public void assertNoFullScan(String label, Runnable storeOperation) {
-    String dbType = TestRuntimeConfig.dbType();
-
     try {
-      if ("postgresql".equals(dbType)) {
-        assertNoFullScanPostgresql(label, storeOperation);
-      } else {
-        assertNoFullScanMysql(label, storeOperation);
-      }
+      SqlDialectTestSupportProvider.get().assertNoFullScan(em(), utx, label, storeOperation);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {
       throw new RuntimeException("Scan check error", e);
     }
-  }
-
-  private void assertNoFullScanPostgresql(String label, Runnable storeOperation) throws Exception {
-    // language=PostgreSQL
-    String statSql =
-        """
-        SELECT seq_scan, idx_scan FROM pg_stat_user_tables
-        WHERE relname = 'scheduler_job'
-        """;
-    PostgresqlScanCounts before = readPostgresqlScanCounts(statSql);
-
-    utx.begin();
-    storeOperation.run();
-    utx.commit();
-
-    PostgresqlScanCounts after = readPostgresqlScanCounts(statSql);
-    long seqDelta = after.seqScan() - before.seqScan();
-    long idxDelta = after.idxScan() - before.idxScan();
-
-    log.info(
-        String.format(
-            "Scan stats [%s]: seq_scan delta=%d, idx_scan delta=%d", label, seqDelta, idxDelta));
-
-    if (seqDelta != 0) {
-      throw new AssertionError(
-          label + ": sequential scan detected on scheduler_job (seq_scan delta=" + seqDelta + ")");
-    }
-  }
-
-  private PostgresqlScanCounts readPostgresqlScanCounts(String statSql) throws Exception {
-    utx.begin();
-    Object result = em().createNativeQuery(statSql).getSingleResult();
-    utx.commit();
-
-    if (!(result instanceof Object[] row) || row.length < 2) {
-      throw new IllegalStateException("Unexpected PostgreSQL scan stats row: " + result);
-    }
-    return new PostgresqlScanCounts(numberAt(row, 0, "seq_scan"), numberAt(row, 1, "idx_scan"));
-  }
-
-  private long numberAt(Object[] row, int index, String columnName) {
-    if (!(row[index] instanceof Number value)) {
-      throw new IllegalStateException("PostgreSQL scan stat " + columnName + " was " + row[index]);
-    }
-    return value.longValue();
-  }
-
-  private void assertNoFullScanMysql(String label, Runnable storeOperation) throws Exception {
-    // MySQL: Select_scan is session-wide (all tables), not per-table like PostgreSQL's
-    // pg_stat_user_tables. Log for informational purposes only.
-    utx.begin();
-    storeOperation.run();
-    utx.commit();
-
-    log.info(
-        String.format(
-            "Scan stats [%s]: MySQL — per-table scan metrics not available, "
-                + "relying on index definitions and EXPLAIN plans for verification",
-            label));
-  }
-
-  private void insertPostgresqlChunk(int batchCount, int offset, String keyPrefix) {
-    // job_id is native uuid; gen_random_uuid() returns a fresh v4 per row.
-    // language=PostgreSQL
-    String sql =
-        """
-        INSERT INTO scheduler_job
-          (job_id, status, scheduled_time, job_type, payload, idempotency_key,
-           business_key, execution_start_time, execution_end_time,
-           created_at, updated_at)
-        SELECT gen_random_uuid(),
-               'SUCCEEDED', NOW() - INTERVAL '1 hour', 'SINGLE',
-               '{"target":"run.ratchet.testsuite.app.TimingJob",\
-        "method":"execute","descriptor":"()V",\
-        "isStatic":true,"args":[]}'::jsonb,
-               gen_random_uuid()::text,
-               '%s-' || (g + %d),
-               NOW() - INTERVAL '1 hour',
-               NOW() - INTERVAL '1 hour' + INTERVAL '10 milliseconds',
-               NOW(), NOW()
-        FROM generate_series(1, %d) AS g
-        """
-            .formatted(keyPrefix, offset, batchCount);
-    em().createNativeQuery(sql).executeUpdate();
-  }
-
-  private void insertMysqlChunk(int batchCount, int offset, String keyPrefix) {
-    // job_id is BINARY(16); UUID_TO_BIN(UUID(), 1) produces a time-ordered 16-byte value.
-    // language=MySQL
-    String setDepthSql = "SET @@cte_max_recursion_depth = " + (batchCount + 1);
-    em().createNativeQuery(setDepthSql).executeUpdate();
-    // language=MySQL
-    String sql =
-        """
-        INSERT INTO scheduler_job
-          (job_id, status, scheduled_time, job_type, payload, idempotency_key,
-           business_key, execution_start_time, execution_end_time,
-           created_at, updated_at)
-        WITH RECURSIVE seq(n) AS (
-          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %d
-        )
-        SELECT UUID_TO_BIN(UUID(), 1),
-               'SUCCEEDED', NOW() - INTERVAL 1 HOUR, 'SINGLE',
-               JSON_OBJECT('target','run.ratchet.testsuite.app.TimingJob',
-                           'method','execute','descriptor','()V','isStatic',true,
-                           'args',JSON_ARRAY()),
-               UUID(),
-               CONCAT('%s-', n + %d),
-               NOW() - INTERVAL 1 HOUR,
-               DATE_ADD(NOW() - INTERVAL 1 HOUR, INTERVAL 10000 MICROSECOND),
-               NOW(), NOW()
-        FROM seq
-        """
-            .formatted(batchCount, keyPrefix, offset);
-    em().createNativeQuery(sql).executeUpdate();
   }
 
   private EntityManager em() {
@@ -249,6 +117,4 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
       // best-effort rollback
     }
   }
-
-  private record PostgresqlScanCounts(long seqScan, long idxScan) {}
 }

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaPerformanceTestHelper.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaPerformanceTestHelper.java
@@ -35,16 +35,34 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
   @Inject private UserTransaction utx;
 
   @Override
-  public void insertBackgroundRows(int count, String keyPrefix) {
+  public void insertTerminalBackgroundRows(int count, int baseOffset, String keyPrefix) {
+    insertBackgroundRows(count, baseOffset, keyPrefix, /* terminal= */ true);
+  }
+
+  @Override
+  public void insertPendingBackgroundRows(int count, int baseOffset, String keyPrefix) {
+    insertBackgroundRows(count, baseOffset, keyPrefix, /* terminal= */ false);
+  }
+
+  private void insertBackgroundRows(int count, int baseOffset, String keyPrefix, boolean terminal) {
     SqlDialectTestSupport dialect = SqlDialectTestSupportProvider.get();
     int chunkSize = 100_000;
+    // Terminal rows grow the cold archive; pending rows grow the hot claim queue. Analyze whichever
+    // table the planner consults for the IT that uses this kind of background.
+    String tableToAnalyze = terminal ? "scheduler_job" : "scheduler_job_queue";
 
     try {
       for (int offset = 0; offset < count; offset += chunkSize) {
         int batchCount = Math.min(chunkSize, count - offset);
+        // Number rows from the cumulative base so ids stay unique across incremental growth calls.
+        int rowOffset = baseOffset + offset;
 
         utx.begin();
-        dialect.insertBackgroundChunk(em(), batchCount, offset, keyPrefix);
+        if (terminal) {
+          dialect.insertTerminalChunk(em(), batchCount, rowOffset, keyPrefix);
+        } else {
+          dialect.insertPendingQueueChunk(em(), batchCount, rowOffset, keyPrefix);
+        }
         utx.commit();
 
         if (count > chunkSize) {
@@ -55,7 +73,7 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
 
       // Refresh table statistics for accurate query planner estimates
       utx.begin();
-      dialect.analyzeSchedulerJob(em());
+      dialect.analyzeTable(em(), tableToAnalyze);
       utx.commit();
     } catch (RuntimeException e) {
       rollbackQuietly();
@@ -71,11 +89,13 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
   public long queryQueueWaitPercentileForClass(String targetClass, double percentile) {
     try {
       utx.begin();
+      // queue_wait_ms lives on the cold scheduler_job row, set at the terminal transition; the
+      // terminal state is terminal_status (status moved to the hot scheduler_job_queue table).
       // language=SQL
       String sql =
           """
           SELECT queue_wait_ms FROM scheduler_job
-          WHERE target_class = :cls AND status = 'SUCCEEDED'
+          WHERE target_class = :cls AND terminal_status = 'SUCCEEDED'
             AND queue_wait_ms IS NOT NULL
           ORDER BY queue_wait_ms
           """;
@@ -96,9 +116,9 @@ public class JpaPerformanceTestHelper implements PerformanceTestHelper {
   }
 
   @Override
-  public void assertNoFullScan(String label, Runnable storeOperation) {
+  public void assertNoFullScan(String table, String label, Runnable storeOperation) {
     try {
-      SqlDialectTestSupportProvider.get().assertNoFullScan(em(), utx, label, storeOperation);
+      SqlDialectTestSupportProvider.get().assertNoFullScan(em(), utx, table, label, storeOperation);
     } catch (RuntimeException e) {
       throw e;
     } catch (Exception e) {

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestCleanupStrategy.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestCleanupStrategy.java
@@ -24,21 +24,20 @@ import java.util.List;
 import java.util.Objects;
 import java.util.logging.Logger;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
+import run.ratchet.tck.store.SqlDialectTestSupport;
 
 /**
  * JPA/SQL implementation of {@link TestCleanupStrategy}.
  *
- * <p>Clears all scheduler tables using native SQL within a JTA transaction. Foreign key checks are
- * temporarily disabled for MySQL. Only packaged in the WAR when a JPA store profile (mysql,
- * postgresql) is active.
+ * <p>Clears all scheduler tables using native SQL within a JTA transaction. The dialect-specific
+ * pieces — foreign-key toggling and TRUNCATE vs DELETE — are delegated to {@link
+ * SqlDialectTestSupport}. Only packaged in the WAR when a JPA store profile (mysql, postgresql,
+ * oracle) is active.
  */
 @ApplicationScoped
 public class JpaTestCleanupStrategy implements TestCleanupStrategy {
 
   private static final Logger log = Logger.getLogger(JpaTestCleanupStrategy.class.getName());
-  private static final String DB_TYPE_MYSQL = "mysql";
-  private static final String DB_TYPE_POSTGRESQL = "postgresql";
-  private static final String DB_TYPE_ORACLE = "oracle";
 
   private static final List<String> TABLES_BEFORE_HOT_STATE =
       List.of(
@@ -74,34 +73,17 @@ public class JpaTestCleanupStrategy implements TestCleanupStrategy {
   @Override
   @Transactional(Transactional.TxType.REQUIRES_NEW)
   public void truncateAll() {
-    String dbType = TestRuntimeConfig.dbType();
-    boolean mysql = DB_TYPE_MYSQL.equals(dbType);
-    // PostgreSQL and Oracle clear via row-level DELETE rather than TRUNCATE. The scheduler poller
-    // keeps ticking through cleanup, and on Oracle a concurrent TRUNCATE both fails outright on
-    // tables that enabled foreign keys reference (ORA-02266) and resets a table's data-object
-    // number, so any in-flight poller query against it dies with ORA-08103. DELETE is MVCC-friendly
-    // and respects the child-before-parent ordering below, so it coexists with the live poller.
-    boolean useDelete = DB_TYPE_POSTGRESQL.equals(dbType) || DB_TYPE_ORACLE.equals(dbType);
-
+    SqlDialectTestSupport dialect = SqlDialectTestSupportProvider.get();
     try {
-      if (mysql) {
-        em().createNativeQuery("SET FOREIGN_KEY_CHECKS = 0").executeUpdate();
-      }
-
+      dialect.disableForeignKeyChecks(em());
       for (String table : tablesToClear()) {
-        if (useDelete) {
-          em().createNativeQuery("DELETE FROM " + table).executeUpdate();
-        } else {
-          em().createNativeQuery("TRUNCATE TABLE " + table).executeUpdate();
-        }
+        dialect.clearTable(em(), table);
       }
     } finally {
-      if (mysql) {
-        try {
-          em().createNativeQuery("SET FOREIGN_KEY_CHECKS = 1").executeUpdate();
-        } catch (Exception e) {
-          log.fine("Unable to re-enable MySQL foreign key checks: " + e.getMessage());
-        }
+      try {
+        dialect.enableForeignKeyChecks(em());
+      } catch (Exception e) {
+        log.fine("Unable to re-enable foreign key checks: " + e.getMessage());
       }
     }
   }

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestDataManipulator.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestDataManipulator.java
@@ -19,7 +19,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.UserTransaction;
-import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.UUID;
@@ -38,23 +37,8 @@ public class JpaTestDataManipulator implements TestDataManipulator {
 
   @Inject private UserTransaction utx;
 
-  /**
-   * Native-query parameter binding for a UUID job_id. MySQL BINARY(16) and Oracle RAW(16) both
-   * store the 16 big-endian bytes of the UUID, and a native query does not run the entity's
-   * AttributeConverter. Hibernate happens to coerce a bare {@link UUID} parameter into those bytes,
-   * but EclipseLink binds it verbatim and the predicate then matches nothing, so pre-convert here.
-   * PostgreSQL is the exception: its native {@code uuid} column type accepts the {@link UUID}
-   * directly.
-   */
   private static Object jobIdParam(UUID jobId) {
-    String dbType = System.getProperty("ratchet.test.db.type", "mysql");
-    if ("postgresql".equals(dbType)) {
-      return jobId;
-    }
-    ByteBuffer buf = ByteBuffer.allocate(16);
-    buf.putLong(jobId.getMostSignificantBits());
-    buf.putLong(jobId.getLeastSignificantBits());
-    return buf.array();
+    return SqlDialectTestSupportProvider.get().jobIdParam(jobId);
   }
 
   @Override

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/PerformanceTestHelper.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/PerformanceTestHelper.java
@@ -26,7 +26,21 @@ package run.ratchet.testsuite.app;
  */
 public interface PerformanceTestHelper {
 
-  void insertBackgroundRows(int count, String keyPrefix);
+  /**
+   * Inserts completed (terminal) background rows that grow the cold archive without becoming
+   * claimable. Used by the table-growth IT. {@code baseOffset} is the number of background rows
+   * already inserted across prior calls, so row numbering (and ids) stay unique across the IT's
+   * incremental growth steps.
+   */
+  void insertTerminalBackgroundRows(int count, int baseOffset, String keyPrefix);
+
+  /**
+   * Inserts live PENDING background rows that grow the hot claim queue. Rows are far-future so a
+   * running poller never drains them. Used by the claim-degradation IT. {@code baseOffset} is the
+   * number of background rows already inserted across prior calls; the deterministic job ids derive
+   * from {@code baseOffset + row}, so it must advance between calls or ids collide.
+   */
+  void insertPendingBackgroundRows(int count, int baseOffset, String keyPrefix);
 
   /**
    * Returns the queue wait time in milliseconds at the given percentile.
@@ -35,5 +49,6 @@ public interface PerformanceTestHelper {
    */
   long queryQueueWaitPercentileForClass(String targetClass, double percentile);
 
-  void assertNoFullScan(String label, Runnable storeOperation);
+  /** Runs {@code storeOperation} and asserts it triggered no sequential scan on {@code table}. */
+  void assertNoFullScan(String table, String label, Runnable storeOperation);
 }

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/SqlDialectTestSupportProvider.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/SqlDialectTestSupportProvider.java
@@ -15,6 +15,8 @@
  */
 package run.ratchet.testsuite.app;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.ServiceLoader;
 import run.ratchet.tck.store.SqlDialectTestSupport;
 
@@ -34,12 +36,25 @@ public final class SqlDialectTestSupportProvider {
   }
 
   private static SqlDialectTestSupport load() {
-    return ServiceLoader.load(SqlDialectTestSupport.class)
-        .findFirst()
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    "No SqlDialectTestSupport registered on the classpath — the active store module"
-                        + " must contribute one via META-INF/services"));
+    // The rest of the testsuite assumes exactly one dialect support. Fail loudly on zero (no store
+    // active) or more than one (misconfigured profiles / stale classpath) rather than silently
+    // picking an arbitrary implementation.
+    List<SqlDialectTestSupport> found = new ArrayList<>();
+    ServiceLoader.load(SqlDialectTestSupport.class).forEach(found::add);
+    if (found.isEmpty()) {
+      throw new IllegalStateException(
+          "No SqlDialectTestSupport registered on the classpath — the active store module"
+              + " must contribute one via META-INF/services");
+    }
+    if (found.size() > 1) {
+      List<String> names = new ArrayList<>();
+      found.forEach(support -> names.add(support.getClass().getName()));
+      names.sort(null);
+      throw new IllegalStateException(
+          "Multiple SqlDialectTestSupport implementations on the classpath ("
+              + String.join(", ", names)
+              + ") — exactly one store module must be active");
+    }
+    return found.get(0);
   }
 }

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/SqlDialectTestSupportProvider.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/SqlDialectTestSupportProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import java.util.ServiceLoader;
+import run.ratchet.tck.store.SqlDialectTestSupport;
+
+/**
+ * Resolves the deployment's single {@link SqlDialectTestSupport} via {@link ServiceLoader}. Each
+ * SQL store registers its implementation, and exactly one store is on the WAR classpath, so the
+ * lookup is unambiguous. The result is cached because the implementations are stateless.
+ */
+public final class SqlDialectTestSupportProvider {
+
+  private static final SqlDialectTestSupport INSTANCE = load();
+
+  private SqlDialectTestSupportProvider() {}
+
+  public static SqlDialectTestSupport get() {
+    return INSTANCE;
+  }
+
+  private static SqlDialectTestSupport load() {
+    return ServiceLoader.load(SqlDialectTestSupport.class)
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "No SqlDialectTestSupport registered on the classpath — the active store module"
+                        + " must contribute one via META-INF/services"));
+  }
+}

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/performance/ClaimQueryDegradationIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/performance/ClaimQueryDegradationIT.java
@@ -19,16 +19,19 @@ import java.time.Instant;
 import java.util.logging.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.testsuite.app.ConfigurableWorkJob;
 import run.ratchet.testsuite.app.PerformanceMetricsCollector;
 import run.ratchet.testsuite.app.ProbabilisticFailingJob;
 import run.ratchet.testsuite.app.TestJobService;
+import run.ratchet.testsuite.app.TestMetricsCollectorAdapter;
 import run.ratchet.testsuite.app.TimingJob;
 import run.ratchet.testsuite.util.PerformanceBaseline;
 import run.ratchet.testsuite.util.PerformanceReport;
 import run.ratchet.testsuite.util.PerformanceReportWriter;
+import run.ratchet.testsuite.util.PollerControl;
 import run.ratchet.testsuite.util.RatchetArchiveBuilder;
 
 /**
@@ -42,6 +45,16 @@ class ClaimQueryDegradationIT extends BasePerformanceIT {
 
   private static final Logger log = Logger.getLogger(ClaimQueryDegradationIT.class.getName());
 
+  @BeforeEach
+  void stopPollerForIsolatedMeasurement() {
+    // This IT bypasses the scheduler and times the claim query directly. Runs after the base
+    // class's @BeforeEach starts the poller, so it leaves the poller quiesced for the test body.
+    // Two reasons: the live poller would race the measured rows, and because
+    // pg_stat_user_tables.seq_scan is a process-global counter, any poll tick landing inside an
+    // assertNoFullScan window would inflate the seq_scan delta and flake the assertion.
+    PollerControl.stopAndAwait(pollerScheduler);
+  }
+
   @Deployment
   public static WebArchive createDeployment() {
     String dbType = System.getProperty("ratchet.test.db.type", "mysql");
@@ -54,6 +67,7 @@ class ClaimQueryDegradationIT extends BasePerformanceIT {
             ConfigurableWorkJob.class,
             ProbabilisticFailingJob.class,
             PerformanceMetricsCollector.class,
+            TestMetricsCollectorAdapter.class,
             TestJobService.class,
             BasePerformanceIT.class,
             PerformanceBaseline.class,
@@ -76,7 +90,7 @@ class ClaimQueryDegradationIT extends BasePerformanceIT {
         // Insert background rows to reach target
         int toInsert = tableSize - previousSize;
         if (toInsert > 0) {
-          perfHelper.insertBackgroundRows(toInsert, "bg-claim");
+          perfHelper.insertPendingBackgroundRows(toInsert, previousSize, "bg-claim");
           log.info("Inserted " + toInsert + " background rows (total target: " + tableSize + ")");
         }
         previousSize = tableSize;
@@ -141,13 +155,14 @@ class ClaimQueryDegradationIT extends BasePerformanceIT {
           "Claim query degradation ratio phase failed at tableSize=" + lastSizeKey, e);
     }
 
-    // Verify actual store methods use index scans at maximum table size
+    // Verify the claim path uses an index scan on the hot queue at maximum table size.
+    // claimNextBatchOptimized supplies job_type (the leading column of idx_claim_executable), so it
+    // exercises the real claim access path. countReadyJobs omits job_type and serves only as the
+    // latency proxy above, not a scan probe. The background rows are far-future, so the claim finds
+    // no due rows and ranges over the index without a sequential scan.
     try {
-      Instant finalNow = Instant.now();
       perfHelper.assertNoFullScan(
-          "countReadyJobs @ " + lastSizeKey, () -> jobAnalyticsStore.countReadyJobs(finalNow));
-
-      perfHelper.assertNoFullScan(
+          "scheduler_job_queue",
           "claimNextBatch @ " + lastSizeKey,
           () ->
               jobClaimStore.claimNextBatchOptimized(JobExecutionType.SINGLE, 10, "perf-test-node"));

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/performance/TableGrowthDegradationIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/performance/TableGrowthDegradationIT.java
@@ -27,6 +27,7 @@ import run.ratchet.testsuite.app.ConfigurableWorkJob;
 import run.ratchet.testsuite.app.PerformanceMetricsCollector;
 import run.ratchet.testsuite.app.ProbabilisticFailingJob;
 import run.ratchet.testsuite.app.TestJobService;
+import run.ratchet.testsuite.app.TestMetricsCollectorAdapter;
 import run.ratchet.testsuite.app.TimingJob;
 import run.ratchet.testsuite.util.PerformanceBaseline;
 import run.ratchet.testsuite.util.PerformanceReport;
@@ -56,6 +57,7 @@ class TableGrowthDegradationIT extends BasePerformanceIT {
             ConfigurableWorkJob.class,
             ProbabilisticFailingJob.class,
             PerformanceMetricsCollector.class,
+            TestMetricsCollectorAdapter.class,
             TestJobService.class,
             BasePerformanceIT.class,
             PerformanceBaseline.class,
@@ -82,7 +84,7 @@ class TableGrowthDegradationIT extends BasePerformanceIT {
       // Insert background rows to reach the target table size
       int toInsert = tableSize - previousSize;
       if (toInsert > 0) {
-        perfHelper.insertBackgroundRows(toInsert, "bg-growth");
+        perfHelper.insertTerminalBackgroundRows(toInsert, previousSize, "bg-growth");
         log.info("Inserted " + toInsert + " background rows (total target: " + tableSize + ")");
       }
       previousSize = tableSize;
@@ -141,11 +143,18 @@ class TableGrowthDegradationIT extends BasePerformanceIT {
   }
 
   private void assertClaimQueriesUseIndexes(String sizeKey) {
+    // The claim path reads only the hot scheduler_job_queue, never the cold scheduler_job this IT
+    // grows. Asserting no sequential scan on the COLD table therefore proves the split keeps claim
+    // isolated from archive growth — the seq_scan delta is zero by design, and a future change that
+    // joined a claim query back to the cold table would trip this guard.
     Instant now = Instant.now();
     perfHelper.assertNoFullScan(
-        "countReadyJobs @ " + sizeKey, () -> jobAnalyticsStore.countReadyJobs(now));
+        "scheduler_job",
+        "countReadyJobs @ " + sizeKey,
+        () -> jobAnalyticsStore.countReadyJobs(now));
 
     perfHelper.assertNoFullScan(
+        "scheduler_job",
         "claimNextBatch @ " + sizeKey,
         () -> jobClaimStore.claimNextBatchOptimized(JobExecutionType.SINGLE, 10, "perf-test-node"));
   }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -241,15 +241,9 @@ public class RatchetArchiveBuilder {
    * SqlDialectTestSupportProvider} performs at runtime.
    */
   private void addSqlDialectTestSupport() {
-    SqlDialectTestSupport support =
-        ServiceLoader.load(SqlDialectTestSupport.class)
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "No SqlDialectTestSupport on the test classpath — the active store module"
-                            + " must contribute one via META-INF/services"));
-    Class<?> implClass = support.getClass();
+    // SqlDialectTestSupportProvider already resolves (and caches) the single implementation via the
+    // same ServiceLoader lookup in this build JVM, so reuse it rather than scanning a second time.
+    Class<?> implClass = SqlDialectTestSupportProvider.get().getClass();
     archive.addClass(SqlDialectTestSupport.class);
     archive.addClass(implClass);
     archive.addClasses(implClass.getDeclaredClasses());

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -16,6 +16,7 @@
 package run.ratchet.testsuite.util;
 
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.TreeMap;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -23,6 +24,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import run.ratchet.store.converter.InstantAttributeConverter;
+import run.ratchet.tck.store.SqlDialectTestSupport;
 import run.ratchet.testsuite.app.DocumentStorePerformanceTestHelper;
 import run.ratchet.testsuite.app.DocumentStoreTestCleanupStrategy;
 import run.ratchet.testsuite.app.DocumentStoreTestDataManipulator;
@@ -30,6 +32,7 @@ import run.ratchet.testsuite.app.JpaPerformanceTestHelper;
 import run.ratchet.testsuite.app.JpaTestCleanupStrategy;
 import run.ratchet.testsuite.app.JpaTestDataManipulator;
 import run.ratchet.testsuite.app.PerformanceTestHelper;
+import run.ratchet.testsuite.app.SqlDialectTestSupportProvider;
 import run.ratchet.testsuite.app.TestCleanupStrategy;
 import run.ratchet.testsuite.app.TestDataManipulator;
 import run.ratchet.testsuite.app.TestEntityManagerProvider;
@@ -203,8 +206,10 @@ public class RatchetArchiveBuilder {
             JpaTestCleanupStrategy.class,
             JpaTestDataManipulator.class,
             JpaPerformanceTestHelper.class,
+            SqlDialectTestSupportProvider.class,
             TestEntityManagerProvider.class,
             InstantAttributeConverter.class);
+        addSqlDialectTestSupport();
         addPersistenceXml(dbType, strategy.jtaDataSourceName());
         addDataSource(strategy);
       }
@@ -225,6 +230,32 @@ public class RatchetArchiveBuilder {
 
   public WebArchive build() {
     return archive;
+  }
+
+  /**
+   * Bundles the active store's {@link SqlDialectTestSupport} into the WAR. Exactly one store is on
+   * the test classpath (profile-gated test-jar dependency), so {@link ServiceLoader} resolves a
+   * single implementation here in the build JVM. ShrinkWrap adds named classes only, so the
+   * interface, the implementation (plus any nested types it declares), and a regenerated service
+   * registration are all added explicitly for the in-container lookup that {@code
+   * SqlDialectTestSupportProvider} performs at runtime.
+   */
+  private void addSqlDialectTestSupport() {
+    SqlDialectTestSupport support =
+        ServiceLoader.load(SqlDialectTestSupport.class)
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "No SqlDialectTestSupport on the test classpath — the active store module"
+                            + " must contribute one via META-INF/services"));
+    Class<?> implClass = support.getClass();
+    archive.addClass(SqlDialectTestSupport.class);
+    archive.addClass(implClass);
+    archive.addClasses(implClass.getDeclaredClasses());
+    archive.addAsResource(
+        new StringAsset(implClass.getName()),
+        "META-INF/services/" + SqlDialectTestSupport.class.getName());
   }
 
   private void addAwaitility() {


### PR DESCRIPTION
## Summary

Replaces the schema migrator's hardcoded dialect handling with a `SchemaMigrationDialect` SPI, and moves the integration testsuite's per-dialect SQL out of the testsuite into the store modules.

Before this, the migrator carried a `Dialect` enum with a per-vendor `switch` for the lock, version-table DDL, and upsert, plus a `dialectFromMetadata()` whitelist that sniffed `DatabaseMetaData.getDatabaseProductName()`. Adding a store meant editing the engine, and look-alike products (CockroachDB on the PostgreSQL wire) had to be rejected by name.

Now the engine owns only the portable machinery — classpath script discovery, checksum validation, statement splitting, the apply loop, and the `ratchet_schema_version` ledger — and delegates the vendor-specific seams to a `SchemaMigrationDialect` each store publishes as a CDI bean. The engine never switches on a product name. `SchemaMigrationLifecycleHook` resolves the dialect from the deployed store's bean (`RATCHET_SCHEMA_MIGRATION_DIALECT` disambiguates when several are present) instead of probing JDBC metadata.

The testsuite gets a parallel cleanup: a `SqlDialectTestSupport` SPI (ServiceLoader-discovered, one per store, living next to each store's `DialectTypeMapper`) absorbs the foreign-key toggling, TRUNCATE-vs-DELETE, UUID binding, bulk inserts, and scan diagnostics that the JPA test helpers used to branch on via `dbType()`. The perf-suite background inserts were also reworked for the hot/cold table split (terminal rows grow the cold archive; pending rows grow the hot queue).

Commits:
- Extract a `SchemaMigrationDialect` SPI from the schema migrator
- Move the testsuite's per-dialect SQL into the store modules
- Modernize the perf-suite background inserts for the hot/cold split
- Reuse the cached test-support lookup in the archive builder (post-review cleanup)

## Testing

Ran in this session:

- [x] `mvn spotless:check` — clean across the touched store/tck/testsuite modules
- [x] `mvn test -pl ratchet-store-core,ratchet-store-mysql,ratchet-store-postgresql` — 213 store-core tests (incl. the rewritten `SchemaMigratorTest` driven by a `RecordingDialect` stub) plus `MysqlSchemaMigrationDialectTest` (6) and `PostgresqlSchemaMigrationDialectTest` (4), all green
- [x] `mvn test-compile -pl ratchet-testsuite -Pmysql`

Not run here (need Docker / the local Arquillian matrix):

- [ ] `mvn clean test -B`
- [ ] Per-store migrator ITs (`MysqlSchemaMigratorIT`, `PostgresqlSchemaMigratorIT`, `OracleSchemaMigratorIT`) — Testcontainers
- [ ] Perf ITs (`ClaimQueryDegradationIT`, `TableGrowthDegradationIT`) across the 5-server × 3-DB matrix
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl :ratchet-testsuite,:ratchet-coverage -am`

## Docs

- [x] No docs update needed — `SchemaMigrationLifecycleHook` resolution rules are documented in its Javadoc; the new SPIs are `@Incubating` store-implementor surface, not user-facing config

## Review Notes

- [x] Public API or SPI change — new `SchemaMigrationDialect` (`@Incubating`, store-core) and `SqlDialectTestSupport` (tck-store, test-only)
- [ ] Breaking change — `SchemaMigrator`'s public constructors now take a `SchemaMigrationDialect` instead of a dialect `String`; `dialectFromMetadata()` is removed. Internal to the store modules, no published API for application code.

## Additional Context

The `usesDedicatedLockConnection()` boolean on the SPI is Oracle's seam: its DDL auto-commits (dropping a transactional lock) and `DBMS_LOCK` needs an EXECUTE grant managed users often lack, so it holds an EXCLUSIVE table lock on a second connection that runs no DDL. MySQL and PostgreSQL hold a session advisory lock on the migration connection itself and return `false`.

Two different discovery mechanisms are used on purpose: CDI `Instance<SchemaMigrationDialect>` for the production hook (runs in a container) and JDK `ServiceLoader<SqlDialectTestSupport>` for the test harness (plain build-JVM + WAR helper). `RatchetArchiveBuilder` bundles only the active store's implementation into the deployment WAR.

A `/simplify` review pass (reuse / simplification / efficiency / altitude) ran over the branch; the only change it produced is the fourth commit (collapsing a duplicate `ServiceLoader` scan in `RatchetArchiveBuilder` onto the already-cached `SqlDialectTestSupportProvider`). The rest of the branch reviewed clean.
