### PR TITLE
Add a Microsoft SQL Server store (ratchet-store-sqlserver)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         server: [wildfly-managed, wildfly-ee11-managed, payara-managed, openliberty-managed]
         # Oracle runs the full server matrix like the other stores; the ojdbc
         # driver stays test-scoped and the gvenzl container supplies the database.
-        database: [mysql, postgresql, mongodb, oracle]
+        database: [mysql, postgresql, mongodb, oracle, sqlserver]
         include:
           - server: glassfish-managed
             database: mysql
@@ -155,6 +155,8 @@ jobs:
             database: mongodb
           - server: glassfish-managed
             database: oracle
+          - server: glassfish-managed
+            database: sqlserver
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <module>stores/ratchet-store-mysql</module>
     <module>stores/ratchet-store-postgresql</module>
     <module>stores/ratchet-store-oracle</module>
+    <module>stores/ratchet-store-sqlserver</module>
     <module>stores/ratchet-store-mongodb</module>
     <module>coordinators/ratchet-coordinator-common</module>
     <module>coordinators/ratchet-coordinator-postgresql</module>
@@ -155,6 +156,7 @@
     <protobuf-java.version>3.25.9</protobuf-java.version>
     <postgresql-driver.version>42.7.11</postgresql-driver.version>
     <ojdbc.version>23.9.0.25.07</ojdbc.version>
+    <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
     <artemis.version>2.54.0</artemis.version>
     <netty.version>4.1.133.Final</netty.version>
@@ -397,6 +399,11 @@
       </dependency>
       <dependency>
         <groupId>run.ratchet</groupId>
+        <artifactId>ratchet-store-sqlserver</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>run.ratchet</groupId>
         <artifactId>ratchet-store-mongodb</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -573,6 +580,14 @@
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgresql-driver.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <!-- SQL Server Driver -->
+      <dependency>
+        <groupId>com.microsoft.sqlserver</groupId>
+        <artifactId>mssql-jdbc</artifactId>
+        <version>${mssql-jdbc.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -11,6 +11,7 @@ exclude:
       - stores/ratchet-store-mysql/src/main/java
       - stores/ratchet-store-postgresql/src/main/java
       - stores/ratchet-store-oracle/src/main/java
+      - stores/ratchet-store-sqlserver/src/main/java
       - testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app
       - stores/ratchet-store-core/src/main/java/run/ratchet/store/converter
       # ExecutorService is used as a test resource
@@ -35,6 +36,7 @@ exclude:
       - stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
       - stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
       - stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStoreImpl.java
+      - stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
 
   - name: SqlSourceToSinkFlow
     paths:

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -47,6 +47,8 @@ exclude:
       - stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
       - stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
       - stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlStoreContext.java
+      - stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperations.java
+      - stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverStoreContext.java
       - testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
 
   - name: BusyWait

--- a/ratchet-bom/pom.xml
+++ b/ratchet-bom/pom.xml
@@ -54,6 +54,11 @@
             </dependency>
             <dependency>
                 <groupId>run.ratchet</groupId>
+                <artifactId>ratchet-store-sqlserver</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>run.ratchet</groupId>
                 <artifactId>ratchet-store-mongodb</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
@@ -23,6 +23,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
@@ -41,6 +42,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobHandle;
@@ -52,8 +56,10 @@ import run.ratchet.api.Recurring;
 import run.ratchet.api.RecurringJobBuilder;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.core.internal.RecurringRegistrationState;
+import run.ratchet.spi.ExecutorProvider;
 import run.ratchet.spi.StartupCoordinator;
 import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.RecurringJobStore;
 
 /**
  * Scans CDI beans for {@link Recurring}-annotated methods and registers them as recurring jobs at
@@ -70,6 +76,8 @@ public class RecurringJobProcessor {
   private static final Logger log = Logger.getLogger(RecurringJobProcessor.class);
   private static final String ORPHAN_CLEANUP_ACTION = "recurring-annotation-orphan-cleanup";
   private static final Duration ORPHAN_CLEANUP_LEASE_TTL = Duration.ofMinutes(5);
+  private static final long REGISTRATION_RETRY_DELAY_MS = 500;
+  private static final int MAX_REGISTRATION_ATTEMPTS = 10;
 
   private static final CronParser CRON_PARSER =
       new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
@@ -86,6 +94,15 @@ public class RecurringJobProcessor {
   private final RatchetOptions options;
   private final Set<Class<?>> discoveredRecurringBeanClasses;
   private final Clock clock;
+
+  // Field-injected (not constructor) so direct-construction test/SE paths leave them null and
+  // register inline; the CDI-managed bean uses the managed scheduled executor (a post-deployment
+  // thread that carries a Jakarta EE component invocation, which @Transactional registration needs)
+  // and the store to verify each master committed before declaring registration complete.
+  @Inject private ExecutorProvider executorProvider;
+  @Inject private Instance<RecurringJobStore> recurringJobStoreInstance;
+
+  private final AtomicBoolean registrationFinalized = new AtomicBoolean();
 
   protected RecurringJobProcessor() {
     this.schedulerService = null;
@@ -212,19 +229,83 @@ public class RecurringJobProcessor {
 
   void onStartup(
       @Observes @Priority(Interceptor.Priority.APPLICATION) @Initialized(ApplicationScoped.class) Object init) {
-    registerRecurringJobs();
+    ScheduledExecutorService scheduler = resolveScheduledExecutor();
+    if (scheduler == null) {
+      // Plain-CDI / SE / unit tests: no managed executor, and the calling thread already carries a
+      // usable transaction context, so register inline.
+      registerRecurringJobs();
+      return;
+    }
+    // On a Jakarta EE container the @Initialized(ApplicationScoped) observer can fire before the
+    // application's component invocation context is established (notably GlassFish 8, which fires
+    // it
+    // mid-deployment). Without that context the @Transactional submit path neither starts nor
+    // commits a transaction, so on EclipseLink 5 + SQL Server (whose JTA pool pins autocommit off)
+    // the recurring-master INSERT is rolled back on connection return and silently lost. Defer
+    // registration to the managed scheduled executor, whose tasks run post-deployment with a proper
+    // component context, and retry until every master is confirmed committed.
+    scheduleDeferredRegistration(scheduler, 1);
   }
 
-  void registerRecurringJobs() {
+  private ScheduledExecutorService resolveScheduledExecutor() {
+    if (executorProvider == null) {
+      return null;
+    }
+    try {
+      return executorProvider.getScheduledExecutor();
+    } catch (RuntimeException e) {
+      log.warnf(
+          e,
+          "Managed scheduled executor unavailable for @Recurring registration; registering inline");
+      return null;
+    }
+  }
+
+  private void scheduleDeferredRegistration(ScheduledExecutorService scheduler, int attempt) {
+    scheduler.schedule(
+        () -> attemptDeferredRegistration(scheduler, attempt),
+        REGISTRATION_RETRY_DELAY_MS,
+        TimeUnit.MILLISECONDS);
+  }
+
+  private void attemptDeferredRegistration(ScheduledExecutorService scheduler, int attempt) {
+    try {
+      boolean committed = registerRecurringJobs();
+      if (!committed && attempt < MAX_REGISTRATION_ATTEMPTS) {
+        log.infof(
+            "@Recurring registration not yet committed (attempt %s/%s); retrying",
+            attempt, MAX_REGISTRATION_ATTEMPTS);
+        scheduleDeferredRegistration(scheduler, attempt + 1);
+      }
+    } catch (RuntimeException e) {
+      log.error("@Recurring registration attempt failed", e);
+      if (attempt < MAX_REGISTRATION_ATTEMPTS) {
+        scheduleDeferredRegistration(scheduler, attempt + 1);
+      }
+    }
+  }
+
+  /**
+   * Registers every discovered {@code @Recurring} method, skipping any whose master is already
+   * committed so the call is idempotent across retries and restarts.
+   *
+   * @return {@code true} once every discovered master is confirmed present in the store (or the
+   *     store does not advertise the recurring capability), so the caller can stop retrying
+   */
+  boolean registerRecurringJobs() {
     Instant startTime = effective().instant();
     log.info("Starting registration of @Recurring annotated jobs");
 
+    RecurringJobStore store = resolveRecurringJobStore();
     List<RecurringMethodRegistration> registrations = discoverRecurringMethods();
     Set<String> discoveredJobIds =
         registrations.stream()
             .map(RecurringMethodRegistration::jobId)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     for (RecurringMethodRegistration registration : registrations) {
+      if (store != null && store.findRecurringByBusinessKey(registration.jobId()).isPresent()) {
+        continue; // already committed (a prior attempt or a previous run) — idempotent skip
+      }
       try {
         registerJob(registration);
       } catch (Exception e) {
@@ -236,6 +317,27 @@ public class RecurringJobProcessor {
       }
     }
 
+    boolean committed =
+        store == null
+            || registrations.stream()
+                .allMatch(r -> store.findRecurringByBusinessKey(r.jobId()).isPresent());
+    if (committed) {
+      finalizeRegistration(startTime, discoveredJobIds);
+    }
+    return committed;
+  }
+
+  private RecurringJobStore resolveRecurringJobStore() {
+    if (recurringJobStoreInstance == null || !recurringJobStoreInstance.isResolvable()) {
+      return null;
+    }
+    return recurringJobStoreInstance.get();
+  }
+
+  private void finalizeRegistration(Instant startTime, Set<String> discoveredJobIds) {
+    if (!registrationFinalized.compareAndSet(false, true)) {
+      return; // already finalized by an earlier attempt
+    }
     log.infof("Completed registration of %s recurring jobs", registeredJobIds.size());
 
     // Publish the discovered key set to the shared registration state BEFORE running cleanup,

--- a/stores/ratchet-store-core/src/main/java/module-info.java
+++ b/stores/ratchet-store-core/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module run.ratchet.store.core {
       run.ratchet.store.mysql,
       run.ratchet.store.postgresql,
       run.ratchet.store.oracle,
+      run.ratchet.store.sqlserver,
       run.ratchet.store.mongodb;
 
   opens run.ratchet.store.converter;

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobLifecycleOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobLifecycleOperations.java
@@ -36,7 +36,7 @@ final class OracleJobLifecycleOperations
       OracleBatchOperations batches) {
     this.transitions = new OracleJobStatusTransitions(ctx);
     this.terminals = new OracleJobTerminalOperations(ctx, reservations, batches);
-    this.recurring = new OracleJobRecurringAndResetOperations(ctx, reservations);
+    this.recurring = new OracleJobRecurringAndResetOperations(ctx);
   }
 
   @Override

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobRecurringAndResetOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobRecurringAndResetOperations.java
@@ -25,8 +25,7 @@ final class OracleJobRecurringAndResetOperations {
 
   private final OracleStoreContext ctx;
 
-  OracleJobRecurringAndResetOperations(
-      OracleStoreContext ctx, OracleBusinessKeyReservations reservations) {
+  OracleJobRecurringAndResetOperations(OracleStoreContext ctx) {
     this.ctx = ctx;
   }
 

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobLifecycleOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobLifecycleOperations.java
@@ -36,7 +36,7 @@ final class PostgresqlJobLifecycleOperations
       PostgresqlBatchOperations batches) {
     this.transitions = new PostgresqlJobStatusTransitions(ctx);
     this.terminals = new PostgresqlJobTerminalOperations(ctx, reservations, batches);
-    this.recurring = new PostgresqlJobRecurringAndResetOperations(ctx, reservations);
+    this.recurring = new PostgresqlJobRecurringAndResetOperations(ctx);
   }
 
   @Override

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRecurringAndResetOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobRecurringAndResetOperations.java
@@ -28,8 +28,7 @@ final class PostgresqlJobRecurringAndResetOperations {
 
   private final PostgresqlStoreContext ctx;
 
-  PostgresqlJobRecurringAndResetOperations(
-      PostgresqlStoreContext ctx, PostgresqlBusinessKeyReservations reservations) {
+  PostgresqlJobRecurringAndResetOperations(PostgresqlStoreContext ctx) {
     this.ctx = ctx;
   }
 

--- a/stores/ratchet-store-sqlserver/README.md
+++ b/stores/ratchet-store-sqlserver/README.md
@@ -4,15 +4,32 @@ SQL Server store implementation for Ratchet.
 
 ## Operator debugging
 
-UUIDv7 IDs are stored as native `uuid` (16 bytes). `psql` formats them as
-hyphenated strings automatically:
+UUIDv7 IDs are stored as `BINARY(16)` holding the canonical big-endian bytes —
+the same byte order as the hyphenated string — not as `UNIQUEIDENTIFIER`. SSMS
+and `sqlcmd` render the column as a `0x...` hex literal, so a raw
+`SELECT * FROM scheduler_job` returns 16 binary bytes rather than a hyphenated
+string.
+
+Query by ID with a `0x` hex literal — drop the hyphens from the UUID:
 
 ```sql
-SELECT * FROM scheduler_job WHERE job_id = '01902c4e-c4f3-7b8a-9d3e-fedcba987654';
+-- 01902c4e-c4f3-7b8a-9d3e-fedcba987654
+SELECT * FROM scheduler_job WHERE job_id = 0x01902C4EC4F37B8A9D3EFEDCBA987654;
 ```
 
-No view layer is needed (unlike the MySQL store) — `psql` handles `uuid`
-natively in both query input and result output.
+Render stored IDs back to that hex form for comparison with `CONVERT(..., 2)`:
+
+```sql
+SELECT CONVERT(CHAR(32), job_id, 2) AS job_id_hex, business_key, terminal_status
+FROM scheduler_job;
+```
+
+Do **not** cast `job_id` through `UNIQUEIDENTIFIER` (e.g.
+`CONVERT(UNIQUEIDENTIFIER, job_id)`): that applies SQL Server's mixed-endian Guid
+byte swap and yields a string that matches no stored row — the reason this store
+uses `BINARY(16)` rather than `UNIQUEIDENTIFIER` in the first place. Tools that
+handle binary IDs correctly (Hibernate, JDBC `getObject(..., UUID.class)`, a
+UUID-aware viewer) can query the tables directly.
 
 Index space at 100M rows × 5 secondary indexes: ~4.8 GB.
 

--- a/stores/ratchet-store-sqlserver/README.md
+++ b/stores/ratchet-store-sqlserver/README.md
@@ -1,0 +1,18 @@
+# ratchet-store-sqlserver
+
+SQL Server store implementation for Ratchet.
+
+## Operator debugging
+
+UUIDv7 IDs are stored as native `uuid` (16 bytes). `psql` formats them as
+hyphenated strings automatically:
+
+```sql
+SELECT * FROM scheduler_job WHERE job_id = '01902c4e-c4f3-7b8a-9d3e-fedcba987654';
+```
+
+No view layer is needed (unlike the MySQL store) — `psql` handles `uuid`
+natively in both query input and result output.
+
+Index space at 100M rows × 5 secondary indexes: ~4.8 GB.
+

--- a/stores/ratchet-store-sqlserver/README.md
+++ b/stores/ratchet-store-sqlserver/README.md
@@ -31,5 +31,25 @@ uses `BINARY(16)` rather than `UNIQUEIDENTIFIER` in the first place. Tools that
 handle binary IDs correctly (Hibernate, JDBC `getObject(..., UUID.class)`, a
 UUID-aware viewer) can query the tables directly.
 
+## Server configuration
+
+Ratchet's claim contract requires the `READ COMMITTED` transaction isolation
+level. SQL Server's own default is `READ COMMITTED`, but **Open Liberty's SQL
+Server data-store helper overrides an unset datasource to
+`TRANSACTION_REPEATABLE_READ`**. Under that default Ratchet's startup isolation
+check fails, so when deploying this store on Open Liberty pin the level
+explicitly:
+
+```xml
+<dataSource id="RatchetDS" jndiName="jdbc/RatchetDS" transactional="true"
+            isolationLevel="TRANSACTION_READ_COMMITTED">
+  ...
+</dataSource>
+```
+
+Other servers either default SQL Server to `READ COMMITTED` (GlassFish, Payara)
+or set it during datasource setup (WildFly), so no extra configuration is needed
+there.
+
 Index space at 100M rows × 5 secondary indexes: ~4.8 GB.
 

--- a/stores/ratchet-store-sqlserver/pom.xml
+++ b/stores/ratchet-store-sqlserver/pom.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>run.ratchet</groupId>
+        <artifactId>ratchet-parent</artifactId>
+        <version>0.1.2-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>ratchet-store-sqlserver</artifactId>
+    <name>Ratchet :: Store SQL Server</name>
+    <description>SQL Server store implementation for Ratchet</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>run.ratchet</groupId>
+            <artifactId>ratchet-store-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>run.ratchet</groupId>
+            <artifactId>ratchet-tck-store</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-mssqlserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse</groupId>
+            <artifactId>yasson</artifactId>
+            <version>3.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+              Same qualified-export fix as ratchet-store-mysql. See that module's pom.xml for
+              the full explanation.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>--add-exports</arg>
+                                <arg>run.ratchet.api/run.ratchet.spi=ALL-UNNAMED</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Publishes a test-jar so the integration testsuite can ServiceLoad this store's
+                 SqlDialectTestSupport implementation into the deployment WAR. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <ratchet.tck.store.name>${project.artifactId}</ratchet.tck.store.name>
+                    </systemPropertyVariables>
+                    <!--
+                      mssql-jdbc binds java.sql.Timestamp to zoneless DATETIME2 using the JVM
+                      default timezone, so a non-UTC JVM skews native-query time comparisons against
+                      SYSUTCDATETIME(). Pin the test JVM to UTC (the store's storage convention),
+                      mirroring the MySQL fixture's connectionTimeZone=UTC.
+                    -->
+                    <argLine>--add-exports run.ratchet.api/run.ratchet.spi=ALL-UNNAMED -Duser.timezone=UTC</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-exports run.ratchet.api/run.ratchet.spi=ALL-UNNAMED -Duser.timezone=UTC</argLine>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/stores/ratchet-store-sqlserver/src/main/java/module-info.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/module-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+module run.ratchet.store.sqlserver {
+  requires run.ratchet.api;
+  requires run.ratchet.store.core;
+  requires jakarta.annotation;
+  requires jakarta.cdi;
+  requires jakarta.inject;
+  requires jakarta.persistence;
+  requires jakarta.transaction;
+  requires java.sql;
+  requires org.jboss.logging;
+
+  exports run.ratchet.store.sqlserver;
+
+  opens run.ratchet.store.sqlserver;
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverArchiveOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverArchiveOperations.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.store.entity.ArchivedJobEntity;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.id.UuidV7Factory;
+import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.ArchiveHelper;
+import run.ratchet.store.util.ArchiveParameterBinder;
+import run.ratchet.store.util.ArchiveQuerySupport;
+import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.RowValues;
+
+final class SqlserverArchiveOperations implements ArchiveStore {
+
+  private static final String MISSING_ARCHIVE_JOB_MESSAGE = "Job not found for archival: ";
+
+  // SQL Server variant of ArchiveParameterBinder.ARCHIVE_VALUE_PLACEHOLDERS: depended_on (29) and
+  // superseded_by (30) are nullable BINARY(16) columns, and mssql-jdbc binds an untyped Java null
+  // as
+  // nvarchar, which SQL Server refuses to implicitly convert to binary. CAST(? AS BINARY(16)) makes
+  // the conversion explicit (a non-null byte[] casts harmlessly). The other 29 placeholders match
+  // the shared binder's positional order exactly.
+  private static final String SQLSERVER_ARCHIVE_VALUE_PLACEHOLDERS =
+      "(" + "?, ".repeat(28) + "CAST(? AS BINARY(16)), CAST(? AS BINARY(16)), ?)";
+
+  // language=SQL Server
+  private static final String INSERT_ARCHIVE_SQL =
+      """
+      INSERT INTO scheduler_job_archive (%s)
+      VALUES %s
+      """
+          .formatted(ArchiveParameterBinder.ARCHIVE_COLUMNS, SQLSERVER_ARCHIVE_VALUE_PLACEHOLDERS);
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverJobReadOperations reads;
+
+  SqlserverArchiveOperations(SqlserverStoreContext ctx, SqlserverJobReadOperations reads) {
+    this.ctx = ctx;
+    this.reads = reads;
+  }
+
+  private static void prepareArchive(ArchivedJobEntity archive) {
+    if (archive.getId() == null) {
+      archive.setId(UuidV7Factory.create());
+    }
+    if (archive.getArchivedAt() == null) {
+      archive.setArchivedAt(Instant.now());
+    }
+  }
+
+  /**
+   * Archives one terminal job in the caller's store transaction.
+   *
+   * @implNote TX: REQUIRED - joins the caller's active store transaction.
+   * @return the archived row that was inserted
+   */
+  @Override
+  public ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy) {
+    try {
+      JobEntity hydrated = reads.hydrateForArchive(job);
+      ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
+      prepareArchive(archive);
+      Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
+      ArchiveParameterBinder.bind(query, archive, 1, UuidByteArrayConverter::toBytes);
+      query.executeUpdate();
+      return archive;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("archive job", e);
+    }
+  }
+
+  /**
+   * Archives all supplied terminal jobs in the caller's store transaction using a single multi-row
+   * insert.
+   *
+   * @implNote TX: REQUIRED - joins the caller's active store transaction.
+   * @return number of archive rows inserted
+   */
+  @Override
+  public int archiveJobsBatch(List<JobEntity> jobsToArchive, String reason, String archivedBy) {
+    if (jobsToArchive.isEmpty()) {
+      return 0;
+    }
+
+    try {
+      List<UUID> ids = jobsToArchive.stream().map(JobEntity::getId).toList();
+      Map<UUID, JobEntity> hydratedById =
+          reads.findByIds(ids).stream()
+              .collect(Collectors.toMap(JobEntity::getId, Function.identity()));
+      List<ArchivedJobEntity> archives = new ArrayList<>(jobsToArchive.size());
+      for (UUID id : ids) {
+        JobEntity hydrated = hydratedById.get(id);
+        if (hydrated == null) {
+          throw new IllegalStateException(MISSING_ARCHIVE_JOB_MESSAGE.concat(String.valueOf(id)));
+        }
+        ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
+        prepareArchive(archive);
+        archives.add(archive);
+      }
+
+      String rows =
+          String.join(
+              ",", Collections.nCopies(archives.size(), SQLSERVER_ARCHIVE_VALUE_PLACEHOLDERS));
+      Query query =
+          ctx.em()
+              .createNativeQuery(
+                  """
+                  INSERT INTO scheduler_job_archive (%s)
+                  VALUES %s
+                  """
+                      .formatted(ArchiveParameterBinder.ARCHIVE_COLUMNS, rows));
+      int parameter = 1;
+      for (ArchivedJobEntity archive : archives) {
+        parameter =
+            ArchiveParameterBinder.bind(query, archive, parameter, UuidByteArrayConverter::toBytes);
+      }
+      query.executeUpdate();
+      return archives.size();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("archive jobs batch", e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<JobEntity> findJobsForArchiving(Instant olderThan, int limit) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT %s
+          FROM scheduler_job c
+          LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+          WHERE c.terminal_status IS NOT NULL
+            AND c.terminated_at < ?
+          ORDER BY c.terminated_at ASC
+          OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY
+          """
+              .formatted(SqlserverJobRowMapper.hydrationSelect());
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, Timestamp.from(olderThan))
+              .setParameter(2, limit)
+              .getResultList();
+      return reads.hydrateRowsWithTags(rows);
+    } catch (RatchetTransientStoreException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find jobs for archiving", e);
+    }
+  }
+
+  @Override
+  public long countJobsForArchiving(Instant olderThan) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job
+        WHERE terminal_status IS NOT NULL AND terminated_at < ?
+        """;
+    return ctx.countByNative(sql, Timestamp.from(olderThan));
+  }
+
+  // SQL template is assembled from a compile-time-constant column list and AND-clauses defined in
+  // this package; runtime values are bound as JDBC parameters via setParameter.
+  @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
+  public List<ArchivedJobEntity> findArchivedJobs(
+      String targetClass, String businessKey, Instant from, Instant to, int limit) {
+    try {
+      var searchQuery =
+          ArchiveQuerySupport.buildFindArchivedJobsQuery(
+              ArchiveParameterBinder.ARCHIVE_COLUMNS, targetClass, businessKey, from, to, limit);
+      // ArchiveQuerySupport emits the portable-majority "... ORDER BY archived_at DESC LIMIT ?"
+      // tail; SQL Server expresses the row cap as OFFSET/FETCH. The bound limit stays last.
+      String sql =
+          searchQuery
+              .sql()
+              .replace(
+                  "ORDER BY archived_at DESC LIMIT ?",
+                  "ORDER BY archived_at DESC OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY");
+      Query query = ctx.em().createNativeQuery(sql);
+      ArchiveQuerySupport.bindParameters(query, searchQuery);
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows = query.getResultList();
+      return rows.stream().map(row -> ArchiveRowMapper.map(row, RowValues::instantOrNull)).toList();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find archived jobs", e);
+    }
+  }
+
+  @Override
+  public int purgeArchivedJobs(Instant olderThan) {
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_job_archive WHERE archived_at < ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, Timestamp.from(olderThan))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("purge archived jobs", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
@@ -19,6 +19,7 @@ import jakarta.persistence.NoResultException;
 import jakarta.persistence.Query;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -114,7 +115,12 @@ final class SqlserverAuxiliaryOperations
   public int purgeLogsOlderThan(Instant cutoff) {
     // language=JPAQL
     String jpql = "DELETE FROM JobLogEntity l WHERE l.ts < :cutoff";
-    return ctx.em().createQuery(jpql).setParameter("cutoff", cutoff).executeUpdate();
+    // ts is DATETIME2(6); floor the cutoff to microseconds so the boundary matches the column
+    // precision rather than mssql-jdbc's nanosecond-precision bind (see existsRecentDlqAlert).
+    return ctx.em()
+        .createQuery(jpql)
+        .setParameter("cutoff", cutoff.truncatedTo(ChronoUnit.MICROS))
+        .executeUpdate();
   }
 
   @Override
@@ -248,7 +254,14 @@ final class SqlserverAuxiliaryOperations
             .createQuery(jpql, Long.class)
             .setParameter("jid", jobId)
             .setParameter("hash", errorHash)
-            .setParameter("cutoff", cutoff)
+            // alert_sent_at is DATETIME2(6), so a persisted Instant is floored to microsecond
+            // precision. The mssql-jdbc driver binds an Instant parameter at full nanosecond
+            // precision and compares it literally, so an unmodified cutoff equal to a stored alert
+            // time fails the `>=` boundary by the sub-microsecond remainder (the MySQL/PG drivers
+            // floor the bind for us, which is why this only surfaces on SQL Server and Oracle, and
+            // only on a nanosecond-resolution clock). Floor the cutoff to match the column
+            // precision.
+            .setParameter("cutoff", cutoff.truncatedTo(ChronoUnit.MICROS))
             .getSingleResult();
     return count > 0;
   }

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.store.entity.DlqAlertEntity;
+import run.ratchet.store.entity.JobExecutionEntity;
+import run.ratchet.store.entity.JobLogEntity;
+import run.ratchet.store.entity.ResourceLimitEntity;
+import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.id.UuidV7Factory;
+import run.ratchet.store.spi.DlqAlertStore;
+import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.ResourcePermitStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.RowValues;
+
+final class SqlserverAuxiliaryOperations
+    implements JobAuditStore, WorkflowConditionStore, DlqAlertStore, ResourcePermitStore {
+
+  private static final int PERMIT_CLEANUP_CHUNK_SIZE = 500;
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverAuxiliaryOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  private static WorkflowConditionEntity mapCondition(Object[] row) {
+    WorkflowConditionEntity condition = new WorkflowConditionEntity();
+    condition.setId(SqlserverJobRowMapper.uuidOrNull(row[0]));
+    condition.setParentJobId(SqlserverJobRowMapper.uuidOrNull(row[1]));
+    condition.setChildJobId(SqlserverJobRowMapper.uuidOrNull(row[2]));
+    condition.setConditionType(WorkflowCondition.ConditionType.valueOf(row[3].toString()));
+    condition.setConditionExpression(row[4] == null ? null : row[4].toString());
+    condition.setConditionPriority(((Number) row[5]).intValue());
+    condition.setCreatedAt(RowValues.instantOrNull(row[6]));
+    return condition;
+  }
+
+  @Override
+  public JobExecutionEntity saveExecution(JobExecutionEntity execution) {
+    if (execution.getId() == null) {
+      ctx.em().persist(execution);
+      return execution;
+    }
+    return ctx.em().merge(execution);
+  }
+
+  @Override
+  public List<JobExecutionEntity> findExecutionsByJobId(UUID jobId, int limit, int offset) {
+    // language=JPAQL
+    String jpql = "SELECT e FROM JobExecutionEntity e WHERE e.jobId = :jid ORDER BY e.attempt ASC";
+    return ctx.em()
+        .createQuery(jpql, JobExecutionEntity.class)
+        .setParameter("jid", jobId)
+        .setFirstResult(offset)
+        .setMaxResults(limit)
+        .getResultList();
+  }
+
+  @Override
+  public Optional<JobExecutionEntity> findLatestExecution(UUID jobId) {
+    // language=JPAQL
+    String jpql = "SELECT e FROM JobExecutionEntity e WHERE e.jobId = :jid ORDER BY e.attempt DESC";
+    List<JobExecutionEntity> results =
+        ctx.em()
+            .createQuery(jpql, JobExecutionEntity.class)
+            .setParameter("jid", jobId)
+            .setMaxResults(1)
+            .getResultList();
+    return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+  }
+
+  @Override
+  public int countExecutionAttempts(UUID jobId) {
+    // language=JPAQL
+    String jpql = "SELECT COUNT(e) FROM JobExecutionEntity e WHERE e.jobId = :jid";
+    return ctx.em()
+        .createQuery(jpql, Long.class)
+        .setParameter("jid", jobId)
+        .getSingleResult()
+        .intValue();
+  }
+
+  @Override
+  public void appendLog(JobLogEntity logEntry) {
+    ctx.em().persist(logEntry);
+  }
+
+  @Override
+  public int purgeLogsOlderThan(Instant cutoff) {
+    // language=JPAQL
+    String jpql = "DELETE FROM JobLogEntity l WHERE l.ts < :cutoff";
+    return ctx.em().createQuery(jpql).setParameter("cutoff", cutoff).executeUpdate();
+  }
+
+  @Override
+  public WorkflowConditionEntity saveCondition(WorkflowConditionEntity condition) {
+    prepareCondition(condition);
+    // language=SQL Server
+    String sql =
+        """
+        MERGE scheduler_workflow_condition WITH (HOLDLOCK) AS tgt
+        USING (VALUES (?, ?, ?, ?, ?, ?, ?))
+          AS src(id, parent_job_id, child_job_id, condition_type, condition_expression,
+                 condition_priority, created_at)
+          ON tgt.id = src.id
+        WHEN MATCHED THEN UPDATE SET
+          parent_job_id = src.parent_job_id,
+          child_job_id = src.child_job_id,
+          condition_type = src.condition_type,
+          condition_expression = src.condition_expression,
+          condition_priority = src.condition_priority,
+          created_at = src.created_at
+        WHEN NOT MATCHED THEN INSERT
+          (id, parent_job_id, child_job_id, condition_type, condition_expression,
+           condition_priority, created_at)
+          VALUES (src.id, src.parent_job_id, src.child_job_id, src.condition_type,
+                  src.condition_expression, src.condition_priority, src.created_at);
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(condition.getId()))
+        .setParameter(2, UuidByteArrayConverter.toBytes(condition.getParentJobId()))
+        .setParameter(3, UuidByteArrayConverter.toBytes(condition.getChildJobId()))
+        .setParameter(4, condition.getConditionType().name())
+        .setParameter(5, condition.getConditionExpression())
+        .setParameter(6, condition.getConditionPriority())
+        .setParameter(7, Timestamp.from(condition.getCreatedAt()))
+        .executeUpdate();
+    return condition;
+  }
+
+  @Override
+  public WorkflowConditionEntity findConditionById(UUID id) {
+    List<WorkflowConditionEntity> results =
+        findConditions(
+            "WHERE id = ?",
+            List.of(UuidByteArrayConverter.toBytes(id)),
+            "ORDER BY condition_priority ASC");
+    return results.isEmpty() ? null : results.get(0);
+  }
+
+  @Override
+  public List<WorkflowConditionEntity> findConditionsByParentJobId(UUID parentJobId) {
+    return findConditions(
+        "WHERE parent_job_id = ?",
+        List.of(UuidByteArrayConverter.toBytes(parentJobId)),
+        "ORDER BY condition_priority ASC");
+  }
+
+  @Override
+  public List<WorkflowConditionEntity> findConditionsByChildJobId(UUID childJobId) {
+    return findConditions(
+        "WHERE child_job_id = ?",
+        List.of(UuidByteArrayConverter.toBytes(childJobId)),
+        "ORDER BY condition_priority ASC");
+  }
+
+  @Override
+  public List<WorkflowConditionEntity> findConditionsByType(
+      UUID parentJobId, WorkflowCondition.ConditionType type) {
+    return findConditions(
+        "WHERE parent_job_id = ? AND condition_type = ?",
+        List.of(UuidByteArrayConverter.toBytes(parentJobId), type.name()),
+        "ORDER BY condition_priority ASC");
+  }
+
+  @Override
+  public void deleteConditionById(UUID id) {
+    // language=SQL Server
+    String sql = "DELETE FROM scheduler_workflow_condition WHERE id = ?";
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(id))
+        .executeUpdate();
+  }
+
+  @Override
+  public void deleteConditionsByParentJobId(UUID parentJobId) {
+    // language=SQL Server
+    String sql = "DELETE FROM scheduler_workflow_condition WHERE parent_job_id = ?";
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(parentJobId))
+        .executeUpdate();
+  }
+
+  @Override
+  public void deleteConditionsByChildJobId(UUID childJobId) {
+    // language=SQL Server
+    String sql = "DELETE FROM scheduler_workflow_condition WHERE child_job_id = ?";
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(childJobId))
+        .executeUpdate();
+  }
+
+  @Override
+  public long countConditionsByParentJobId(UUID parentJobId) {
+    // language=SQL Server
+    String sql = "SELECT COUNT(*) FROM scheduler_workflow_condition WHERE parent_job_id = ?";
+    return ctx.countByNative(sql, UuidByteArrayConverter.toBytes(parentJobId));
+  }
+
+  @Override
+  public DlqAlertEntity saveDlqAlert(DlqAlertEntity alert) {
+    if (alert.getId() == null) {
+      ctx.em().persist(alert);
+      return alert;
+    }
+    return ctx.em().merge(alert);
+  }
+
+  @Override
+  public boolean existsRecentDlqAlert(UUID jobId, String errorHash, Instant cutoff) {
+    // language=JPAQL
+    String jpql =
+        """
+        SELECT COUNT(a) FROM DlqAlertEntity a
+        WHERE a.jobId = :jid AND a.errorHash = :hash AND a.alertSentAt >= :cutoff
+        """;
+    Long count =
+        ctx.em()
+            .createQuery(jpql, Long.class)
+            .setParameter("jid", jobId)
+            .setParameter("hash", errorHash)
+            .setParameter("cutoff", cutoff)
+            .getSingleResult();
+    return count > 0;
+  }
+
+  @Override
+  public boolean tryAcquirePermit(String resource, UUID jobId, String nodeId) {
+    try {
+      // language=SQL Server
+      String lockSql =
+          """
+          SELECT resource_name FROM scheduler_resource_limit WITH (UPDLOCK, HOLDLOCK, ROWLOCK)
+          WHERE resource_name = ?
+          """;
+      @SuppressWarnings("unchecked")
+      List<Object> lockedLimits =
+          ctx.em().createNativeQuery(lockSql).setParameter(1, resource).getResultList();
+      if (lockedLimits.isEmpty()) {
+        throw new IllegalArgumentException("Resource is not configured: " + resource);
+      }
+
+      // language=SQL Server
+      String existingSql =
+          """
+          SELECT COUNT(*) FROM scheduler_resource_permit
+          WHERE resource_name = ? AND job_id = ?
+          """;
+      Object existing =
+          ctx.em()
+              .createNativeQuery(existingSql)
+              .setParameter(1, resource)
+              .setParameter(2, UuidByteArrayConverter.toBytes(jobId))
+              .getSingleResult();
+      if (((Number) existing).intValue() > 0) {
+        return true;
+      }
+
+      // SQL Server uses one statement snapshot even after waiting on FOR UPDATE. Keep the lock
+      // acquisition as its own statement, then count and insert together with a fresh snapshot.
+      // language=SQL Server
+      String insertSql =
+          """
+          INSERT INTO scheduler_resource_permit
+            (id, resource_name, job_id, node_id, acquired_at)
+          SELECT ?, resource_name, ?, ?, ?
+          FROM scheduler_resource_limit
+          WHERE resource_name = ?
+            AND (
+              SELECT COUNT(*) FROM scheduler_resource_permit
+              WHERE resource_name = ?
+            ) < max_concurrent
+          """;
+      int inserted =
+          ctx.em()
+              .createNativeQuery(insertSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(UuidV7Factory.create()))
+              .setParameter(2, UuidByteArrayConverter.toBytes(jobId))
+              .setParameter(3, nodeId)
+              .setParameter(4, Timestamp.from(Instant.now()))
+              .setParameter(5, resource)
+              .setParameter(6, resource)
+              .executeUpdate();
+      return inserted > 0;
+    } catch (IllegalArgumentException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("try acquire permit", e);
+    }
+  }
+
+  @Override
+  public void releasePermit(String resource, UUID jobId) {
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_resource_permit WHERE resource_name = ? AND job_id = ?";
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, resource)
+          .setParameter(2, UuidByteArrayConverter.toBytes(jobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("release resource permit", e);
+    }
+  }
+
+  @Override
+  public void releaseAllPermits(UUID jobId) {
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_resource_permit WHERE job_id = ?";
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("release all permits", e);
+    }
+  }
+
+  @Override
+  public int getPermitRetryDelay(String resource) {
+    try {
+      // language=SQL Server
+      String sql = "SELECT retry_delay_ms FROM scheduler_resource_limit WHERE resource_name = ?";
+      Object result = ctx.em().createNativeQuery(sql).setParameter(1, resource).getSingleResult();
+      return ((Number) result).intValue();
+    } catch (NoResultException e) {
+      return ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get permit retry delay", e);
+    }
+  }
+
+  @Override
+  public void configureResource(
+      String name, int maxConcurrent, int retryDelayMs, String description) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          MERGE scheduler_resource_limit WITH (HOLDLOCK) AS tgt
+          USING (VALUES (?, ?, ?, ?))
+            AS src(resource_name, max_concurrent, retry_delay_ms, description)
+            ON tgt.resource_name = src.resource_name
+          WHEN MATCHED THEN UPDATE SET
+            max_concurrent = src.max_concurrent,
+            retry_delay_ms = src.retry_delay_ms,
+            description = src.description,
+            updated_at = SYSUTCDATETIME()
+          WHEN NOT MATCHED THEN INSERT
+            (resource_name, max_concurrent, retry_delay_ms, description, created_at, updated_at)
+            VALUES (src.resource_name, src.max_concurrent, src.retry_delay_ms, src.description,
+                    SYSUTCDATETIME(), SYSUTCDATETIME());
+          """;
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, name)
+          .setParameter(2, maxConcurrent)
+          .setParameter(3, retryDelayMs)
+          .setParameter(4, description)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("configure resource", e);
+    }
+  }
+
+  @Override
+  public int cleanupOrphanedPermits(List<String> staleNodeIds) {
+    if (staleNodeIds.isEmpty()) {
+      return 0;
+    }
+    try {
+      int deleted = 0;
+      for (int start = 0; start < staleNodeIds.size(); start += PERMIT_CLEANUP_CHUNK_SIZE) {
+        deleted +=
+            cleanupOrphanedPermitsChunk(
+                staleNodeIds.subList(
+                    start, Math.min(start + PERMIT_CLEANUP_CHUNK_SIZE, staleNodeIds.size())));
+      }
+      return deleted;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("cleanup orphaned permits", e);
+    }
+  }
+
+  private int cleanupOrphanedPermitsChunk(List<String> staleNodeIds) {
+    String placeholders = String.join(",", Collections.nCopies(staleNodeIds.size(), "?"));
+    // language=SQL Server
+    String sql = "DELETE FROM scheduler_resource_permit WHERE node_id IN (" + placeholders + ")";
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    for (String nodeId : staleNodeIds) {
+      query.setParameter(parameter++, nodeId);
+    }
+    return query.executeUpdate();
+  }
+
+  private void prepareCondition(WorkflowConditionEntity condition) {
+    if (condition.getId() == null) {
+      condition.setId(UuidV7Factory.create());
+    }
+    if (condition.getCreatedAt() == null) {
+      condition.setCreatedAt(Instant.now());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<WorkflowConditionEntity> findConditions(
+      String whereClause, List<Object> params, String orderClause) {
+    // language=SQL Server
+    String sqlPrefix =
+        """
+        SELECT id, parent_job_id, child_job_id, condition_type, condition_expression,
+               condition_priority, created_at
+        FROM scheduler_workflow_condition
+        """;
+    Query query = ctx.em().createNativeQuery(sqlPrefix + whereClause + " " + orderClause);
+    for (int i = 0; i < params.size(); i++) {
+      query.setParameter(i + 1, params.get(i));
+    }
+    return ((List<Object[]>) query.getResultList())
+        .stream().map(SqlserverAuxiliaryOperations::mapCondition).toList();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
@@ -19,7 +19,6 @@ import jakarta.persistence.NoResultException;
 import jakarta.persistence.Query;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -119,7 +118,7 @@ final class SqlserverAuxiliaryOperations
     // precision rather than mssql-jdbc's nanosecond-precision bind (see existsRecentDlqAlert).
     return ctx.em()
         .createQuery(jpql)
-        .setParameter("cutoff", cutoff.truncatedTo(ChronoUnit.MICROS))
+        .setParameter("cutoff", SqlserverTimestamps.floorMicros(cutoff))
         .executeUpdate();
   }
 
@@ -262,7 +261,7 @@ final class SqlserverAuxiliaryOperations
             // floor the bind for us, which is why this only surfaces on SQL Server and Oracle, and
             // only on a nanosecond-resolution clock). Floor the cutoff to match the column
             // precision.
-            .setParameter("cutoff", cutoff.truncatedTo(ChronoUnit.MICROS))
+            .setParameter("cutoff", SqlserverTimestamps.floorMicros(cutoff))
             .getSingleResult();
     return count > 0;
   }

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java
@@ -229,7 +229,8 @@ final class SqlserverAuxiliaryOperations
   public long countConditionsByParentJobId(UUID parentJobId) {
     // language=SQL Server
     String sql = "SELECT COUNT(*) FROM scheduler_workflow_condition WHERE parent_job_id = ?";
-    return ctx.countByNative(sql, UuidByteArrayConverter.toBytes(parentJobId));
+    // Cast to Object so the byte[] is bound as a single varargs parameter, not spread.
+    return ctx.countByNative(sql, (Object) UuidByteArrayConverter.toBytes(parentJobId));
   }
 
   @Override

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverBatchOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverBatchOperations.java
@@ -1,0 +1,395 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import org.jboss.logging.Logger;
+import run.ratchet.store.converter.PayloadSerializerHolder;
+import run.ratchet.store.dto.BatchProgress;
+import run.ratchet.store.entity.BatchEntity;
+import run.ratchet.store.entity.BatchMetricsEntity;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.BatchProgressRows;
+
+final class SqlserverBatchOperations implements BatchStore {
+
+  private static final Logger log = Logger.getLogger(SqlserverBatchOperations.class);
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverBatchOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public BatchEntity saveBatch(BatchEntity batch) {
+    // language=SQL Server
+    String sql =
+        """
+        MERGE scheduler_batch WITH (HOLDLOCK) AS tgt
+        USING (VALUES (?, ?, ?, ?, ?, ?))
+          AS src(batch_id, total_items, completed_items, failed_items,
+                 completion_processed, progress_hook)
+          ON tgt.batch_id = src.batch_id
+        WHEN MATCHED THEN UPDATE SET
+          total_items = src.total_items,
+          completed_items = src.completed_items,
+          failed_items = src.failed_items,
+          completion_processed = src.completion_processed,
+          progress_hook = src.progress_hook,
+          version = tgt.version + 1
+        WHEN NOT MATCHED THEN INSERT
+          (batch_id, total_items, completed_items, failed_items,
+           completion_processed, progress_hook)
+          VALUES (src.batch_id, src.total_items, src.completed_items, src.failed_items,
+                  src.completion_processed, src.progress_hook)
+        OUTPUT inserted.batch_id, inserted.total_items, inserted.completed_items,
+               inserted.failed_items, inserted.completion_processed, inserted.version,
+               inserted.progress_hook;
+        """;
+    Object row =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(batch.getId()))
+            .setParameter(2, batch.getTotalItems())
+            .setParameter(3, batch.getCompletedItems())
+            .setParameter(4, batch.getFailedItems())
+            .setParameter(5, Boolean.TRUE.equals(batch.getCompletionProcessed()))
+            .setParameter(6, progressHookJson(batch.getProgressHook()))
+            .getSingleResult();
+    return row instanceof Object[] values ? mapBatchRow(values) : batch;
+  }
+
+  @Override
+  public Optional<BatchEntity> findBatchById(UUID batchId) {
+    BatchEntity batch = ctx.em().find(BatchEntity.class, batchId);
+    refreshIfManaged(batch);
+    return Optional.ofNullable(batch);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<BatchEntity> findBatchesByIds(List<UUID> batchIds) {
+    if (batchIds == null || batchIds.isEmpty()) {
+      return List.of();
+    }
+    String placeholders = "?,".repeat(batchIds.size());
+    // language=SQL Server
+    String sql =
+        """
+        SELECT batch_id, total_items, completed_items, failed_items,
+               completion_processed, version, progress_hook
+        FROM scheduler_batch
+        WHERE batch_id IN (%s)
+        """
+            .formatted(placeholders.substring(0, placeholders.length() - 1));
+    var query = ctx.em().createNativeQuery(sql);
+    for (int i = 0; i < batchIds.size(); i++) {
+      query.setParameter(i + 1, UuidByteArrayConverter.toBytes(batchIds.get(i)));
+    }
+    List<Object[]> rows = query.getResultList();
+    List<BatchEntity> batches = new ArrayList<>(rows.size());
+    for (Object[] row : rows) {
+      batches.add(mapBatchRow(row));
+    }
+    return batches;
+  }
+
+  @Override
+  public BatchProgress incrementCompletedAtomic(UUID batchId) {
+    return incrementAtomic(batchId, BatchCounter.COMPLETED);
+  }
+
+  @Override
+  public BatchProgress incrementFailedAtomic(UUID batchId) {
+    return incrementAtomic(batchId, BatchCounter.FAILED);
+  }
+
+  private BatchProgress incrementAtomic(UUID batchId, BatchCounter counter) {
+    // language=SQL Server
+    String sql =
+        String.format(
+            """
+        UPDATE scheduler_batch SET %1$s = %1$s + 1
+        OUTPUT inserted.completed_items, inserted.failed_items, inserted.total_items,
+               inserted.progress_hook
+        WHERE batch_id = ?
+        """,
+            counter.columnName);
+    try {
+      Object result =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(batchId))
+              .getSingleResult();
+      return mapIncrementResult(batchId, result, this::parseProgressHook);
+    } catch (NoResultException e) {
+      throw new IllegalStateException("Batch not found: " + batchId, e);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("increment batch " + counter.operationName, e);
+    }
+  }
+
+  static BatchProgress mapIncrementResult(
+      UUID batchId, Object result, Function<Object, JobPayload> progressHookParser) {
+    if (!(result instanceof Object[] row)) {
+      throw new IllegalStateException(
+          "Expected batch progress row for batch "
+              + batchId
+              + " to be Object[] but was "
+              + typeName(result));
+    }
+    if (row.length < 4) {
+      throw new IllegalStateException(
+          "Expected batch progress row for batch "
+              + batchId
+              + " to contain at least 4 columns but found "
+              + row.length);
+    }
+    requireNumber(batchId, row, 0, "completed_items");
+    requireNumber(batchId, row, 1, "failed_items");
+    requireNumber(batchId, row, 2, "total_items");
+    return BatchProgressRows.fromCurrentRow(batchId, row, progressHookParser);
+  }
+
+  private static void requireNumber(UUID batchId, Object[] row, int index, String columnName) {
+    if (!(row[index] instanceof Number)) {
+      throw new IllegalStateException(
+          "Expected batch progress column "
+              + columnName
+              + " for batch "
+              + batchId
+              + " to be numeric but was "
+              + typeName(row[index]));
+    }
+  }
+
+  private static String typeName(Object value) {
+    return value == null ? "null" : value.getClass().getName();
+  }
+
+  @Override
+  public boolean markBatchCompleteIfReady(UUID batchId) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_batch SET completion_processed = 1
+        WHERE batch_id = ? AND completion_processed = 0
+          AND (completed_items + failed_items) >= total_items
+        """;
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(batchId))
+            .executeUpdate();
+    return updated > 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<UUID> findRecoverableBatchIds(int limit) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT batch_id FROM scheduler_batch
+        WHERE completion_processed = 0
+          AND (completed_items + failed_items) >= total_items
+        ORDER BY (SELECT 1) OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY
+        """;
+    List<?> results = ctx.em().createNativeQuery(sql).setParameter(1, limit).getResultList();
+    return results.stream().map(SqlserverJobRowMapper::uuidOrNull).toList();
+  }
+
+  @Override
+  public boolean updateBatchTotalItems(UUID batchId, int totalItems) {
+    // language=SQL Server
+    String sql = "UPDATE scheduler_batch SET total_items = ? WHERE batch_id = ?";
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, totalItems)
+            .setParameter(2, UuidByteArrayConverter.toBytes(batchId))
+            .executeUpdate();
+    return updated > 0;
+  }
+
+  @Override
+  public BatchMetricsEntity saveBatchMetrics(BatchMetricsEntity metrics) {
+    if (metrics.getBatchJob() == null) {
+      metrics.setBatchJob(ctx.em().getReference(JobEntity.class, metrics.getBatchId()));
+    }
+    // language=SQL Server
+    String sql =
+        """
+        MERGE scheduler_batch_metrics WITH (HOLDLOCK) AS tgt
+        USING (VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?))
+          AS src(batch_id, total_duration_ms, child_execution_ms, overhead_ms, child_count,
+                 success_count, failure_count, started_at, completed_at)
+          ON tgt.batch_id = src.batch_id
+        WHEN MATCHED THEN UPDATE SET
+          total_duration_ms = src.total_duration_ms,
+          child_execution_ms = src.child_execution_ms,
+          overhead_ms = src.overhead_ms,
+          child_count = src.child_count,
+          success_count = src.success_count,
+          failure_count = src.failure_count,
+          started_at = src.started_at,
+          completed_at = src.completed_at,
+          version = tgt.version + 1
+        WHEN NOT MATCHED THEN INSERT
+          (batch_id, total_duration_ms, child_execution_ms, overhead_ms, child_count,
+           success_count, failure_count, started_at, completed_at)
+          VALUES (src.batch_id, src.total_duration_ms, src.child_execution_ms, src.overhead_ms,
+                  src.child_count, src.success_count, src.failure_count, src.started_at,
+                  src.completed_at);
+        """;
+    Query query = ctx.em().createNativeQuery(sql);
+    query.setParameter(1, UuidByteArrayConverter.toBytes(metrics.getBatchId()));
+    query.setParameter(2, metrics.getTotalDurationMs());
+    query.setParameter(3, metrics.getChildExecutionMs());
+    query.setParameter(4, metrics.getOverheadMs());
+    query.setParameter(5, metrics.getChildCount());
+    query.setParameter(6, metrics.getSuccessCount());
+    query.setParameter(7, metrics.getFailureCount());
+    query.setParameter(8, timestampOrNull(metrics.getStartedAt()));
+    query.setParameter(9, timestampOrNull(metrics.getCompletedAt()));
+    query.executeUpdate();
+    return metrics;
+  }
+
+  @Override
+  public Optional<BatchMetricsEntity> findBatchMetrics(UUID batchId) {
+    return Optional.ofNullable(ctx.em().find(BatchMetricsEntity.class, batchId));
+  }
+
+  @Override
+  public void addChildExecutionTime(UUID batchId, long durationMs) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_batch_metrics
+        SET child_execution_ms = COALESCE(child_execution_ms, 0) + ?,
+            success_count = success_count + 1
+        WHERE batch_id = ?
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, durationMs)
+        .setParameter(2, UuidByteArrayConverter.toBytes(batchId))
+        .executeUpdate();
+  }
+
+  @Override
+  public void finalizeBatchMetrics(UUID batchId) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_batch_metrics
+        SET completed_at = SYSUTCDATETIME(),
+            total_duration_ms = CASE WHEN started_at IS NOT NULL
+              THEN DATEDIFF_BIG(MILLISECOND, started_at, SYSUTCDATETIME())
+              ELSE NULL END,
+            overhead_ms = CASE WHEN started_at IS NOT NULL AND child_execution_ms IS NOT NULL
+              THEN DATEDIFF_BIG(MILLISECOND, started_at, SYSUTCDATETIME())
+                   - child_execution_ms
+              ELSE NULL END
+        WHERE batch_id = ? AND completed_at IS NULL
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(batchId))
+        .executeUpdate();
+  }
+
+  @Override
+  public void updateBatchMetricsChildCount(UUID batchId, int childCount) {
+    // language=SQL Server
+    String sql = "UPDATE scheduler_batch_metrics SET child_count = ? WHERE batch_id = ?";
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, childCount)
+        .setParameter(2, UuidByteArrayConverter.toBytes(batchId))
+        .executeUpdate();
+  }
+
+  private JobPayload parseProgressHook(Object jsonValue) {
+    if (jsonValue == null) {
+      return null;
+    }
+    try {
+      return PayloadSerializerHolder.get().deserialize(jsonValue.toString(), JobPayload.class);
+    } catch (IllegalArgumentException e) {
+      log.warn("Failed to deserialize stored batch progress hook payload", e);
+      throw new IllegalArgumentException("JobPayload deserialization error", e);
+    }
+  }
+
+  private static Timestamp timestampOrNull(java.time.Instant instant) {
+    return instant == null ? null : Timestamp.from(instant);
+  }
+
+  private BatchEntity mapBatchRow(Object[] row) {
+    BatchEntity batch = new BatchEntity();
+    batch.setId(SqlserverJobRowMapper.uuidOrNull(row[0]));
+    batch.setTotalItems(((Number) row[1]).intValue());
+    batch.setCompletedItems(((Number) row[2]).intValue());
+    batch.setFailedItems(((Number) row[3]).intValue());
+    batch.setCompletionProcessed(asBoolean(row[4]));
+    batch.setVersion(row[5] == null ? null : ((Number) row[5]).intValue());
+    batch.setProgressHook(parseProgressHook(row[6]));
+    return batch;
+  }
+
+  private static boolean asBoolean(Object value) {
+    if (value instanceof Boolean bool) {
+      return bool;
+    }
+    return value != null && ((Number) value).intValue() != 0;
+  }
+
+  private void refreshIfManaged(BatchEntity batch) {
+    if (batch != null && ctx.em().contains(batch)) {
+      ctx.em().refresh(batch);
+    }
+  }
+
+  private String progressHookJson(JobPayload progressHook) {
+    return progressHook == null ? null : PayloadSerializerHolder.get().serialize(progressHook);
+  }
+
+  private enum BatchCounter {
+    COMPLETED("completed_items", "completed counter"),
+    FAILED("failed_items", "failed counter");
+
+    private final String columnName;
+    private final String operationName;
+
+    BatchCounter(String columnName, String operationName) {
+      this.columnName = columnName;
+      this.operationName = operationName;
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverBusinessKeyReservations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverBusinessKeyReservations.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.BusinessKeyReservations;
+import run.ratchet.store.util.StatusClassifier;
+
+final class SqlserverBusinessKeyReservations {
+
+  static final String OWNER_TABLE_QUEUE = BusinessKeyReservations.OWNER_TABLE_QUEUE;
+  static final String OWNER_TABLE_RECURRING = BusinessKeyReservations.OWNER_TABLE_RECURRING;
+
+  private static final int DELETE_RESERVATIONS_CHUNK_SIZE = 500;
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverBusinessKeyReservations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  static String ownerTableFor(JobExecutionType jobType) {
+    return BusinessKeyReservations.ownerTableFor(jobType);
+  }
+
+  static String ownerTableFor(String jobType) {
+    return BusinessKeyReservations.ownerTableFor(jobType);
+  }
+
+  void insertReservation(String businessKey, UUID ownerJobId, String ownerTable) {
+    try {
+      // Keep DML local: SQL Server owns its timestamp expression. UUID columns are BINARY(16), so
+      // bind ids as canonical bytes via UuidByteArrayConverter.toBytes.
+      // language=SQL Server
+      String sql =
+          """
+          INSERT INTO scheduler_business_key_reservation
+            (business_key, owner_job_id, owner_table, reserved_at)
+          VALUES (?, ?, ?, SYSUTCDATETIME())
+          """;
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, businessKey)
+          .setParameter(2, UuidByteArrayConverter.toBytes(ownerJobId))
+          .setParameter(3, ownerTable)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("insert business key reservation", e);
+    }
+  }
+
+  int bindInsert(Query q, JobEntity job, int i) {
+    q.setParameter(i++, job.getBusinessKey());
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(job.getId()));
+    q.setParameter(i++, ownerTableFor(job.getJobType()));
+    return i;
+  }
+
+  @SuppressWarnings("UnusedReturnValue")
+  int deleteReservationByOwner(UUID ownerJobId) {
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_business_key_reservation WHERE owner_job_id = ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(ownerJobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete business key reservation", e);
+    }
+  }
+
+  void deleteReservationsByOwners(List<UUID> ownerJobIds) {
+    if (ownerJobIds.isEmpty()) {
+      return;
+    }
+    for (int start = 0; start < ownerJobIds.size(); start += DELETE_RESERVATIONS_CHUNK_SIZE) {
+      deleteReservationsByOwnersChunk(
+          ownerJobIds.subList(
+              start, Math.min(start + DELETE_RESERVATIONS_CHUNK_SIZE, ownerJobIds.size())));
+    }
+  }
+
+  private void deleteReservationsByOwnersChunk(List<UUID> ownerJobIds) {
+    try {
+      String placeholders = String.join(",", Collections.nCopies(ownerJobIds.size(), "?"));
+      // language=SQL Server
+      String sql =
+          "DELETE FROM scheduler_business_key_reservation WHERE owner_job_id IN ("
+              + placeholders
+              + ")";
+      Query query = ctx.em().createNativeQuery(sql);
+      int parameter = 1;
+      for (UUID ownerJobId : ownerJobIds) {
+        query.setParameter(parameter++, UuidByteArrayConverter.toBytes(ownerJobId));
+      }
+      query.executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete business key reservations", e);
+    }
+  }
+
+  void syncForJob(JobEntity job) {
+    try {
+      deleteReservationByOwner(job.getId());
+      JobStatus status = StatusClassifier.effectiveStatus(job.getStatus());
+      if (StatusClassifier.isLiveStatus(status) && job.getBusinessKey() != null) {
+        insertReservation(job.getBusinessKey(), job.getId(), ownerTableFor(job.getJobType()));
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("sync business key reservation", e);
+    }
+  }
+
+  /**
+   * Rebuilds the active reservation for one job.
+   *
+   * @implNote TX: REQUIRED - callers must invoke this inside the same store transaction that
+   *     changed the job state. The delete/read/insert sequence must commit or roll back as one
+   *     unit.
+   */
+  void syncForJob(UUID ownerJobId, JobStatus status) {
+    try {
+      deleteReservationByOwner(ownerJobId);
+      if (!StatusClassifier.isLiveStatus(status)) {
+        return;
+      }
+      // language=SQL Server
+      String selectSql = "SELECT business_key, job_type FROM scheduler_job WHERE job_id = ?";
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(selectSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(ownerJobId))
+              .getResultList();
+      if (rows.isEmpty()) {
+        return;
+      }
+      Object[] row = rows.get(0);
+      String businessKey = (String) row[0];
+      if (businessKey != null) {
+        insertReservation(businessKey, ownerJobId, ownerTableFor((String) row[1]));
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("sync business key reservation", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverConstraintDetector.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverConstraintDetector.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientException;
+import run.ratchet.store.ConstraintDetector;
+
+/** SQL Server-specific constraint violation detector. */
+class SqlserverConstraintDetector implements ConstraintDetector {
+
+  // SQL Server vendor error codes (mssql-jdbc surfaces these via SQLException.getErrorCode()).
+  private static final int ERROR_UNIQUE_CONSTRAINT = 2627; // PRIMARY KEY / UNIQUE constraint
+  private static final int ERROR_UNIQUE_INDEX = 2601; // duplicate key in a unique index
+  private static final int ERROR_DEADLOCK = 1205;
+  private static final int ERROR_SNAPSHOT_CONFLICT = 3960; // snapshot isolation update conflict
+
+  private static SQLException findSqlException(Throwable t) {
+    while (t != null) {
+      if (t instanceof SQLException sql) {
+        return sql;
+      }
+      t = t.getCause();
+    }
+    return null;
+  }
+
+  @Override
+  public String constraintName(Exception e) {
+    SQLException sql = findSqlException(e);
+    if (sql == null) {
+      return null;
+    }
+    // SQL Server names the constraint in single quotes:
+    // "Violation of UNIQUE KEY constraint 'uk_idempotency_key'. Cannot insert duplicate key ..."
+    String message = sql.getMessage();
+    if (message == null) {
+      return null;
+    }
+    int marker = message.indexOf("constraint '");
+    int start = marker >= 0 ? marker + "constraint '".length() - 1 : message.indexOf('\'');
+    if (start >= 0) {
+      int end = message.indexOf('\'', start + 1);
+      if (end > start) {
+        return message.substring(start + 1, end);
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean isDuplicateKey(Exception e) {
+    SQLException sql = findSqlException(e);
+    if (sql == null) {
+      return false;
+    }
+    if (sql.getErrorCode() == ERROR_UNIQUE_CONSTRAINT || sql.getErrorCode() == ERROR_UNIQUE_INDEX) {
+      return true;
+    }
+    String message = sql.getMessage();
+    return message != null
+        && (message.contains("Violation of UNIQUE KEY constraint")
+            || message.contains("Violation of PRIMARY KEY constraint")
+            || message.contains("Cannot insert duplicate key"));
+  }
+
+  @Override
+  public boolean isDeadlock(Exception e) {
+    SQLException sql = findSqlException(e);
+    if (sql == null) {
+      return false;
+    }
+    return sql.getErrorCode() == ERROR_DEADLOCK
+        || sql.getErrorCode() == ERROR_SNAPSHOT_CONFLICT
+        || "40001".equals(sql.getSQLState());
+  }
+
+  @Override
+  public boolean isTransientConnectionFailure(Exception e) {
+    Throwable current = e;
+    while (current != null) {
+      if (current instanceof SQLTransientException || current instanceof SQLRecoverableException) {
+        return true;
+      }
+      if (current instanceof SQLException sql) {
+        String sqlState = sql.getSQLState();
+        if (sqlState != null && sqlState.startsWith("08")) {
+          return true;
+        }
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverConstraintDetector.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverConstraintDetector.java
@@ -52,7 +52,8 @@ class SqlserverConstraintDetector implements ConstraintDetector {
       return null;
     }
     int marker = message.indexOf("constraint '");
-    int start = marker >= 0 ? marker + "constraint '".length() - 1 : message.indexOf('\'');
+    // Opening quote: the one in "constraint '" when present, else the first quote in the message.
+    int start = marker >= 0 ? message.indexOf('\'', marker) : message.indexOf('\'');
     if (start >= 0) {
       int end = message.indexOf('\'', start + 1);
       if (end > start) {

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverEntityManagerProvider.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverEntityManagerProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import run.ratchet.store.spi.RatchetEntityManagerProvider;
+
+/** Default SQL Server EntityManager provider using the deployment's unnamed persistence context. */
+@ApplicationScoped
+class SqlserverEntityManagerProvider implements RatchetEntityManagerProvider {
+
+  @PersistenceContext private EntityManager em;
+
+  @Override
+  public EntityManager getEntityManager() {
+    return em;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobClaimOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobClaimOperations.java
@@ -57,10 +57,11 @@ final class SqlserverJobClaimOperations implements JobClaimStore {
   }
 
   /**
-   * Selects due PENDING rows in effective-priority order with {@code FOR UPDATE SKIP LOCKED}. The
-   * caller transitions the locked rows to RUNNING via a separate UPDATE; the priority ordering
-   * established here is preserved through that UPDATE because the caller iterates the SELECT rows
-   * directly. {@code UPDATE…RETURNING} from a CTE would emit rows in heap order instead.
+   * Selects due PENDING rows in effective-priority order, locking them with {@code WITH (UPDLOCK,
+   * READPAST, ROWLOCK)} so concurrent claimers skip the already-locked rows. The caller transitions
+   * the locked rows to RUNNING via a separate UPDATE; the priority ordering established here is
+   * preserved through that UPDATE because the caller iterates the SELECT rows directly. A single
+   * {@code UPDATE … OUTPUT} from a CTE would emit rows in heap order instead.
    *
    * <p>Placeholder order: typeFilter params → executionTargetFilter params → tagFilter params →
    * boostInterval (if &gt; 0) → limit.

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobClaimOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobClaimOperations.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.NodeTagFilter;
+import run.ratchet.store.dto.JobClaimDto;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.ExecutionTargetFilter;
+import run.ratchet.store.spi.JobClaimStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.JobClaimSqlSupport;
+import run.ratchet.store.util.RowValues;
+import run.ratchet.store.util.StatusClassifier;
+
+final class SqlserverJobClaimOperations implements JobClaimStore {
+
+  static final String EXECUTABLE_JOB_TYPE_FILTER =
+      "job_type IN ('SINGLE','BATCH_CHILD','CHAIN_STEP','WORKFLOW_BRANCH')";
+
+  private static final String CLAIM_SELECT_COLUMNS = ClaimColumn.selectClause();
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverJobReadOperations reads;
+
+  SqlserverJobClaimOperations(SqlserverStoreContext ctx, SqlserverJobReadOperations reads) {
+    this.ctx = ctx;
+    this.reads = reads;
+  }
+
+  // Overdue minutes since the row was due: DATEDIFF(SECOND, ...) is seconds, /60.0 converts to
+  // minutes.
+  private static String pgOverdueMinutes(String timeColumn) {
+    return "DATEDIFF(SECOND, " + timeColumn + ", SYSUTCDATETIME())/60.0";
+  }
+
+  /**
+   * Selects due PENDING rows in effective-priority order with {@code FOR UPDATE SKIP LOCKED}. The
+   * caller transitions the locked rows to RUNNING via a separate UPDATE; the priority ordering
+   * established here is preserved through that UPDATE because the caller iterates the SELECT rows
+   * directly. {@code UPDATE…RETURNING} from a CTE would emit rows in heap order instead.
+   *
+   * <p>Placeholder order: typeFilter params → executionTargetFilter params → tagFilter params →
+   * boostInterval (if &gt; 0) → limit.
+   */
+  // language=SQL Server
+  private static String buildQueueSelectSql(
+      String selectColumns,
+      String typeFilter,
+      String executionTargetFilterSql,
+      String tagFilterSql,
+      String timeColumn,
+      int boostInterval) {
+    return """
+        SELECT %s
+        FROM scheduler_job_queue WITH (UPDLOCK, READPAST, ROWLOCK)
+        WHERE status = 'PENDING'
+          AND %s <= SYSUTCDATETIME()
+          AND %s%s%s
+        ORDER BY %s
+        OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY
+        """
+        .formatted(
+            selectColumns,
+            timeColumn,
+            typeFilter,
+            executionTargetFilterSql,
+            tagFilterSql,
+            JobClaimSqlSupport.buildBoostedOrderBy(
+                timeColumn, pgOverdueMinutes(timeColumn), boostInterval));
+  }
+
+  // language=SQL Server
+  private static String buildHydratedQueueSelectSql(
+      String selectColumns,
+      String typeFilter,
+      String tagFilterSql,
+      String timeColumn,
+      int boostInterval) {
+    return """
+        SELECT %s
+        FROM scheduler_job c
+        JOIN scheduler_job_queue q WITH (UPDLOCK, READPAST, ROWLOCK) ON q.job_id = c.job_id
+        WHERE q.status = 'PENDING'
+          AND %s <= SYSUTCDATETIME()
+          AND %s%s
+        ORDER BY %s
+        OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY
+        """
+        .formatted(
+            selectColumns,
+            timeColumn,
+            typeFilter,
+            tagFilterSql,
+            JobClaimSqlSupport.buildBoostedOrderBy(
+                timeColumn, pgOverdueMinutes(timeColumn), boostInterval, "q."));
+  }
+
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
+  @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
+  public List<JobEntity> claimNextBatch(int limit, String nodeId, NodeTagFilter tagFilter) {
+    if (limit <= 0) {
+      return List.of();
+    }
+    try {
+      int boostInterval = ctx.priorityBoostIntervalMinutes();
+      String tagSql = JobClaimSqlSupport.buildTagFilterSql(tagFilter, "q");
+      Query selectQuery =
+          ctx.em()
+              .createNativeQuery(
+                  buildHydratedQueueSelectSql(
+                      SqlserverJobRowMapper.hydrationSelect(),
+                      "q.job_type IN ('SINGLE','BATCH_CHILD','CHAIN_STEP','WORKFLOW_BRANCH')",
+                      tagSql,
+                      "q.scheduled_time",
+                      boostInterval));
+      int parameter = 1;
+      parameter = JobClaimSqlSupport.bindTagFilter(selectQuery, tagFilter, parameter);
+      if (boostInterval > 0) {
+        selectQuery.setParameter(parameter++, boostInterval);
+      }
+      selectQuery.setParameter(parameter, limit);
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows =
+          ctx.timedStoreOperation(
+              "claim_lookup",
+              selectQuery::getResultList,
+              result -> result.isEmpty() ? "empty" : "hit");
+      if (rows.isEmpty()) {
+        return List.of();
+      }
+      List<JobEntity> ordered = reads.hydrateRowsWithTags(rows);
+      List<UUID> ids = new ArrayList<>(ordered.size());
+      for (JobEntity job : ordered) {
+        ids.add(job.getId());
+      }
+      Instant now = Instant.now();
+      markPendingClaimsRunning(ids, nodeId, now);
+      for (JobEntity job : ordered) {
+        job.setStatus(JobStatus.RUNNING);
+        job.setPickedBy(nodeId);
+        job.setPickedAt(now);
+      }
+      return ordered;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("claim jobs", e);
+    }
+  }
+
+  // SQL template is a compile-time constant defined in this package; runtime values are bound as
+  // JDBC parameters via setParameter.
+  @Override
+  @SuppressWarnings("SqlSourceToSinkFlow")
+  public List<JobClaimDto> claimNextBatchOptimized(
+      JobExecutionType jobType,
+      int limit,
+      String nodeId,
+      NodeTagFilter tagFilter,
+      ExecutionTargetFilter executionTargetFilter) {
+    if (limit <= 0 || !StatusClassifier.isPollerExecutable(jobType)) {
+      return List.of();
+    }
+    try {
+      int boostInterval = ctx.priorityBoostIntervalMinutes();
+      String tagSql = JobClaimSqlSupport.buildTagFilterSql(tagFilter, "scheduler_job_queue");
+      String executionTargetSql =
+          JobClaimSqlSupport.buildExecutionTargetFilterSql(
+              executionTargetFilter, "execution_target");
+      Query selectQuery =
+          ctx.em()
+              .createNativeQuery(
+                  buildQueueSelectSql(
+                      CLAIM_SELECT_COLUMNS,
+                      "job_type = ?",
+                      executionTargetSql,
+                      tagSql,
+                      "scheduled_time",
+                      boostInterval));
+      int parameter = 1;
+      selectQuery.setParameter(parameter++, jobType.name());
+      parameter =
+          JobClaimSqlSupport.bindExecutionTargetFilter(
+              selectQuery, executionTargetFilter, parameter);
+      parameter = JobClaimSqlSupport.bindTagFilter(selectQuery, tagFilter, parameter);
+      if (boostInterval > 0) {
+        selectQuery.setParameter(parameter++, boostInterval);
+      }
+      selectQuery.setParameter(parameter, limit);
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows = selectQuery.getResultList();
+      if (rows.isEmpty()) {
+        return List.of();
+      }
+
+      List<UUID> ids = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        ids.add(new ClaimRow(row).jobId());
+      }
+      return claimOptimizedRows(rows, ids, nodeId);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("optimized claim", e);
+    }
+  }
+
+  private List<JobClaimDto> claimOptimizedRows(List<Object[]> rows, List<UUID> ids, String nodeId) {
+    return ctx.timedStoreOperation(
+        "claim_mark_running_batch",
+        () -> {
+          Instant now = Instant.now();
+          markPendingClaimsRunning(ids, nodeId, now);
+
+          List<JobClaimDto> claims = new ArrayList<>(rows.size());
+          for (int i = 0; i < rows.size(); i++) {
+            ClaimRow row = new ClaimRow(rows.get(i));
+            claims.add(
+                new JobClaimDto(
+                    ids.get(i),
+                    JobStatus.RUNNING,
+                    row.jobType(),
+                    row.priority(),
+                    row.scheduledTime(),
+                    row.version(),
+                    row.timeoutSeconds(),
+                    nodeId,
+                    now,
+                    row.businessKey(),
+                    row.attempts(),
+                    row.maxRetries(),
+                    row.executionTarget()));
+          }
+          return claims;
+        },
+        claims -> claims.isEmpty() ? "miss" : "updated");
+  }
+
+  private void markPendingClaimsRunning(List<UUID> ids, String nodeId, Instant now) {
+    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET status = 'RUNNING',
+            picked_by = ?,
+            picked_at = ?,
+            updated_at = ?,
+            version = version + 1
+        WHERE job_id IN (%s) AND status = 'PENDING'
+        """
+            .formatted(placeholders);
+    Query query = ctx.em().createNativeQuery(sql);
+    Timestamp nowTs = Timestamp.from(now);
+    int p = 1;
+    query.setParameter(p++, nodeId);
+    query.setParameter(p++, nowTs);
+    query.setParameter(p++, nowTs);
+    for (UUID id : ids) {
+      query.setParameter(p++, UuidByteArrayConverter.toBytes(id));
+    }
+    query.executeUpdate();
+  }
+
+  private enum ClaimColumn {
+    JOB_ID("job_id"),
+    STATUS("status"),
+    JOB_TYPE("job_type"),
+    PRIORITY("priority"),
+    SCHEDULED_TIME("scheduled_time"),
+    VERSION("version"),
+    TIMEOUT_SEC("timeout_sec"),
+    PICKED_BY("picked_by"),
+    PICKED_AT("picked_at"),
+    BUSINESS_KEY("business_key"),
+    ATTEMPTS("attempts"),
+    MAX_RETRIES("max_retries"),
+    EXECUTION_TARGET("execution_target");
+
+    private final String sqlName;
+
+    ClaimColumn(String sqlName) {
+      this.sqlName = sqlName;
+    }
+
+    static String selectClause() {
+      return Arrays.stream(values()).map(ClaimColumn::sqlName).collect(Collectors.joining(", "));
+    }
+
+    String sqlName() {
+      return sqlName;
+    }
+  }
+
+  private record ClaimRow(Object[] values) {
+    ClaimRow {
+      Objects.requireNonNull(values, "values");
+    }
+
+    UUID jobId() {
+      return SqlserverJobRowMapper.uuidOrNull(value(ClaimColumn.JOB_ID));
+    }
+
+    JobExecutionType jobType() {
+      return JobExecutionType.valueOf((String) value(ClaimColumn.JOB_TYPE));
+    }
+
+    JobPriority priority() {
+      return SqlserverJobRowMapper.safeJobPriority(number(ClaimColumn.PRIORITY).intValue());
+    }
+
+    Instant scheduledTime() {
+      return RowValues.instantOrNull(value(ClaimColumn.SCHEDULED_TIME));
+    }
+
+    int version() {
+      return number(ClaimColumn.VERSION).intValue();
+    }
+
+    int timeoutSeconds() {
+      return number(ClaimColumn.TIMEOUT_SEC).intValue();
+    }
+
+    String businessKey() {
+      return (String) value(ClaimColumn.BUSINESS_KEY);
+    }
+
+    String executionTarget() {
+      return (String) value(ClaimColumn.EXECUTION_TARGET);
+    }
+
+    int attempts() {
+      return number(ClaimColumn.ATTEMPTS).intValue();
+    }
+
+    int maxRetries() {
+      return number(ClaimColumn.MAX_RETRIES).intValue();
+    }
+
+    private Number number(ClaimColumn column) {
+      return (Number) value(column);
+    }
+
+    private Object value(ClaimColumn column) {
+      return values[column.ordinal()];
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobClaimOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobClaimOperations.java
@@ -40,9 +40,6 @@ import run.ratchet.store.util.StatusClassifier;
 
 final class SqlserverJobClaimOperations implements JobClaimStore {
 
-  static final String EXECUTABLE_JOB_TYPE_FILTER =
-      "job_type IN ('SINGLE','BATCH_CHILD','CHAIN_STEP','WORKFLOW_BRANCH')";
-
   private static final String CLAIM_SELECT_COLUMNS = ClaimColumn.selectClause();
 
   private final SqlserverStoreContext ctx;
@@ -55,7 +52,7 @@ final class SqlserverJobClaimOperations implements JobClaimStore {
 
   // Overdue minutes since the row was due: DATEDIFF(SECOND, ...) is seconds, /60.0 converts to
   // minutes.
-  private static String pgOverdueMinutes(String timeColumn) {
+  private static String overdueMinutes(String timeColumn) {
     return "DATEDIFF(SECOND, " + timeColumn + ", SYSUTCDATETIME())/60.0";
   }
 
@@ -92,7 +89,7 @@ final class SqlserverJobClaimOperations implements JobClaimStore {
             executionTargetFilterSql,
             tagFilterSql,
             JobClaimSqlSupport.buildBoostedOrderBy(
-                timeColumn, pgOverdueMinutes(timeColumn), boostInterval));
+                timeColumn, overdueMinutes(timeColumn), boostInterval));
   }
 
   // language=SQL Server
@@ -118,7 +115,7 @@ final class SqlserverJobClaimOperations implements JobClaimStore {
             typeFilter,
             tagFilterSql,
             JobClaimSqlSupport.buildBoostedOrderBy(
-                timeColumn, pgOverdueMinutes(timeColumn), boostInterval, "q."));
+                timeColumn, overdueMinutes(timeColumn), boostInterval, "q."));
   }
 
   // SQL template is a compile-time constant defined in this package; runtime values are bound as

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobCountOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobCountOperations.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.util.RowValues;
+
+final class SqlserverJobCountOperations {
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverJobCountOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  long countPendingJobs() {
+    return countJobsByStatus(JobStatus.PENDING);
+  }
+
+  long countJobsByStatus(JobStatus status) {
+    if (SqlserverJobRowMapper.isLiveStatus(status)) {
+      // language=SQL Server
+      String sql = "SELECT COUNT(*) FROM scheduler_job_queue WHERE status = ?";
+      return ctx.countByNative(sql, status.name());
+    }
+    // language=SQL Server
+    String sql = "SELECT COUNT(*) FROM scheduler_job WHERE terminal_status = ?";
+    return ctx.countByNative(sql, status.name());
+  }
+
+  @SuppressWarnings("unchecked")
+  Map<JobStatus, Long> countJobsByStatuses() {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT status, COUNT(*) FROM scheduler_job_queue
+        GROUP BY status
+        UNION ALL
+        SELECT terminal_status, COUNT(*) FROM scheduler_job
+        WHERE terminal_status IS NOT NULL
+        GROUP BY terminal_status
+        """;
+    List<Object[]> rows = ctx.em().createNativeQuery(sql).getResultList();
+    Map<JobStatus, Long> counts = new EnumMap<>(JobStatus.class);
+    for (Object[] row : rows) {
+      counts.merge(JobStatus.valueOf((String) row[0]), ((Number) row[1]).longValue(), Long::sum);
+    }
+    return counts;
+  }
+
+  long countActiveJobs(JobExecutionType jobType) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job_queue
+        WHERE job_type = ? AND status IN ('PENDING','RUNNING')
+        """;
+    return ctx.countByNative(sql, jobType.name());
+  }
+
+  long countActiveNodes() {
+    // language=SQL Server
+    String sql = "SELECT COUNT(*) FROM scheduler_node";
+    return ctx.countByNative(sql);
+  }
+
+  long countReadyJobs(Instant now) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job_queue
+        WHERE status = 'PENDING' AND scheduled_time <= ?
+        """;
+    return ctx.countByNative(sql, Timestamp.from(now));
+  }
+
+  long countStuckJobs(Instant stuckThreshold) {
+    return countRunningJobsPickedBefore(stuckThreshold);
+  }
+
+  long countLongRunningJobs(Instant threshold) {
+    return countRunningJobsPickedBefore(threshold);
+  }
+
+  private long countRunningJobsPickedBefore(Instant threshold) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job_queue
+        WHERE status = 'RUNNING' AND picked_at < ?
+        """;
+    return ctx.countByNative(sql, Timestamp.from(threshold));
+  }
+
+  long countPendingBatchChildren() {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job_queue
+        WHERE job_type = 'BATCH_CHILD' AND status = 'PENDING'
+        """;
+    return ctx.countByNative(sql);
+  }
+
+  long countPendingJobsByPriority(JobPriority priority) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job_queue
+        WHERE status = 'PENDING' AND priority = ?
+        """;
+    return ctx.countByNative(sql, priority.ordinal());
+  }
+
+  @SuppressWarnings("unchecked")
+  Map<JobPriority, Long> countPendingJobsByPriorities() {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT priority, COUNT(*)
+        FROM scheduler_job_queue
+        WHERE status = 'PENDING'
+        GROUP BY priority
+        """;
+    List<Object[]> rows = ctx.em().createNativeQuery(sql).getResultList();
+    Map<JobPriority, Long> counts = new EnumMap<>(JobPriority.class);
+    JobPriority[] values = JobPriority.values();
+    for (Object[] row : rows) {
+      int ordinal = ((Number) row[0]).intValue();
+      if (ordinal >= 0 && ordinal < values.length) {
+        counts.put(values[ordinal], ((Number) row[1]).longValue());
+      }
+    }
+    return counts;
+  }
+
+  long countPendingJobsByType(JobExecutionType jobType) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COUNT(*) FROM scheduler_job_queue
+        WHERE status = 'PENDING' AND job_type = ?
+        """;
+    return ctx.countByNative(sql, jobType.name());
+  }
+
+  @SuppressWarnings("unchecked")
+  Map<JobExecutionType, Long> countPendingJobsByTypes() {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT job_type, COUNT(*)
+        FROM scheduler_job_queue
+        WHERE status = 'PENDING'
+        GROUP BY job_type
+        """;
+    List<Object[]> rows = ctx.em().createNativeQuery(sql).getResultList();
+    Map<JobExecutionType, Long> counts = new EnumMap<>(JobExecutionType.class);
+    for (Object[] row : rows) {
+      counts.put(JobExecutionType.valueOf((String) row[0]), ((Number) row[1]).longValue());
+    }
+    return counts;
+  }
+
+  long countJobsByStatusSince(JobStatus status, Instant since) {
+    if (SqlserverJobRowMapper.isLiveStatus(status)) {
+      // language=SQL Server
+      String sql = "SELECT COUNT(*) FROM scheduler_job_queue WHERE status = ? AND updated_at >= ?";
+      return ctx.countByNative(sql, status.name(), Timestamp.from(since));
+    }
+    // language=SQL Server
+    String sql =
+        "SELECT COUNT(*) FROM scheduler_job WHERE terminal_status = ? AND terminated_at >= ?";
+    return ctx.countByNative(sql, status.name(), Timestamp.from(since));
+  }
+
+  long countJobsWithRetries() {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT
+          (SELECT COUNT(*) FROM scheduler_job_queue WHERE attempts > 0)
+          + (SELECT COUNT(*) FROM scheduler_job WHERE total_attempts > 0)
+        """;
+    return ctx.countByNative(sql);
+  }
+
+  double getRetryRateStats(Instant since) {
+    try {
+      Timestamp sinceTs = Timestamp.from(since);
+      // language=SQL Server
+      String sql =
+          """
+          SELECT COALESCE(
+            CAST(
+              ((SELECT COUNT(*) FROM scheduler_job_queue
+                  WHERE attempts > 0 AND updated_at >= ?)
+               + (SELECT COUNT(*) FROM scheduler_job
+                  WHERE total_attempts > 0 AND terminated_at >= ?))
+              AS DOUBLE PRECISION)
+            / NULLIF(
+              ((SELECT COUNT(*) FROM scheduler_job_queue WHERE updated_at >= ?)
+               + (SELECT COUNT(*) FROM scheduler_job
+                  WHERE terminated_at >= ?)), 0), 0)
+          """;
+      Object result =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, sinceTs)
+              .setParameter(2, sinceTs)
+              .setParameter(3, sinceTs)
+              .setParameter(4, sinceTs)
+              .getSingleResult();
+      return result == null ? 0.0 : ((Number) result).doubleValue();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get retry rate stats", e);
+    }
+  }
+
+  double getAverageProcessingTime(Instant since) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COALESCE(AVG(execution_duration_ms), 0) FROM scheduler_job
+        WHERE terminal_status = 'SUCCEEDED' AND execution_duration_ms IS NOT NULL
+          AND terminated_at >= ?
+        """;
+    Object result =
+        ctx.em().createNativeQuery(sql).setParameter(1, Timestamp.from(since)).getSingleResult();
+    return result == null ? 0.0 : ((Number) result).doubleValue();
+  }
+
+  double getAverageBatchSize(Instant since) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COALESCE(AVG(b.total_items), 0) FROM scheduler_batch b
+        JOIN scheduler_job c ON c.job_id = b.batch_id
+        LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        WHERE COALESCE(q.updated_at, c.terminated_at) >= ?
+        """;
+    Object result =
+        ctx.em().createNativeQuery(sql).setParameter(1, Timestamp.from(since)).getSingleResult();
+    return result == null ? 0.0 : ((Number) result).doubleValue();
+  }
+
+  @SuppressWarnings("unchecked")
+  Optional<Instant> getOldestPendingJobTime() {
+    // language=SQL Server
+    String sql = "SELECT MIN(scheduled_time) FROM scheduler_job_queue WHERE status = 'PENDING'";
+    List<Object> results = ctx.em().createNativeQuery(sql).getResultList();
+    if (results.isEmpty() || results.get(0) == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(RowValues.instantOrNull(results.get(0)));
+  }
+
+  long getQueueWaitTimePercentile(double percentile) {
+    if (Double.isNaN(percentile) || percentile < 0.0 || percentile > 1.0) {
+      throw new IllegalArgumentException("percentile must be in [0.0, 1.0], got: " + percentile);
+    }
+    // PERCENTILE_DISC (discrete) returns an actually-observed value by nearest-rank, matching the
+    // MySQL CUME_DIST path and the Mongo sort+skip path. PERCENTILE_CONT would interpolate between
+    // observed values and diverge from the other stores.
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COALESCE(MAX(p), 0) FROM (
+          SELECT PERCENTILE_DISC(?) WITHIN GROUP (ORDER BY queue_wait_ms) OVER () AS p
+          FROM scheduler_job WHERE queue_wait_ms IS NOT NULL
+            AND terminal_status = 'SUCCEEDED'
+        ) t
+        """;
+    Object result = ctx.em().createNativeQuery(sql).setParameter(1, percentile).getSingleResult();
+    return result == null ? 0L : ((Number) result).longValue();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobCountOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobCountOperations.java
@@ -207,35 +207,23 @@ final class SqlserverJobCountOperations {
   }
 
   double getRetryRateStats(Instant since) {
-    try {
-      Timestamp sinceTs = Timestamp.from(since);
-      // language=SQL Server
-      String sql =
-          """
-          SELECT COALESCE(
-            CAST(
-              ((SELECT COUNT(*) FROM scheduler_job_queue
-                  WHERE attempts > 0 AND updated_at >= ?)
-               + (SELECT COUNT(*) FROM scheduler_job
-                  WHERE total_attempts > 0 AND terminated_at >= ?))
-              AS DOUBLE PRECISION)
-            / NULLIF(
-              ((SELECT COUNT(*) FROM scheduler_job_queue WHERE updated_at >= ?)
-               + (SELECT COUNT(*) FROM scheduler_job
-                  WHERE terminated_at >= ?)), 0), 0)
-          """;
-      Object result =
-          ctx.em()
-              .createNativeQuery(sql)
-              .setParameter(1, sinceTs)
-              .setParameter(2, sinceTs)
-              .setParameter(3, sinceTs)
-              .setParameter(4, sinceTs)
-              .getSingleResult();
-      return result == null ? 0.0 : ((Number) result).doubleValue();
-    } catch (RuntimeException e) {
-      throw ctx.translateTransientStoreException("get retry rate stats", e);
-    }
+    Timestamp sinceTs = Timestamp.from(since);
+    // language=SQL Server
+    String sql =
+        """
+        SELECT COALESCE(
+          CAST(
+            ((SELECT COUNT(*) FROM scheduler_job_queue
+                WHERE attempts > 0 AND updated_at >= ?)
+             + (SELECT COUNT(*) FROM scheduler_job
+                WHERE total_attempts > 0 AND terminated_at >= ?))
+            AS DOUBLE PRECISION)
+          / NULLIF(
+            ((SELECT COUNT(*) FROM scheduler_job_queue WHERE updated_at >= ?)
+             + (SELECT COUNT(*) FROM scheduler_job
+                WHERE terminated_at >= ?)), 0), 0)
+        """;
+    return ctx.doubleByNativeOrZero(sql, sinceTs, sinceTs, sinceTs, sinceTs);
   }
 
   double getAverageProcessingTime(Instant since) {
@@ -246,9 +234,7 @@ final class SqlserverJobCountOperations {
         WHERE terminal_status = 'SUCCEEDED' AND execution_duration_ms IS NOT NULL
           AND terminated_at >= ?
         """;
-    Object result =
-        ctx.em().createNativeQuery(sql).setParameter(1, Timestamp.from(since)).getSingleResult();
-    return result == null ? 0.0 : ((Number) result).doubleValue();
+    return ctx.doubleByNativeOrZero(sql, Timestamp.from(since));
   }
 
   double getAverageBatchSize(Instant since) {
@@ -260,9 +246,7 @@ final class SqlserverJobCountOperations {
         LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
         WHERE COALESCE(q.updated_at, c.terminated_at) >= ?
         """;
-    Object result =
-        ctx.em().createNativeQuery(sql).setParameter(1, Timestamp.from(since)).getSingleResult();
-    return result == null ? 0.0 : ((Number) result).doubleValue();
+    return ctx.doubleByNativeOrZero(sql, Timestamp.from(since));
   }
 
   @SuppressWarnings("unchecked")

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobCrudOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobCrudOperations.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.JobAnalyticsStore;
+import run.ratchet.store.spi.JobBulkStore;
+import run.ratchet.store.spi.JobCrudStore;
+
+final class SqlserverJobCrudOperations implements JobCrudStore, JobBulkStore, JobAnalyticsStore {
+
+  private final SqlserverJobReadOperations reads;
+  private final SqlserverJobCountOperations counts;
+  private final SqlserverJobDeleteOperations deletes;
+  private final SqlserverJobWriteOperations writes;
+  private final SqlserverTagOperations tags;
+
+  SqlserverJobCrudOperations(
+      SqlserverJobReadOperations reads,
+      SqlserverJobCountOperations counts,
+      SqlserverJobDeleteOperations deletes,
+      SqlserverJobWriteOperations writes,
+      SqlserverTagOperations tags) {
+    this.reads = reads;
+    this.counts = counts;
+    this.deletes = deletes;
+    this.writes = writes;
+    this.tags = tags;
+  }
+
+  @Override
+  public JobEntity create(JobEntity job) {
+    writes.saveInsert(job);
+    return job;
+  }
+
+  @Override
+  public JobEntity save(JobEntity job) {
+    return writes.save(job);
+  }
+
+  @Override
+  public Optional<JobEntity> findById(UUID id) {
+    return reads.findById(id);
+  }
+
+  @Override
+  public Optional<JobEntity> findByIdLatest(UUID id) {
+    return reads.findByIdLatest(id);
+  }
+
+  @Override
+  public void delete(UUID id) {
+    deletes.delete(id);
+  }
+
+  @Override
+  public JobStatus getJobStatus(UUID id) {
+    return reads.getJobStatus(id);
+  }
+
+  @Override
+  public List<JobEntity> findByIds(List<UUID> ids) {
+    return reads.findByIds(ids);
+  }
+
+  @Override
+  public Optional<JobEntity> findActiveByBusinessKey(String businessKey) {
+    return reads.findActiveByBusinessKey(businessKey);
+  }
+
+  @Override
+  public Optional<JobEntity> findByIdempotencyKey(String idempotencyKey) {
+    return reads.findByIdempotencyKey(idempotencyKey);
+  }
+
+  @Override
+  public List<JobEntity> findDependants(UUID parentJobId, int limit, int offset) {
+    return reads.findDependants(parentJobId, limit, offset);
+  }
+
+  @Override
+  public long countPendingJobs() {
+    return counts.countPendingJobs();
+  }
+
+  @Override
+  public long countJobsByStatus(JobStatus status) {
+    return counts.countJobsByStatus(status);
+  }
+
+  @Override
+  public Map<JobStatus, Long> countJobsByStatuses() {
+    return counts.countJobsByStatuses();
+  }
+
+  @Override
+  public long countActiveJobs(JobExecutionType jobType) {
+    return counts.countActiveJobs(jobType);
+  }
+
+  @Override
+  public long countActiveNodes() {
+    return counts.countActiveNodes();
+  }
+
+  @Override
+  public long countReadyJobs(Instant now) {
+    return counts.countReadyJobs(now);
+  }
+
+  @Override
+  public long countStuckJobs(Instant stuckThreshold) {
+    return counts.countStuckJobs(stuckThreshold);
+  }
+
+  @Override
+  public long countLongRunningJobs(Instant threshold) {
+    return counts.countLongRunningJobs(threshold);
+  }
+
+  @Override
+  public long countPendingBatchChildren() {
+    return counts.countPendingBatchChildren();
+  }
+
+  @Override
+  public long countPendingJobsByPriority(JobPriority priority) {
+    return counts.countPendingJobsByPriority(priority);
+  }
+
+  @Override
+  public Map<JobPriority, Long> countPendingJobsByPriorities() {
+    return counts.countPendingJobsByPriorities();
+  }
+
+  @Override
+  public long countPendingJobsByType(JobExecutionType jobType) {
+    return counts.countPendingJobsByType(jobType);
+  }
+
+  @Override
+  public Map<JobExecutionType, Long> countPendingJobsByTypes() {
+    return counts.countPendingJobsByTypes();
+  }
+
+  @Override
+  public long countJobsByStatusSince(JobStatus status, Instant since) {
+    return counts.countJobsByStatusSince(status, since);
+  }
+
+  @Override
+  public long countJobsWithRetries() {
+    return counts.countJobsWithRetries();
+  }
+
+  @Override
+  public double getRetryRateStats(Instant since) {
+    return counts.getRetryRateStats(since);
+  }
+
+  @Override
+  public double getAverageProcessingTime(Instant since) {
+    return counts.getAverageProcessingTime(since);
+  }
+
+  @Override
+  public double getAverageBatchSize(Instant since) {
+    return counts.getAverageBatchSize(since);
+  }
+
+  @Override
+  public Optional<Instant> getOldestPendingJobTime() {
+    return counts.getOldestPendingJobTime();
+  }
+
+  @Override
+  public long getQueueWaitTimePercentile(double percentile) {
+    return counts.getQueueWaitTimePercentile(percentile);
+  }
+
+  @Override
+  public void bulkInsert(List<JobEntity> jobs) {
+    writes.bulkInsert(jobs);
+  }
+
+  @Override
+  public int deleteJobsByIds(List<UUID> ids) {
+    return deletes.deleteJobsByIds(ids);
+  }
+
+  @Override
+  public int deleteDlqOlderThan(Instant cutoff) {
+    return deletes.deleteDlqOlderThan(cutoff);
+  }
+
+  @Override
+  public int resetOrphanJobs(Duration grace) {
+    return deletes.resetOrphanJobs(grace);
+  }
+
+  @Override
+  public int resetOrphanJobsBefore(Instant cutoff) {
+    return deletes.resetOrphanJobsBefore(cutoff);
+  }
+
+  @Override
+  public int resetOrphanJobsForNode(String nodeId) {
+    return deletes.resetOrphanJobsForNode(nodeId);
+  }
+
+  @Override
+  public Map<JobStatus, Long> countJobsByStatusForTag(String tag) {
+    return tags.countJobsByStatusForTag(tag);
+  }
+
+  @Override
+  public Map<String, Long> countJobsByParamForTag(String tag, String paramKey) {
+    return tags.countJobsByParamForTag(tag, paramKey);
+  }
+
+  @Override
+  public Map<String, Long> countJobsByExecutionNodeForTag(String tag) {
+    return tags.countJobsByExecutionNodeForTag(tag);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobDeleteOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobDeleteOperations.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+final class SqlserverJobDeleteOperations {
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverBusinessKeyReservations reservations;
+
+  SqlserverJobDeleteOperations(
+      SqlserverStoreContext ctx, SqlserverBusinessKeyReservations reservations) {
+    this.ctx = ctx;
+    this.reservations = reservations;
+  }
+
+  void delete(UUID id) {
+    try {
+      reservations.deleteReservationByOwner(id);
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_job WHERE job_id = ?";
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(id))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete job", e);
+    }
+  }
+
+  int deleteJobsByIds(List<UUID> ids) {
+    if (ids.isEmpty()) {
+      return 0;
+    }
+    try {
+      reservations.deleteReservationsByOwners(ids);
+      String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_job WHERE job_id IN (" + placeholders + ")";
+      Query jobDelete = ctx.em().createNativeQuery(sql);
+      bindUuidParameters(jobDelete, ids);
+      return jobDelete.executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete jobs by ids", e);
+    }
+  }
+
+  int deleteDlqOlderThan(Instant cutoff) {
+    try {
+      // language=SQL Server
+      String deleteSql =
+          """
+          DELETE FROM scheduler_job
+          WHERE terminal_status = 'FAILED' AND total_attempts >= max_retries
+            AND terminated_at < ?
+          """;
+      return ctx.em()
+          .createNativeQuery(deleteSql)
+          .setParameter(1, Timestamp.from(cutoff))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete dlq older than cutoff", e);
+    }
+  }
+
+  private static void bindUuidParameters(Query query, List<UUID> ids) {
+    int parameter = 1;
+    for (UUID id : ids) {
+      query.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
+    }
+  }
+
+  int resetOrphanJobs(Duration grace) {
+    try {
+      long graceSeconds = grace.toSeconds();
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              picked_by = NULL, picked_at = NULL,
+              updated_at = SYSUTCDATETIME()
+          WHERE status = 'RUNNING'
+            AND NOT EXISTS (
+              SELECT 1 FROM scheduler_node n
+              WHERE n.node_id = scheduler_job_queue.picked_by
+                AND n.heartbeat_ts > DATEADD(SECOND, -(?), SYSUTCDATETIME())
+            )
+            AND DATEDIFF_BIG(SECOND, picked_at, SYSUTCDATETIME()) >= ?
+          """;
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, graceSeconds)
+          .setParameter(2, graceSeconds)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("reset orphan jobs", e);
+    }
+  }
+
+  int resetOrphanJobsBefore(Instant cutoff) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              picked_by = NULL, picked_at = NULL,
+              updated_at = SYSUTCDATETIME()
+          WHERE status = 'RUNNING'
+            AND NOT EXISTS (
+              SELECT 1 FROM scheduler_node n
+              WHERE n.node_id = scheduler_job_queue.picked_by
+                AND n.heartbeat_ts >= ?
+            )
+            AND picked_at < ?
+          """;
+      Timestamp cutoffTimestamp = Timestamp.from(cutoff);
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, cutoffTimestamp)
+          .setParameter(2, cutoffTimestamp)
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("reset orphan jobs before cutoff", e);
+    }
+  }
+
+  int resetOrphanJobsForNode(String nodeId) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              picked_by = NULL, picked_at = NULL,
+              updated_at = SYSUTCDATETIME()
+          WHERE status = 'RUNNING' AND picked_by = ?
+          """;
+      return ctx.em().createNativeQuery(sql).setParameter(1, nodeId).executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("reset orphan jobs for node", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobDeleteOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobDeleteOperations.java
@@ -77,7 +77,7 @@ final class SqlserverJobDeleteOperations {
           """;
       return ctx.em()
           .createNativeQuery(deleteSql)
-          .setParameter(1, Timestamp.from(cutoff))
+          .setParameter(1, SqlserverTimestamps.microTimestamp(cutoff))
           .executeUpdate();
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("delete dlq older than cutoff", e);
@@ -136,7 +136,7 @@ final class SqlserverJobDeleteOperations {
             )
             AND picked_at < ?
           """;
-      Timestamp cutoffTimestamp = Timestamp.from(cutoff);
+      Timestamp cutoffTimestamp = SqlserverTimestamps.microTimestamp(cutoff);
       return ctx.em()
           .createNativeQuery(sql)
           .setParameter(1, cutoffTimestamp)

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobLifecycleOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobLifecycleOperations.java
@@ -36,7 +36,7 @@ final class SqlserverJobLifecycleOperations
       SqlserverBatchOperations batches) {
     this.transitions = new SqlserverJobStatusTransitions(ctx);
     this.terminals = new SqlserverJobTerminalOperations(ctx, reservations, batches);
-    this.recurring = new SqlserverJobRecurringAndResetOperations(ctx, reservations);
+    this.recurring = new SqlserverJobRecurringAndResetOperations(ctx);
   }
 
   @Override

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobLifecycleOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobLifecycleOperations.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.time.Instant;
+import java.util.UUID;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.JobPauseStore;
+import run.ratchet.store.spi.JobRetryStore;
+import run.ratchet.store.spi.JobTerminalStore;
+
+final class SqlserverJobLifecycleOperations
+    implements JobBatchStatusStore, JobTerminalStore, JobRetryStore, JobPauseStore {
+
+  private final SqlserverJobStatusTransitions transitions;
+  private final SqlserverJobTerminalOperations terminals;
+  private final SqlserverJobRecurringAndResetOperations recurring;
+
+  SqlserverJobLifecycleOperations(
+      SqlserverStoreContext ctx,
+      SqlserverBusinessKeyReservations reservations,
+      SqlserverBatchOperations batches) {
+    this.transitions = new SqlserverJobStatusTransitions(ctx);
+    this.terminals = new SqlserverJobTerminalOperations(ctx, reservations, batches);
+    this.recurring = new SqlserverJobRecurringAndResetOperations(ctx, reservations);
+  }
+
+  @Override
+  public void updateJobStatus(UUID id, JobStatus status, String errorMessage) {
+    terminals.updateJobStatus(id, status, errorMessage);
+  }
+
+  @Override
+  public boolean compareAndSwapStatus(
+      UUID id, JobStatus expected, JobStatus newStatus, String error) {
+    return terminals.compareAndSwapStatus(id, expected, newStatus, error);
+  }
+
+  @Override
+  public int incrementRetryAttempt(UUID id) {
+    return terminals.incrementRetryAttempt(id);
+  }
+
+  @Override
+  public boolean tryPickUpJob(UUID id, String nodeId) {
+    return transitions.tryPickUpJob(id, nodeId);
+  }
+
+  @Override
+  public boolean markJobSucceeded(
+      UUID id,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs) {
+    return terminals.markJobSucceeded(
+        id, resultJson, resultType, start, end, durationMs, queueWaitMs);
+  }
+
+  @Override
+  public boolean markJobSucceededMinimal(
+      UUID id, Instant start, Instant end, Long durationMs, Long queueWaitMs) {
+    return terminals.markJobSucceededMinimal(id, start, end, durationMs, queueWaitMs);
+  }
+
+  @Override
+  public boolean markJobSucceededAndUpdateBatch(
+      UUID jobId,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs,
+      UUID batchId) {
+    return terminals.markJobSucceededAndUpdateBatch(
+        jobId, resultJson, resultType, start, end, durationMs, queueWaitMs, batchId);
+  }
+
+  @Override
+  public boolean scheduleJobRetry(UUID id, String error, Instant newScheduledTime, int attempts) {
+    return terminals.scheduleJobRetry(id, error, newScheduledTime, attempts);
+  }
+
+  @Override
+  public boolean markJobFailedTerminal(UUID id, String terminalError, int totalAttempts) {
+    return terminals.markJobFailedTerminal(id, terminalError, totalAttempts);
+  }
+
+  @Override
+  public boolean cancelJob(UUID id) {
+    return terminals.cancelJob(id);
+  }
+
+  @Override
+  public boolean resetRunningJob(UUID id, String nodeId) {
+    return recurring.resetRunningJob(id, nodeId);
+  }
+
+  @Override
+  public int resetRunningJobs(String nodeId) {
+    return recurring.resetRunningJobs(nodeId);
+  }
+
+  @Override
+  public int cancelJobsByTag(String tag) {
+    return recurring.cancelJobsByTag(tag);
+  }
+
+  @Override
+  public boolean resetFailedToPending(UUID id) {
+    return terminals.resetFailedToPending(id);
+  }
+
+  @Override
+  public boolean transitionToPaused(UUID id, JobStatus expected) {
+    return transitions.transitionToPaused(id, expected);
+  }
+
+  @Override
+  public boolean transitionFromPaused(UUID id, JobStatus target) {
+    return transitions.transitionFromPaused(id, target);
+  }
+
+  @Override
+  public JobStatus transitionFromPausedAtomic(UUID id) {
+    return transitions.transitionFromPausedAtomic(id);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperations.java
@@ -1,0 +1,637 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobQuerySortField;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.JobType;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.query.JobQueryCursor;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+/**
+ * Dashboard-oriented search and count queries over the SQL Server store.
+ *
+ * <p>Uses the same LEFT JOIN projection as {@link SqlserverJobReadOperations} so that {@link
+ * SqlserverJobRowMapper#hydrate} can reconstruct both live and terminal jobs from a single result
+ * set. WHERE clause conditions are built with a parameterized {@link StringBuilder}; no
+ * user-supplied values are concatenated into SQL strings.
+ *
+ * <p>When {@link JobFilter#includeArchived()} is true and no principal filter is active, a {@code
+ * UNION ALL} pulls matching rows from {@code scheduler_job_archive} into the same result set. See
+ * MySQL counterpart for column-mapping details; the SQL Server projection is identical in
+ * structure.
+ */
+final class SqlserverJobQueryOperations {
+
+  /*
+   * Keep this builder dialect-local. It mirrors the MySQL builder in shape, but the common-looking
+   * clauses sit next to SQL Server-specific hydration columns, trace JSON extraction, archive UNION
+   * positions, and native UUID binding. Limit future sharing to small pure helpers with contract
+   * tests.
+   */
+
+  // language=SQL Server
+  private static final String HYDRATION_FROM =
+      """
+      FROM scheduler_job c
+      LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+      """;
+
+  /**
+   * Archive rows projected to match {@link SqlserverJobRowMapper#hydrationSelect()} column
+   * positions. NULL placeholders occupy columns not present in the archive.
+   *
+   * <p>This projection MUST emit exactly the same number of columns as {@code hydrationSelect()}.
+   * The two SELECTs are combined with {@code UNION ALL}; a column-count mismatch is rejected by SQL
+   * Server before any row is returned, breaking every archive-inclusive search. The leading two
+   * NULLs cover {@code payload}/{@code params}, which the archive does not retain.
+   */
+  // language=SQL Server
+  private static final String ARCHIVE_PROJECTION =
+      """
+      a.original_job_id,
+      a.job_type,
+      a.priority,
+      a.max_retries,
+      a.backoff_policy,
+      a.backoff_param_ms,
+      a.timeout_sec,
+      a.cron_expr,
+      a.zone_id,
+      NULL,
+      NULL,
+      a.target_class,
+      a.method_name,
+      NULL,
+      a.business_key,
+      NULL,
+      NULL,
+      NULL,
+      a.depended_on,
+      a.superseded_by,
+      a.original_created_at,
+      NULL,
+      a.final_status,
+      a.final_error,
+      a.total_attempts,
+      a.completion_time,
+      a.first_execution_time,
+      NULL,
+      a.total_execution_time_ms,
+      a.queue_wait_ms,
+      a.job_result,
+      a.result_type,
+      NULL,
+      NULL,
+      NULL,
+      a.original_scheduled_time,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      a.archived_at,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      NULL\
+      """;
+
+  private static final int MAX_RESULT_LIMIT = 1000;
+
+  /*
+   * SQL Server allows ORDER BY by output-column position after UNION. These constants are mapped
+   * to SqlserverJobRowMapper.hydrationSelect()/ARCHIVE_PROJECTION positions, which must stay in
+   * lock-step. They are internal constants, not caller input; dynamic ORDER BY text is bounded to
+   * this mapping plus ASC/DESC derived from a boolean.
+   */
+  private static final int POS_JOB_ID = 1;
+  private static final int POS_PRIORITY = 3;
+  private static final int POS_CREATED_AT = 21;
+  private static final int POS_TERMINAL_STATUS = 23;
+  private static final int POS_Q_SCHEDULED_TIME = 36;
+  private static final int POS_Q_UPDATED_AT = 43;
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverTagOperations tags;
+
+  SqlserverJobQueryOperations(SqlserverStoreContext ctx, SqlserverTagOperations tags) {
+    this.ctx = ctx;
+    this.tags = tags;
+  }
+
+  private static Object parseSortValue(JobQueryCursor cursor) {
+    return switch (cursor.sortField()) {
+      case CREATED_AT, SCHEDULED_TIME, UPDATED_AT ->
+          Timestamp.from(Instant.parse(cursor.sortValue()));
+      case PRIORITY -> Integer.parseInt(cursor.sortValue());
+      case STATUS -> cursor.sortValue();
+    };
+  }
+
+  private static ParsedCursor parseCursor(JobFilter filter) {
+    if (filter == null || filter.cursor() == null) {
+      return null;
+    }
+    try {
+      JobQueryCursor cursor = JobQueryCursor.decode(filter.cursor());
+      if (!cursor.matchesFilterSort(filter)) {
+        // Cursor was minted for a different sort field/direction; seeking on it while ORDER BY
+        // uses the live sort would skip or repeat rows. Fall back to offset pagination instead.
+        return null;
+      }
+      return new ParsedCursor(cursor, parseSortValue(cursor));
+    } catch (IllegalArgumentException | DateTimeParseException ignored) {
+      return null;
+    }
+  }
+
+  private static void appendStringEq(
+      String col, String value, StringBuilder where, List<Object> params) {
+    if (value == null || value.isEmpty()) {
+      return;
+    }
+    and(where, col + " = ?");
+    params.add(value);
+  }
+
+  // ── WHERE clause builder ────────────────────────────────────────────────
+
+  private static void appendInstantGte(
+      String col, Instant value, StringBuilder where, List<Object> params) {
+    if (value == null) {
+      return;
+    }
+    and(where, col + " >= ?");
+    params.add(Timestamp.from(value));
+  }
+
+  private static void appendInstantLt(
+      String col, Instant value, StringBuilder where, List<Object> params) {
+    if (value == null) {
+      return;
+    }
+    and(where, col + " < ?");
+    params.add(Timestamp.from(value));
+  }
+
+  private static String buildOrderBy(JobFilter filter) {
+    if (filter == null) {
+      return " ORDER BY c.created_at DESC, c.job_id ASC";
+    }
+    JobQuerySortField field =
+        filter.sortField() != null ? filter.sortField() : JobQuerySortField.CREATED_AT;
+    String dir = filter.sortAscending() ? "ASC" : "DESC";
+    return " ORDER BY " + sortColumn(field) + " " + dir + ", c.job_id ASC";
+  }
+
+  private static String sortColumn(JobQuerySortField field) {
+    return switch (field) {
+      case CREATED_AT -> "c.created_at";
+      case SCHEDULED_TIME -> "COALESCE(q.scheduled_time, c.execution_start_time, c.created_at)";
+      case UPDATED_AT -> "COALESCE(q.updated_at, c.terminated_at, c.created_at)";
+      case PRIORITY -> "c.priority";
+      case STATUS -> "COALESCE(q.status, c.terminal_status)";
+    };
+  }
+
+  private static String archiveSortColumn(JobQuerySortField field) {
+    return switch (field) {
+      case CREATED_AT -> "a.original_created_at";
+      case SCHEDULED_TIME -> "a.original_scheduled_time";
+      case UPDATED_AT -> "a.archived_at";
+      case PRIORITY -> "a.priority";
+      case STATUS -> "a.final_status";
+    };
+  }
+
+  private static int unionSortColumnPosition(JobFilter filter) {
+    JobQuerySortField field =
+        (filter == null || filter.sortField() == null)
+            ? JobQuerySortField.CREATED_AT
+            : filter.sortField();
+    return switch (field) {
+      case CREATED_AT -> POS_CREATED_AT;
+      case SCHEDULED_TIME -> POS_Q_SCHEDULED_TIME;
+      case UPDATED_AT -> POS_Q_UPDATED_AT;
+      case PRIORITY -> POS_PRIORITY;
+      case STATUS -> POS_TERMINAL_STATUS;
+    };
+  }
+
+  /**
+   * Decides whether the archive UNION should be appended to the live-row query.
+   *
+   * <p>The archive UNION is intentionally skipped when {@code callerPrincipal} is non-null because
+   * principal-scoped queries do not span archived rows: the archive table does not carry the
+   * principal column, so appending the UNION would silently return archived rows belonging to other
+   * principals. Callers that need both principal scoping and archive inclusion must handle that at
+   * the policy or service layer; see {@code JobAuthorizationPolicy.filterForPrincipal} for the
+   * rationale.
+   */
+  private static boolean useArchive(JobFilter filter) {
+    return filter != null
+        && filter.includeArchived()
+        && (filter.callerPrincipal() == null || filter.callerPrincipal().isEmpty());
+  }
+
+  private static void and(StringBuilder where, String condition) {
+    if (where.length() > 0) {
+      where.append(" AND ");
+    }
+    where.append(condition);
+  }
+
+  private static String placeholders(int count) {
+    return "?,".repeat(count - 1) + "?";
+  }
+
+  private static void bindParams(Query q, List<Object> params) {
+    for (int i = 0; i < params.size(); i++) {
+      q.setParameter(i + 1, params.get(i));
+    }
+  }
+
+  /*
+   * LIMIT/OFFSET are concatenated because JPA providers vary in native-query support for binding
+   * them. The values are primitive ints computed by this store layer (limit is clamped by caller
+   * before use), so they cannot carry SQL tokens.
+   */
+  private static String limitOffsetClause(int limit, int offset) {
+    return " OFFSET " + offset + " ROWS FETCH NEXT " + limit + " ROWS ONLY";
+  }
+
+  @SuppressWarnings("unchecked")
+  List<JobEntity> searchJobs(JobFilter filter, int limit, int offset) {
+    boolean archive = useArchive(filter);
+    int safeLimit = Math.min(limit, MAX_RESULT_LIMIT);
+    ParsedCursor cursor = parseCursor(filter);
+    // A valid cursor uses keyset pagination, so offset applies only without a usable cursor.
+    int effectiveOffset = cursor != null ? 0 : offset;
+
+    List<Object> params = new ArrayList<>();
+    String sql;
+    if (archive) {
+      sql = buildUnionSearchSql(filter, params, safeLimit, effectiveOffset);
+    } else {
+      sql =
+          "SELECT "
+              + SqlserverJobRowMapper.hydrationSelect()
+              + " "
+              + HYDRATION_FROM
+              + buildWhere(filter, params)
+              + buildOrderBy(filter)
+              + limitOffsetClause(safeLimit, effectiveOffset);
+    }
+
+    try {
+      Query q = ctx.em().createNativeQuery(sql);
+      bindParams(q, params);
+      List<Object[]> rows = q.getResultList();
+      List<JobEntity> result = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        JobEntity job = SqlserverJobRowMapper.hydrate(row);
+        if (job != null) {
+          result.add(job);
+        }
+      }
+      tags.hydrateTagsBatch(result);
+      return result;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("search jobs", e);
+    }
+  }
+
+  long countJobs(JobFilter filter) {
+    boolean archive = useArchive(filter);
+    List<Object> params = new ArrayList<>();
+    String sql;
+    if (archive) {
+      sql =
+          "SELECT COUNT(*) FROM ("
+              + "SELECT 1 "
+              + HYDRATION_FROM
+              + buildWhere(filter, params)
+              + " UNION ALL "
+              + "SELECT 1 FROM scheduler_job_archive a"
+              + buildArchiveWhere(filter, params)
+              + ") AS combined";
+    } else {
+      // language=SQL Server
+      sql = "SELECT COUNT(*) " + HYDRATION_FROM + buildWhere(filter, params);
+    }
+    try {
+      Query q = ctx.em().createNativeQuery(sql);
+      bindParams(q, params);
+      return ((Number) q.getSingleResult()).longValue();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs", e);
+    }
+  }
+
+  private String buildWhere(JobFilter filter, List<Object> params) {
+    if (filter == null) {
+      return "";
+    }
+    StringBuilder where = new StringBuilder();
+
+    appendStatusCondition(filter, where, params);
+    appendJobTypeCondition(filter, where, params);
+    appendPriorityCondition(filter, where, params);
+    appendStringEq("c.business_key", filter.businessKey(), where, params);
+    appendStringEq("c.idempotency_key", filter.idempotencyKey(), where, params);
+    appendStringEq("c.target_class", filter.targetClass(), where, params);
+    appendStringEq("c.caller_principal", filter.callerPrincipal(), where, params);
+    appendStringEq("q.picked_by", filter.pickedBy(), where, params);
+    appendStringEq("c.resource_name", filter.resourceName(), where, params);
+    appendStringEq(
+        "JSON_VALUE(c.trace_context, '$.traceparent')", filter.traceCorrelationId(), where, params);
+    appendParentJobId(filter, where, params);
+    appendTagCondition(filter, where, params);
+    appendInstantGte("c.created_at", filter.createdAfter(), where, params);
+    appendInstantLt("c.created_at", filter.createdBefore(), where, params);
+    appendInstantGte(
+        "COALESCE(q.scheduled_time, c.execution_start_time)",
+        filter.scheduledAfter(),
+        where,
+        params);
+    appendInstantLt(
+        "COALESCE(q.scheduled_time, c.execution_start_time)",
+        filter.scheduledBefore(),
+        where,
+        params);
+    appendInstantGte(
+        "COALESCE(q.updated_at, c.terminated_at, c.created_at)",
+        filter.updatedAfter(),
+        where,
+        params);
+    appendCursorCondition(filter, where, params);
+
+    if (where.length() == 0) {
+      return "";
+    }
+    return " WHERE " + where;
+  }
+
+  private String buildArchiveWhere(JobFilter filter, List<Object> params) {
+    if (filter == null) {
+      return "";
+    }
+    StringBuilder where = new StringBuilder();
+
+    appendArchiveStatusCondition(filter, where, params);
+    appendArchiveJobTypeCondition(filter, where, params);
+    appendArchivePriorityCondition(filter, where, params);
+    appendStringEq("a.business_key", filter.businessKey(), where, params);
+    appendStringEq("a.target_class", filter.targetClass(), where, params);
+    appendArchiveParentJobId(filter, where, params);
+    appendInstantGte("a.original_created_at", filter.createdAfter(), where, params);
+    appendInstantLt("a.original_created_at", filter.createdBefore(), where, params);
+    appendInstantGte("a.original_scheduled_time", filter.scheduledAfter(), where, params);
+    appendInstantLt("a.original_scheduled_time", filter.scheduledBefore(), where, params);
+    appendInstantGte("a.archived_at", filter.updatedAfter(), where, params);
+    appendArchiveCursorCondition(filter, where, params);
+
+    return where.length() == 0 ? "" : " WHERE " + where;
+  }
+
+  private String buildUnionSearchSql(JobFilter filter, List<Object> params, int limit, int offset) {
+    List<Object> liveParams = new ArrayList<>();
+    String liveWhere = buildWhere(filter, liveParams);
+    List<Object> archiveParams = new ArrayList<>();
+    String archiveWhere = buildArchiveWhere(filter, archiveParams);
+    params.addAll(liveParams);
+    params.addAll(archiveParams);
+
+    int sortPos = unionSortColumnPosition(filter);
+    String dir = (filter != null && filter.sortAscending()) ? "ASC" : "DESC";
+
+    return "SELECT * FROM ("
+        + "SELECT "
+        + SqlserverJobRowMapper.hydrationSelect()
+        + " "
+        + HYDRATION_FROM
+        + liveWhere
+        + " UNION ALL "
+        + "SELECT "
+        + ARCHIVE_PROJECTION
+        + " FROM scheduler_job_archive a"
+        + archiveWhere
+        + ") AS combined"
+        + " ORDER BY "
+        + sortPos
+        + " "
+        + dir
+        + ", "
+        + POS_JOB_ID
+        + " ASC"
+        + limitOffsetClause(limit, offset);
+  }
+
+  private void appendStatusCondition(JobFilter filter, StringBuilder where, List<Object> params) {
+    Set<JobStatus> statuses = filter.statuses();
+    if (statuses == null || statuses.isEmpty()) {
+      return;
+    }
+    Set<JobStatus> live = EnumSet.noneOf(JobStatus.class);
+    Set<JobStatus> terminal = EnumSet.noneOf(JobStatus.class);
+    for (JobStatus s : statuses) {
+      if (SqlserverJobRowMapper.isLiveStatus(s)) {
+        live.add(s);
+      } else {
+        terminal.add(s);
+      }
+    }
+
+    if (!live.isEmpty() && !terminal.isEmpty()) {
+      String livePh = placeholders(live.size());
+      String termPh = placeholders(terminal.size());
+      and(
+          where,
+          "(q.status IN ("
+              + livePh
+              + ") OR (q.job_id IS NULL AND c.terminal_status IN ("
+              + termPh
+              + ")))");
+      live.stream().map(JobStatus::name).forEach(params::add);
+      terminal.stream().map(JobStatus::name).forEach(params::add);
+    } else if (!live.isEmpty()) {
+      and(where, "q.status IN (" + placeholders(live.size()) + ")");
+      live.stream().map(JobStatus::name).forEach(params::add);
+    } else {
+      and(
+          where,
+          "(q.job_id IS NULL AND c.terminal_status IN (" + placeholders(terminal.size()) + "))");
+      terminal.stream().map(JobStatus::name).forEach(params::add);
+    }
+  }
+
+  private void appendArchiveStatusCondition(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    Set<JobStatus> statuses = filter.statuses();
+    if (statuses == null || statuses.isEmpty()) {
+      return;
+    }
+    Set<JobStatus> terminal =
+        statuses.stream()
+            .filter(s -> !SqlserverJobRowMapper.isLiveStatus(s))
+            .collect(Collectors.toCollection(() -> EnumSet.noneOf(JobStatus.class)));
+    if (terminal.isEmpty()) {
+      and(where, "1 = 0");
+      return;
+    }
+    and(where, "a.final_status IN (" + placeholders(terminal.size()) + ")");
+    terminal.stream().map(JobStatus::name).forEach(params::add);
+  }
+
+  private void appendJobTypeCondition(JobFilter filter, StringBuilder where, List<Object> params) {
+    appendJobTypeCondition("c.job_type", filter.types(), where, params);
+  }
+
+  // ── ORDER BY builder ────────────────────────────────────────────────────
+
+  private void appendArchiveJobTypeCondition(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    appendJobTypeCondition("a.job_type", filter.types(), where, params);
+  }
+
+  private void appendPriorityCondition(JobFilter filter, StringBuilder where, List<Object> params) {
+    appendPriorityCondition("c.priority", filter.priorities(), where, params);
+  }
+
+  private void appendArchivePriorityCondition(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    appendPriorityCondition("a.priority", filter.priorities(), where, params);
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  private void appendParentJobId(JobFilter filter, StringBuilder where, List<Object> params) {
+    UUID parentJobId = filter.parentJobId();
+    if (parentJobId == null) {
+      return;
+    }
+    appendUuidEq("c.depends_on", parentJobId, where, params);
+  }
+
+  private void appendArchiveParentJobId(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    UUID parentJobId = filter.parentJobId();
+    if (parentJobId == null) {
+      return;
+    }
+    appendUuidEq("a.depended_on", parentJobId, where, params);
+  }
+
+  private void appendJobTypeCondition(
+      String column, Set<JobType> types, StringBuilder where, List<Object> params) {
+    if (types == null || types.isEmpty()) {
+      return;
+    }
+    List<String> execTypeNames =
+        Stream.of(JobExecutionType.values())
+            .filter(e -> types.contains(e.toPublicType()))
+            .map(Enum::name)
+            .collect(Collectors.toList());
+    if (execTypeNames.isEmpty()) {
+      return;
+    }
+    and(where, column + " IN (" + placeholders(execTypeNames.size()) + ")");
+    params.addAll(execTypeNames);
+  }
+
+  private void appendPriorityCondition(
+      String column, Set<JobPriority> priorities, StringBuilder where, List<Object> params) {
+    if (priorities == null || priorities.isEmpty()) {
+      return;
+    }
+    and(where, column + " IN (" + placeholders(priorities.size()) + ")");
+    priorities.stream().map(JobPriority::ordinal).forEach(params::add);
+  }
+
+  private void appendUuidEq(String column, UUID value, StringBuilder where, List<Object> params) {
+    and(where, column + " = ?");
+    params.add(UuidByteArrayConverter.toBytes(value));
+  }
+
+  private void appendTagCondition(JobFilter filter, StringBuilder where, List<Object> params) {
+    Set<String> filterTags = filter.tags();
+    if (filterTags == null || filterTags.isEmpty()) {
+      return;
+    }
+    // JobFilter tags use any-tag (OR) semantics: a job matches when it has at least one requested
+    // tag. All-tag semantics would need grouped counts or repeated EXISTS predicates.
+    and(
+        where,
+        "c.job_id IN (SELECT job_id FROM scheduler_job_tag WHERE tag IN ("
+            + placeholders(filterTags.size())
+            + "))");
+    params.addAll(filterTags);
+  }
+
+  private void appendCursorCondition(JobFilter filter, StringBuilder where, List<Object> params) {
+    ParsedCursor parsed = parseCursor(filter);
+    if (parsed == null) {
+      return;
+    }
+    JobQueryCursor cursor = parsed.cursor();
+    String sortCol = sortColumn(cursor.sortField());
+    String op = filter.sortAscending() ? ">" : "<";
+    and(where, "(" + sortCol + " " + op + " ? OR (" + sortCol + " = ? AND c.job_id > ?))");
+    params.add(parsed.sortValue());
+    params.add(parsed.sortValue());
+    params.add(UuidByteArrayConverter.toBytes(cursor.jobId()));
+  }
+
+  private void appendArchiveCursorCondition(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    ParsedCursor parsed = parseCursor(filter);
+    if (parsed == null) {
+      return;
+    }
+    JobQueryCursor cursor = parsed.cursor();
+    String sortCol = archiveSortColumn(cursor.sortField());
+    String op = filter.sortAscending() ? ">" : "<";
+    and(where, "(" + sortCol + " " + op + " ? OR (" + sortCol + " = ? AND a.original_job_id > ?))");
+    params.add(parsed.sortValue());
+    params.add(parsed.sortValue());
+    params.add(UuidByteArrayConverter.toBytes(cursor.jobId()));
+  }
+
+  private record ParsedCursor(JobQueryCursor cursor, Object sortValue) {}
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobReadOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobReadOperations.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+final class SqlserverJobReadOperations {
+
+  private static final Logger log = Logger.getLogger(SqlserverJobReadOperations.class);
+  private static final int FIND_BY_IDS_CHUNK_SIZE = 500;
+
+  // language=SQL Server
+  private static final String HYDRATION_FROM =
+      """
+      FROM scheduler_job c
+      LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+      """;
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverTagOperations tags;
+
+  SqlserverJobReadOperations(SqlserverStoreContext ctx, SqlserverTagOperations tags) {
+    this.ctx = ctx;
+    this.tags = tags;
+  }
+
+  @SuppressWarnings("unchecked")
+  Optional<JobEntity> findById(UUID id) {
+    try {
+      // language=SQL Server
+      String sql =
+          "SELECT "
+              + SqlserverJobRowMapper.hydrationSelect()
+              + " "
+              + HYDRATION_FROM
+              + " WHERE c.job_id = ?";
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .getResultList();
+      if (rows.isEmpty()) {
+        return Optional.empty();
+      }
+      JobEntity job = SqlserverJobRowMapper.hydrate(rows.get(0));
+      tags.hydrateTagsSingle(job);
+      return Optional.of(job);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find job by id", e);
+    }
+  }
+
+  Optional<JobEntity> findByIdLatest(UUID id) {
+    return findById(id);
+  }
+
+  @SuppressWarnings("unchecked")
+  JobStatus getJobStatus(UUID id) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT q.status, c.terminal_status
+          FROM scheduler_job c
+          LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+          WHERE c.job_id = ?
+          """;
+      List<Object[]> results =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .getResultList();
+      if (results.isEmpty()) {
+        return null;
+      }
+      Object[] row = results.get(0);
+      String live = (String) row[0];
+      if (live != null) {
+        return JobStatus.valueOf(live);
+      }
+      String terminal = (String) row[1];
+      if (terminal != null) {
+        return JobStatus.valueOf(terminal);
+      }
+      throw new IllegalStateException("Job " + id + " has no live or terminal status");
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get job status", e);
+    }
+  }
+
+  List<JobEntity> findByIds(List<UUID> ids) {
+    try {
+      if (ids.isEmpty()) {
+        return List.of();
+      }
+      List<JobEntity> jobs = new ArrayList<>(ids.size());
+      for (int start = 0; start < ids.size(); start += FIND_BY_IDS_CHUNK_SIZE) {
+        jobs.addAll(
+            findByIdsChunk(
+                ids.subList(start, Math.min(start + FIND_BY_IDS_CHUNK_SIZE, ids.size()))));
+      }
+      tags.hydrateTagsBatch(jobs);
+      return jobs;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find jobs by ids", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<JobEntity> findByIdsChunk(List<UUID> ids) {
+    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+    // language=SQL Server
+    String sql =
+        "SELECT "
+            + SqlserverJobRowMapper.hydrationSelect()
+            + " "
+            + HYDRATION_FROM
+            + " WHERE c.job_id IN ("
+            + placeholders
+            + ")";
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    for (UUID id : ids) {
+      query.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
+    }
+    List<Object[]> rows = query.getResultList();
+    List<JobEntity> jobs = new ArrayList<>(rows.size());
+    for (Object[] row : rows) {
+      jobs.add(SqlserverJobRowMapper.hydrate(row));
+    }
+    return jobs;
+  }
+
+  @SuppressWarnings("unchecked")
+  Optional<JobEntity> findActiveByBusinessKey(String businessKey) {
+    try {
+      // language=SQL Server
+      String sql =
+          "SELECT TOP 1 br.owner_table, "
+              + SqlserverJobRowMapper.hydrationSelect()
+              + " FROM scheduler_business_key_reservation br "
+              + "JOIN scheduler_job c ON c.job_id = br.owner_job_id "
+              + "LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id "
+              + "WHERE br.business_key = ?";
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, businessKey).getResultList();
+      if (rows.isEmpty()) {
+        return Optional.empty();
+      }
+      Object[] full = rows.get(0);
+      String ownerTable = (String) full[0];
+      Object[] hydrationRow = new Object[SqlserverJobRowMapper.HYDRATION_COL_COUNT];
+      System.arraycopy(full, 1, hydrationRow, 0, SqlserverJobRowMapper.HYDRATION_COL_COUNT);
+      JobEntity job = SqlserverJobRowMapper.hydrate(hydrationRow);
+      if (SqlserverBusinessKeyReservations.OWNER_TABLE_QUEUE.equals(ownerTable)
+          && hydrationRow[SqlserverJobRowMapper.IDX_Q_STATUS] == null) {
+        log.errorf(
+            "bkres invariant violation: business_key=%s claims QUEUE owner job=%s but no hot row",
+            businessKey, job.getId());
+        throw new IllegalStateException(
+            "Business key reservation "
+                + businessKey
+                + " claims QUEUE owner job "
+                + job.getId()
+                + " but no hot row exists");
+      }
+      tags.hydrateTagsSingle(job);
+      return Optional.of(job);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find active job by business key", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  Optional<JobEntity> findByIdempotencyKey(String idempotencyKey) {
+    try {
+      // language=SQL Server
+      String sql =
+          "SELECT TOP 1 "
+              + SqlserverJobRowMapper.hydrationSelect()
+              + " "
+              + HYDRATION_FROM
+              + " WHERE c.idempotency_key = ?";
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, idempotencyKey).getResultList();
+      if (rows.isEmpty()) {
+        return Optional.empty();
+      }
+      JobEntity job = SqlserverJobRowMapper.hydrate(rows.get(0));
+      tags.hydrateTagsSingle(job);
+      return Optional.of(job);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find job by idempotency key", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  List<JobEntity> findDependants(UUID parentJobId, int limit, int offset) {
+    try {
+      // language=SQL Server
+      String sql =
+          "SELECT "
+              + SqlserverJobRowMapper.hydrationSelect()
+              + " "
+              + HYDRATION_FROM
+              + " WHERE c.depends_on = ? ORDER BY c.created_at ASC, c.job_id ASC";
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(parentJobId))
+              .setFirstResult(offset)
+              .setMaxResults(limit)
+              .getResultList();
+      List<JobEntity> jobs = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        jobs.add(SqlserverJobRowMapper.hydrate(row));
+      }
+      tags.hydrateTagsBatch(jobs);
+      return jobs;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find dependant jobs", e);
+    }
+  }
+
+  JobEntity hydrateForArchive(JobEntity job) {
+    return findById(job.getId())
+        .orElseThrow(() -> new IllegalStateException("Job not found for archival: " + job.getId()));
+  }
+
+  List<JobEntity> hydrateRowsWithTags(List<Object[]> rows) {
+    List<JobEntity> jobs = SqlserverJobRowMapper.hydrateRows(rows);
+    tags.hydrateTagsBatch(jobs);
+    return jobs;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRecurringAndResetOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRecurringAndResetOperations.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+// Reset + cancel-by-tag operations against the executable scheduler_job table. Recurring-master
+// pause / resume / cancel / orphan-cleanup live on SqlserverRecurringJobOperations against
+// scheduler_recurring_job.
+final class SqlserverJobRecurringAndResetOperations {
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverJobRecurringAndResetOperations(
+      SqlserverStoreContext ctx, SqlserverBusinessKeyReservations reservations) {
+    this.ctx = ctx;
+  }
+
+  boolean resetRunningJob(UUID id, String nodeId) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET status = 'PENDING', picked_by = NULL, picked_at = NULL,
+            updated_at = SYSUTCDATETIME()
+        WHERE job_id = ? AND status = 'RUNNING' AND picked_by = ?
+        """;
+    return ctx.timedStoreOperation(
+            "reset_running_job",
+            () ->
+                ctx.em()
+                    .createNativeQuery(sql)
+                    .setParameter(1, UuidByteArrayConverter.toBytes(id))
+                    .setParameter(2, nodeId)
+                    .executeUpdate(),
+            updated -> updated > 0 ? "updated" : "miss")
+        > 0;
+  }
+
+  int resetRunningJobs(String nodeId) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET status = 'PENDING', picked_by = NULL, picked_at = NULL,
+            updated_at = SYSUTCDATETIME()
+        WHERE status = 'RUNNING' AND picked_by = ?
+        """;
+    return ctx.timedStoreOperation(
+        "reset_running_jobs",
+        () -> ctx.em().createNativeQuery(sql).setParameter(1, nodeId).executeUpdate(),
+        updated -> updated > 0 ? "updated" : "miss");
+  }
+
+  int cancelJobsByTag(String tag) {
+    return ctx.timedStoreOperation(
+        "cancel_jobs_by_tag",
+        () -> doCancelJobsByTag(tag),
+        cancelled -> cancelled > 0 ? "updated" : "miss");
+  }
+
+  private int doCancelJobsByTag(String tag) {
+    // Lock the candidate hot rows first, inside the method transaction, before touching the cold
+    // row. SQL Server's UPDATE ... FROM does NOT lock the FROM-referenced rows, so a cold UPDATE
+    // alone leaves the queue row free for a concurrent poller to claim into RUNNING between the
+    // cancel and the hot DELETE — the DELETE (which only matches PENDING/PAUSED/WAITING) would then
+    // skip the now-RUNNING row, stranding it forever while the reservation is still freed. Holding
+    // UPDLOCK on each queue row makes the claim path's READPAST step past it, so a
+    // claim cannot interleave. Mirrors the single-job cancel gate in
+    // SqlserverJobTerminalOperations.
+    // language=SQL Server
+    String lockSql =
+        """
+        SELECT q.job_id
+        FROM scheduler_job_queue q WITH (UPDLOCK, ROWLOCK)
+        JOIN scheduler_job j ON j.job_id = q.job_id
+        JOIN scheduler_job_tag t ON t.job_id = q.job_id
+        WHERE t.tag = ?
+          AND j.job_type <> 'RECURRING'
+          AND j.terminal_status IS NULL
+          AND q.status IN ('PENDING','PAUSED','WAITING')
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object> lockedRows =
+        ctx.em().createNativeQuery(lockSql).setParameter(1, tag).getResultList();
+    if (lockedRows.isEmpty()) {
+      return 0;
+    }
+    List<UUID> ids = new ArrayList<>(lockedRows.size());
+    for (Object row : lockedRows) {
+      ids.add(SqlserverJobRowMapper.uuidOrNull(row));
+    }
+    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+
+    // language=SQL Server
+    String coldSql =
+        """
+        UPDATE scheduler_job
+        SET terminal_status = 'CANCELED',
+            terminated_at = SYSUTCDATETIME()
+        WHERE job_id IN (%s)
+          AND terminal_status IS NULL
+        """
+            .formatted(placeholders);
+    int cancelled = bindIds(coldSql, ids).executeUpdate();
+
+    // language=SQL Server
+    String hotSql = "DELETE FROM scheduler_job_queue WHERE job_id IN (%s)".formatted(placeholders);
+    int hotDeleted = bindIds(hotSql, ids).executeUpdate();
+    if (hotDeleted != cancelled) {
+      throw new IllegalStateException(
+          "cancel-by-tag canceled "
+              + cancelled
+              + " cold rows but removed "
+              + hotDeleted
+              + " hot rows for tag "
+              + tag);
+    }
+
+    // language=SQL Server
+    String reservationsSql =
+        "DELETE FROM scheduler_business_key_reservation WHERE owner_job_id IN (%s)"
+            .formatted(placeholders);
+    bindIds(reservationsSql, ids).executeUpdate();
+    return cancelled;
+  }
+
+  private Query bindIds(String sql, List<UUID> ids) {
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    for (UUID id : ids) {
+      query.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
+    }
+    return query;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRecurringAndResetOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRecurringAndResetOperations.java
@@ -29,8 +29,7 @@ final class SqlserverJobRecurringAndResetOperations {
 
   private final SqlserverStoreContext ctx;
 
-  SqlserverJobRecurringAndResetOperations(
-      SqlserverStoreContext ctx, SqlserverBusinessKeyReservations reservations) {
+  SqlserverJobRecurringAndResetOperations(SqlserverStoreContext ctx) {
     this.ctx = ctx;
   }
 

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRowMapper.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRowMapper.java
@@ -44,6 +44,24 @@ import run.ratchet.store.util.StatusClassifier;
  */
 final class SqlserverJobRowMapper extends AbstractJobRowMapper {
 
+  // language=SQL Server
+  private static final String HYDRATION_SELECT =
+      """
+      c.job_id, c.job_type, c.priority, c.max_retries, c.backoff_policy,
+      c.backoff_param_ms, c.timeout_sec, c.cron_expr, c.zone_id,
+      c.payload, c.params, c.target_class, c.method_name, c.idempotency_key,
+      c.business_key, c.resource_name, c.on_success_payload,
+      c.on_failure_payload, c.depends_on, c.superseded_by, c.created_at,
+      c.caller_principal, c.terminal_status, c.terminal_error,
+      c.total_attempts, c.terminated_at, c.execution_start_time, c.execution_end_time,
+      c.execution_duration_ms, c.queue_wait_ms, c.job_result, c.result_type,
+      c.trace_context, c.recurring_master_id,
+      q.status, q.scheduled_time, q.attempts,
+      q.picked_by, q.picked_at, q.paused_from_status, q.last_error, q.version, q.updated_at,
+      q.signal_key, q.signal_timeout, q.signal_payload, q.signal_payload_type,
+      q.signal_outcome, q.signal_rejection_reason, q.signal_delivered_at,
+      q.signal_delivered_by, q.signal_delivery_id, c.encrypted_payload\
+      """;
   static final int HYDRATION_COL_COUNT = AbstractJobRowMapper.HYDRATION_COL_COUNT;
   static final int IDX_Q_STATUS = AbstractJobRowMapper.IDX_Q_STATUS;
   private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
@@ -61,23 +79,7 @@ final class SqlserverJobRowMapper extends AbstractJobRowMapper {
    * their query. The column order matches {@link AbstractJobRowMapper}'s index constants.
    */
   static String hydrationSelect() {
-    // language=SQL Server
-    return """
-        c.job_id, c.job_type, c.priority, c.max_retries, c.backoff_policy,
-        c.backoff_param_ms, c.timeout_sec, c.cron_expr, c.zone_id,
-        c.payload, c.params, c.target_class, c.method_name, c.idempotency_key,
-        c.business_key, c.resource_name, c.on_success_payload,
-        c.on_failure_payload, c.depends_on, c.superseded_by, c.created_at,
-        c.caller_principal, c.terminal_status, c.terminal_error,
-        c.total_attempts, c.terminated_at, c.execution_start_time, c.execution_end_time,
-        c.execution_duration_ms, c.queue_wait_ms, c.job_result, c.result_type,
-        c.trace_context, c.recurring_master_id,
-        q.status, q.scheduled_time, q.attempts,
-        q.picked_by, q.picked_at, q.paused_from_status, q.last_error, q.version, q.updated_at,
-        q.signal_key, q.signal_timeout, q.signal_payload, q.signal_payload_type,
-        q.signal_outcome, q.signal_rejection_reason, q.signal_delivered_at,
-        q.signal_delivered_by, q.signal_delivery_id, c.encrypted_payload\
-        """;
+    return HYDRATION_SELECT;
   }
 
   static JobEntity hydrate(Object[] row) {

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRowMapper.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRowMapper.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.spi.ProtectedSurface;
+import run.ratchet.store.context.AbstractJobRowMapper;
+import run.ratchet.store.converter.JobPayloadConverter;
+import run.ratchet.store.converter.JsonMapConverter;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.PayloadEncryptor;
+import run.ratchet.store.util.RowValues;
+import run.ratchet.store.util.StatusClassifier;
+
+/**
+ * Hydrates {@link JobEntity} from the hot/cold split schema:
+ *
+ * <ul>
+ *   <li>Cold metadata + terminal fields from {@code scheduler_job} (alias {@code c}).
+ *   <li>Live state from {@code scheduler_job_queue} (alias {@code q}) when present.
+ * </ul>
+ *
+ * <p>Shares the column indexes and hydration body with {@link AbstractJobRowMapper}; only the
+ * projection differs (SQL Server casts JSON columns to {@code }).
+ */
+final class SqlserverJobRowMapper extends AbstractJobRowMapper {
+
+  static final int HYDRATION_COL_COUNT = AbstractJobRowMapper.HYDRATION_COL_COUNT;
+  static final int IDX_Q_STATUS = AbstractJobRowMapper.IDX_Q_STATUS;
+  private static final JobPayloadConverter JOB_PAYLOAD_CONVERTER = new JobPayloadConverter();
+  private static final JsonMapConverter JSON_MAP_CONVERTER = new JsonMapConverter();
+  private static final SqlserverJobRowMapper SHARED = new SqlserverJobRowMapper();
+
+  private SqlserverJobRowMapper() {
+    super("SQL Server");
+  }
+
+  /**
+   * Returns a SELECT projection joining the cold metadata table {@code scheduler_job} (alias {@code
+   * c}) with the hot queue table {@code scheduler_job_queue} (alias {@code q}). Callers must
+   * include {@code FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id} in
+   * their query. The column order matches {@link AbstractJobRowMapper}'s index constants.
+   */
+  static String hydrationSelect() {
+    // language=SQL Server
+    return """
+        c.job_id, c.job_type, c.priority, c.max_retries, c.backoff_policy,
+        c.backoff_param_ms, c.timeout_sec, c.cron_expr, c.zone_id,
+        c.payload, c.params, c.target_class, c.method_name, c.idempotency_key,
+        c.business_key, c.resource_name, c.on_success_payload,
+        c.on_failure_payload, c.depends_on, c.superseded_by, c.created_at,
+        c.caller_principal, c.terminal_status, c.terminal_error,
+        c.total_attempts, c.terminated_at, c.execution_start_time, c.execution_end_time,
+        c.execution_duration_ms, c.queue_wait_ms, c.job_result, c.result_type,
+        c.trace_context, c.recurring_master_id,
+        q.status, q.scheduled_time, q.attempts,
+        q.picked_by, q.picked_at, q.paused_from_status, q.last_error, q.version, q.updated_at,
+        q.signal_key, q.signal_timeout, q.signal_payload, q.signal_payload_type,
+        q.signal_outcome, q.signal_rejection_reason, q.signal_delivered_at,
+        q.signal_delivered_by, q.signal_delivery_id, c.encrypted_payload\
+        """;
+  }
+
+  static JobEntity hydrate(Object[] row) {
+    return SHARED.hydrateRow(row);
+  }
+
+  static List<JobEntity> hydrateRows(List<Object[]> rows) {
+    List<JobEntity> jobs = new ArrayList<>(rows.size());
+    for (Object[] row : rows) {
+      jobs.add(hydrate(row));
+    }
+    return jobs;
+  }
+
+  static boolean isLiveStatus(JobStatus s) {
+    return StatusClassifier.isLiveStatus(s);
+  }
+
+  static boolean isTerminalStatus(JobStatus s) {
+    return StatusClassifier.isTerminalStatus(s);
+  }
+
+  static String stringOrNull(Object value) {
+    return RowValues.stringOrNull(value);
+  }
+
+  static Long longOrNull(Object value) {
+    return RowValues.longOrNull(value);
+  }
+
+  static UUID uuidOrNull(Object value) {
+    return RowValues.uuidOrNull(value);
+  }
+
+  static JobPriority safeJobPriority(int ordinal) {
+    return RowValues.safeJobPriority(ordinal);
+  }
+
+  static String payloadToJson(JobEntity job, boolean active) {
+    return PayloadEncryptor.encryptArgs(
+        JOB_PAYLOAD_CONVERTER.convertToDatabaseColumn(job.getPayload()),
+        active,
+        EncryptionTarget.rowBound(ProtectedSurface.PAYLOAD_ARGS, job.getId()));
+  }
+
+  static String paramsToJson(JobEntity job, boolean active) {
+    return PayloadEncryptor.encryptParamMap(
+        JSON_MAP_CONVERTER.convertToDatabaseColumn(job.getParams()),
+        active,
+        EncryptionTarget.rowBound(ProtectedSurface.PARAM_VALUE, job.getId()));
+  }
+
+  static String callbackPayloadToJson(
+      JobEntity job, JobPayload payload, ProtectedSurface surface, boolean active) {
+    return PayloadEncryptor.encryptArgs(
+        JOB_PAYLOAD_CONVERTER.convertToDatabaseColumn(payload),
+        active,
+        EncryptionTarget.rowBound(surface, job.getId()));
+  }
+
+  static String traceContextToJson(JobEntity job) {
+    return JSON_MAP_CONVERTER.convertToDatabaseColumn(job.getTraceContext());
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRowMapper.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobRowMapper.java
@@ -39,8 +39,9 @@ import run.ratchet.store.util.StatusClassifier;
  *   <li>Live state from {@code scheduler_job_queue} (alias {@code q}) when present.
  * </ul>
  *
- * <p>Shares the column indexes and hydration body with {@link AbstractJobRowMapper}; only the
- * projection differs (SQL Server casts JSON columns to {@code }).
+ * <p>Shares the column indexes and hydration body with {@link AbstractJobRowMapper}. SQL Server
+ * stores the JSON columns as {@code NVARCHAR(MAX)}, so unlike PostgreSQL (which casts native {@code
+ * json} to {@code ::text}) the projection selects them directly with no cast.
  */
 final class SqlserverJobRowMapper extends AbstractJobRowMapper {
 

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStatusTransitions.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStatusTransitions.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.util.List;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+final class SqlserverJobStatusTransitions {
+
+  private static final Logger log = Logger.getLogger(SqlserverJobStatusTransitions.class);
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverJobStatusTransitions(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  boolean tryPickUpJob(UUID id, String nodeId) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET status = 'RUNNING', picked_by = ?, picked_at = SYSUTCDATETIME(),
+            updated_at = SYSUTCDATETIME()
+        WHERE job_id = ? AND status = 'PENDING'
+        """;
+    return ctx.timedStoreOperation(
+            "pickup_job",
+            () ->
+                ctx.em()
+                    .createNativeQuery(sql)
+                    .setParameter(1, nodeId)
+                    .setParameter(2, UuidByteArrayConverter.toBytes(id))
+                    .executeUpdate(),
+            updated -> updated > 0 ? "updated" : "miss")
+        > 0;
+  }
+
+  boolean transitionToPaused(UUID id, JobStatus expected) {
+    if (expected == JobStatus.PAUSED) {
+      throw new IllegalArgumentException("transitionToPaused expects expected != PAUSED");
+    }
+    if (expected == JobStatus.WAITING) {
+      log.debugf("transitionToPaused(%s, WAITING) is a no-op — waiting jobs cannot be paused", id);
+      return false;
+    }
+    if (!SqlserverJobRowMapper.isLiveStatus(expected)) {
+      log.debugf(
+          "transitionToPaused(%s, %s) is a no-op post hot/cold-split — terminal jobs cannot be paused",
+          id, expected);
+      return false;
+    }
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PAUSED', paused_from_status = ?, updated_at = SYSUTCDATETIME()
+          WHERE job_id = ? AND status = ?
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, expected.name())
+              .setParameter(2, UuidByteArrayConverter.toBytes(id))
+              .setParameter(3, expected.name())
+              .executeUpdate();
+      return updated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("transition job to paused", e);
+    }
+  }
+
+  boolean transitionFromPaused(UUID id, JobStatus target) {
+    if (!SqlserverJobRowMapper.isLiveStatus(target)
+        || target == JobStatus.PAUSED
+        || target == JobStatus.WAITING) {
+      throw new IllegalArgumentException(
+          "transitionFromPaused expects a non-PAUSED live status; got " + target);
+    }
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = ?, paused_from_status = NULL, updated_at = SYSUTCDATETIME()
+          WHERE job_id = ? AND status = 'PAUSED'
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, target.name())
+              .setParameter(2, UuidByteArrayConverter.toBytes(id))
+              .executeUpdate();
+      return updated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("transition job from paused", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  JobStatus transitionFromPausedAtomic(UUID id) {
+    try {
+      // language=SQL Server
+      String selectSql =
+          """
+          SELECT paused_from_status FROM scheduler_job_queue WITH (UPDLOCK, ROWLOCK)
+          WHERE job_id = ? AND status = 'PAUSED'
+          """;
+      List<?> results =
+          ctx.em()
+              .createNativeQuery(selectSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .getResultList();
+      if (results.isEmpty()) {
+        return null;
+      }
+      String pausedFrom = (String) results.get(0);
+      JobStatus target = pausedFrom != null ? JobStatus.valueOf(pausedFrom) : JobStatus.PENDING;
+      // language=SQL Server
+      String updateSql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = ?, paused_from_status = NULL, updated_at = SYSUTCDATETIME()
+          WHERE job_id = ? AND status = 'PAUSED'
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(updateSql)
+              .setParameter(1, target.name())
+              .setParameter(2, UuidByteArrayConverter.toBytes(id))
+              .executeUpdate();
+      return updated > 0 ? target : null;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("transition job from paused atomically", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStore.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStore.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.DlqAlertStore;
+import run.ratchet.store.spi.JobAnalyticsStore;
+import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobQueryStore;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.store.spi.LockStore;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.ResourcePermitStore;
+import run.ratchet.store.spi.SignalStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+/**
+ * Public SQL Server-specific store type.
+ *
+ * <p>The CDI implementation is package-private; consumers can inject this interface without
+ * exposing the concrete store as an extension point.
+ *
+ * <p>The SQL Server store advertises every optional capability, so this type extends the mandatory
+ * {@link JobStore} core plus all capability interfaces. Listing them explicitly (rather than
+ * relying on transitive inheritance) keeps each capability in the bean's CDI type closure so {@code
+ * Instance<CapabilityType>} resolves against this store.
+ */
+public interface SqlserverJobStore
+    extends JobStore,
+        RecurringJobStore,
+        BatchStore,
+        WorkflowConditionStore,
+        SignalStore,
+        ResourcePermitStore,
+        LockStore,
+        ArchiveStore,
+        JobQueryStore,
+        JobAnalyticsStore,
+        JobAuditStore,
+        DlqAlertStore {}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
@@ -792,6 +792,18 @@ class SqlserverJobStoreImpl implements SqlserverJobStore {
     return signals.findJobsBySignalDeliveryId(deliveryId);
   }
 
+  // Probes the current session's isolation level. The @@SPID-scoped sys.dm_exec_sessions row is
+  // always visible to the session itself, so this needs no VIEW SERVER STATE grant.
+  // READ_COMMITTED_SNAPSHOT still reports level 2 (read committed). (SQL Server has no SHOW-style
+  // statement; the PostgreSQL "SHOW transaction_isolation" this was ported from is invalid T-SQL.)
+  // language=SQL Server
+  static final String ISOLATION_PROBE_SQL =
+      "SELECT CASE transaction_isolation_level"
+          + " WHEN 0 THEN 'unspecified' WHEN 1 THEN 'read uncommitted'"
+          + " WHEN 2 THEN 'read committed' WHEN 3 THEN 'repeatable read'"
+          + " WHEN 4 THEN 'serializable' WHEN 5 THEN 'snapshot' END"
+          + " FROM sys.dm_exec_sessions WHERE session_id = @@SPID";
+
   @PostConstruct
   void checkIsolationLevel() {
     if (em == null) {
@@ -800,12 +812,13 @@ class SqlserverJobStoreImpl implements SqlserverJobStore {
     IsolationCheck.verifyReadCommitted(
         em,
         "SQL Server",
-        List.of("SHOW transaction_isolation"),
+        List.of(ISOLATION_PROBE_SQL),
         "read committed",
-        "SERIALIZABLE and REPEATABLE READ both surface SQLState 40001 serialization failures on"
-            + " concurrent job claims, which Ratchet's claim loop does not retry. Set"
-            + " default_transaction_isolation = 'read committed' in sqlserver.conf or unset any"
-            + " connection pool override (e.g. hibernate.connection.isolation=2).",
+        "SERIALIZABLE, REPEATABLE READ, and SNAPSHOT isolation surface error 1205 deadlock victims"
+            + " on concurrent job claims, which Ratchet's claim loop does not retry. Ratchet's SQL"
+            + " Server store relies on READ COMMITTED (the engine default; with"
+            + " READ_COMMITTED_SNAPSHOT ON it still reports level 2). Clear any connection-pool"
+            + " override that raises the level (e.g. hibernate.connection.isolation).",
         options.store().isolationCheckMode());
     initDelegates();
   }

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
@@ -1,0 +1,887 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.NodeTagFilter;
+import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.dto.BatchProgress;
+import run.ratchet.store.dto.JobClaimDto;
+import run.ratchet.store.entity.ArchivedJobEntity;
+import run.ratchet.store.entity.BatchEntity;
+import run.ratchet.store.entity.BatchMetricsEntity;
+import run.ratchet.store.entity.DlqAlertEntity;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.entity.JobLogEntity;
+import run.ratchet.store.entity.NodeEntity;
+import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.spi.ExecutionTargetFilter;
+import run.ratchet.store.spi.RatchetEntityManagerProvider;
+import run.ratchet.store.util.IsolationCheck;
+
+/**
+ * Package-private SQL Server CDI implementation behind the public {@link SqlserverJobStore} type.
+ *
+ * <p>This class is intentionally a CDI/test wiring composite. Cohesive package-private operation
+ * classes own the actual SQL for each store area, while this type owns injection, lifecycle, and
+ * SPI forwarding.
+ *
+ * <p>The type-level {@link Transactional} annotation gives forwarded store writes the default
+ * {@code REQUIRED} boundary. Read methods deliberately do NOT override with {@code SUPPORTS}: the
+ * MySQL sibling was confirmed via bisect to hang under that override on JTA-managed EclipseLink
+ * containers (Payara, GlassFish, OpenLiberty) — the borrowed pool connection is returned with
+ * auto-commit disabled, leaving an open transaction holding metadata locks on subsequent writes.
+ * SQL Server uses the same EclipseLink connection-release model, so the same fix is applied here
+ * pre-emptively. The class-level {@code REQUIRED} keeps each read in a clean tx boundary that
+ * commits before the connection returns to the pool.
+ */
+@ApplicationScoped
+@Transactional
+class SqlserverJobStoreImpl implements SqlserverJobStore {
+
+  private final RatchetEntityManagerProvider entityManagerProvider;
+  private final MetricsCollector metricsCollector;
+  private final RatchetOptions options;
+  private EntityManager em;
+
+  private SqlserverStoreContext ctx;
+  private SqlserverBusinessKeyReservations reservations;
+  private SqlserverTagOperations tags;
+  private SqlserverJobCrudOperations jobs;
+  private SqlserverJobQueryOperations query;
+  private SqlserverBatchOperations batches;
+  private SqlserverJobClaimOperations claims;
+  private SqlserverJobLifecycleOperations lifecycle;
+  private SqlserverNodeLockOperations nodeLocks;
+  private SqlserverArchiveOperations archives;
+  private SqlserverAuxiliaryOperations auxiliary;
+  private SqlserverSignalOperations signals;
+  private SqlserverRecurringJobOperations recurringJobs;
+
+  /** No-arg constructor required by CDI normal-scope proxying. Not for direct use. */
+  protected SqlserverJobStoreImpl() {
+    this.entityManagerProvider = null;
+    this.metricsCollector = null;
+    this.options = null;
+  }
+
+  @Inject
+  SqlserverJobStoreImpl(
+      RatchetEntityManagerProvider entityManagerProvider,
+      MetricsCollector metricsCollector,
+      RatchetOptions options) {
+    this.entityManagerProvider = entityManagerProvider;
+    this.metricsCollector = metricsCollector;
+    this.options = options;
+  }
+
+  @Override
+  public JobEntity create(JobEntity job) {
+    return jobs.create(job);
+  }
+
+  @Override
+  public JobEntity save(JobEntity job) {
+    return jobs.save(job);
+  }
+
+  @Override
+  public Optional<JobEntity> findById(UUID id) {
+    return jobs.findById(id);
+  }
+
+  @Override
+  public Optional<JobEntity> findByIdLatest(UUID id) {
+    return jobs.findByIdLatest(id);
+  }
+
+  @Override
+  public void delete(UUID id) {
+    jobs.delete(id);
+  }
+
+  @Override
+  public JobStatus getJobStatus(UUID id) {
+    return jobs.getJobStatus(id);
+  }
+
+  @Override
+  public List<JobEntity> findByIds(List<UUID> ids) {
+    return jobs.findByIds(ids);
+  }
+
+  @Override
+  public Optional<JobEntity> findActiveByBusinessKey(String businessKey) {
+    return jobs.findActiveByBusinessKey(businessKey);
+  }
+
+  @Override
+  public Optional<JobEntity> findByIdempotencyKey(String idempotencyKey) {
+    return jobs.findByIdempotencyKey(idempotencyKey);
+  }
+
+  @Override
+  public List<JobEntity> findDependants(UUID parentJobId, int limit, int offset) {
+    return jobs.findDependants(parentJobId, limit, offset);
+  }
+
+  @Override
+  public Optional<Instant> findEarliestRecurringNextFire() {
+    return recurringJobs.findEarliestRecurringNextFire();
+  }
+
+  @Override
+  public long countPendingJobs() {
+    return jobs.countPendingJobs();
+  }
+
+  @Override
+  public long countJobsByStatus(JobStatus status) {
+    return jobs.countJobsByStatus(status);
+  }
+
+  @Override
+  public Map<JobStatus, Long> countJobsByStatuses() {
+    return jobs.countJobsByStatuses();
+  }
+
+  @Override
+  public long countActiveJobs(JobExecutionType jobType) {
+    return jobs.countActiveJobs(jobType);
+  }
+
+  @Override
+  public long countActiveNodes() {
+    return jobs.countActiveNodes();
+  }
+
+  @Override
+  public long countReadyJobs(Instant now) {
+    return jobs.countReadyJobs(now);
+  }
+
+  @Override
+  public long countStuckJobs(Instant stuckThreshold) {
+    return jobs.countStuckJobs(stuckThreshold);
+  }
+
+  @Override
+  public long countLongRunningJobs(Instant threshold) {
+    return jobs.countLongRunningJobs(threshold);
+  }
+
+  @Override
+  public long countPendingBatchChildren() {
+    return jobs.countPendingBatchChildren();
+  }
+
+  @Override
+  public long countPendingJobsByPriority(JobPriority priority) {
+    return jobs.countPendingJobsByPriority(priority);
+  }
+
+  @Override
+  public Map<JobPriority, Long> countPendingJobsByPriorities() {
+    return jobs.countPendingJobsByPriorities();
+  }
+
+  @Override
+  public long countPendingJobsByType(JobExecutionType jobType) {
+    return jobs.countPendingJobsByType(jobType);
+  }
+
+  @Override
+  public Map<JobExecutionType, Long> countPendingJobsByTypes() {
+    return jobs.countPendingJobsByTypes();
+  }
+
+  @Override
+  public long countJobsByStatusSince(JobStatus status, Instant since) {
+    return jobs.countJobsByStatusSince(status, since);
+  }
+
+  @Override
+  public long countJobsWithRetries() {
+    return jobs.countJobsWithRetries();
+  }
+
+  @Override
+  public double getRetryRateStats(Instant since) {
+    return jobs.getRetryRateStats(since);
+  }
+
+  @Override
+  public double getAverageProcessingTime(Instant since) {
+    return jobs.getAverageProcessingTime(since);
+  }
+
+  @Override
+  public double getAverageBatchSize(Instant since) {
+    return jobs.getAverageBatchSize(since);
+  }
+
+  @Override
+  public Optional<Instant> getOldestPendingJobTime() {
+    return jobs.getOldestPendingJobTime();
+  }
+
+  @Override
+  public long getQueueWaitTimePercentile(double percentile) {
+    return jobs.getQueueWaitTimePercentile(percentile);
+  }
+
+  @Override
+  public void bulkInsert(List<JobEntity> jobsToInsert) {
+    jobs.bulkInsert(jobsToInsert);
+  }
+
+  @Override
+  public int deleteJobsByIds(List<UUID> ids) {
+    return jobs.deleteJobsByIds(ids);
+  }
+
+  @Override
+  public int deleteDlqOlderThan(Instant cutoff) {
+    return jobs.deleteDlqOlderThan(cutoff);
+  }
+
+  @Override
+  public int resetOrphanJobs(Duration grace) {
+    return jobs.resetOrphanJobs(grace);
+  }
+
+  @Override
+  public int resetOrphanJobsBefore(Instant cutoff) {
+    return jobs.resetOrphanJobsBefore(cutoff);
+  }
+
+  @Override
+  public int resetOrphanJobsForNode(String nodeId) {
+    return jobs.resetOrphanJobsForNode(nodeId);
+  }
+
+  @Override
+  public List<JobEntity> claimNextBatch(int limit, String nodeId, NodeTagFilter tagFilter) {
+    return claims.claimNextBatch(limit, nodeId, tagFilter);
+  }
+
+  @Override
+  public List<JobClaimDto> claimNextBatchOptimized(
+      JobExecutionType jobType,
+      int limit,
+      String nodeId,
+      NodeTagFilter tagFilter,
+      ExecutionTargetFilter executionTargetFilter) {
+    return claims.claimNextBatchOptimized(jobType, limit, nodeId, tagFilter, executionTargetFilter);
+  }
+
+  @Override
+  public void updateJobStatus(UUID id, JobStatus status, String errorMessage) {
+    lifecycle.updateJobStatus(id, status, errorMessage);
+  }
+
+  @Override
+  public boolean compareAndSwapStatus(
+      UUID id, JobStatus expected, JobStatus newStatus, String error) {
+    return lifecycle.compareAndSwapStatus(id, expected, newStatus, error);
+  }
+
+  @Override
+  public int incrementRetryAttempt(UUID id) {
+    return lifecycle.incrementRetryAttempt(id);
+  }
+
+  @Override
+  public boolean tryPickUpJob(UUID id, String nodeId) {
+    return lifecycle.tryPickUpJob(id, nodeId);
+  }
+
+  @Override
+  public boolean markJobSucceeded(
+      UUID id,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs) {
+    return lifecycle.markJobSucceeded(
+        id, resultJson, resultType, start, end, durationMs, queueWaitMs);
+  }
+
+  @Override
+  public boolean markJobSucceededMinimal(
+      UUID id, Instant start, Instant end, Long durationMs, Long queueWaitMs) {
+    return lifecycle.markJobSucceededMinimal(id, start, end, durationMs, queueWaitMs);
+  }
+
+  @Override
+  public boolean markJobSucceededAndUpdateBatch(
+      UUID jobId,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs,
+      UUID batchId) {
+    return lifecycle.markJobSucceededAndUpdateBatch(
+        jobId, resultJson, resultType, start, end, durationMs, queueWaitMs, batchId);
+  }
+
+  @Override
+  public boolean markJobFailedTerminal(UUID id, String terminalError, int totalAttempts) {
+    return lifecycle.markJobFailedTerminal(id, terminalError, totalAttempts);
+  }
+
+  @Override
+  public boolean cancelJob(UUID id) {
+    return lifecycle.cancelJob(id);
+  }
+
+  @Override
+  public boolean scheduleJobRetry(UUID id, String error, Instant newScheduledTime, int attempts) {
+    return lifecycle.scheduleJobRetry(id, error, newScheduledTime, attempts);
+  }
+
+  @Override
+  public boolean resetFailedToPending(UUID id) {
+    return lifecycle.resetFailedToPending(id);
+  }
+
+  @Override
+  public boolean resetRunningJob(UUID id, String nodeId) {
+    return lifecycle.resetRunningJob(id, nodeId);
+  }
+
+  @Override
+  public int resetRunningJobs(String nodeId) {
+    return lifecycle.resetRunningJobs(nodeId);
+  }
+
+  @Override
+  public int cancelJobsByTag(String tag) {
+    return lifecycle.cancelJobsByTag(tag);
+  }
+
+  @Override
+  public int cancelRecurringJobsByTag(String tag) {
+    return recurringJobs.cancelRecurringJobsByTag(tag);
+  }
+
+  @Override
+  public int cancelRecurringJobsByBusinessKeys(Set<String> businessKeys) {
+    return recurringJobs.cancelRecurringJobsByBusinessKeys(businessKeys);
+  }
+
+  @Override
+  public int cancelOrphanedRecurringAnnotationJobs(
+      Set<String> registeredIds, Instant nodeStartTime) {
+    return recurringJobs.cancelOrphanedRecurringAnnotationJobs(registeredIds, nodeStartTime);
+  }
+
+  @Override
+  public boolean transitionToPaused(UUID id, JobStatus expected) {
+    return lifecycle.transitionToPaused(id, expected);
+  }
+
+  @Override
+  public boolean transitionFromPaused(UUID id, JobStatus target) {
+    return lifecycle.transitionFromPaused(id, target);
+  }
+
+  @Override
+  public JobStatus transitionFromPausedAtomic(UUID id) {
+    return lifecycle.transitionFromPausedAtomic(id);
+  }
+
+  @Override
+  public boolean pauseRecurring(UUID id) {
+    return recurringJobs.pauseRecurring(id);
+  }
+
+  @Override
+  public boolean resumeRecurring(UUID id) {
+    return recurringJobs.resumeRecurring(id);
+  }
+
+  @Override
+  public BatchEntity saveBatch(BatchEntity batch) {
+    return batches.saveBatch(batch);
+  }
+
+  @Override
+  public Optional<BatchEntity> findBatchById(UUID batchId) {
+    return batches.findBatchById(batchId);
+  }
+
+  @Override
+  public List<BatchEntity> findBatchesByIds(List<UUID> batchIds) {
+    return batches.findBatchesByIds(batchIds);
+  }
+
+  @Override
+  public BatchProgress incrementCompletedAtomic(UUID batchId) {
+    return batches.incrementCompletedAtomic(batchId);
+  }
+
+  @Override
+  public BatchProgress incrementFailedAtomic(UUID batchId) {
+    return batches.incrementFailedAtomic(batchId);
+  }
+
+  @Override
+  public boolean markBatchCompleteIfReady(UUID batchId) {
+    return batches.markBatchCompleteIfReady(batchId);
+  }
+
+  @Override
+  public List<UUID> findRecoverableBatchIds(int limit) {
+    return batches.findRecoverableBatchIds(limit);
+  }
+
+  @Override
+  public boolean updateBatchTotalItems(UUID batchId, int totalItems) {
+    return batches.updateBatchTotalItems(batchId, totalItems);
+  }
+
+  @Override
+  public BatchMetricsEntity saveBatchMetrics(BatchMetricsEntity metrics) {
+    return batches.saveBatchMetrics(metrics);
+  }
+
+  @Override
+  public Optional<BatchMetricsEntity> findBatchMetrics(UUID batchId) {
+    return batches.findBatchMetrics(batchId);
+  }
+
+  @Override
+  public void addChildExecutionTime(UUID batchId, long durationMs) {
+    batches.addChildExecutionTime(batchId, durationMs);
+  }
+
+  @Override
+  public void finalizeBatchMetrics(UUID batchId) {
+    batches.finalizeBatchMetrics(batchId);
+  }
+
+  @Override
+  public void updateBatchMetricsChildCount(UUID batchId, int childCount) {
+    batches.updateBatchMetricsChildCount(batchId, childCount);
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public boolean tryLock(String name, Duration ttl, String nodeId) {
+    return nodeLocks.tryLock(name, ttl, nodeId);
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public void unlock(String name, String nodeId) {
+    nodeLocks.unlock(name, nodeId);
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public boolean renewLock(String name, Duration extension, String nodeId) {
+    return nodeLocks.renewLock(name, extension, nodeId);
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public void upsertHeartbeat(String nodeId, Instant ts) {
+    nodeLocks.upsertHeartbeat(nodeId, ts);
+  }
+
+  @Override
+  public Optional<NodeEntity> findNodeById(String nodeId) {
+    return nodeLocks.findNodeById(nodeId);
+  }
+
+  @Override
+  public List<NodeEntity> findInactiveNodesSince(Instant cutoff) {
+    return nodeLocks.findInactiveNodesSince(cutoff);
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public int deleteInactiveNodesSince(Instant cutoff) {
+    return nodeLocks.deleteInactiveNodesSince(cutoff);
+  }
+
+  @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
+  public int deleteInactiveNodesByIds(java.util.Collection<String> nodeIds) {
+    return nodeLocks.deleteInactiveNodesByIds(nodeIds);
+  }
+
+  @Override
+  public Instant getDatabaseTime() {
+    return nodeLocks.getDatabaseTime();
+  }
+
+  @Override
+  public ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy) {
+    return archives.archiveJob(job, reason, archivedBy);
+  }
+
+  @Override
+  public int archiveJobsBatch(List<JobEntity> jobsToArchive, String reason, String archivedBy) {
+    return archives.archiveJobsBatch(jobsToArchive, reason, archivedBy);
+  }
+
+  @Override
+  public List<JobEntity> findJobsForArchiving(Instant olderThan, int limit) {
+    return archives.findJobsForArchiving(olderThan, limit);
+  }
+
+  @Override
+  public long countJobsForArchiving(Instant olderThan) {
+    return archives.countJobsForArchiving(olderThan);
+  }
+
+  @Override
+  public List<ArchivedJobEntity> findArchivedJobs(
+      String targetClass, String businessKey, Instant from, Instant to, int limit) {
+    return archives.findArchivedJobs(targetClass, businessKey, from, to, limit);
+  }
+
+  @Override
+  public int purgeArchivedJobs(Instant olderThan) {
+    return archives.purgeArchivedJobs(olderThan);
+  }
+
+  @Override
+  public JobExecutionEntity saveExecution(JobExecutionEntity execution) {
+    return auxiliary.saveExecution(execution);
+  }
+
+  @Override
+  public List<JobExecutionEntity> findExecutionsByJobId(UUID jobId, int limit, int offset) {
+    return auxiliary.findExecutionsByJobId(jobId, limit, offset);
+  }
+
+  @Override
+  public Optional<JobExecutionEntity> findLatestExecution(UUID jobId) {
+    return auxiliary.findLatestExecution(jobId);
+  }
+
+  @Override
+  public int countExecutionAttempts(UUID jobId) {
+    return auxiliary.countExecutionAttempts(jobId);
+  }
+
+  @Override
+  public void appendLog(JobLogEntity log) {
+    auxiliary.appendLog(log);
+  }
+
+  @Override
+  public int purgeLogsOlderThan(Instant cutoff) {
+    return auxiliary.purgeLogsOlderThan(cutoff);
+  }
+
+  @Override
+  public void insertTags(UUID jobId, List<String> tagsToInsert) {
+    tags.insertTags(jobId, tagsToInsert);
+  }
+
+  @Override
+  public int deleteTagsByJobId(UUID jobId) {
+    return tags.deleteTagsByJobId(jobId);
+  }
+
+  @Override
+  public List<UUID> findJobIdsByTag(String tag, int limit, int offset) {
+    return tags.findJobIdsByTag(tag, limit, offset);
+  }
+
+  @Override
+  public Map<JobStatus, Long> countJobsByStatusForTag(String tag) {
+    return jobs.countJobsByStatusForTag(tag);
+  }
+
+  @Override
+  public Map<String, Long> countJobsByParamForTag(String tag, String paramKey) {
+    return jobs.countJobsByParamForTag(tag, paramKey);
+  }
+
+  @Override
+  public Map<String, Long> countJobsByExecutionNodeForTag(String tag) {
+    return jobs.countJobsByExecutionNodeForTag(tag);
+  }
+
+  @Override
+  public WorkflowConditionEntity saveCondition(WorkflowConditionEntity condition) {
+    return auxiliary.saveCondition(condition);
+  }
+
+  @Override
+  public WorkflowConditionEntity findConditionById(UUID id) {
+    return auxiliary.findConditionById(id);
+  }
+
+  @Override
+  public List<WorkflowConditionEntity> findConditionsByParentJobId(UUID parentJobId) {
+    return auxiliary.findConditionsByParentJobId(parentJobId);
+  }
+
+  @Override
+  public List<WorkflowConditionEntity> findConditionsByChildJobId(UUID childJobId) {
+    return auxiliary.findConditionsByChildJobId(childJobId);
+  }
+
+  @Override
+  public List<WorkflowConditionEntity> findConditionsByType(
+      UUID parentJobId, WorkflowCondition.ConditionType type) {
+    return auxiliary.findConditionsByType(parentJobId, type);
+  }
+
+  @Override
+  public void deleteConditionById(UUID id) {
+    auxiliary.deleteConditionById(id);
+  }
+
+  @Override
+  public void deleteConditionsByParentJobId(UUID parentJobId) {
+    auxiliary.deleteConditionsByParentJobId(parentJobId);
+  }
+
+  @Override
+  public void deleteConditionsByChildJobId(UUID childJobId) {
+    auxiliary.deleteConditionsByChildJobId(childJobId);
+  }
+
+  @Override
+  public long countConditionsByParentJobId(UUID parentJobId) {
+    return auxiliary.countConditionsByParentJobId(parentJobId);
+  }
+
+  @Override
+  public DlqAlertEntity saveDlqAlert(DlqAlertEntity alert) {
+    return auxiliary.saveDlqAlert(alert);
+  }
+
+  @Override
+  public boolean existsRecentDlqAlert(UUID jobId, String errorHash, Instant cutoff) {
+    return auxiliary.existsRecentDlqAlert(jobId, errorHash, cutoff);
+  }
+
+  @Override
+  public boolean tryAcquirePermit(String resource, UUID jobId, String nodeId) {
+    return auxiliary.tryAcquirePermit(resource, jobId, nodeId);
+  }
+
+  @Override
+  public void releasePermit(String resource, UUID jobId) {
+    auxiliary.releasePermit(resource, jobId);
+  }
+
+  @Override
+  public void releaseAllPermits(UUID jobId) {
+    auxiliary.releaseAllPermits(jobId);
+  }
+
+  @Override
+  public int getPermitRetryDelay(String resource) {
+    return auxiliary.getPermitRetryDelay(resource);
+  }
+
+  @Override
+  public void configureResource(
+      String name, int maxConcurrent, int retryDelayMs, String description) {
+    auxiliary.configureResource(name, maxConcurrent, retryDelayMs, description);
+  }
+
+  @Override
+  public int cleanupOrphanedPermits(List<String> staleNodeIds) {
+    return auxiliary.cleanupOrphanedPermits(staleNodeIds);
+  }
+
+  @Override
+  public List<JobEntity> searchJobs(JobFilter filter, int limit, int offset) {
+    return query.searchJobs(filter, limit, offset);
+  }
+
+  @Override
+  public long countJobs(JobFilter filter) {
+    return query.countJobs(filter);
+  }
+
+  @Override
+  public List<JobEntity> findTimedOutSignalJobs(Instant now, int limit) {
+    return signals.findTimedOutSignalJobs(now, limit);
+  }
+
+  @Override
+  public int deliverSignalById(
+      UUID jobId,
+      String payload,
+      String payloadType,
+      String outcome,
+      String rejectionReason,
+      String deliveredBy,
+      Instant deliveredAt,
+      String deliveryId) {
+    return signals.deliverSignalById(
+        jobId,
+        payload,
+        payloadType,
+        outcome,
+        rejectionReason,
+        deliveredBy,
+        deliveredAt,
+        deliveryId);
+  }
+
+  @Override
+  public int deliverSignalByKey(
+      String signalKey,
+      String payload,
+      String payloadType,
+      String outcome,
+      String rejectionReason,
+      String deliveredBy,
+      Instant deliveredAt,
+      String deliveryId) {
+    return signals.deliverSignalByKey(
+        signalKey,
+        payload,
+        payloadType,
+        outcome,
+        rejectionReason,
+        deliveredBy,
+        deliveredAt,
+        deliveryId);
+  }
+
+  @Override
+  public List<JobEntity> findJobsBySignalDeliveryId(String deliveryId) {
+    return signals.findJobsBySignalDeliveryId(deliveryId);
+  }
+
+  @PostConstruct
+  void checkIsolationLevel() {
+    if (em == null) {
+      em = entityManagerProvider.getEntityManager();
+    }
+    IsolationCheck.verifyReadCommitted(
+        em,
+        "SQL Server",
+        List.of("SHOW transaction_isolation"),
+        "read committed",
+        "SERIALIZABLE and REPEATABLE READ both surface SQLState 40001 serialization failures on"
+            + " concurrent job claims, which Ratchet's claim loop does not retry. Set"
+            + " default_transaction_isolation = 'read committed' in sqlserver.conf or unset any"
+            + " connection pool override (e.g. hibernate.connection.isolation=2).",
+        options.store().isolationCheckMode());
+    initDelegates();
+  }
+
+  private void initDelegates() {
+    ctx =
+        new SqlserverStoreContext(
+            em, metricsCollector, options.store().priorityBoostIntervalMinutes());
+    reservations = new SqlserverBusinessKeyReservations(ctx);
+    tags = new SqlserverTagOperations(ctx);
+    SqlserverJobReadOperations reads = new SqlserverJobReadOperations(ctx, tags);
+    jobs =
+        new SqlserverJobCrudOperations(
+            reads,
+            new SqlserverJobCountOperations(ctx),
+            new SqlserverJobDeleteOperations(ctx, reservations),
+            new SqlserverJobWriteOperations(ctx, reservations, tags),
+            tags);
+    query = new SqlserverJobQueryOperations(ctx, tags);
+    batches = new SqlserverBatchOperations(ctx);
+    claims = new SqlserverJobClaimOperations(ctx, reads);
+    lifecycle = new SqlserverJobLifecycleOperations(ctx, reservations, batches);
+    nodeLocks = new SqlserverNodeLockOperations(ctx);
+    archives = new SqlserverArchiveOperations(ctx, reads);
+    auxiliary = new SqlserverAuxiliaryOperations(ctx);
+    signals = new SqlserverSignalOperations(ctx);
+    recurringJobs = new SqlserverRecurringJobOperations(ctx, reservations);
+  }
+
+  // ---------- RecurringJobStore delegates ----------
+
+  @Override
+  public List<run.ratchet.store.spi.RecurringJobDefinition> claimDueRecurring(
+      int limit, String nodeId, NodeTagFilter tagFilter) {
+    return recurringJobs.claimDueRecurring(limit, nodeId, tagFilter);
+  }
+
+  @Override
+  public void advanceNextFire(UUID id, Instant nextFire) {
+    recurringJobs.advanceNextFire(id, nextFire);
+  }
+
+  @Override
+  public boolean cancelRecurringAndArchive(
+      UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
+    return recurringJobs.cancelRecurringAndArchive(id, reason);
+  }
+
+  @Override
+  public boolean cancelRecurringJobByBusinessKey(String businessKey) {
+    return recurringJobs.cancelRecurringJobByBusinessKey(businessKey);
+  }
+
+  @Override
+  public UUID createRecurring(run.ratchet.store.spi.RecurringJobDefinition definition) {
+    return recurringJobs.createRecurring(definition);
+  }
+
+  @Override
+  public boolean updateRecurring(UUID id, run.ratchet.store.spi.RecurringJobDefinition definition) {
+    return recurringJobs.updateRecurring(id, definition);
+  }
+
+  @Override
+  public Optional<run.ratchet.store.spi.RecurringJobDefinition> getRecurring(UUID id) {
+    return recurringJobs.getRecurring(id);
+  }
+
+  @Override
+  public Optional<run.ratchet.store.spi.RecurringJobDefinition> findRecurringByBusinessKey(
+      String businessKey) {
+    return recurringJobs.findRecurringByBusinessKey(businessKey);
+  }
+
+  @Override
+  public List<run.ratchet.store.spi.RecurringJobDefinition> listAll() {
+    return recurringJobs.listAll();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobTerminalOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobTerminalOperations.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.NoResultException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+/*
+ * Keep terminal transitions dialect-local until a shared helper can preserve each backend's
+ * SQL shape explicitly. These methods mirror MySQL conceptually, but SQL Server uses
+ * SYSUTCDATETIME() and UPDATE ... FROM semantics. UUID columns are BINARY(16), so ids bind as
+ * canonical bytes via UuidByteArrayConverter.toBytes.
+ */
+final class SqlserverJobTerminalOperations {
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverBusinessKeyReservations reservations;
+  private final SqlserverBatchOperations batches;
+
+  SqlserverJobTerminalOperations(
+      SqlserverStoreContext ctx,
+      SqlserverBusinessKeyReservations reservations,
+      SqlserverBatchOperations batches) {
+    this.ctx = ctx;
+    this.reservations = reservations;
+    this.batches = batches;
+  }
+
+  void updateJobStatus(UUID id, JobStatus status, String errorMessage) {
+    ctx.timedStoreOperation(
+        "update_status",
+        () -> {
+          if (SqlserverJobRowMapper.isLiveStatus(status)) {
+            // language=SQL Server
+            String sql =
+                """
+                UPDATE scheduler_job_queue
+                SET status = ?, last_error = ?, updated_at = SYSUTCDATETIME()
+                WHERE job_id = ?
+                """;
+            return ctx.em()
+                .createNativeQuery(sql)
+                .setParameter(1, status.name())
+                .setParameter(2, errorMessage)
+                .setParameter(3, UuidByteArrayConverter.toBytes(id))
+                .executeUpdate();
+          }
+          if (status == JobStatus.CANCELED) {
+            return cancelJob(id) ? 1 : 0;
+          }
+          if (status == JobStatus.FAILED) {
+            return markJobFailedTerminal(id, errorMessage, 0) ? 1 : 0;
+          }
+          if (status == JobStatus.SUCCEEDED) {
+            return markJobSucceededMinimal(id, null, null, null, null) ? 1 : 0;
+          }
+          throw new IllegalArgumentException("Unsupported status target: " + status);
+        },
+        updated -> updated > 0 ? "updated" : "miss");
+  }
+
+  boolean compareAndSwapStatus(UUID id, JobStatus expected, JobStatus newStatus, String error) {
+    return ctx.timedStoreOperation(
+        "compare_and_swap_status",
+        () -> {
+          if (!SqlserverJobRowMapper.isLiveStatus(expected)) {
+            throw new IllegalArgumentException(
+                "compareAndSwapStatus expected must be a live status; got " + expected);
+          }
+          if (SqlserverJobRowMapper.isLiveStatus(newStatus)) {
+            // language=SQL Server
+            String sql =
+                """
+                UPDATE scheduler_job_queue
+                SET status = ?, last_error = ?, updated_at = SYSUTCDATETIME()
+                WHERE job_id = ? AND status = ?
+                """;
+            return ctx.em()
+                    .createNativeQuery(sql)
+                    .setParameter(1, newStatus.name())
+                    .setParameter(2, error)
+                    .setParameter(3, UuidByteArrayConverter.toBytes(id))
+                    .setParameter(4, expected.name())
+                    .executeUpdate()
+                > 0;
+          }
+          if (newStatus == JobStatus.CANCELED) {
+            return lockExpectedQueueStatusForTerminalCas(id, expected) && cancelJob(id);
+          }
+          if (newStatus == JobStatus.FAILED) {
+            if (expected != JobStatus.RUNNING && expected != JobStatus.WAITING) {
+              return false;
+            }
+            return markJobFailedTerminalFromStatus(id, error, null, expected);
+          }
+          throw new IllegalArgumentException("Unsupported CAS target newStatus: " + newStatus);
+        },
+        updated -> updated ? "updated" : "miss");
+  }
+
+  int incrementRetryAttempt(UUID id) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET attempts = attempts + 1, updated_at = SYSUTCDATETIME()
+        OUTPUT inserted.attempts
+        WHERE job_id = ? AND status IN ('RUNNING', 'WAITING')
+        """;
+    return ctx.timedStoreOperation(
+        "increment_retry_attempt",
+        () -> {
+          try {
+            Object result =
+                ctx.em()
+                    .createNativeQuery(sql)
+                    .setParameter(1, UuidByteArrayConverter.toBytes(id))
+                    .getSingleResult();
+            return ((Number) result).intValue();
+          } catch (NoResultException e) {
+            return -1;
+          }
+        },
+        attempts -> attempts > 0 ? "updated" : "miss");
+  }
+
+  boolean markJobSucceeded(
+      UUID id,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs) {
+    return ctx.timedStoreOperation(
+        "mark_succeeded",
+        () ->
+            doMarkTerminalSuccessWithResult(
+                id, resultJson, resultType, start, end, durationMs, queueWaitMs),
+        updated -> updated ? "updated" : "miss");
+  }
+
+  boolean markJobSucceededMinimal(
+      UUID id, Instant start, Instant end, Long durationMs, Long queueWaitMs) {
+    return ctx.timedStoreOperation(
+        "mark_succeeded_minimal",
+        () -> doMarkTerminalSuccessMinimal(id, start, end, durationMs, queueWaitMs),
+        updated -> updated ? "updated" : "miss");
+  }
+
+  boolean markJobSucceededAndUpdateBatch(
+      UUID jobId,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs,
+      UUID batchId) {
+    boolean succeeded =
+        markJobSucceeded(jobId, resultJson, resultType, start, end, durationMs, queueWaitMs);
+    if (succeeded) {
+      try {
+        batches.incrementCompletedAtomic(batchId);
+      } catch (RuntimeException e) {
+        throw ctx.translateTransientStoreException(
+            "increment completed batch after job success", e);
+      }
+    }
+    return succeeded;
+  }
+
+  boolean scheduleJobRetry(UUID id, String error, Instant newScheduledTime, int attempts) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET status = 'PENDING', last_error = ?, scheduled_time = ?, attempts = ?,
+            picked_by = NULL, picked_at = NULL, updated_at = SYSUTCDATETIME()
+        WHERE job_id = ? AND status IN ('RUNNING', 'WAITING')
+        """;
+    return ctx.timedStoreOperation(
+            "schedule_retry",
+            () ->
+                ctx.em()
+                    .createNativeQuery(sql)
+                    .setParameter(1, error)
+                    .setParameter(2, Timestamp.from(newScheduledTime))
+                    .setParameter(3, attempts)
+                    .setParameter(4, UuidByteArrayConverter.toBytes(id))
+                    .executeUpdate(),
+            updated -> updated > 0 ? "updated" : "miss")
+        > 0;
+  }
+
+  boolean markJobFailedTerminal(UUID id, String terminalError, int totalAttempts) {
+    return ctx.timedStoreOperation(
+        "mark_failed_terminal",
+        () -> markJobFailedTerminalFromStatus(id, terminalError, totalAttempts, JobStatus.RUNNING),
+        updated -> updated ? "updated" : "miss");
+  }
+
+  private boolean lockExpectedQueueStatusForTerminalCas(UUID id, JobStatus expected) {
+    // The terminal cancel path deletes any live queue row after updating the cold row. Lock the
+    // expected hot row first so this multi-statement path preserves CAS semantics inside the
+    // method transaction: either this caller owns the expected status, or it reports a miss.
+    // language=SQL Server
+    String gateSql =
+        """
+        SELECT job_id
+        FROM scheduler_job_queue WITH (UPDLOCK, ROWLOCK)
+        WHERE job_id = ? AND status = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object> rows =
+        ctx.em()
+            .createNativeQuery(gateSql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .setParameter(2, expected.name())
+            .getResultList();
+    return !rows.isEmpty();
+  }
+
+  boolean cancelJob(UUID id) {
+    return ctx.timedStoreOperation(
+        "cancel_job", () -> doCancelJob(id), updated -> updated ? "updated" : "miss");
+  }
+
+  private boolean doCancelJob(UUID id) {
+    try {
+      // language=SQL Server
+      String selectSql =
+          """
+          SELECT terminal_status
+          FROM scheduler_job WITH (UPDLOCK, ROWLOCK)
+          WHERE job_id = ?
+          """;
+      @SuppressWarnings("unchecked")
+      List<Object> rows =
+          ctx.em()
+              .createNativeQuery(selectSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .getResultList();
+      if (rows.isEmpty()) {
+        return false;
+      }
+      String existingTerminal = (String) rows.get(0);
+      if (existingTerminal != null) {
+        return false;
+      }
+      // Recurring masters live in scheduler_recurring_job — cancel-by-id of a recurring master
+      // routes through RecurringJobStore.cancelRecurringAndArchive, not through here.
+      // language=SQL Server
+      String deleteHotSql =
+          """
+          DELETE FROM scheduler_job_queue
+          WHERE job_id = ? AND status IN ('PENDING','RUNNING','PAUSED','WAITING')
+          """;
+      // language=SQL Server
+      String updateColdSql =
+          """
+          UPDATE c
+          SET terminal_status = 'CANCELED',
+              terminated_at = SYSUTCDATETIME(),
+              execution_start_time =
+                  CASE WHEN q.status = 'RUNNING'
+                       THEN COALESCE(c.execution_start_time, q.picked_at, SYSUTCDATETIME())
+                       ELSE c.execution_start_time END,
+              execution_end_time =
+                  CASE WHEN q.status = 'RUNNING'
+                       THEN SYSUTCDATETIME()
+                       ELSE c.execution_end_time END,
+              execution_duration_ms =
+                  CASE WHEN q.status = 'RUNNING'
+                       THEN CASE WHEN DATEDIFF_BIG(
+                                   MILLISECOND,
+                                   COALESCE(c.execution_start_time, q.picked_at, SYSUTCDATETIME()),
+                                   SYSUTCDATETIME()) < 0
+                            THEN 0
+                            ELSE DATEDIFF_BIG(
+                                   MILLISECOND,
+                                   COALESCE(c.execution_start_time, q.picked_at, SYSUTCDATETIME()),
+                                   SYSUTCDATETIME()) END
+                       ELSE c.execution_duration_ms END
+          FROM scheduler_job c JOIN scheduler_job_queue q ON q.job_id = c.job_id
+          WHERE c.job_id = ?
+            AND c.terminal_status IS NULL
+            AND q.status IN ('PENDING','RUNNING','PAUSED','WAITING')
+          """;
+      int coldUpdated =
+          ctx.em()
+              .createNativeQuery(updateColdSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .executeUpdate();
+      if (coldUpdated == 0) {
+        return false;
+      }
+      int hotDeleted =
+          ctx.em()
+              .createNativeQuery(deleteHotSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .executeUpdate();
+      if (hotDeleted == 0) {
+        throw new IllegalStateException(
+            "cancel updated cold row but did not remove hot row for job " + id);
+      }
+      reservations.deleteReservationByOwner(id);
+      return coldUpdated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("cancel job", e);
+    }
+  }
+
+  boolean resetFailedToPending(UUID id) {
+    try {
+      // language=SQL Server
+      String selectSql =
+          """
+          SELECT terminal_status, job_type, priority, business_key, timeout_sec, max_retries,
+                 execution_target
+          FROM scheduler_job WITH (UPDLOCK, ROWLOCK)
+          WHERE job_id = ?
+          """;
+      @SuppressWarnings("unchecked")
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(selectSql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(id))
+              .getResultList();
+      if (rows.isEmpty()) {
+        return false;
+      }
+      Object[] row = rows.get(0);
+      String terminal = (String) row[0];
+      if (!"FAILED".equals(terminal)) {
+        return false;
+      }
+      String jobType = (String) row[1];
+      int priority = ((Number) row[2]).intValue();
+      String businessKey = (String) row[3];
+      int timeoutSec = ((Number) row[4]).intValue();
+      int maxRetries = ((Number) row[5]).intValue();
+      String executionTarget = (String) row[6];
+
+      // language=SQL Server
+      String clearTerminalSql =
+          """
+          UPDATE scheduler_job
+          SET terminal_status = NULL, terminal_error = NULL,
+              job_result = NULL, result_type = NULL,
+              execution_start_time = NULL, execution_end_time = NULL,
+              execution_duration_ms = NULL, queue_wait_ms = NULL,
+              total_attempts = NULL, terminated_at = NULL
+          WHERE job_id = ? AND terminal_status = 'FAILED'
+          """;
+      ctx.em()
+          .createNativeQuery(clearTerminalSql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(id))
+          .executeUpdate();
+
+      // language=SQL Server
+      String insertHotSql =
+          """
+          INSERT INTO scheduler_job_queue
+            (job_id, status, job_type, priority, scheduled_time, business_key,
+             timeout_sec, max_retries, attempts, version, updated_at, execution_target)
+          VALUES (?, 'PENDING', ?, ?, SYSUTCDATETIME(), ?, ?, ?, 0, 0,
+                  SYSUTCDATETIME(), ?)
+          """;
+      ctx.em()
+          .createNativeQuery(insertHotSql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(id))
+          .setParameter(2, jobType)
+          .setParameter(3, priority)
+          .setParameter(4, businessKey)
+          .setParameter(5, timeoutSec)
+          .setParameter(6, maxRetries)
+          .setParameter(7, executionTarget)
+          .executeUpdate();
+
+      if (businessKey != null) {
+        try {
+          reservations.insertReservation(
+              businessKey, id, SqlserverBusinessKeyReservations.OWNER_TABLE_QUEUE);
+        } catch (RuntimeException e) {
+          if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
+            throw new RatchetTransientStoreException(
+                "Cannot resurrect job " + id + ": business key already held", e);
+          }
+          throw e;
+        }
+      }
+      return true;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("reset failed job to pending", e);
+    }
+  }
+
+  private boolean markJobFailedTerminalFromStatus(
+      UUID id, String terminalError, Integer totalAttempts, JobStatus expectedStatus) {
+    String attemptsExpression = totalAttempts == null ? "q.attempts" : "?";
+    // language=SQL Server
+    String updateColdSql =
+        """
+        UPDATE c
+        SET terminal_status = 'FAILED',
+            terminal_error = ?,
+            total_attempts = %s,
+            terminated_at = SYSUTCDATETIME(),
+            execution_start_time =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN COALESCE(c.execution_start_time, q.picked_at, SYSUTCDATETIME())
+                     ELSE c.execution_start_time END,
+            execution_end_time =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN SYSUTCDATETIME()
+                     ELSE c.execution_end_time END,
+            execution_duration_ms =
+                CASE WHEN q.status = 'RUNNING'
+                     THEN CASE WHEN DATEDIFF_BIG(
+                                 MILLISECOND,
+                                 COALESCE(c.execution_start_time, q.picked_at, SYSUTCDATETIME()),
+                                 SYSUTCDATETIME()) < 0
+                          THEN 0
+                          ELSE DATEDIFF_BIG(
+                                 MILLISECOND,
+                                 COALESCE(c.execution_start_time, q.picked_at, SYSUTCDATETIME()),
+                                 SYSUTCDATETIME()) END
+                     ELSE c.execution_duration_ms END
+        FROM scheduler_job c JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        WHERE c.job_id = ?
+          AND c.terminal_status IS NULL AND q.status = ?
+        """
+            .formatted(attemptsExpression);
+    var query = ctx.em().createNativeQuery(updateColdSql).setParameter(1, terminalError);
+    int parameter = 2;
+    if (totalAttempts != null) {
+      query.setParameter(parameter++, totalAttempts);
+    }
+    int coldUpdated =
+        query
+            .setParameter(parameter++, UuidByteArrayConverter.toBytes(id))
+            .setParameter(parameter, expectedStatus.name())
+            .executeUpdate();
+    if (coldUpdated == 0) {
+      return false;
+    }
+    // language=SQL Server
+    String deleteHotSql = "DELETE FROM scheduler_job_queue WHERE job_id = ? AND status = ?";
+    int hotDeleted =
+        ctx.em()
+            .createNativeQuery(deleteHotSql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .setParameter(2, expectedStatus.name())
+            .executeUpdate();
+    if (hotDeleted == 0) {
+      throw new IllegalStateException(
+          "terminal failure updated cold row but did not remove hot row for job " + id);
+    }
+    reservations.deleteReservationByOwner(id);
+    return true;
+  }
+
+  private boolean doMarkTerminalSuccessWithResult(
+      UUID id,
+      String resultJson,
+      String resultType,
+      Instant start,
+      Instant end,
+      Long durationMs,
+      Long queueWaitMs) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE c
+        SET terminal_status = 'SUCCEEDED',
+            job_result = ?, result_type = ?,
+            execution_start_time = ?, execution_end_time = ?,
+            execution_duration_ms = ?, queue_wait_ms = ?,
+            total_attempts = q.attempts, terminated_at = SYSUTCDATETIME()
+        FROM scheduler_job c JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        WHERE c.job_id = ?
+          AND c.terminal_status IS NULL AND q.status = 'RUNNING'
+        """;
+    int coldUpdated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, resultJson)
+            .setParameter(2, resultType)
+            .setParameter(3, start != null ? Timestamp.from(start) : null)
+            .setParameter(4, end != null ? Timestamp.from(end) : null)
+            .setParameter(5, durationMs)
+            .setParameter(6, queueWaitMs)
+            .setParameter(7, UuidByteArrayConverter.toBytes(id))
+            .executeUpdate();
+    if (coldUpdated == 0) {
+      return false;
+    }
+    deleteHotRowAndReservationAfterSuccess(id);
+    return true;
+  }
+
+  private boolean doMarkTerminalSuccessMinimal(
+      UUID id, Instant start, Instant end, Long durationMs, Long queueWaitMs) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE c
+        SET terminal_status = 'SUCCEEDED',
+            execution_start_time = ?, execution_end_time = ?,
+            execution_duration_ms = ?, queue_wait_ms = ?,
+            total_attempts = q.attempts, terminated_at = SYSUTCDATETIME()
+        FROM scheduler_job c JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        WHERE c.job_id = ?
+          AND c.terminal_status IS NULL AND q.status = 'RUNNING'
+        """;
+    int coldUpdated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, start != null ? Timestamp.from(start) : null)
+            .setParameter(2, end != null ? Timestamp.from(end) : null)
+            .setParameter(3, durationMs)
+            .setParameter(4, queueWaitMs)
+            .setParameter(5, UuidByteArrayConverter.toBytes(id))
+            .executeUpdate();
+    if (coldUpdated == 0) {
+      return false;
+    }
+    deleteHotRowAndReservationAfterSuccess(id);
+    return true;
+  }
+
+  private void deleteHotRowAndReservationAfterSuccess(UUID id) {
+    // language=SQL Server
+    String sql = "DELETE FROM scheduler_job_queue WHERE job_id = ? AND status = 'RUNNING'";
+    int deleted =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .executeUpdate();
+    if (deleted == 0) {
+      throw new IllegalStateException(
+          "terminal success updated cold row but failed to remove hot row for job " + id);
+    }
+    reservations.deleteReservationByOwner(id);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobWriteOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobWriteOperations.java
@@ -1,0 +1,710 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static run.ratchet.store.util.JobWriteSupport.assignIdIfMissing;
+import static run.ratchet.store.util.JobWriteSupport.checkHotField;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
+import run.ratchet.api.exception.RatchetOptimisticLockException;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.spi.ProtectedSurface;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.JobWriteSupport;
+import run.ratchet.store.util.RowValues;
+
+final class SqlserverJobWriteOperations {
+
+  // SQL Server caps a single statement at 2100 bound parameters. The widest insert here
+  // (scheduler_job) binds 25 columns per row, so 80 rows * 25 = 2000 stays safely under the limit.
+  private static final int MAX_BULK_INSERT_ROWS = 80;
+
+  // language=SQL Server
+  private static final String COLD_INSERT_PREFIX =
+      """
+      INSERT INTO scheduler_job (
+        job_id, job_type, priority, max_retries, backoff_policy, backoff_param_ms,
+        timeout_sec, cron_expr, zone_id, payload, params, idempotency_key,
+        business_key, resource_name, on_success_payload, on_failure_payload, depends_on,
+        superseded_by, created_at, caller_principal, trace_context, recurring_master_id,
+        execution_target, encrypted_payload, encryption_key_id)
+      VALUES
+      """;
+
+  // depends_on (17), superseded_by (18), recurring_master_id (22) are nullable BINARY(16) columns.
+  // mssql-jdbc binds an untyped Java null as nvarchar, and SQL Server forbids the implicit
+  // nvarchar -> binary conversion (it allowed nvarchar -> uniqueidentifier, which is why this only
+  // surfaced after the BINARY(16) migration). CAST(? AS BINARY(16)) makes the conversion explicit
+  // so
+  // a null binds cleanly; a non-null byte[] (varbinary) casts to binary harmlessly.
+  private static final String COLD_INSERT_VALUES =
+      """
+      (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+              ?, ?, CAST(? AS BINARY(16)), CAST(? AS BINARY(16)), ?, ?, ?, CAST(? AS BINARY(16)), ?, ?, ?)
+      """;
+
+  private static final String COLD_INSERT_SQL = COLD_INSERT_PREFIX + COLD_INSERT_VALUES;
+
+  // language=SQL Server
+  private static final String HOT_INSERT_PREFIX =
+      """
+      INSERT INTO scheduler_job_queue (
+        job_id, status, job_type, priority, scheduled_time, business_key, timeout_sec,
+        max_retries, attempts, picked_by, picked_at, paused_from_status, last_error,
+        version, updated_at, signal_key, signal_timeout, signal_payload, signal_payload_type,
+        signal_outcome, signal_rejection_reason, signal_delivered_at, signal_delivered_by,
+        signal_delivery_id, execution_target)
+      VALUES
+      """;
+
+  private static final String HOT_INSERT_VALUES =
+      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+  private static final String HOT_INSERT_SQL = HOT_INSERT_PREFIX + HOT_INSERT_VALUES;
+
+  // language=SQL Server
+  private static final String BKRES_INSERT_PREFIX =
+      """
+      INSERT INTO scheduler_business_key_reservation
+        (business_key, owner_job_id, owner_table, reserved_at)
+      VALUES
+      """;
+
+  private static final String BKRES_INSERT_VALUES = "(?, ?, ?, SYSUTCDATETIME())";
+
+  private static final int IDX_HOT_STATUS = 0;
+  private static final int IDX_HOT_SCHEDULED_TIME = 1;
+  private static final int IDX_HOT_ATTEMPTS = 2;
+  private static final int IDX_HOT_PICKED_BY = 3;
+  private static final int IDX_HOT_PICKED_AT = 4;
+  private static final int IDX_HOT_PAUSED_FROM_STATUS = 5;
+  private static final int IDX_HOT_LAST_ERROR = 6;
+  private static final int IDX_HOT_VERSION = 7;
+  private static final int IDX_HOT_TERMINAL_STATUS = 8;
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverBusinessKeyReservations reservations;
+  private final SqlserverTagOperations tags;
+
+  SqlserverJobWriteOperations(
+      SqlserverStoreContext ctx,
+      SqlserverBusinessKeyReservations reservations,
+      SqlserverTagOperations tags) {
+    this.ctx = ctx;
+    this.reservations = reservations;
+    this.tags = tags;
+  }
+
+  JobEntity save(JobEntity job) {
+    if (job.getId() == null) {
+      saveInsert(job);
+    } else {
+      saveColdUpdate(job);
+    }
+    return job;
+  }
+
+  void bulkInsert(List<JobEntity> jobs) {
+    if (jobs.isEmpty()) {
+      return;
+    }
+    Instant now = Instant.now();
+    Timestamp nowTs = Timestamp.from(now);
+
+    for (JobEntity job : jobs) {
+      assignIdIfMissing(job);
+      if (job.getCreatedAt() == null) {
+        job.setCreatedAt(now);
+      }
+      if (job.getUpdatedAt() == null) {
+        job.setUpdatedAt(now);
+      }
+    }
+
+    try {
+      executeColdBulkInsert(jobs, nowTs);
+      executeHotBulkInsert(jobs, nowTs);
+      executeTerminalBackfills(jobs, nowTs);
+      executeBusinessKeyBulkInsert(jobs);
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
+        throw new RatchetTransientStoreException("Active business key in use", e);
+      }
+      throw e;
+    } finally {
+      detachInsertedJobs(jobs);
+    }
+  }
+
+  void saveInsert(JobEntity job) {
+    assignIdIfMissing(job);
+    Instant now = Instant.now();
+    Timestamp nowTs = Timestamp.from(now);
+    if (job.getCreatedAt() == null) {
+      job.setCreatedAt(now);
+    }
+    if (job.getUpdatedAt() == null) {
+      job.setUpdatedAt(now);
+    }
+
+    boolean recurring = job.getJobType() == JobExecutionType.RECURRING;
+    boolean hasBkey = job.getBusinessKey() != null;
+    boolean bornTerminal =
+        job.getStatus() != null && SqlserverJobRowMapper.isTerminalStatus(job.getStatus());
+
+    try {
+      executeColdInsert(job, nowTs);
+      if (bornTerminal) {
+        executeColdTerminalBackfill(job, nowTs);
+        job.setTerminalStatus(job.getStatus());
+      } else {
+        if (!recurring) {
+          executeHotInsert(job, nowTs);
+        }
+        if (hasBkey) {
+          String ownerTable =
+              recurring
+                  ? SqlserverBusinessKeyReservations.OWNER_TABLE_RECURRING
+                  : SqlserverBusinessKeyReservations.OWNER_TABLE_QUEUE;
+          reservations.insertReservation(job.getBusinessKey(), job.getId(), ownerTable);
+        }
+      }
+      if (job.getTags() != null && !job.getTags().isEmpty()) {
+        tags.insertTags(job.getId(), job.getTags());
+      }
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateIdempotencyKey(e)) {
+        throw new DuplicateIdempotencyKeyException(job.getIdempotencyKey(), e);
+      }
+      if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
+        throw new RatchetTransientStoreException(
+            "Active business key in use for job " + job.getId(), e);
+      }
+      throw e;
+    }
+  }
+
+  private void executeColdTerminalBackfill(JobEntity job, Timestamp nowTs) {
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job
+        SET terminal_status = ?, terminal_error = ?, total_attempts = ?, terminated_at = ?
+        WHERE job_id = ?
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, job.getStatus().name())
+        .setParameter(2, job.getLastError())
+        .setParameter(3, job.getAttempts())
+        .setParameter(4, nowTs)
+        .setParameter(5, UuidByteArrayConverter.toBytes(job.getId()))
+        .executeUpdate();
+  }
+
+  private void executeColdInsert(JobEntity job, Timestamp nowTs) {
+    Query q = ctx.em().createNativeQuery(COLD_INSERT_SQL);
+    bindColdInsert(q, job, nowTs);
+    q.executeUpdate();
+  }
+
+  private void executeHotInsert(JobEntity job, Timestamp nowTs) {
+    Query q = ctx.em().createNativeQuery(HOT_INSERT_SQL);
+    bindHotInsert(q, job, nowTs);
+    q.executeUpdate();
+  }
+
+  private void bindColdInsert(Query q, JobEntity job, Timestamp nowTs) {
+    bindColdInsert(q, job, nowTs, 1);
+  }
+
+  private int bindColdInsert(Query q, JobEntity job, Timestamp nowTs, int i) {
+    boolean active = JobEncryption.activeFor(job);
+    String keyId = JobEncryption.keyId(active);
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(job.getId()));
+    q.setParameter(i++, job.getJobType().name());
+    q.setParameter(i++, job.getPriority().ordinal());
+    q.setParameter(i++, job.getMaxRetries());
+    q.setParameter(i++, job.getBackoffPolicy().name());
+    q.setParameter(i++, job.getBackoffParamMs());
+    q.setParameter(i++, job.getTimeoutSec());
+    q.setParameter(i++, JobWriteSupport.coerceCronExpr(job.getCronExpr()));
+    q.setParameter(i++, JobWriteSupport.coerceZoneId(job.getZoneId()));
+    q.setParameter(i++, SqlserverJobRowMapper.payloadToJson(job, active));
+    q.setParameter(i++, SqlserverJobRowMapper.paramsToJson(job, active));
+    q.setParameter(i++, job.getIdempotencyKey());
+    q.setParameter(i++, job.getBusinessKey());
+    q.setParameter(i++, job.getResourceName());
+    q.setParameter(
+        i++,
+        SqlserverJobRowMapper.callbackPayloadToJson(
+            job, job.getOnSuccessPayload(), ProtectedSurface.ON_SUCCESS_PAYLOAD, active));
+    q.setParameter(
+        i++,
+        SqlserverJobRowMapper.callbackPayloadToJson(
+            job, job.getOnFailurePayload(), ProtectedSurface.ON_FAILURE_PAYLOAD, active));
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(job.getDependsOn()));
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(job.getSupersededBy()));
+    q.setParameter(i++, job.getCreatedAt() != null ? Timestamp.from(job.getCreatedAt()) : nowTs);
+    q.setParameter(i++, job.getCallerPrincipal());
+    q.setParameter(i++, SqlserverJobRowMapper.traceContextToJson(job));
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(job.getRecurringMasterId()));
+    q.setParameter(i++, job.getExecutionTarget());
+    q.setParameter(i++, active);
+    q.setParameter(i, keyId);
+    return i + 1;
+  }
+
+  private void bindHotInsert(Query q, JobEntity job, Timestamp nowTs) {
+    bindHotInsert(q, job, nowTs, 1);
+  }
+
+  private int bindHotInsert(Query q, JobEntity job, Timestamp nowTs, int i) {
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(job.getId()));
+    JobStatus s = job.getStatus() != null ? job.getStatus() : JobStatus.PENDING;
+    q.setParameter(i++, s.name());
+    q.setParameter(i++, job.getJobType().name());
+    q.setParameter(i++, job.getPriority().ordinal());
+    Instant scheduled = job.getScheduledTime();
+    q.setParameter(i++, scheduled != null ? Timestamp.from(scheduled) : nowTs);
+    q.setParameter(i++, job.getBusinessKey());
+    q.setParameter(i++, job.getTimeoutSec());
+    q.setParameter(i++, job.getMaxRetries());
+    q.setParameter(i++, job.getAttempts());
+    q.setParameter(i++, job.getPickedBy());
+    q.setParameter(i++, job.getPickedAt() != null ? Timestamp.from(job.getPickedAt()) : null);
+    q.setParameter(
+        i++, job.getPausedFromStatus() != null ? job.getPausedFromStatus().name() : null);
+    q.setParameter(i++, job.getLastError());
+    q.setParameter(i++, job.getVersion() != null ? job.getVersion() : 0);
+    q.setParameter(i++, nowTs);
+    q.setParameter(i++, job.getSignalKey());
+    q.setParameter(
+        i++, job.getSignalTimeout() != null ? Timestamp.from(job.getSignalTimeout()) : null);
+    q.setParameter(i++, job.getSignalPayload());
+    q.setParameter(i++, job.getSignalPayloadType());
+    q.setParameter(i++, job.getSignalOutcome());
+    q.setParameter(i++, job.getSignalRejectionReason());
+    q.setParameter(
+        i++,
+        job.getSignalDeliveredAt() != null ? Timestamp.from(job.getSignalDeliveredAt()) : null);
+    q.setParameter(i++, job.getSignalDeliveredBy());
+    q.setParameter(i++, job.getSignalDeliveryId());
+    q.setParameter(i, job.getExecutionTarget());
+    return i + 1;
+  }
+
+  private void executeColdBulkInsert(List<JobEntity> jobs, Timestamp nowTs) {
+    for (int start = 0; start < jobs.size(); start += MAX_BULK_INSERT_ROWS) {
+      List<JobEntity> chunk =
+          jobs.subList(start, Math.min(start + MAX_BULK_INSERT_ROWS, jobs.size()));
+      Query query =
+          ctx.em()
+              .createNativeQuery(
+                  COLD_INSERT_PREFIX + repeatValues(COLD_INSERT_VALUES, chunk.size()));
+      int parameter = 1;
+      for (JobEntity job : chunk) {
+        parameter = bindColdInsert(query, job, nowTs, parameter);
+      }
+      query.executeUpdate();
+    }
+  }
+
+  private void executeHotBulkInsert(List<JobEntity> jobs, Timestamp nowTs) {
+    List<JobEntity> hotJobs =
+        jobs.stream()
+            .filter(job -> job.getJobType() != JobExecutionType.RECURRING)
+            .filter(
+                job ->
+                    job.getStatus() == null
+                        || !SqlserverJobRowMapper.isTerminalStatus(job.getStatus()))
+            .toList();
+    for (int start = 0; start < hotJobs.size(); start += MAX_BULK_INSERT_ROWS) {
+      List<JobEntity> chunk =
+          hotJobs.subList(start, Math.min(start + MAX_BULK_INSERT_ROWS, hotJobs.size()));
+      Query query =
+          ctx.em()
+              .createNativeQuery(HOT_INSERT_PREFIX + repeatValues(HOT_INSERT_VALUES, chunk.size()));
+      int parameter = 1;
+      for (JobEntity job : chunk) {
+        parameter = bindHotInsert(query, job, nowTs, parameter);
+      }
+      query.executeUpdate();
+    }
+  }
+
+  private void executeTerminalBackfills(List<JobEntity> jobs, Timestamp nowTs) {
+    List<JobEntity> terminalJobs =
+        jobs.stream()
+            .filter(job -> job.getStatus() != null)
+            .filter(job -> SqlserverJobRowMapper.isTerminalStatus(job.getStatus()))
+            .toList();
+    for (int start = 0; start < terminalJobs.size(); start += MAX_BULK_INSERT_ROWS) {
+      List<JobEntity> chunk =
+          terminalJobs.subList(start, Math.min(start + MAX_BULK_INSERT_ROWS, terminalJobs.size()));
+      String values =
+          String.join(
+              ",",
+              Collections.nCopies(
+                  chunk.size(),
+                  "(CAST(? AS BINARY(16)), CAST(? AS VARCHAR(16)), ?, ?, CAST(? AS DATETIME2(6)))"));
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job AS c
+          SET terminal_status = v.terminal_status,
+              terminal_error = v.terminal_error,
+              total_attempts = v.total_attempts,
+              terminated_at = v.terminated_at
+          FROM (VALUES %s) AS v(job_id, terminal_status, terminal_error, total_attempts, terminated_at)
+          WHERE c.job_id = v.job_id
+          """
+              .formatted(values);
+      Query query = ctx.em().createNativeQuery(sql);
+      int parameter = 1;
+      for (JobEntity job : chunk) {
+        query.setParameter(parameter++, UuidByteArrayConverter.toBytes(job.getId()));
+        query.setParameter(parameter++, job.getStatus().name());
+        query.setParameter(parameter++, job.getLastError());
+        query.setParameter(parameter++, job.getAttempts());
+        query.setParameter(parameter++, nowTs);
+        job.setTerminalStatus(job.getStatus());
+      }
+      query.executeUpdate();
+    }
+  }
+
+  private void detachInsertedJobs(List<JobEntity> jobs) {
+    for (JobEntity job : jobs) {
+      if (ctx.em().contains(job)) {
+        ctx.em().detach(job);
+      }
+    }
+  }
+
+  private void executeBusinessKeyBulkInsert(List<JobEntity> jobs) {
+    List<JobEntity> keyedJobs =
+        jobs.stream()
+            .filter(job -> job.getBusinessKey() != null)
+            .filter(
+                job ->
+                    job.getStatus() == null
+                        || !SqlserverJobRowMapper.isTerminalStatus(job.getStatus()))
+            .toList();
+    for (int start = 0; start < keyedJobs.size(); start += MAX_BULK_INSERT_ROWS) {
+      List<JobEntity> chunk =
+          keyedJobs.subList(start, Math.min(start + MAX_BULK_INSERT_ROWS, keyedJobs.size()));
+      Query query =
+          ctx.em()
+              .createNativeQuery(
+                  BKRES_INSERT_PREFIX + repeatValues(BKRES_INSERT_VALUES, chunk.size()));
+      int parameter = 1;
+      for (JobEntity job : chunk) {
+        parameter = reservations.bindInsert(query, job, parameter);
+      }
+      query.executeUpdate();
+    }
+  }
+
+  private static String repeatValues(String values, int count) {
+    return String.join(", ", Collections.nCopies(count, values));
+  }
+
+  private void saveColdUpdate(JobEntity job) {
+    Object[] row = snapshotHotRow(job.getId());
+    if (tryScheduledTimeOnlyHotUpdate(job, row)) {
+      return;
+    }
+    if (tryHotMutationDispatch(job, row)) {
+      return;
+    }
+    guardAgainstHotMutation(job, row);
+
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job
+        SET params = ?,
+            on_success_payload = ?,
+            on_failure_payload = ?,
+            depends_on = CAST(? AS BINARY(16)),
+            superseded_by = CAST(? AS BINARY(16)),
+            resource_name = ?
+        WHERE job_id = ?
+        """;
+    boolean active = JobEncryption.activeFor(job);
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, SqlserverJobRowMapper.paramsToJson(job, active))
+        .setParameter(
+            2,
+            SqlserverJobRowMapper.callbackPayloadToJson(
+                job, job.getOnSuccessPayload(), ProtectedSurface.ON_SUCCESS_PAYLOAD, active))
+        .setParameter(
+            3,
+            SqlserverJobRowMapper.callbackPayloadToJson(
+                job, job.getOnFailurePayload(), ProtectedSurface.ON_FAILURE_PAYLOAD, active))
+        .setParameter(4, UuidByteArrayConverter.toBytes(job.getDependsOn()))
+        .setParameter(5, UuidByteArrayConverter.toBytes(job.getSupersededBy()))
+        .setParameter(6, job.getResourceName())
+        .setParameter(7, UuidByteArrayConverter.toBytes(job.getId()))
+        .executeUpdate();
+  }
+
+  private boolean tryScheduledTimeOnlyHotUpdate(JobEntity job, Object[] row) {
+    UUID id = job.getId();
+    if (row == null) {
+      return false;
+    }
+    String storedStatus = (String) row[IDX_HOT_STATUS];
+    if (!"PENDING".equals(storedStatus) && !"WAITING".equals(storedStatus)) {
+      return false;
+    }
+    Instant storedSched = RowValues.instantOrNull(row[IDX_HOT_SCHEDULED_TIME]);
+    Instant incomingSched = job.getScheduledTime();
+    if (Objects.equals(storedSched, incomingSched)) {
+      return false;
+    }
+    if (!Objects.equals(JobStatus.valueOf(storedStatus), job.getStatus())
+        || !Objects.equals(((Number) row[IDX_HOT_ATTEMPTS]).intValue(), job.getAttempts())
+        || !Objects.equals(row[IDX_HOT_PICKED_BY], job.getPickedBy())
+        || !Objects.equals(RowValues.instantOrNull(row[IDX_HOT_PICKED_AT]), job.getPickedAt())
+        || !Objects.equals(
+            row[IDX_HOT_PAUSED_FROM_STATUS] != null
+                ? JobStatus.valueOf((String) row[IDX_HOT_PAUSED_FROM_STATUS])
+                : null,
+            job.getPausedFromStatus())
+        || !Objects.equals(row[IDX_HOT_LAST_ERROR], job.getLastError())
+        || !Objects.equals(((Number) row[IDX_HOT_VERSION]).intValue(), job.getVersion())) {
+      return false;
+    }
+    // language=SQL Server
+    String updateSql =
+        """
+        UPDATE scheduler_job_queue
+        SET scheduled_time = ?, updated_at = SYSUTCDATETIME()
+        WHERE job_id = ? AND status = ?
+        """;
+    ctx.em()
+        .createNativeQuery(updateSql)
+        .setParameter(1, incomingSched != null ? Timestamp.from(incomingSched) : null)
+        .setParameter(2, UuidByteArrayConverter.toBytes(id))
+        .setParameter(3, storedStatus)
+        .executeUpdate();
+    return true;
+  }
+
+  private void updateHotLiveViaVersion(JobEntity incoming, int expectedVersion) {
+    UUID id = incoming.getId();
+    JobStatus status = incoming.getStatus() != null ? incoming.getStatus() : JobStatus.PENDING;
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_queue
+        SET status = ?, scheduled_time = ?, attempts = ?, picked_by = ?, picked_at = ?,
+            paused_from_status = ?, last_error = ?, version = version + 1,
+            updated_at = SYSUTCDATETIME()
+        WHERE job_id = ? AND version = ?
+        """;
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, status.name())
+            .setParameter(
+                2,
+                incoming.getScheduledTime() != null
+                    ? Timestamp.from(incoming.getScheduledTime())
+                    : null)
+            .setParameter(3, incoming.getAttempts())
+            .setParameter(4, incoming.getPickedBy())
+            .setParameter(
+                5, incoming.getPickedAt() != null ? Timestamp.from(incoming.getPickedAt()) : null)
+            .setParameter(
+                6,
+                incoming.getPausedFromStatus() != null
+                    ? incoming.getPausedFromStatus().name()
+                    : null)
+            .setParameter(7, incoming.getLastError())
+            .setParameter(8, UuidByteArrayConverter.toBytes(id))
+            .setParameter(9, expectedVersion)
+            .executeUpdate();
+    if (updated == 0) {
+      throw new RatchetOptimisticLockException("Concurrent modification on job " + id);
+    }
+    incoming.setVersion(expectedVersion + 1);
+  }
+
+  private void terminalizeViaSave(JobEntity incoming, int expectedVersion) {
+    UUID id = incoming.getId();
+    int deleted =
+        ctx.em()
+            .createNativeQuery("DELETE FROM scheduler_job_queue WHERE job_id = ? AND version = ?")
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .setParameter(2, expectedVersion)
+            .executeUpdate();
+    if (deleted == 0) {
+      throw new RatchetOptimisticLockException("Concurrent modification on job " + id);
+    }
+    // language=SQL Server
+    String updateSql =
+        """
+        UPDATE scheduler_job
+        SET terminal_status = ?,
+            terminal_error = COALESCE(?, terminal_error),
+            terminated_at = SYSUTCDATETIME()
+        WHERE job_id = ? AND terminal_status IS NULL
+        """;
+    ctx.em()
+        .createNativeQuery(updateSql)
+        .setParameter(1, incoming.getStatus().name())
+        .setParameter(2, incoming.getLastError())
+        .setParameter(3, UuidByteArrayConverter.toBytes(id))
+        .executeUpdate();
+    reservations.deleteReservationByOwner(id);
+    incoming.setVersion(expectedVersion + 1);
+    incoming.setTerminalStatus(incoming.getStatus());
+  }
+
+  @SuppressWarnings("unchecked")
+  private Object[] snapshotHotRow(UUID id) {
+    // language=SQL Server
+    String sql =
+        """
+        SELECT q.status, q.scheduled_time, q.attempts, q.picked_by, q.picked_at,
+               q.paused_from_status, q.last_error, q.version,
+               c.terminal_status
+        FROM scheduler_job c
+        LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id
+        WHERE c.job_id = ?
+        """;
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .getResultList();
+    return rows.isEmpty() ? null : rows.get(0);
+  }
+
+  private void guardAgainstHotMutation(JobEntity incoming, Object[] row) {
+    UUID id = incoming.getId();
+    if (row == null) {
+      throw new IllegalStateException("save() called on missing job id=" + id);
+    }
+    String qStatus = (String) row[IDX_HOT_STATUS];
+    String terminal = (String) row[IDX_HOT_TERMINAL_STATUS];
+
+    if (qStatus != null) {
+      JobStatus storedStatus = JobStatus.valueOf(qStatus);
+      checkHotField(id, "status", incoming.getStatus(), storedStatus);
+      checkHotField(
+          id,
+          "scheduledTime",
+          incoming.getScheduledTime(),
+          RowValues.instantOrNull(row[IDX_HOT_SCHEDULED_TIME]));
+      Integer storedAttempts = ((Number) row[IDX_HOT_ATTEMPTS]).intValue();
+      checkHotField(id, "attempts", incoming.getAttempts(), storedAttempts);
+      checkHotField(id, "pickedBy", incoming.getPickedBy(), row[IDX_HOT_PICKED_BY]);
+      checkHotField(
+          id, "pickedAt", incoming.getPickedAt(), RowValues.instantOrNull(row[IDX_HOT_PICKED_AT]));
+      String pausedFrom = (String) row[IDX_HOT_PAUSED_FROM_STATUS];
+      JobStatus storedPausedFrom = pausedFrom != null ? JobStatus.valueOf(pausedFrom) : null;
+      checkHotField(id, "pausedFromStatus", incoming.getPausedFromStatus(), storedPausedFrom);
+      checkHotField(id, "lastError", incoming.getLastError(), row[IDX_HOT_LAST_ERROR]);
+      Integer storedVersion = ((Number) row[IDX_HOT_VERSION]).intValue();
+      checkHotField(id, "version", incoming.getVersion(), storedVersion);
+      return;
+    }
+
+    if (terminal != null) {
+      JobStatus storedTerminal = JobStatus.valueOf(terminal);
+      if (incoming.getTerminalStatus() != storedTerminal) {
+        throw new RatchetOptimisticLockException("Concurrent modification on job " + id);
+      }
+      JobStatus incomingStatus = incoming.getStatus();
+      if (incomingStatus != null && incomingStatus != storedTerminal) {
+        throw new IllegalStateException(
+            "save() rejected: cannot mutate terminal job id="
+                + id
+                + " (terminal="
+                + terminal
+                + ", incoming.status="
+                + incomingStatus
+                + "). Use resetFailedToPending or markJobFailedTerminal.");
+      }
+      return;
+    }
+  }
+
+  private boolean tryHotMutationDispatch(JobEntity incoming, Object[] row) {
+    UUID id = incoming.getId();
+    if (row == null) {
+      return false;
+    }
+    String hotStatusStr = (String) row[IDX_HOT_STATUS];
+    String terminalStr = (String) row[IDX_HOT_TERMINAL_STATUS];
+    if (terminalStr != null || hotStatusStr == null) {
+      return false;
+    }
+
+    JobStatus storedStatus = JobStatus.valueOf(hotStatusStr);
+    Instant storedSched = RowValues.instantOrNull(row[IDX_HOT_SCHEDULED_TIME]);
+    int storedAttempts = ((Number) row[IDX_HOT_ATTEMPTS]).intValue();
+    Object storedPickedBy = row[IDX_HOT_PICKED_BY];
+    Instant storedPickedAt = RowValues.instantOrNull(row[IDX_HOT_PICKED_AT]);
+    String storedPausedFromStr = (String) row[IDX_HOT_PAUSED_FROM_STATUS];
+    JobStatus storedPausedFrom =
+        storedPausedFromStr != null ? JobStatus.valueOf(storedPausedFromStr) : null;
+    Object storedLastError = row[IDX_HOT_LAST_ERROR];
+    int storedVersion = ((Number) row[IDX_HOT_VERSION]).intValue();
+
+    boolean statusDiffers = incoming.getStatus() != null && incoming.getStatus() != storedStatus;
+    boolean anyHotFieldDiffers =
+        statusDiffers
+            || !Objects.equals(incoming.getScheduledTime(), storedSched)
+            || incoming.getAttempts() != storedAttempts
+            || !Objects.equals(incoming.getPickedBy(), storedPickedBy)
+            || !Objects.equals(incoming.getPickedAt(), storedPickedAt)
+            || !Objects.equals(incoming.getPausedFromStatus(), storedPausedFrom)
+            || !Objects.equals(incoming.getLastError(), storedLastError);
+
+    if (!anyHotFieldDiffers) {
+      return false;
+    }
+
+    Integer incomingVersion = incoming.getVersion();
+    if (incomingVersion != null && incomingVersion.intValue() != storedVersion) {
+      throw new RatchetOptimisticLockException("Concurrent modification on job " + id);
+    }
+
+    if (statusDiffers && incoming.getStatus().isTerminal()) {
+      terminalizeViaSave(incoming, storedVersion);
+    } else {
+      updateHotLiveViaVersion(incoming, storedVersion);
+    }
+    return true;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverNodeLockOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverNodeLockOperations.java
@@ -170,7 +170,7 @@ final class SqlserverNodeLockOperations implements LockStore, NodeStore {
               + " ORDER BY (SELECT 1) OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";
       return ctx.em()
           .createNativeQuery(sql, NodeEntity.class)
-          .setParameter(1, Timestamp.from(cutoff))
+          .setParameter(1, SqlserverTimestamps.microTimestamp(cutoff))
           .setParameter(2, MAX_INACTIVE_NODES)
           .getResultList();
     } catch (RuntimeException e) {
@@ -185,7 +185,7 @@ final class SqlserverNodeLockOperations implements LockStore, NodeStore {
       String sql = "DELETE FROM scheduler_node WHERE heartbeat_ts < ?";
       return ctx.em()
           .createNativeQuery(sql)
-          .setParameter(1, Timestamp.from(cutoff))
+          .setParameter(1, SqlserverTimestamps.microTimestamp(cutoff))
           .executeUpdate();
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("delete inactive nodes", e);

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverNodeLockOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverNodeLockOperations.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static run.ratchet.store.util.LockValidation.durationMicros;
+import static run.ratchet.store.util.LockValidation.requireLockName;
+import static run.ratchet.store.util.LockValidation.requirePositiveDuration;
+
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import run.ratchet.store.entity.NodeEntity;
+import run.ratchet.store.spi.LockStore;
+import run.ratchet.store.spi.NodeStore;
+
+final class SqlserverNodeLockOperations implements LockStore, NodeStore {
+
+  private static final int MAX_INACTIVE_NODES = 1000;
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverNodeLockOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public boolean tryLock(String name, Duration ttl, String nodeId) {
+    requireLockName(name);
+    requirePositiveDuration(ttl, "ttl");
+    Objects.requireNonNull(nodeId, "nodeId");
+    try {
+      long ttlMicros = durationMicros(ttl);
+      // expires_at is computed as whole seconds + sub-second microsecond remainder: DATEADD's
+      // interval argument is a 32-bit int and a microsecond TTL overflows it past ~35.8 minutes.
+      // language=SQL Server
+      String sql =
+          """
+          MERGE scheduler_lock WITH (HOLDLOCK) AS tgt
+          USING (VALUES (?, ?, ?)) AS src(lock_name, owner_node, ttl_micros)
+            ON tgt.lock_name = src.lock_name
+          WHEN MATCHED AND (tgt.expires_at < SYSUTCDATETIME()
+                            OR tgt.owner_node = src.owner_node) THEN UPDATE SET
+            owner_node = src.owner_node,
+            locked_at = SYSUTCDATETIME(),
+            expires_at = DATEADD(MICROSECOND, src.ttl_micros % 1000000,
+                                 DATEADD(SECOND, src.ttl_micros / 1000000, SYSUTCDATETIME()))
+          WHEN NOT MATCHED THEN INSERT (lock_name, owner_node, locked_at, expires_at)
+            VALUES (src.lock_name, src.owner_node, SYSUTCDATETIME(),
+                    DATEADD(MICROSECOND, src.ttl_micros % 1000000,
+                            DATEADD(SECOND, src.ttl_micros / 1000000, SYSUTCDATETIME())));
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, name)
+              .setParameter(2, nodeId)
+              .setParameter(3, ttlMicros)
+              .executeUpdate();
+      return updated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("try lock", e);
+    }
+  }
+
+  @Override
+  public void unlock(String name, String nodeId) {
+    requireLockName(name);
+    Objects.requireNonNull(nodeId, "nodeId");
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_lock WHERE lock_name = ? AND owner_node = ?";
+      ctx.em().createNativeQuery(sql).setParameter(1, name).setParameter(2, nodeId).executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("unlock", e);
+    }
+  }
+
+  @Override
+  public boolean renewLock(String name, Duration extension, String nodeId) {
+    requireLockName(name);
+    requirePositiveDuration(extension, "extension");
+    Objects.requireNonNull(nodeId, "nodeId");
+    try {
+      long extensionMicros = durationMicros(extension);
+      // DATEADD's interval argument is a 32-bit int; microseconds overflow it at ~35.8 minutes, so
+      // add whole seconds and the sub-second microsecond remainder separately. Whole seconds fit an
+      // int for any realistic lease.
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_lock
+          SET expires_at = DATEADD(MICROSECOND, ? % 1000000,
+                                   DATEADD(SECOND, ? / 1000000, SYSUTCDATETIME()))
+          WHERE lock_name = ? AND owner_node = ?
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, extensionMicros)
+              .setParameter(2, extensionMicros)
+              .setParameter(3, name)
+              .setParameter(4, nodeId)
+              .executeUpdate();
+      return updated > 0;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("renew lock", e);
+    }
+  }
+
+  @Override
+  public void upsertHeartbeat(String nodeId, Instant ts) {
+    Objects.requireNonNull(nodeId, "nodeId");
+    Objects.requireNonNull(ts, "ts");
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          MERGE scheduler_node WITH (HOLDLOCK) AS tgt
+          USING (VALUES (?, ?, ?)) AS src(node_id, heartbeat_ts, started_at)
+            ON tgt.node_id = src.node_id
+          WHEN MATCHED THEN UPDATE SET heartbeat_ts = src.heartbeat_ts
+          WHEN NOT MATCHED THEN INSERT (node_id, heartbeat_ts, started_at)
+            VALUES (src.node_id, src.heartbeat_ts, src.started_at);
+          """;
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, nodeId)
+          .setParameter(2, Timestamp.from(ts))
+          .setParameter(3, Timestamp.from(ts))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("upsert heartbeat", e);
+    }
+  }
+
+  @Override
+  public Optional<NodeEntity> findNodeById(String nodeId) {
+    try {
+      return Optional.ofNullable(ctx.em().find(NodeEntity.class, nodeId));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find node by id", e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<NodeEntity> findInactiveNodesSince(Instant cutoff) {
+    try {
+      // language=SQL Server
+      String sql =
+          "SELECT * FROM scheduler_node WHERE heartbeat_ts < ?"
+              + " ORDER BY (SELECT 1) OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";
+      return ctx.em()
+          .createNativeQuery(sql, NodeEntity.class)
+          .setParameter(1, Timestamp.from(cutoff))
+          .setParameter(2, MAX_INACTIVE_NODES)
+          .getResultList();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find inactive nodes", e);
+    }
+  }
+
+  @Override
+  public int deleteInactiveNodesSince(Instant cutoff) {
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_node WHERE heartbeat_ts < ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, Timestamp.from(cutoff))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete inactive nodes", e);
+    }
+  }
+
+  @Override
+  public int deleteInactiveNodesByIds(Collection<String> nodeIds) {
+    if (nodeIds.isEmpty()) {
+      return 0;
+    }
+    try {
+      String placeholders = String.join(",", Collections.nCopies(nodeIds.size(), "?"));
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_node WHERE node_id IN (" + placeholders + ")";
+      var query = ctx.em().createNativeQuery(sql);
+      int parameter = 1;
+      for (String nodeId : nodeIds) {
+        query.setParameter(parameter++, nodeId);
+      }
+      return query.executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete inactive nodes by id", e);
+    }
+  }
+
+  @Override
+  public Instant getDatabaseTime() {
+    try {
+      // language=SQL Server
+      String sql = "SELECT DATEDIFF_BIG(MILLISECOND, '19700101', SYSUTCDATETIME())";
+      Object epochMillis = ctx.em().createNativeQuery(sql).getSingleResult();
+      if (epochMillis instanceof Number n) {
+        return Instant.ofEpochMilli(n.longValue());
+      }
+      throw new IllegalStateException(
+          "Unexpected database epoch millis result type: "
+              + (epochMillis == null ? "null" : epochMillis.getClass().getName()));
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("get database time", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
@@ -114,14 +114,7 @@ final class SqlserverRecurringJobOperations implements RecurringJobStore {
     if (rows.isEmpty() || rows.get(0) == null) {
       return Optional.empty();
     }
-    Object v = rows.get(0);
-    if (v instanceof Timestamp ts) {
-      return Optional.of(ts.toInstant());
-    }
-    if (v instanceof Instant inst) {
-      return Optional.of(inst);
-    }
-    return Optional.empty();
+    return Optional.ofNullable(RowValues.instantOrNull(rows.get(0)));
   }
 
   @Override

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
@@ -369,9 +369,9 @@ final class SqlserverRecurringJobOperations implements RecurringJobStore {
   private int archiveAndDeleteChunk(List<UUID> ids, ArchiveReason reason) {
     String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
     // language=SQL Server
-    // ON CONFLICT DO NOTHING keeps cancel idempotent under concurrent cancels for the same id:
-    // the loser of the race no-ops on the archive insert instead of throwing a PK violation,
-    // and the DELETE below is naturally idempotent.
+    // The NOT EXISTS guard keeps cancel idempotent under concurrent cancels for the same id: the
+    // loser of the race inserts no archive row instead of throwing a PK violation, and the DELETE
+    // below is naturally idempotent.
     String archiveSql =
         "INSERT INTO scheduler_recurring_job_archive ("
             + "id, cron_expr, zone_id, payload, on_success_payload, on_failure_payload,"

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
@@ -1,0 +1,440 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import run.ratchet.api.NodeTagFilter;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.spi.ProtectedSurface;
+import run.ratchet.store.spi.RecurringJobDefinition;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.JobClaimSqlSupport;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.RecurringJobRows;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * SQL Server implementation of {@link RecurringJobStore} against the dedicated {@code
+ * scheduler_recurring_job} table.
+ */
+final class SqlserverRecurringJobOperations implements RecurringJobStore {
+
+  private static final int CANCEL_CHUNK = 500;
+
+  // language=SQL Server
+  private static final String SELECT_COLUMNS =
+      "id, priority, max_retries, backoff_policy, backoff_param_ms, timeout_sec, cron_expr,"
+          + " zone_id, next_fire, is_paused, paused_at, payload,"
+          + " on_success_payload, on_failure_payload, business_key, resource_name,"
+          + " execution_target, created_at, caller_principal, encrypted_payload";
+
+  private final SqlserverStoreContext ctx;
+  private final SqlserverBusinessKeyReservations reservations;
+
+  SqlserverRecurringJobOperations(
+      SqlserverStoreContext ctx, SqlserverBusinessKeyReservations reservations) {
+    this.ctx = ctx;
+    this.reservations = reservations;
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "SqlSourceToSinkFlow"})
+  public List<RecurringJobDefinition> claimDueRecurring(
+      int limit, String nodeId, NodeTagFilter tagFilter) {
+    if (limit <= 0) {
+      return List.of();
+    }
+    try {
+      String tagSql = JobClaimSqlSupport.buildTagFilterSql(tagFilter, "r", "id");
+      // language=SQL Server
+      String sql =
+          "SELECT "
+              + SELECT_COLUMNS
+              + " FROM scheduler_recurring_job r WITH (UPDLOCK, READPAST, ROWLOCK)"
+              + " WHERE r.is_paused = 0"
+              + " AND r.next_fire <= SYSUTCDATETIME()"
+              + tagSql
+              + " ORDER BY r.priority DESC, r.next_fire ASC, r.id ASC"
+              + " OFFSET 0 ROWS FETCH NEXT ? ROWS ONLY";
+      Query q = ctx.em().createNativeQuery(sql);
+      int p = 1;
+      p = JobClaimSqlSupport.bindTagFilter(q, tagFilter, p);
+      q.setParameter(p, limit);
+      List<Object[]> rows = q.getResultList();
+      List<RecurringJobDefinition> defs = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        defs.add(hydrate(row));
+      }
+      return defs;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("claim recurring (new)", e);
+    }
+  }
+
+  @Override
+  public void advanceNextFire(UUID id, Instant nextFire) {
+    // language=SQL Server
+    String sql = "UPDATE scheduler_recurring_job SET next_fire = ? WHERE id = ?";
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, Timestamp.from(nextFire))
+        .setParameter(2, UuidByteArrayConverter.toBytes(id))
+        .executeUpdate();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<Instant> findEarliestRecurringNextFire() {
+    // language=SQL Server
+    String sql = "SELECT MIN(next_fire) FROM scheduler_recurring_job WHERE is_paused = 0";
+    List<?> rows = ctx.em().createNativeQuery(sql).getResultList();
+    if (rows.isEmpty() || rows.get(0) == null) {
+      return Optional.empty();
+    }
+    Object v = rows.get(0);
+    if (v instanceof Timestamp ts) {
+      return Optional.of(ts.toInstant());
+    }
+    if (v instanceof Instant inst) {
+      return Optional.of(inst);
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean pauseRecurring(UUID id) {
+    // language=SQL Server
+    String sql =
+        "UPDATE scheduler_recurring_job SET is_paused = 1, paused_at = SYSUTCDATETIME()"
+            + " WHERE id = ? AND is_paused = 0";
+    return ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .executeUpdate()
+        > 0;
+  }
+
+  @Override
+  public boolean resumeRecurring(UUID id) {
+    // language=SQL Server
+    String sql =
+        "UPDATE scheduler_recurring_job SET is_paused = 0, paused_at = NULL"
+            + " WHERE id = ? AND is_paused = 1";
+    return ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .executeUpdate()
+        > 0;
+  }
+
+  @Override
+  public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
+    return archiveAndDelete(List.of(id), reason) > 0;
+  }
+
+  @Override
+  public int cancelOrphanedRecurringAnnotationJobs(
+      Set<String> knownBusinessKeys, Instant nodeStartTime) {
+    // language=SQL Server
+    String baseSql =
+        "SELECT id FROM scheduler_recurring_job"
+            + " WHERE business_key IS NOT NULL AND created_at < ?";
+    String suffix =
+        knownBusinessKeys.isEmpty()
+            ? ""
+            : " AND business_key NOT IN ("
+                + String.join(",", Collections.nCopies(knownBusinessKeys.size(), "?"))
+                + ")";
+    Query q = ctx.em().createNativeQuery(baseSql + suffix);
+    int p = 1;
+    q.setParameter(p++, Timestamp.from(nodeStartTime));
+    for (String key : knownBusinessKeys) {
+      q.setParameter(p++, key);
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> raw = q.getResultList();
+    List<UUID> ids = toUuids(raw);
+    return archiveAndDelete(ids, ArchiveReason.CANCELED);
+  }
+
+  @Override
+  public int cancelRecurringJobsByTag(String tag) {
+    // language=SQL Server
+    String sql =
+        "SELECT r.id FROM scheduler_recurring_job r"
+            + " JOIN scheduler_job_tag t ON t.job_id = r.id"
+            + " WHERE t.tag = ?";
+    @SuppressWarnings("unchecked")
+    List<Object> raw = ctx.em().createNativeQuery(sql).setParameter(1, tag).getResultList();
+    return archiveAndDelete(toUuids(raw), ArchiveReason.CANCELED);
+  }
+
+  @Override
+  public boolean cancelRecurringJobByBusinessKey(String businessKey) {
+    return cancelRecurringJobsByBusinessKeys(Set.of(businessKey)) > 0;
+  }
+
+  @Override
+  public int cancelRecurringJobsByBusinessKeys(Set<String> businessKeys) {
+    if (businessKeys.isEmpty()) {
+      return 0;
+    }
+    String placeholders = String.join(",", Collections.nCopies(businessKeys.size(), "?"));
+    // language=SQL Server
+    String sql =
+        "SELECT id FROM scheduler_recurring_job WHERE business_key IN (" + placeholders + ")";
+    Query q = ctx.em().createNativeQuery(sql);
+    int p = 1;
+    for (String key : businessKeys) {
+      q.setParameter(p++, key);
+    }
+    @SuppressWarnings("unchecked")
+    List<Object> raw = q.getResultList();
+    return archiveAndDelete(toUuids(raw), ArchiveReason.CANCELED);
+  }
+
+  @Override
+  public UUID createRecurring(RecurringJobDefinition d) {
+    // language=SQL Server
+    String sql =
+        "INSERT INTO scheduler_recurring_job ("
+            + "id, priority, max_retries, backoff_policy, backoff_param_ms, timeout_sec,"
+            + " cron_expr, zone_id, next_fire, is_paused, paused_at, payload,"
+            + " on_success_payload, on_failure_payload, business_key, resource_name,"
+            + " execution_target, created_at, caller_principal, encrypted_payload)"
+            + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,"
+            + " ?, ?, ?, ?, ?, ?, ?, ?)";
+    Instant created = d.createdAt() != null ? d.createdAt() : Instant.now();
+    boolean active = JobEncryption.activeFor(d.encryptedPayload());
+    Query q = ctx.em().createNativeQuery(sql);
+    int i = 1;
+    q.setParameter(i++, UuidByteArrayConverter.toBytes(d.id()));
+    q.setParameter(i++, d.priority());
+    q.setParameter(i++, d.maxRetries());
+    q.setParameter(i++, d.backoffPolicy() != null ? d.backoffPolicy().name() : "NONE");
+    q.setParameter(i++, d.backoffParamMs());
+    q.setParameter(i++, d.timeoutSec());
+    q.setParameter(i++, d.cronExpr());
+    q.setParameter(i++, d.zoneId() != null ? d.zoneId() : "UTC");
+    q.setParameter(i++, Timestamp.from(d.nextFire()));
+    q.setParameter(i++, d.paused());
+    q.setParameter(i++, d.pausedAt() != null ? Timestamp.from(d.pausedAt()) : null);
+    q.setParameter(
+        i++,
+        RecurringJobRows.encryptPayloadColumn(
+            d.payload(), active, ProtectedSurface.PAYLOAD_ARGS, d.id()));
+    q.setParameter(
+        i++,
+        RecurringJobRows.encryptPayloadColumn(
+            d.onSuccessPayload(), active, ProtectedSurface.ON_SUCCESS_PAYLOAD, d.id()));
+    q.setParameter(
+        i++,
+        RecurringJobRows.encryptPayloadColumn(
+            d.onFailurePayload(), active, ProtectedSurface.ON_FAILURE_PAYLOAD, d.id()));
+    q.setParameter(i++, d.businessKey());
+    q.setParameter(i++, d.resourceName());
+    q.setParameter(i++, d.executionTarget());
+    q.setParameter(i++, Timestamp.from(created));
+    q.setParameter(i++, d.callerPrincipal());
+    q.setParameter(i, active);
+    try {
+      q.executeUpdate();
+      if (d.businessKey() != null) {
+        reservations.insertReservation(
+            d.businessKey(), d.id(), SqlserverBusinessKeyReservations.OWNER_TABLE_RECURRING);
+      }
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateBusinessKey(e)) {
+        throw new RatchetTransientStoreException(
+            "Active business key in use for recurring master " + d.id(), e);
+      }
+      throw e;
+    }
+    return d.id();
+  }
+
+  @Override
+  public boolean updateRecurring(UUID id, RecurringJobDefinition d) {
+    // language=SQL Server
+    String sql =
+        "UPDATE scheduler_recurring_job SET"
+            + " priority = ?, max_retries = ?, backoff_policy = ?, backoff_param_ms = ?,"
+            + " timeout_sec = ?, cron_expr = ?, zone_id = ?, next_fire = ?,"
+            + " payload = ?,"
+            + " on_success_payload = ?, on_failure_payload = ?,"
+            + " resource_name = ?, execution_target = ?, encrypted_payload = ?"
+            + " WHERE id = ?";
+    boolean active = JobEncryption.activeFor(d.encryptedPayload());
+    Query q = ctx.em().createNativeQuery(sql);
+    int i = 1;
+    q.setParameter(i++, d.priority());
+    q.setParameter(i++, d.maxRetries());
+    q.setParameter(i++, d.backoffPolicy() != null ? d.backoffPolicy().name() : "NONE");
+    q.setParameter(i++, d.backoffParamMs());
+    q.setParameter(i++, d.timeoutSec());
+    q.setParameter(i++, d.cronExpr());
+    q.setParameter(i++, d.zoneId() != null ? d.zoneId() : "UTC");
+    q.setParameter(i++, Timestamp.from(d.nextFire()));
+    q.setParameter(
+        i++,
+        RecurringJobRows.encryptPayloadColumn(
+            d.payload(), active, ProtectedSurface.PAYLOAD_ARGS, id));
+    q.setParameter(
+        i++,
+        RecurringJobRows.encryptPayloadColumn(
+            d.onSuccessPayload(), active, ProtectedSurface.ON_SUCCESS_PAYLOAD, id));
+    q.setParameter(
+        i++,
+        RecurringJobRows.encryptPayloadColumn(
+            d.onFailurePayload(), active, ProtectedSurface.ON_FAILURE_PAYLOAD, id));
+    q.setParameter(i++, d.resourceName());
+    q.setParameter(i++, d.executionTarget());
+    q.setParameter(i++, active);
+    q.setParameter(i, UuidByteArrayConverter.toBytes(id));
+    return q.executeUpdate() > 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<RecurringJobDefinition> getRecurring(UUID id) {
+    // language=SQL Server
+    String sql = "SELECT " + SELECT_COLUMNS + " FROM scheduler_recurring_job WHERE id = ?";
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(hydrate(rows.get(0)));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<RecurringJobDefinition> findRecurringByBusinessKey(String businessKey) {
+    // language=SQL Server
+    String sql =
+        "SELECT TOP 1 " + SELECT_COLUMNS + " FROM scheduler_recurring_job WHERE business_key = ?";
+    List<Object[]> rows =
+        ctx.em().createNativeQuery(sql).setParameter(1, businessKey).getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(hydrate(rows.get(0)));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<RecurringJobDefinition> listAll() {
+    // language=SQL Server
+    String sql = "SELECT " + SELECT_COLUMNS + " FROM scheduler_recurring_job";
+    List<Object[]> rows = ctx.em().createNativeQuery(sql).getResultList();
+    List<RecurringJobDefinition> defs = new ArrayList<>(rows.size());
+    for (Object[] row : rows) {
+      defs.add(hydrate(row));
+    }
+    return defs;
+  }
+
+  private int archiveAndDelete(List<UUID> ids, ArchiveReason reason) {
+    if (ids.isEmpty()) {
+      return 0;
+    }
+    int total = 0;
+    for (int start = 0; start < ids.size(); start += CANCEL_CHUNK) {
+      total +=
+          archiveAndDeleteChunk(
+              ids.subList(start, Math.min(start + CANCEL_CHUNK, ids.size())), reason);
+    }
+    return total;
+  }
+
+  private int archiveAndDeleteChunk(List<UUID> ids, ArchiveReason reason) {
+    String placeholders = String.join(",", Collections.nCopies(ids.size(), "?"));
+    // language=SQL Server
+    // ON CONFLICT DO NOTHING keeps cancel idempotent under concurrent cancels for the same id:
+    // the loser of the race no-ops on the archive insert instead of throwing a PK violation,
+    // and the DELETE below is naturally idempotent.
+    String archiveSql =
+        "INSERT INTO scheduler_recurring_job_archive ("
+            + "id, cron_expr, zone_id, payload, on_success_payload, on_failure_payload,"
+            + " business_key, execution_target, created_at, caller_principal, archived_at,"
+            + " archive_reason)"
+            + " SELECT r.id, r.cron_expr, r.zone_id, r.payload, r.on_success_payload,"
+            + " r.on_failure_payload, r.business_key, r.execution_target, r.created_at,"
+            + " r.caller_principal, SYSUTCDATETIME(), ?"
+            + " FROM scheduler_recurring_job r WHERE r.id IN ("
+            + placeholders
+            + ")"
+            + " AND NOT EXISTS (SELECT 1 FROM scheduler_recurring_job_archive a"
+            + " WHERE a.id = r.id)";
+    Query archiveQ = ctx.em().createNativeQuery(archiveSql);
+    int p = 1;
+    archiveQ.setParameter(p++, reason.name());
+    for (UUID id : ids) {
+      archiveQ.setParameter(p++, UuidByteArrayConverter.toBytes(id));
+    }
+    archiveQ.executeUpdate();
+
+    reservations.deleteReservationsByOwners(ids);
+
+    // scheduler_job_tag.job_id is polymorphic since fk_job_tag_job was dropped; cancel must
+    // delete recurring master tag rows explicitly so they don't outlive the master row.
+    // language=SQL Server
+    String tagDeleteSql = "DELETE FROM scheduler_job_tag WHERE job_id IN (" + placeholders + ")";
+    Query tagDeleteQ = ctx.em().createNativeQuery(tagDeleteSql);
+    int tp = 1;
+    for (UUID id : ids) {
+      tagDeleteQ.setParameter(tp++, UuidByteArrayConverter.toBytes(id));
+    }
+    tagDeleteQ.executeUpdate();
+
+    // language=SQL Server
+    String deleteSql = "DELETE FROM scheduler_recurring_job WHERE id IN (" + placeholders + ")";
+    Query deleteQ = ctx.em().createNativeQuery(deleteSql);
+    p = 1;
+    for (UUID id : ids) {
+      deleteQ.setParameter(p++, UuidByteArrayConverter.toBytes(id));
+    }
+    return deleteQ.executeUpdate();
+  }
+
+  private static List<UUID> toUuids(List<Object> raw) {
+    List<UUID> ids = new ArrayList<>(raw.size());
+    for (Object id : raw) {
+      if (id != null) {
+        // BINARY(16) columns come back as byte[]; RowValues decodes byte[]/UUID/CharSequence.
+        ids.add(RowValues.uuidOrNull(id));
+      }
+    }
+    return ids;
+  }
+
+  private static RecurringJobDefinition hydrate(Object[] row) {
+    return RecurringJobRows.hydrate(row);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverSchemaMigrationDialect.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverSchemaMigrationDialect.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import run.ratchet.store.migration.SchemaMigrationDialect;
+import run.ratchet.store.migration.SchemaMigrationException;
+
+/**
+ * SQL Server schema migration dialect.
+ *
+ * <p>The migration lock is a session-scoped {@code sp_getapplock}. Because {@code @LockOwner =
+ * 'Session'} ties the lock to the connection rather than a transaction, it survives the migrator's
+ * per-script commits without a dedicated lock connection (see {@link
+ * #usesDedicatedLockConnection()}). The version-record upsert is a {@code MERGE}.
+ */
+@ApplicationScoped
+public class SqlserverSchemaMigrationDialect implements SchemaMigrationDialect {
+
+  private static final String LOCK_NAME = "ratchet_schema_migration";
+  // sp_getapplock @LockTimeout is in milliseconds; a second migrator that cannot acquire the lock
+  // within this window fails loudly.
+  private static final int LOCK_TIMEOUT_MILLIS = 30000;
+
+  @Override
+  public String id() {
+    return "sqlserver";
+  }
+
+  @Override
+  public String createVersionTableSql() {
+    // SQL Server has no CREATE TABLE IF NOT EXISTS; guard with OBJECT_ID. Single batch, no internal
+    // semicolon, so it runs as one JDBC statement. The statement runs under the migration lock, so
+    // there is no concurrent-create race to handle.
+    return """
+        IF OBJECT_ID(N'ratchet_schema_version', N'U') IS NULL
+        CREATE TABLE ratchet_schema_version
+        (
+            version     VARCHAR(20)  NOT NULL,
+            applied_at  DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+            description VARCHAR(200) NOT NULL,
+            checksum    VARCHAR(64),
+            CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
+        )\
+        """;
+  }
+
+  @Override
+  public String recordVersionSql() {
+    // T-SQL requires a MERGE statement to be terminated with a semicolon.
+    return "MERGE ratchet_schema_version AS tgt"
+        + " USING (VALUES (?, ?, ?)) AS src(version, description, checksum)"
+        + " ON tgt.version = src.version"
+        + " WHEN MATCHED THEN UPDATE SET description = src.description,"
+        + " checksum = src.checksum"
+        + " WHEN NOT MATCHED THEN INSERT (version, description, checksum)"
+        + " VALUES (src.version, src.description, src.checksum);";
+  }
+
+  @Override
+  public boolean usesDedicatedLockConnection() {
+    return false;
+  }
+
+  @Override
+  public void acquireLock(Connection connection) throws SQLException {
+    // sp_getapplock returns >= 0 on grant (0 immediate, 1 after wait), < 0 on failure. A
+    // Session-owned lock is held for the life of the connection, so it survives the migrator's
+    // per-script commits without a dedicated lock connection.
+    try (Statement statement = connection.createStatement();
+        ResultSet resultSet =
+            statement.executeQuery(
+                "DECLARE @r int;"
+                    + " EXEC @r = sp_getapplock @Resource = '"
+                    + LOCK_NAME
+                    + "', @LockMode = 'Exclusive', @LockOwner = 'Session', @LockTimeout = "
+                    + LOCK_TIMEOUT_MILLIS
+                    + ";"
+                    + " SELECT @r;")) {
+      if (!resultSet.next() || resultSet.getInt(1) < 0) {
+        throw new SchemaMigrationException("Timed out acquiring SQL Server schema migration lock");
+      }
+    }
+  }
+
+  @Override
+  public void releaseLock(Connection connection) throws SQLException {
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(
+          "EXEC sp_releaseapplock @Resource = '" + LOCK_NAME + "', @LockOwner = 'Session'");
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverSignalOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverSignalOperations.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.jboss.logging.Logger;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.SignalStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * SQL Server implementation of {@link SignalStore}.
+ *
+ * <p>All operations target {@code scheduler_job_queue} — the live-state table in the hot/cold split
+ * — because WAITING is a non-terminal status that lives there.
+ */
+final class SqlserverSignalOperations implements SignalStore {
+
+  private static final Logger log = Logger.getLogger(SqlserverSignalOperations.class);
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverSignalOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  private static UUID toUuid(Object value) {
+    // BINARY(16) columns come back as byte[]; RowValues decodes byte[]/UUID/CharSequence uniformly.
+    return RowValues.uuidOrNull(value);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<JobEntity> findTimedOutSignalJobs(Instant now, int limit) {
+    if (limit <= 0) {
+      throw new IllegalArgumentException("limit must be positive: " + limit);
+    }
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT q.job_id, q.signal_key, q.signal_timeout, q.status,
+                 c.job_type, c.priority, c.max_retries, c.business_key,
+                 c.backoff_policy, c.backoff_param_ms,
+                 q.signal_payload, q.signal_payload_type, q.signal_outcome,
+                 q.signal_rejection_reason, q.signal_delivered_at,
+                 q.signal_delivered_by, q.signal_delivery_id
+          FROM scheduler_job_queue q
+          JOIN scheduler_job c ON c.job_id = q.job_id
+          WHERE q.status = 'WAITING'
+            AND q.signal_timeout IS NOT NULL
+            AND q.signal_timeout <= ?
+          ORDER BY q.signal_timeout ASC, q.job_id ASC
+          """;
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, Timestamp.from(now))
+              .setMaxResults(limit)
+              .getResultList();
+
+      List<JobEntity> result = new ArrayList<>(rows.size());
+      for (Object[] row : rows) {
+        JobEntity job = new JobEntity();
+        job.setId(toUuid(row[0]));
+        job.setSignalKey((String) row[1]);
+        job.setSignalTimeout(RowValues.instantOrNull(row[2]));
+        job.setStatus(JobStatus.WAITING);
+        job.setJobType(row[4] != null ? JobExecutionType.valueOf((String) row[4]) : null);
+        job.setPriority(
+            row[5] != null
+                ? SqlserverJobRowMapper.safeJobPriority(((Number) row[5]).intValue())
+                : JobPriority.NORMAL);
+        job.setMaxRetries(row[6] != null ? ((Number) row[6]).intValue() : 0);
+        job.setBusinessKey((String) row[7]);
+        job.setBackoffPolicy(
+            row[8] != null ? BackoffPolicy.valueOf((String) row[8]) : BackoffPolicy.NONE);
+        job.setBackoffParamMs(row[9] != null ? ((Number) row[9]).intValue() : 0);
+        job.setSignalPayload((String) row[10]);
+        job.setSignalPayloadType((String) row[11]);
+        job.setSignalOutcome((String) row[12]);
+        job.setSignalRejectionReason((String) row[13]);
+        job.setSignalDeliveredAt(RowValues.instantOrNull(row[14]));
+        job.setSignalDeliveredBy((String) row[15]);
+        job.setSignalDeliveryId((String) row[16]);
+        result.add(job);
+      }
+      return result;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find timed out signal jobs", e);
+    }
+  }
+
+  @Override
+  public int deliverSignalById(
+      UUID jobId,
+      String payload,
+      String payloadType,
+      String outcome,
+      String rejectionReason,
+      String deliveredBy,
+      Instant deliveredAt,
+      String deliveryId) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              signal_payload = ?,
+              signal_payload_type = ?,
+              signal_outcome = ?,
+              signal_rejection_reason = ?,
+              signal_delivered_at = ?,
+              signal_delivered_by = ?,
+              signal_delivery_id = ?,
+              updated_at = SYSUTCDATETIME()
+          WHERE job_id = ? AND status = 'WAITING'
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, payload)
+              .setParameter(2, payloadType)
+              .setParameter(3, outcome)
+              .setParameter(4, rejectionReason)
+              .setParameter(5, deliveredAt != null ? Timestamp.from(deliveredAt) : null)
+              .setParameter(6, deliveredBy)
+              .setParameter(7, deliveryId)
+              .setParameter(8, UuidByteArrayConverter.toBytes(jobId))
+              .executeUpdate();
+      log.debugf("deliverSignalById(%s): %s row(s) updated", jobId, updated);
+      return updated;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("deliver signal by id", e);
+    }
+  }
+
+  @Override
+  public int deliverSignalByKey(
+      String signalKey,
+      String payload,
+      String payloadType,
+      String outcome,
+      String rejectionReason,
+      String deliveredBy,
+      Instant deliveredAt,
+      String deliveryId) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          UPDATE scheduler_job_queue
+          SET status = 'PENDING',
+              signal_payload = ?,
+              signal_payload_type = ?,
+              signal_outcome = ?,
+              signal_rejection_reason = ?,
+              signal_delivered_at = ?,
+              signal_delivered_by = ?,
+              signal_delivery_id = ?,
+              updated_at = SYSUTCDATETIME()
+          WHERE signal_key = ? AND status = 'WAITING'
+          """;
+      int updated =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, payload)
+              .setParameter(2, payloadType)
+              .setParameter(3, outcome)
+              .setParameter(4, rejectionReason)
+              .setParameter(5, deliveredAt != null ? Timestamp.from(deliveredAt) : null)
+              .setParameter(6, deliveredBy)
+              .setParameter(7, deliveryId)
+              .setParameter(8, signalKey)
+              .executeUpdate();
+      log.debugf("deliverSignalByKey('%s'): %s row(s) updated", signalKey, updated);
+      return updated;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("deliver signal by key", e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public List<JobEntity> findJobsBySignalDeliveryId(String deliveryId) {
+    try {
+      if (deliveryId == null || deliveryId.isBlank()) {
+        return List.of();
+      }
+      String sql =
+          "SELECT "
+              + SqlserverJobRowMapper.hydrationSelect()
+              + " FROM scheduler_job c LEFT JOIN scheduler_job_queue q ON q.job_id = c.job_id"
+              + " WHERE q.signal_delivery_id = ?";
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, deliveryId).getResultList();
+      return SqlserverJobRowMapper.hydrateRows(rows);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find jobs by signal delivery id", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverStoreContext.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverStoreContext.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.EntityManager;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.ConstraintDetector;
+import run.ratchet.store.context.AbstractSqlStoreContext;
+
+final class SqlserverStoreContext extends AbstractSqlStoreContext {
+
+  private final SqlserverConstraintDetector constraintDetector = new SqlserverConstraintDetector();
+
+  SqlserverStoreContext(EntityManager em) {
+    this(em, noopMetricsCollector(), 15);
+  }
+
+  SqlserverStoreContext(EntityManager em, int priorityBoostIntervalMinutes) {
+    this(em, noopMetricsCollector(), priorityBoostIntervalMinutes);
+  }
+
+  SqlserverStoreContext(
+      EntityManager em, MetricsCollector metricsCollector, int priorityBoostIntervalMinutes) {
+    super(em, metricsCollector, priorityBoostIntervalMinutes);
+  }
+
+  @Override
+  protected String dialectMetric() {
+    return "sqlserver";
+  }
+
+  @Override
+  protected String dialectLabel() {
+    return "SQL Server";
+  }
+
+  @Override
+  public ConstraintDetector constraintDetector() {
+    return constraintDetector;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverTagOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverTagOperations.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+final class SqlserverTagOperations implements TagStore {
+
+  private static final int MAX_TAG_HYDRATION_IDS = 250;
+  private static final int INSERT_TAG_BATCH_SIZE = 250;
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverTagOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  private static Map<String, Long> toStringCountMap(List<Object[]> rows) {
+    Map<String, Long> counts = new TreeMap<>();
+    for (Object[] row : rows) {
+      String key = (String) row[0];
+      if (key == null || key.isBlank()) {
+        continue;
+      }
+      counts.put(key, ((Number) row[1]).longValue());
+    }
+    return counts;
+  }
+
+  @Override
+  public void insertTags(UUID jobId, List<String> tags) {
+    if (tags == null || tags.isEmpty()) {
+      return;
+    }
+    try {
+      List<String> uniqueTags = new ArrayList<>(new LinkedHashSet<>(tags));
+      for (int start = 0; start < uniqueTags.size(); start += INSERT_TAG_BATCH_SIZE) {
+        int end = Math.min(start + INSERT_TAG_BATCH_SIZE, uniqueTags.size());
+        insertTagChunk(jobId, uniqueTags.subList(start, end));
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("insert job tags", e);
+    }
+  }
+
+  private void insertTagChunk(UUID jobId, List<String> tags) {
+    String values = String.join(", ", Collections.nCopies(tags.size(), "(?, ?)"));
+    // language=SQL Server
+    String sql =
+        """
+        INSERT INTO scheduler_job_tag (job_id, tag)
+        SELECT v.job_id, v.tag FROM (VALUES %s) AS v(job_id, tag)
+        WHERE NOT EXISTS (
+          SELECT 1 FROM scheduler_job_tag e
+          WHERE e.job_id = v.job_id AND e.tag = v.tag
+        )
+        """
+            .formatted(values);
+    Query query = ctx.em().createNativeQuery(sql);
+    int parameter = 1;
+    byte[] jobIdBytes = UuidByteArrayConverter.toBytes(jobId);
+    for (String tag : tags) {
+      query.setParameter(parameter++, jobIdBytes);
+      query.setParameter(parameter++, tag);
+    }
+    query.executeUpdate();
+  }
+
+  @Override
+  public int deleteTagsByJobId(UUID jobId) {
+    try {
+      // language=SQL Server
+      String sql = "DELETE FROM scheduler_job_tag WHERE job_id = ?";
+      return ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("delete job tags", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  List<UUID> findJobIdsByTag(String tag, int limit, int offset) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT job_id FROM scheduler_job_tag WHERE tag = ?
+          ORDER BY job_id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY
+          """;
+      List<?> results =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, tag)
+              .setParameter(2, offset)
+              .setParameter(3, limit)
+              .getResultList();
+      return results.stream().map(SqlserverJobRowMapper::uuidOrNull).toList();
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("find job ids by tag", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  Map<JobStatus, Long> countJobsByStatusForTag(String tag) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT s, SUM(c) FROM (
+            SELECT q.status AS s, COUNT(*) AS c FROM scheduler_job_queue q
+              JOIN scheduler_job_tag t ON t.job_id = q.job_id
+              WHERE t.tag = ? GROUP BY q.status
+            UNION ALL
+            SELECT c.terminal_status AS s, COUNT(*) AS c FROM scheduler_job c
+              JOIN scheduler_job_tag t ON t.job_id = c.job_id
+              WHERE t.tag = ? AND c.terminal_status IS NOT NULL
+              GROUP BY c.terminal_status
+          ) u GROUP BY s
+          """;
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, tag).setParameter(2, tag).getResultList();
+      Map<JobStatus, Long> counts = new EnumMap<>(JobStatus.class);
+      for (Object[] row : rows) {
+        counts.put(JobStatus.valueOf((String) row[0]), ((Number) row[1]).longValue());
+      }
+      return counts;
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by status for tag", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  Map<String, Long> countJobsByParamForTag(String tag, String paramKey) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT param_value, COUNT(*) FROM (
+            SELECT JSON_VALUE(j.params, '$."' + ? + '"') AS param_value
+            FROM scheduler_job j
+            JOIN scheduler_job_tag t ON j.job_id = t.job_id
+            WHERE t.tag = ? AND JSON_VALUE(j.params, '$."' + ? + '"') IS NOT NULL
+          ) x
+          GROUP BY param_value
+          ORDER BY param_value
+          """;
+      List<Object[]> rows =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, paramKey)
+              .setParameter(2, tag)
+              .setParameter(3, paramKey)
+              .getResultList();
+      return toStringCountMap(rows);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by param for tag", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  Map<String, Long> countJobsByExecutionNodeForTag(String tag) {
+    try {
+      // language=SQL Server
+      String sql =
+          """
+          SELECT node, SUM(c) FROM (
+            SELECT q.picked_by AS node, COUNT(*) AS c
+              FROM scheduler_job_queue q
+              JOIN scheduler_job_tag t ON t.job_id = q.job_id
+              WHERE t.tag = ? AND q.picked_by IS NOT NULL AND q.picked_by <> ''
+              GROUP BY q.picked_by
+            UNION ALL
+            SELECT e.node_id AS node, COUNT(*) AS c
+              FROM scheduler_job c2
+              JOIN scheduler_job_tag t ON t.job_id = c2.job_id
+              JOIN scheduler_job_execution e ON e.job_id = c2.job_id
+              WHERE t.tag = ? AND c2.terminal_status IS NOT NULL
+                AND e.id = (SELECT TOP 1 e2.id FROM scheduler_job_execution e2
+                            WHERE e2.job_id = c2.job_id
+                            ORDER BY e2.attempt DESC, e2.started_at DESC, e2.id DESC)
+                AND e.node_id IS NOT NULL AND e.node_id <> ''
+              GROUP BY e.node_id
+          ) u GROUP BY node ORDER BY node
+          """;
+      List<Object[]> rows =
+          ctx.em().createNativeQuery(sql).setParameter(1, tag).setParameter(2, tag).getResultList();
+      return toStringCountMap(rows);
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("count jobs by execution node for tag", e);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  void hydrateTagsSingle(JobEntity job) {
+    if (job == null || job.getId() == null) return;
+    try {
+      // language=SQL Server
+      String sql = "SELECT tag FROM scheduler_job_tag WHERE job_id = ?";
+      List<String> tags =
+          ctx.em()
+              .createNativeQuery(sql)
+              .setParameter(1, UuidByteArrayConverter.toBytes(job.getId()))
+              .getResultList();
+      if (!tags.isEmpty()) {
+        job.setTags(tags);
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("hydrate job tags", e);
+    }
+  }
+
+  void hydrateTagsBatch(List<JobEntity> jobs) {
+    if (jobs.isEmpty()) return;
+    try {
+      List<UUID> ids = new ArrayList<>(jobs.size());
+      Map<UUID, JobEntity> byId = new HashMap<>();
+      for (JobEntity job : jobs) {
+        if (job.getId() != null) {
+          ids.add(job.getId());
+          byId.put(job.getId(), job);
+        }
+      }
+      if (ids.isEmpty()) return;
+      for (int start = 0; start < ids.size(); start += MAX_TAG_HYDRATION_IDS) {
+        List<UUID> chunk = ids.subList(start, Math.min(start + MAX_TAG_HYDRATION_IDS, ids.size()));
+        String placeholders = String.join(",", Collections.nCopies(chunk.size(), "?"));
+        // language=SQL Server
+        String sql =
+            "SELECT job_id, tag FROM scheduler_job_tag WHERE job_id IN ("
+                + placeholders
+                + ") ORDER BY job_id";
+        Query tagQuery = ctx.em().createNativeQuery(sql);
+        int parameter = 1;
+        for (UUID id : chunk) {
+          tagQuery.setParameter(parameter++, UuidByteArrayConverter.toBytes(id));
+        }
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = tagQuery.getResultList();
+        applyHydratedTagRows(rows, byId);
+      }
+    } catch (RuntimeException e) {
+      throw ctx.translateTransientStoreException("hydrate job tags batch", e);
+    }
+  }
+
+  private static void applyHydratedTagRows(List<Object[]> rows, Map<UUID, JobEntity> byId) {
+    for (Object[] row : rows) {
+      UUID jobId = SqlserverJobRowMapper.uuidOrNull(row[0]);
+      String tag = (String) row[1];
+      JobEntity job = byId.get(jobId);
+      if (job == null) continue;
+      List<String> tags = job.getTags();
+      if (tags == null) {
+        tags = new ArrayList<>();
+        job.setTags(tags);
+      }
+      tags.add(tag);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverTimestamps.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverTimestamps.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Helpers for binding {@link Instant} cutoffs against SQL Server's {@code DATETIME2(6)} columns.
+ *
+ * <p>A persisted Instant is floored to microsecond precision by the column. The mssql-jdbc driver,
+ * however, binds an Instant or Timestamp parameter at full nanosecond precision and compares it
+ * literally, so a cutoff taken from the same Instant as a stored row misses an exclusive ({@code
+ * <}) or inclusive-lower ({@code >=}) boundary by the sub-microsecond remainder. This only surfaces
+ * on a nanosecond-resolution clock (Linux); macOS returns microseconds, which hides it. The MySQL
+ * and PostgreSQL drivers floor the bind to the column scale for us; SQL Server does not.
+ *
+ * <p>Flooring the bound value to microseconds restores the boundary behaviour the stores share.
+ */
+final class SqlserverTimestamps {
+
+  private SqlserverTimestamps() {}
+
+  /** Floors an Instant to microsecond precision to match a {@code DATETIME2(6)} column. */
+  static Instant floorMicros(Instant value) {
+    return value == null ? null : value.truncatedTo(ChronoUnit.MICROS);
+  }
+
+  /**
+   * Binds an Instant cutoff as a microsecond-precision {@link Timestamp} for native comparisons.
+   */
+  static Timestamp microTimestamp(Instant value) {
+    return value == null ? null : Timestamp.from(floorMicros(value));
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/converter/UuidByteArrayConverter.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/converter/UuidByteArrayConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+/**
+ * Converts {@link UUID} to a 16-byte big-endian {@code byte[]} for SQL Server's {@code BINARY(16)}
+ * column type, and back.
+ *
+ * <p>The SQL Server store deliberately stores UUIDs as {@code BINARY(16)} holding the canonical
+ * big-endian bytes rather than the native {@code UNIQUEIDENTIFIER} type. {@code UNIQUEIDENTIFIER}
+ * uses .NET-Guid mixed-endian storage, which EclipseLink 5.0 (GlassFish 8 / Jakarta EE 11 RI) reads
+ * byte-swapped from native queries — claimed job ids then no longer match their rows and every job
+ * stalls PENDING. Raw bytes are provider-independent, so every JPA provider decodes them
+ * identically.
+ *
+ * <p>Wired into the persistence unit via {@code META-INF/orm-sqlserver.xml}, applied per-attribute
+ * to every UUID field. Native queries bypass {@link AttributeConverter} per JPA spec — for those
+ * call sites use {@link #toBytes(UUID)} directly before {@code setParameter}. Reads round-trip
+ * through {@code RowValues.uuidOrNull}, which decodes the same big-endian byte order.
+ */
+@Converter
+public final class UuidByteArrayConverter implements AttributeConverter<UUID, byte[]> {
+
+  public static byte[] toBytes(UUID uuid) {
+    if (uuid == null) {
+      return null;
+    }
+    ByteBuffer buf = ByteBuffer.allocate(16);
+    buf.putLong(uuid.getMostSignificantBits());
+    buf.putLong(uuid.getLeastSignificantBits());
+    return buf.array();
+  }
+
+  public static UUID fromBytes(byte[] bytes) {
+    if (bytes == null) {
+      return null;
+    }
+    if (bytes.length != 16) {
+      throw new IllegalArgumentException(
+          "Expected 16-byte UUID column value, got " + bytes.length + " bytes");
+    }
+    ByteBuffer buf = ByteBuffer.wrap(bytes);
+    return new UUID(buf.getLong(), buf.getLong());
+  }
+
+  @Override
+  public byte[] convertToDatabaseColumn(UUID uuid) {
+    return toBytes(uuid);
+  }
+
+  @Override
+  public UUID convertToEntityAttribute(byte[] bytes) {
+    return fromBytes(bytes);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/resources/META-INF/beans.xml
+++ b/stores/ratchet-store-sqlserver/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+           https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="annotated"
+       version="4.0">
+</beans>

--- a/stores/ratchet-store-sqlserver/src/main/resources/META-INF/orm-sqlserver.xml
+++ b/stores/ratchet-store-sqlserver/src/main/resources/META-INF/orm-sqlserver.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SQL Server-specific JPA mapping override. Forces UUID columns to round-trip via
+  UuidByteArrayConverter so any JPA provider produces 16 canonical big-endian bytes for BINARY(16).
+
+  The SQL Server store stores UUIDs as BINARY(16), NOT the native UNIQUEIDENTIFIER type:
+  UNIQUEIDENTIFIER uses .NET-Guid mixed-endian storage that EclipseLink 5.0 (GlassFish 8 / EE 11 RI)
+  reads byte-swapped from native queries. Raw bytes read identically across every provider.
+
+  This file is for EclipseLink (and other non-Hibernate JPA providers) only. Do NOT reference it in
+  a Hibernate-backed deployment: Hibernate maps UUID to BINARY(16) natively on the SQL Server
+  dialect, and Hibernate 7 rejects an AttributeConverter on an @Id attribute
+  (org.hibernate.AnnotationException). On Hibernate, omit this file entirely — no mapping file is
+  needed.
+
+  Production users wiring ratchet-store-sqlserver into a non-Hibernate persistence-unit must
+  reference this file from their persistence.xml: <mapping-file>META-INF/orm-sqlserver.xml</mapping-file>.
+
+  Native queries bypass AttributeConverter per JPA spec; in-store native-SQL call sites convert
+  manually via UuidByteArrayConverter.toBytes(uuid).
+
+  JPA 3.1 spec note: <convert> cannot be a child of <id>; use class-level <convert> with an
+  attribute-name attribute to apply a converter to id, basic, or relationship fields uniformly.
+-->
+<entity-mappings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+                 xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence/orm
+                                     https://jakarta.ee/xml/ns/persistence/orm/orm_3_1.xsd"
+                 version="3.1">
+
+    <converter class="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter"/>
+
+    <entity class="run.ratchet.store.entity.JobEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="dependsOn"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="supersededBy"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.ArchivedJobEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="originalJobId"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="dependedOn"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="supersededBy"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.BatchEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.BatchMetricsEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="batchId"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.DlqAlertEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="jobId"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.JobExecutionEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="jobId"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.JobLogEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="jobId"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.ResourcePermitEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="jobId"/>
+    </entity>
+
+    <entity class="run.ratchet.store.entity.WorkflowConditionEntity">
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="id"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="parentJobId"/>
+        <convert converter="run.ratchet.store.sqlserver.converter.UuidByteArrayConverter" attribute-name="childJobId"/>
+    </entity>
+
+</entity-mappings>

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/EXPLAIN-PLANS.md
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/EXPLAIN-PLANS.md
@@ -1,58 +1,50 @@
 # SQL Server Claim EXPLAIN Plans
 
-Captured on 2026-04-19 with Testcontainers `postgres:16` after seeding 600 pending executable jobs
-across multiple execution types.
+Captured 2026-06-24 by `SqlserverExplainPlanCaptureIT` against Testcontainers
+`mcr.microsoft.com/mssql/server:2022-latest` after seeding pending executable jobs across multiple
+execution types. The IT writes the full plan to `target/explain-plans/sqlserver-optimized-claim.xml`;
+the summary below is the relevant excerpt.
 
 ## Optimized Executable Claim
 
 The RI hot path calls `claimNextBatchOptimized(jobType, limit, nodeId)`, which runs as **two
-statements**, not a CTE: a `SELECT … FOR UPDATE SKIP LOCKED` that locks the due rows in
-effective-priority order, then a separate `UPDATE … WHERE job_id IN (…)` that transitions exactly
-those rows to RUNNING. The split is deliberate — a single `UPDATE … RETURNING` from a `WITH picked
-AS (…)` CTE would emit rows in heap order rather than the claimed priority order (see the
-`SqlserverJobClaimOperations` claim-select Javadoc). The plan below is for the `SELECT`, captured
-with `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` in a transaction that is rolled back. Because the
-fixture table is intentionally small, the test sets `enable_seqscan = off` locally to verify that
-the intended claim index remains selectable.
+statements**, not a CTE: a `SELECT … WITH (UPDLOCK, READPAST, ROWLOCK)` that locks the due rows in
+effective-priority order (`READPAST` makes a concurrent claim skip rows another node already locked),
+then a separate `UPDATE … WHERE job_id IN (…)` that transitions exactly those rows to RUNNING. The
+split is deliberate — a single `UPDATE … OUTPUT` from a `WITH picked AS (…)` CTE would emit rows in
+heap order rather than the claimed priority order (see the `SqlserverJobClaimOperations` claim-select
+Javadoc).
+
+The plan below is for the `SELECT`, captured with `SET SHOWPLAN_XML ON`, which returns the estimated
+plan without executing the statement. The filtered index is forced with `WITH
+(INDEX(idx_claim_executable))`: SQL Server rejects that hint outright if the filtered index can no
+longer serve the claim shape, so a passing capture proves the index remains usable. (The production
+claim adds an age-boost term to the `ORDER BY`; it is omitted here so the captured plan isolates index
+selection, and the boost only reinforces the `Sort` that is already present.)
 
 ```sql
--- Statement 1: lock the due rows in effective-priority order
-EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
-SELECT job_id
-FROM scheduler_job_queue
+SELECT job_id, status, job_type, priority, scheduled_time, version, timeout_sec,
+       picked_by, picked_at, business_key, attempts, max_retries, execution_target
+FROM scheduler_job_queue WITH (INDEX(idx_claim_executable), UPDLOCK, READPAST, ROWLOCK)
 WHERE status = 'PENDING'
-  AND scheduled_time <= statement_timestamp()
+  AND scheduled_time <= SYSUTCDATETIME()
   AND job_type = 'SINGLE'
-ORDER BY
-  (priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time))) / (60.0 * 15))) DESC,
-  scheduled_time ASC,
-  job_id ASC
-LIMIT 50
-FOR UPDATE SKIP LOCKED;
-
--- Statement 2: transition exactly the locked rows, preserving the order from statement 1
-UPDATE scheduler_job_queue
-SET status = 'RUNNING',
-    picked_by = 'explain-node',
-    picked_at = statement_timestamp(),
-    updated_at = statement_timestamp(),
-    version = version + 1
-WHERE job_id IN ( /* job_ids returned by statement 1, in order */ )
-  AND status = 'PENDING';
+ORDER BY priority DESC, scheduled_time ASC, job_id ASC
+OFFSET 0 ROWS FETCH NEXT 50 ROWS ONLY;
 ```
 
-Relevant JSON excerpt:
+Plan shape (top-down), from the captured SHOWPLAN XML:
 
-```json
-{
-  "Node Type": "Bitmap Index Scan",
-  "Index Name": "idx_claim_executable",
-  "Actual Rows": 150,
-  "Index Cond": "((job_type = 'SINGLE'::text) AND (scheduled_time <= statement_timestamp()))"
-}
+```
+Sort (TopN Sort)                          -- effective-priority order, bounded by FETCH NEXT 50
+  └─ Nested Loops (Inner Join)
+       ├─ Index Seek  [idx_claim_executable]      Ordered=1  ScanDirection=FORWARD  (filtered index)
+       └─ Clustered Index Seek  [pk_scheduler_job_queue]   Lookup=1   -- fetch the non-covered columns
 ```
 
-The selected rows feed a `Sort` node on computed effective priority. That sort is expected because
-the age-boost term depends on `statement_timestamp()` and is not immutable. The index invariant is
-that the plan uses `idx_claim_executable` (the partial index on `scheduler_job_queue` filtered by
-`status = 'PENDING'`) to reduce the due candidate set before sorting.
+The seek on `idx_claim_executable` (the filtered index on `scheduler_job_queue`, predicated on
+`status = 'PENDING'`) reduces the due-candidate set, and a nested-loop key lookup into the clustered
+primary key fetches the remaining columns. The `TopN Sort` on top is expected: rows are ordered by
+effective priority, which the index alone does not provide. The index invariant the IT asserts is
+that the plan references both `scheduler_job_queue` and `idx_claim_executable` — i.e. the claim still
+seeks the filtered index rather than scanning the table.

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/EXPLAIN-PLANS.md
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/EXPLAIN-PLANS.md
@@ -1,0 +1,58 @@
+# SQL Server Claim EXPLAIN Plans
+
+Captured on 2026-04-19 with Testcontainers `postgres:16` after seeding 600 pending executable jobs
+across multiple execution types.
+
+## Optimized Executable Claim
+
+The RI hot path calls `claimNextBatchOptimized(jobType, limit, nodeId)`, which runs as **two
+statements**, not a CTE: a `SELECT … FOR UPDATE SKIP LOCKED` that locks the due rows in
+effective-priority order, then a separate `UPDATE … WHERE job_id IN (…)` that transitions exactly
+those rows to RUNNING. The split is deliberate — a single `UPDATE … RETURNING` from a `WITH picked
+AS (…)` CTE would emit rows in heap order rather than the claimed priority order (see the
+`SqlserverJobClaimOperations` claim-select Javadoc). The plan below is for the `SELECT`, captured
+with `EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)` in a transaction that is rolled back. Because the
+fixture table is intentionally small, the test sets `enable_seqscan = off` locally to verify that
+the intended claim index remains selectable.
+
+```sql
+-- Statement 1: lock the due rows in effective-priority order
+EXPLAIN (ANALYZE, BUFFERS, FORMAT JSON)
+SELECT job_id
+FROM scheduler_job_queue
+WHERE status = 'PENDING'
+  AND scheduled_time <= statement_timestamp()
+  AND job_type = 'SINGLE'
+ORDER BY
+  (priority + FLOOR(GREATEST(0, EXTRACT(EPOCH FROM (statement_timestamp() - scheduled_time))) / (60.0 * 15))) DESC,
+  scheduled_time ASC,
+  job_id ASC
+LIMIT 50
+FOR UPDATE SKIP LOCKED;
+
+-- Statement 2: transition exactly the locked rows, preserving the order from statement 1
+UPDATE scheduler_job_queue
+SET status = 'RUNNING',
+    picked_by = 'explain-node',
+    picked_at = statement_timestamp(),
+    updated_at = statement_timestamp(),
+    version = version + 1
+WHERE job_id IN ( /* job_ids returned by statement 1, in order */ )
+  AND status = 'PENDING';
+```
+
+Relevant JSON excerpt:
+
+```json
+{
+  "Node Type": "Bitmap Index Scan",
+  "Index Name": "idx_claim_executable",
+  "Actual Rows": 150,
+  "Index Cond": "((job_type = 'SINGLE'::text) AND (scheduled_time <= statement_timestamp()))"
+}
+```
+
+The selected rows feed a `Sort` node on computed effective priority. That sort is expected because
+the age-boost term depends on `statement_timestamp()` and is not immutable. The index invariant is
+that the plan uses `idx_claim_executable` (the partial index on `scheduler_job_queue` filtered by
+`status = 'PENDING'`) to reduce the due candidate set before sorting.

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/README.md
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/README.md
@@ -1,0 +1,8 @@
+# Ratchet SQL Server DDL
+
+- `sqlserver-schema.sql` is the authoritative clean-install schema.
+- `ratchet_schema_version` is populated by the env-var-driven `SchemaMigrationLifecycleHook` (`RATCHET_SCHEMA_AUTO_MIGRATE=true`) or by external migration tooling that records each applied `V###`.
+- Auto-migration supports SQL Server only. Other products (including CockroachDB) are unsupported because they lack `pg_advisory_lock` semantics.
+- Migration scripts live under `ddl/migrations/` and use the `V###__description.sql` naming convention. Only one script ships today:
+  - `V001__initial_schema.sql` — the squashed baseline. It is the full end-state schema (hot/cold job split, business-key reservations, `caller_principal` audit column, query-layer indexes), not an incremental step. The historical pre-release `V*` chain was squashed before any production deployment, so no upgrade path from those intermediate versions is needed.
+- The baseline must match the schema shipped in `sqlserver-schema.sql`.

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/README.md
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/README.md
@@ -2,7 +2,7 @@
 
 - `sqlserver-schema.sql` is the authoritative clean-install schema.
 - `ratchet_schema_version` is populated by the env-var-driven `SchemaMigrationLifecycleHook` (`RATCHET_SCHEMA_AUTO_MIGRATE=true`) or by external migration tooling that records each applied `V###`.
-- Auto-migration supports SQL Server only. Other products (including CockroachDB) are unsupported because they lack `pg_advisory_lock` semantics.
+- Auto-migration is SQL Server only. The migrator serializes concurrent starters with a session-scoped `sp_getapplock` advisory lock.
 - Migration scripts live under `ddl/migrations/` and use the `V###__description.sql` naming convention. Only one script ships today:
   - `V001__initial_schema.sql` — the squashed baseline. It is the full end-state schema (hot/cold job split, business-key reservations, `caller_principal` audit column, query-layer indexes), not an incremental step. The historical pre-release `V*` chain was squashed before any production deployment, so no upgrade path from those intermediate versions is needed.
 - The baseline must match the schema shipped in `sqlserver-schema.sql`.

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/migrations/V001__initial_schema.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/migrations/V001__initial_schema.sql
@@ -1,0 +1,426 @@
+-- Ratchet SQL Server V001 — squashed baseline schema.
+--
+-- This file is the single baseline for the Ratchet SQL Server schema. It mirrors the
+-- canonical end-state in ddl/sqlserver-schema.sql. Prior intermediate migrations were
+-- squashed before any production installs existed. Future schema changes ship as
+-- incremental migrations layered on top of this baseline.
+--
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+
+-- 0. ratchet_schema_version
+-- Guarded create: the SchemaMigrator creates this table itself before applying V001, so a plain
+-- CREATE would collide on the migrator path. (Fresh init-script runs simply create it.)
+IF OBJECT_ID(N'ratchet_schema_version', N'U') IS NULL
+CREATE TABLE ratchet_schema_version
+(
+    version     VARCHAR(20)  NOT NULL,
+    applied_at  DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+    description VARCHAR(200) NOT NULL,
+    checksum    VARCHAR(64),
+    CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
+);
+
+-- 1. scheduler_node
+CREATE TABLE scheduler_node
+(
+    node_id      VARCHAR(64)  NOT NULL,
+    heartbeat_ts DATETIME2(6) NOT NULL,
+    started_at   DATETIME2(6) NOT NULL,
+    node_info    NVARCHAR(MAX),
+    CONSTRAINT pk_scheduler_node PRIMARY KEY (node_id)
+);
+
+CREATE INDEX idx_node_heartbeat ON scheduler_node (heartbeat_ts);
+
+-- 2. scheduler_lock
+CREATE TABLE scheduler_lock
+(
+    lock_name  VARCHAR(128) NOT NULL,
+    owner_node VARCHAR(64)  NOT NULL,
+    locked_at  DATETIME2(6) NOT NULL,
+    expires_at DATETIME2(6) NOT NULL,
+    CONSTRAINT pk_scheduler_lock PRIMARY KEY (lock_name)
+);
+
+CREATE INDEX idx_lock_expires ON scheduler_lock (expires_at);
+
+-- 3. scheduler_resource_limit
+CREATE TABLE scheduler_resource_limit
+(
+    resource_name  VARCHAR(100) NOT NULL,
+    max_concurrent INT          NOT NULL,
+    retry_delay_ms INT          NOT NULL DEFAULT 5000,
+    description    VARCHAR(255),
+    created_at     DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+    updated_at     DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_resource_limit PRIMARY KEY (resource_name)
+);
+
+-- 3a. scheduler_recurring_job — recurring-master definitions.
+CREATE TABLE scheduler_recurring_job
+(
+    id                 BINARY(16) NOT NULL,
+    priority           INT              NOT NULL DEFAULT 2,
+    max_retries        INT              NOT NULL DEFAULT 0,
+    backoff_policy     VARCHAR(16)      NOT NULL DEFAULT 'NONE',
+    backoff_param_ms   INT              NOT NULL DEFAULT 0,
+    timeout_sec        INT              NOT NULL DEFAULT 0,
+    cron_expr          VARCHAR(64)      NOT NULL,
+    zone_id            VARCHAR(32)      NOT NULL DEFAULT 'UTC',
+    next_fire          DATETIME2(6)     NOT NULL,
+    is_paused          BIT              NOT NULL DEFAULT 0,
+    paused_at          DATETIME2(6),
+    payload            NVARCHAR(MAX)    NOT NULL,
+    on_success_payload NVARCHAR(MAX),
+    on_failure_payload NVARCHAR(MAX),
+    business_key       VARCHAR(512),
+    resource_name      VARCHAR(100),
+    execution_target   VARCHAR(64),
+    target_class       AS (CAST(JSON_VALUE(payload, '$.target') AS VARCHAR(255))) PERSISTED,
+    method_name        AS (CAST(JSON_VALUE(payload, '$.method') AS VARCHAR(128))) PERSISTED,
+    created_at         DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    caller_principal   VARCHAR(255),
+    encrypted_payload  BIT              NOT NULL DEFAULT 0,
+    CONSTRAINT pk_scheduler_recurring_job PRIMARY KEY (id),
+    CONSTRAINT chk_rec_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_rec_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL'))
+);
+
+-- Claim index: filtered on unpaused rows for claim-scan efficiency.
+CREATE INDEX idx_rec_claim ON scheduler_recurring_job (next_fire) WHERE is_paused = 0;
+CREATE INDEX idx_rec_business_key ON scheduler_recurring_job (business_key);
+CREATE INDEX idx_rec_target_class ON scheduler_recurring_job (target_class);
+
+-- 3b. scheduler_recurring_job_archive.
+CREATE TABLE scheduler_recurring_job_archive
+(
+    id                 BINARY(16) NOT NULL,
+    cron_expr          VARCHAR(64)      NOT NULL,
+    zone_id            VARCHAR(32)      NOT NULL,
+    payload            NVARCHAR(MAX)    NOT NULL,
+    on_success_payload NVARCHAR(MAX),
+    on_failure_payload NVARCHAR(MAX),
+    business_key       VARCHAR(512),
+    execution_target   VARCHAR(64),
+    created_at         DATETIME2(6)     NOT NULL,
+    caller_principal   VARCHAR(255),
+    archived_at        DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    archive_reason     VARCHAR(16)      NOT NULL,
+    CONSTRAINT pk_scheduler_recurring_job_archive PRIMARY KEY (id),
+    CONSTRAINT chk_recurring_archive_reason CHECK (archive_reason IN ('CANCELED', 'EXHAUSTED'))
+);
+
+CREATE INDEX idx_archive_rec_business_key ON scheduler_recurring_job_archive (business_key);
+CREATE INDEX idx_archive_rec_archived_at ON scheduler_recurring_job_archive (archived_at);
+
+-- 4. scheduler_job — COLD metadata + terminal fields.
+CREATE TABLE scheduler_job
+(
+    job_id                BINARY(16) NOT NULL,
+    job_type              VARCHAR(20)      NOT NULL,
+    priority              INT              NOT NULL DEFAULT 2,
+    max_retries           INT              NOT NULL DEFAULT 0,
+    backoff_policy        VARCHAR(16)      NOT NULL DEFAULT 'NONE',
+    backoff_param_ms      INT              NOT NULL DEFAULT 0,
+    timeout_sec           INT              NOT NULL DEFAULT 0,
+    cron_expr             VARCHAR(64)      NOT NULL DEFAULT '',
+    zone_id               VARCHAR(32)      NOT NULL DEFAULT 'UTC',
+    payload               NVARCHAR(MAX)    NOT NULL,
+    params                NVARCHAR(MAX),
+    trace_context         NVARCHAR(MAX),
+    target_class          AS (CAST(JSON_VALUE(payload, '$.target') AS VARCHAR(255))) PERSISTED,
+    method_name           AS (CAST(JSON_VALUE(payload, '$.method') AS VARCHAR(128))) PERSISTED,
+    idempotency_key       VARCHAR(36)      NOT NULL,
+    business_key          VARCHAR(512),
+    resource_name         VARCHAR(100),
+    execution_target      VARCHAR(64),
+    on_success_payload    NVARCHAR(MAX),
+    on_failure_payload    NVARCHAR(MAX),
+    depends_on            BINARY(16),
+    superseded_by         BINARY(16),
+    created_at            DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    caller_principal      VARCHAR(255),
+    terminal_status       VARCHAR(16),
+    terminal_error        NVARCHAR(MAX),
+    total_attempts        INT,
+    terminated_at         DATETIME2(6),
+    execution_start_time  DATETIME2(6),
+    execution_end_time    DATETIME2(6),
+    execution_duration_ms BIGINT,
+    queue_wait_ms         BIGINT,
+    job_result            NVARCHAR(MAX),
+    result_type           VARCHAR(100),
+    recurring_master_id   BINARY(16),
+    encrypted_payload     BIT              NOT NULL DEFAULT 0,
+    encryption_key_id     VARCHAR(256),
+    CONSTRAINT pk_scheduler_job PRIMARY KEY (job_id),
+    CONSTRAINT uk_idempotency_key UNIQUE (idempotency_key),
+    CONSTRAINT chk_job_type CHECK (job_type IN
+                                   ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD',
+                                    'CHAIN_STEP', 'DLQ_ALERT', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
+    CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL')),
+    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
+    CONSTRAINT fk_job_recurring_master FOREIGN KEY (recurring_master_id)
+        REFERENCES scheduler_recurring_job (id) ON DELETE SET NULL
+);
+
+-- 4a. Hot authoritative queue state for executable jobs.
+CREATE TABLE scheduler_job_queue
+(
+    job_id                  BINARY(16) NOT NULL,
+    status                  VARCHAR(16)      NOT NULL DEFAULT 'PENDING',
+    job_type                VARCHAR(20)      NOT NULL,
+    priority                INT              NOT NULL DEFAULT 2,
+    scheduled_time          DATETIME2(6)     NOT NULL,
+    business_key            VARCHAR(512),
+    timeout_sec             INT              NOT NULL DEFAULT 0,
+    max_retries             INT              NOT NULL DEFAULT 0,
+    attempts                INT              NOT NULL DEFAULT 0,
+    picked_by               VARCHAR(64),
+    picked_at               DATETIME2(6),
+    paused_from_status      VARCHAR(16),
+    last_error              NVARCHAR(MAX),
+    version                 INT              NOT NULL DEFAULT 0,
+    updated_at              DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    signal_key              VARCHAR(255),
+    signal_timeout          DATETIME2(6),
+    signal_payload          NVARCHAR(MAX),
+    signal_payload_type     VARCHAR(16),
+    signal_outcome          VARCHAR(32),
+    signal_rejection_reason NVARCHAR(MAX),
+    signal_delivered_at     DATETIME2(6),
+    signal_delivered_by     VARCHAR(255),
+    signal_delivery_id      VARCHAR(36),
+    execution_target        VARCHAR(64),
+    CONSTRAINT pk_scheduler_job_queue PRIMARY KEY (job_id),
+    CONSTRAINT chk_queue_status CHECK (status IN ('PENDING', 'RUNNING', 'PAUSED', 'WAITING')),
+    CONSTRAINT chk_queue_job_type CHECK (job_type IN
+                                         ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD',
+                                          'CHAIN_STEP', 'DLQ_ALERT', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
+    CONSTRAINT chk_queue_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_queue_paused_from_status CHECK (paused_from_status IS NULL OR paused_from_status IN ('PENDING', 'RUNNING', 'PAUSED')),
+    CONSTRAINT fk_job_queue_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+-- Hot-path claim index. Filtered on PENDING.
+CREATE INDEX idx_claim_executable
+    ON scheduler_job_queue (job_type, scheduled_time ASC, priority DESC, job_id ASC)
+    WHERE status = 'PENDING';
+
+CREATE INDEX idx_queue_orphan ON scheduler_job_queue (status, picked_at, picked_by);
+CREATE INDEX idx_signal_key_status ON scheduler_job_queue (signal_key, status);
+CREATE INDEX idx_signal_timeout_status ON scheduler_job_queue (status, signal_timeout);
+CREATE INDEX idx_signal_delivery_id ON scheduler_job_queue (signal_delivery_id);
+
+-- 4b. Business-key active-uniqueness reservation table.
+CREATE TABLE scheduler_business_key_reservation
+(
+    business_key VARCHAR(512)     NOT NULL,
+    owner_job_id BINARY(16) NOT NULL,
+    owner_table  VARCHAR(16)      NOT NULL,
+    reserved_at  DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_business_key_reservation PRIMARY KEY (business_key),
+    CONSTRAINT chk_bk_owner_table CHECK (owner_table IN ('QUEUE', 'RECURRING'))
+);
+
+CREATE INDEX idx_bk_owner ON scheduler_business_key_reservation (owner_job_id);
+
+-- Lookup/relationship indexes (cold).
+CREATE INDEX idx_job_depends_on ON scheduler_job (depends_on);
+CREATE INDEX idx_job_superseded_by ON scheduler_job (superseded_by);
+CREATE INDEX idx_job_business_key ON scheduler_job (business_key);
+CREATE INDEX idx_job_created_at ON scheduler_job (created_at);
+CREATE INDEX idx_job_terminal ON scheduler_job (terminal_status, terminated_at);
+CREATE INDEX idx_job_recurring_master_id ON scheduler_job (recurring_master_id);
+CREATE INDEX idx_job_encryption_key_id ON scheduler_job (encryption_key_id);
+
+-- 5. scheduler_job_tag
+CREATE TABLE scheduler_job_tag
+(
+    job_id BINARY(16) NOT NULL,
+    tag    VARCHAR(64)      NOT NULL,
+    CONSTRAINT pk_scheduler_job_tag PRIMARY KEY (job_id, tag)
+);
+
+CREATE INDEX idx_job_tag_tag_job ON scheduler_job_tag (tag, job_id);
+
+-- 6. scheduler_batch
+CREATE TABLE scheduler_batch
+(
+    batch_id             BINARY(16) NOT NULL,
+    total_items          INT              NOT NULL DEFAULT 0,
+    completed_items      INT              NOT NULL DEFAULT 0,
+    failed_items         INT              NOT NULL DEFAULT 0,
+    completion_processed BIT              NOT NULL DEFAULT 0,
+    version              INT              NOT NULL DEFAULT 0,
+    progress_hook        NVARCHAR(MAX),
+    CONSTRAINT pk_scheduler_batch PRIMARY KEY (batch_id),
+    CONSTRAINT fk_batch_job FOREIGN KEY (batch_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+-- 7. scheduler_batch_metrics
+CREATE TABLE scheduler_batch_metrics
+(
+    batch_id           BINARY(16) NOT NULL,
+    total_duration_ms  BIGINT,
+    child_execution_ms BIGINT,
+    overhead_ms        BIGINT,
+    child_count        INT              NOT NULL DEFAULT 0,
+    success_count      INT              NOT NULL DEFAULT 0,
+    failure_count      INT              NOT NULL DEFAULT 0,
+    started_at         DATETIME2(6),
+    completed_at       DATETIME2(6),
+    version            INT              NOT NULL DEFAULT 0,
+    CONSTRAINT pk_scheduler_batch_metrics PRIMARY KEY (batch_id),
+    CONSTRAINT fk_batch_metrics_job FOREIGN KEY (batch_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+-- 8. scheduler_job_execution
+CREATE TABLE scheduler_job_execution
+(
+    id            BINARY(16) NOT NULL,
+    job_id        BINARY(16) NOT NULL,
+    attempt       INT              NOT NULL,
+    node_id       VARCHAR(64)      NOT NULL,
+    started_at    DATETIME2(6)     NOT NULL,
+    ended_at      DATETIME2(6),
+    status        VARCHAR(16)      NOT NULL DEFAULT 'RUNNING',
+    error_message NVARCHAR(MAX),
+    error_class   VARCHAR(255),
+    duration_ms   BIGINT,
+    CONSTRAINT pk_scheduler_job_execution PRIMARY KEY (id),
+    CONSTRAINT chk_execution_status CHECK (status IN ('RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELED')),
+    CONSTRAINT fk_execution_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_job_execution_job ON scheduler_job_execution (job_id);
+CREATE INDEX idx_job_execution_node ON scheduler_job_execution (node_id, started_at);
+CREATE INDEX idx_job_execution_status ON scheduler_job_execution (status, started_at);
+
+-- 9. scheduler_job_log
+CREATE TABLE scheduler_job_log
+(
+    log_id  BINARY(16) NOT NULL,
+    job_id  BINARY(16) NOT NULL,
+    ts      DATETIME2(6)     NOT NULL,
+    level   VARCHAR(8)       NOT NULL,
+    message NVARCHAR(MAX)    NOT NULL,
+    mdc     NVARCHAR(MAX),
+    CONSTRAINT pk_scheduler_job_log PRIMARY KEY (log_id),
+    CONSTRAINT fk_log_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE,
+    CONSTRAINT chk_log_level CHECK (level IN ('TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR'))
+);
+
+CREATE INDEX idx_joblog_job_ts ON scheduler_job_log (job_id, ts);
+CREATE INDEX idx_joblog_ts ON scheduler_job_log (ts);
+
+-- 10. scheduler_job_archive
+CREATE TABLE scheduler_job_archive
+(
+    archive_id              BINARY(16) NOT NULL,
+    original_job_id         BINARY(16) NOT NULL,
+    final_status            VARCHAR(16)      NOT NULL,
+    job_type                VARCHAR(20)      NOT NULL,
+    priority                INT              NOT NULL,
+    total_attempts          INT              NOT NULL DEFAULT 0,
+    max_retries             INT              NOT NULL DEFAULT 0,
+    backoff_policy          VARCHAR(16)      NOT NULL DEFAULT 'NONE',
+    backoff_param_ms        INT              NOT NULL DEFAULT 0,
+    timeout_sec             INT              NOT NULL DEFAULT 0,
+    target_class            VARCHAR(255),
+    method_name             VARCHAR(128),
+    business_key            VARCHAR(512),
+    cron_expr               VARCHAR(64),
+    zone_id                 VARCHAR(32),
+    original_scheduled_time DATETIME2(6)     NOT NULL,
+    original_created_at     DATETIME2(6)     NOT NULL,
+    first_execution_time    DATETIME2(6),
+    completion_time         DATETIME2(6),
+    total_execution_time_ms BIGINT,
+    queue_wait_ms           BIGINT,
+    archived_at             DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    archived_by             VARCHAR(64),
+    archive_reason          VARCHAR(128),
+    job_result              NVARCHAR(MAX),
+    result_type             VARCHAR(100),
+    final_error             NVARCHAR(MAX),
+    payload_summary         NVARCHAR(MAX),
+    depended_on             BINARY(16),
+    superseded_by           BINARY(16),
+    tags                    VARCHAR(512),
+    CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
+    CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
+    CONSTRAINT chk_archive_job_type CHECK (job_type IN
+                                           ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD',
+                                            'CHAIN_STEP', 'DLQ_ALERT', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
+    CONSTRAINT chk_archive_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_archive_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL'))
+);
+
+CREATE INDEX idx_archive_original_id ON scheduler_job_archive (original_job_id);
+CREATE INDEX idx_archive_status ON scheduler_job_archive (final_status);
+CREATE INDEX idx_archive_created_range ON scheduler_job_archive (original_created_at);
+CREATE INDEX idx_archive_completed_range ON scheduler_job_archive (completion_time);
+CREATE INDEX idx_archive_archived_at ON scheduler_job_archive (archived_at);
+CREATE INDEX idx_archive_target_class ON scheduler_job_archive (target_class);
+CREATE INDEX idx_archive_business_key ON scheduler_job_archive (business_key);
+CREATE INDEX idx_archive_job_type ON scheduler_job_archive (job_type);
+CREATE INDEX idx_archive_priority ON scheduler_job_archive (priority);
+
+-- 11. scheduler_workflow_condition
+-- SQL Server forbids two ON DELETE CASCADE foreign keys from one table to the same parent
+-- ("multiple cascade paths"). Both parent_job_id and child_job_id reference scheduler_job, so
+-- neither cascades; the store deletes condition rows explicitly on job removal.
+CREATE TABLE scheduler_workflow_condition
+(
+    id                   BINARY(16) NOT NULL,
+    parent_job_id        BINARY(16) NOT NULL,
+    child_job_id         BINARY(16) NOT NULL,
+    condition_type       VARCHAR(32)      NOT NULL,
+    condition_expression NVARCHAR(MAX),
+    condition_priority   INT              NOT NULL DEFAULT 0,
+    created_at           DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_workflow_condition PRIMARY KEY (id),
+    CONSTRAINT fk_workflow_parent FOREIGN KEY (parent_job_id) REFERENCES scheduler_job (job_id),
+    CONSTRAINT fk_workflow_child FOREIGN KEY (child_job_id) REFERENCES scheduler_job (job_id),
+    CONSTRAINT chk_condition_type CHECK (condition_type IN
+                                         ('SUCCESS', 'FAILURE', 'CUSTOM', 'RESULT_VALUE',
+                                          'BATCH_SUCCESS', 'BATCH_FAILURE', 'BATCH_SUCCESS_RATE',
+                                          'BATCH_FAILURE_COUNT', 'BATCH_CUSTOM'))
+);
+
+CREATE INDEX idx_workflow_parent ON scheduler_workflow_condition (parent_job_id);
+CREATE INDEX idx_workflow_child ON scheduler_workflow_condition (child_job_id);
+CREATE INDEX idx_workflow_priority ON scheduler_workflow_condition (parent_job_id, condition_priority);
+
+-- 12. scheduler_dlq_alerts
+CREATE TABLE scheduler_dlq_alerts
+(
+    id            BINARY(16) NOT NULL,
+    job_id        BINARY(16) NOT NULL,
+    error_hash    VARCHAR(64)      NOT NULL,
+    alert_sent_at DATETIME2(6),
+    alert_channel VARCHAR(100),
+    CONSTRAINT pk_scheduler_dlq_alerts PRIMARY KEY (id),
+    CONSTRAINT uk_job_error_hash UNIQUE (job_id, error_hash),
+    CONSTRAINT fk_dlq_alert_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_dlq_sent_at ON scheduler_dlq_alerts (alert_sent_at);
+
+-- 13. scheduler_resource_permit
+CREATE TABLE scheduler_resource_permit
+(
+    id            BINARY(16) NOT NULL,
+    resource_name VARCHAR(100)     NOT NULL,
+    job_id        BINARY(16) NOT NULL,
+    node_id       VARCHAR(64)      NOT NULL,
+    acquired_at   DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_resource_permit PRIMARY KEY (id),
+    CONSTRAINT fk_resource_permit_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
+CREATE INDEX idx_resource_permit_job ON scheduler_resource_permit (job_id);

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-debug-indexes.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-debug-indexes.sql
@@ -1,0 +1,11 @@
+-- Optional debug indexes for ratchet-store-sqlserver.
+--
+-- These indexes are NOT applied by the standard sqlserver-schema.sql. They support
+-- ad-hoc queries against scheduler_job by target class or method name during
+-- debugging, support escalations, or one-off audits. They add write amplification
+-- on every job insert/update, so they are off by default.
+--
+-- Apply only if you actively query scheduler_job by target_class or method_name.
+
+CREATE INDEX idx_target_class ON scheduler_job (target_class);
+CREATE INDEX idx_method_name ON scheduler_job (method_name);

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-schema.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-schema.sql
@@ -1,0 +1,446 @@
+-- Ratchet canonical schema — SQL Server (Microsoft SQL Server 2022+ / Azure SQL).
+--
+-- Storage durables (mirror of the PostgreSQL/MySQL stores, dialect-translated):
+--   * uuid            -> BINARY(16) holding the canonical big-endian 16 bytes (NOT UNIQUEIDENTIFIER,
+--                        whose .NET-Guid mixed-endian storage EclipseLink 5.0 / GlassFish reads
+--                        byte-swapped from native queries). Raw bytes read identically across every
+--                        JPA provider; RowValues.uuidOrNull decodes the byte[]. Native writes
+--                        pre-convert via UuidByteArrayConverter.toBytes; JPA-managed writes route
+--                        through the converter (orm-sqlserver.xml on EclipseLink; Hibernate maps
+--                        UUID -> BINARY(16) natively). Time-sortable, so a clustered PK inserts
+--                        sequentially.
+--   * JSONB / JSON    -> NVARCHAR(MAX) (SQL Server JSON is text + JSON_VALUE/OPENJSON functions).
+--   * TIMESTAMPTZ(6)  -> DATETIME2(6). Ratchet stores UTC instants; DATETIME2 is zoneless so the
+--                        UTC convention is preserved and DEFAULTs use SYSUTCDATETIME().
+--   * BOOLEAN         -> BIT (0/1).
+--   * generated cols  -> PERSISTED computed columns over JSON_VALUE(...), CAST to a bounded VARCHAR
+--                        so they fit the nonclustered index key limit (1700 bytes).
+--
+-- SQL Server cannot index NVARCHAR(MAX) and has no MySQL-style prefix-length syntax, so every
+-- indexed / filter-predicate / enum-ish column is a bounded VARCHAR(n); only genuinely freeform
+-- columns (payloads, messages, errors) stay NVARCHAR(MAX).
+--
+-- This file is also the Testcontainers init script, executed by ScriptUtils which splits on ';'.
+-- Keep every statement a single flat statement: no GO batch separators, no IF...BEGIN...END guards.
+--
+-- PERSISTED computed columns and filtered indexes require these session SET options ON. mssql-jdbc
+-- already defaults them ON, but set them explicitly so the script is correct under any client.
+SET QUOTED_IDENTIFIER ON;
+SET ANSI_NULLS ON;
+
+-- 0. ratchet_schema_version
+-- Guarded create: the SchemaMigrator creates this table itself before applying V001, so a plain
+-- CREATE would collide on the migrator path. (Fresh init-script runs simply create it.)
+IF OBJECT_ID(N'ratchet_schema_version', N'U') IS NULL
+CREATE TABLE ratchet_schema_version
+(
+    version     VARCHAR(20)  NOT NULL,
+    applied_at  DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+    description VARCHAR(200) NOT NULL,
+    checksum    VARCHAR(64),
+    CONSTRAINT pk_ratchet_schema_version PRIMARY KEY (version)
+);
+
+-- 1. scheduler_node
+CREATE TABLE scheduler_node
+(
+    node_id      VARCHAR(64)  NOT NULL,
+    heartbeat_ts DATETIME2(6) NOT NULL,
+    started_at   DATETIME2(6) NOT NULL,
+    node_info    NVARCHAR(MAX),
+    CONSTRAINT pk_scheduler_node PRIMARY KEY (node_id)
+);
+
+CREATE INDEX idx_node_heartbeat ON scheduler_node (heartbeat_ts);
+
+-- 2. scheduler_lock
+CREATE TABLE scheduler_lock
+(
+    lock_name  VARCHAR(128) NOT NULL,
+    owner_node VARCHAR(64)  NOT NULL,
+    locked_at  DATETIME2(6) NOT NULL,
+    expires_at DATETIME2(6) NOT NULL,
+    CONSTRAINT pk_scheduler_lock PRIMARY KEY (lock_name)
+);
+
+CREATE INDEX idx_lock_expires ON scheduler_lock (expires_at);
+
+-- 3. scheduler_resource_limit
+CREATE TABLE scheduler_resource_limit
+(
+    resource_name  VARCHAR(100) NOT NULL,
+    max_concurrent INT          NOT NULL,
+    retry_delay_ms INT          NOT NULL DEFAULT 5000,
+    description    VARCHAR(255),
+    created_at     DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+    updated_at     DATETIME2(6) NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_resource_limit PRIMARY KEY (resource_name)
+);
+
+-- 3a. scheduler_recurring_job — recurring-master definitions.
+CREATE TABLE scheduler_recurring_job
+(
+    id                 BINARY(16) NOT NULL,
+    priority           INT              NOT NULL DEFAULT 2,
+    max_retries        INT              NOT NULL DEFAULT 0,
+    backoff_policy     VARCHAR(16)      NOT NULL DEFAULT 'NONE',
+    backoff_param_ms   INT              NOT NULL DEFAULT 0,
+    timeout_sec        INT              NOT NULL DEFAULT 0,
+    cron_expr          VARCHAR(64)      NOT NULL,
+    zone_id            VARCHAR(32)      NOT NULL DEFAULT 'UTC',
+    next_fire          DATETIME2(6)     NOT NULL,
+    is_paused          BIT              NOT NULL DEFAULT 0,
+    paused_at          DATETIME2(6),
+    payload            NVARCHAR(MAX)    NOT NULL,
+    on_success_payload NVARCHAR(MAX),
+    on_failure_payload NVARCHAR(MAX),
+    business_key       VARCHAR(512),
+    resource_name      VARCHAR(100),
+    execution_target   VARCHAR(64),
+    target_class       AS (CAST(JSON_VALUE(payload, '$.target') AS VARCHAR(255))) PERSISTED,
+    method_name        AS (CAST(JSON_VALUE(payload, '$.method') AS VARCHAR(128))) PERSISTED,
+    created_at         DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    caller_principal   VARCHAR(255),
+    encrypted_payload  BIT              NOT NULL DEFAULT 0,
+    CONSTRAINT pk_scheduler_recurring_job PRIMARY KEY (id),
+    CONSTRAINT chk_rec_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_rec_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL'))
+);
+
+-- Claim index: filtered on unpaused rows for claim-scan efficiency.
+CREATE INDEX idx_rec_claim ON scheduler_recurring_job (next_fire) WHERE is_paused = 0;
+CREATE INDEX idx_rec_business_key ON scheduler_recurring_job (business_key);
+CREATE INDEX idx_rec_target_class ON scheduler_recurring_job (target_class);
+
+-- 3b. scheduler_recurring_job_archive.
+CREATE TABLE scheduler_recurring_job_archive
+(
+    id                 BINARY(16) NOT NULL,
+    cron_expr          VARCHAR(64)      NOT NULL,
+    zone_id            VARCHAR(32)      NOT NULL,
+    payload            NVARCHAR(MAX)    NOT NULL,
+    on_success_payload NVARCHAR(MAX),
+    on_failure_payload NVARCHAR(MAX),
+    business_key       VARCHAR(512),
+    execution_target   VARCHAR(64),
+    created_at         DATETIME2(6)     NOT NULL,
+    caller_principal   VARCHAR(255),
+    archived_at        DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    archive_reason     VARCHAR(16)      NOT NULL,
+    CONSTRAINT pk_scheduler_recurring_job_archive PRIMARY KEY (id),
+    CONSTRAINT chk_recurring_archive_reason CHECK (archive_reason IN ('CANCELED', 'EXHAUSTED'))
+);
+
+CREATE INDEX idx_archive_rec_business_key ON scheduler_recurring_job_archive (business_key);
+CREATE INDEX idx_archive_rec_archived_at ON scheduler_recurring_job_archive (archived_at);
+
+-- 4. scheduler_job — COLD metadata + terminal fields.
+CREATE TABLE scheduler_job
+(
+    job_id                BINARY(16) NOT NULL,
+    job_type              VARCHAR(20)      NOT NULL,
+    priority              INT              NOT NULL DEFAULT 2,
+    max_retries           INT              NOT NULL DEFAULT 0,
+    backoff_policy        VARCHAR(16)      NOT NULL DEFAULT 'NONE',
+    backoff_param_ms      INT              NOT NULL DEFAULT 0,
+    timeout_sec           INT              NOT NULL DEFAULT 0,
+    cron_expr             VARCHAR(64)      NOT NULL DEFAULT '',
+    zone_id               VARCHAR(32)      NOT NULL DEFAULT 'UTC',
+    payload               NVARCHAR(MAX)    NOT NULL,
+    params                NVARCHAR(MAX),
+    trace_context         NVARCHAR(MAX),
+    target_class          AS (CAST(JSON_VALUE(payload, '$.target') AS VARCHAR(255))) PERSISTED,
+    method_name           AS (CAST(JSON_VALUE(payload, '$.method') AS VARCHAR(128))) PERSISTED,
+    idempotency_key       VARCHAR(36)      NOT NULL,
+    business_key          VARCHAR(512),
+    resource_name         VARCHAR(100),
+    execution_target      VARCHAR(64),
+    on_success_payload    NVARCHAR(MAX),
+    on_failure_payload    NVARCHAR(MAX),
+    depends_on            BINARY(16),
+    superseded_by         BINARY(16),
+    created_at            DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    caller_principal      VARCHAR(255),
+    terminal_status       VARCHAR(16),
+    terminal_error        NVARCHAR(MAX),
+    total_attempts        INT,
+    terminated_at         DATETIME2(6),
+    execution_start_time  DATETIME2(6),
+    execution_end_time    DATETIME2(6),
+    execution_duration_ms BIGINT,
+    queue_wait_ms         BIGINT,
+    job_result            NVARCHAR(MAX),
+    result_type           VARCHAR(100),
+    recurring_master_id   BINARY(16),
+    encrypted_payload     BIT              NOT NULL DEFAULT 0,
+    encryption_key_id     VARCHAR(256),
+    CONSTRAINT pk_scheduler_job PRIMARY KEY (job_id),
+    CONSTRAINT uk_idempotency_key UNIQUE (idempotency_key),
+    CONSTRAINT chk_job_type CHECK (job_type IN
+                                   ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD',
+                                    'CHAIN_STEP', 'DLQ_ALERT', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
+    CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL')),
+    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
+    CONSTRAINT fk_job_recurring_master FOREIGN KEY (recurring_master_id)
+        REFERENCES scheduler_recurring_job (id) ON DELETE SET NULL
+);
+
+-- 4a. Hot authoritative queue state for executable jobs.
+CREATE TABLE scheduler_job_queue
+(
+    job_id                  BINARY(16) NOT NULL,
+    status                  VARCHAR(16)      NOT NULL DEFAULT 'PENDING',
+    job_type                VARCHAR(20)      NOT NULL,
+    priority                INT              NOT NULL DEFAULT 2,
+    scheduled_time          DATETIME2(6)     NOT NULL,
+    business_key            VARCHAR(512),
+    timeout_sec             INT              NOT NULL DEFAULT 0,
+    max_retries             INT              NOT NULL DEFAULT 0,
+    attempts                INT              NOT NULL DEFAULT 0,
+    picked_by               VARCHAR(64),
+    picked_at               DATETIME2(6),
+    paused_from_status      VARCHAR(16),
+    last_error              NVARCHAR(MAX),
+    version                 INT              NOT NULL DEFAULT 0,
+    updated_at              DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    signal_key              VARCHAR(255),
+    signal_timeout          DATETIME2(6),
+    signal_payload          NVARCHAR(MAX),
+    signal_payload_type     VARCHAR(16),
+    signal_outcome          VARCHAR(32),
+    signal_rejection_reason NVARCHAR(MAX),
+    signal_delivered_at     DATETIME2(6),
+    signal_delivered_by     VARCHAR(255),
+    signal_delivery_id      VARCHAR(36),
+    execution_target        VARCHAR(64),
+    CONSTRAINT pk_scheduler_job_queue PRIMARY KEY (job_id),
+    CONSTRAINT chk_queue_status CHECK (status IN ('PENDING', 'RUNNING', 'PAUSED', 'WAITING')),
+    CONSTRAINT chk_queue_job_type CHECK (job_type IN
+                                         ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD',
+                                          'CHAIN_STEP', 'DLQ_ALERT', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
+    CONSTRAINT chk_queue_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_queue_paused_from_status CHECK (paused_from_status IS NULL OR paused_from_status IN ('PENDING', 'RUNNING', 'PAUSED')),
+    CONSTRAINT fk_job_queue_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+-- Hot-path claim index. Filtered on PENDING.
+CREATE INDEX idx_claim_executable
+    ON scheduler_job_queue (job_type, scheduled_time ASC, priority DESC, job_id ASC)
+    WHERE status = 'PENDING';
+
+CREATE INDEX idx_queue_orphan ON scheduler_job_queue (status, picked_at, picked_by);
+CREATE INDEX idx_signal_key_status ON scheduler_job_queue (signal_key, status);
+CREATE INDEX idx_signal_timeout_status ON scheduler_job_queue (status, signal_timeout);
+CREATE INDEX idx_signal_delivery_id ON scheduler_job_queue (signal_delivery_id);
+
+-- 4b. Business-key active-uniqueness reservation table.
+CREATE TABLE scheduler_business_key_reservation
+(
+    business_key VARCHAR(512)     NOT NULL,
+    owner_job_id BINARY(16) NOT NULL,
+    owner_table  VARCHAR(16)      NOT NULL,
+    reserved_at  DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_business_key_reservation PRIMARY KEY (business_key),
+    CONSTRAINT chk_bk_owner_table CHECK (owner_table IN ('QUEUE', 'RECURRING'))
+);
+
+CREATE INDEX idx_bk_owner ON scheduler_business_key_reservation (owner_job_id);
+
+-- Lookup/relationship indexes (cold).
+CREATE INDEX idx_job_depends_on ON scheduler_job (depends_on);
+CREATE INDEX idx_job_superseded_by ON scheduler_job (superseded_by);
+CREATE INDEX idx_job_business_key ON scheduler_job (business_key);
+CREATE INDEX idx_job_created_at ON scheduler_job (created_at);
+CREATE INDEX idx_job_terminal ON scheduler_job (terminal_status, terminated_at);
+CREATE INDEX idx_job_recurring_master_id ON scheduler_job (recurring_master_id);
+CREATE INDEX idx_job_encryption_key_id ON scheduler_job (encryption_key_id);
+
+-- 5. scheduler_job_tag
+CREATE TABLE scheduler_job_tag
+(
+    job_id BINARY(16) NOT NULL,
+    tag    VARCHAR(64)      NOT NULL,
+    CONSTRAINT pk_scheduler_job_tag PRIMARY KEY (job_id, tag)
+);
+
+CREATE INDEX idx_job_tag_tag_job ON scheduler_job_tag (tag, job_id);
+
+-- 6. scheduler_batch
+CREATE TABLE scheduler_batch
+(
+    batch_id             BINARY(16) NOT NULL,
+    total_items          INT              NOT NULL DEFAULT 0,
+    completed_items      INT              NOT NULL DEFAULT 0,
+    failed_items         INT              NOT NULL DEFAULT 0,
+    completion_processed BIT              NOT NULL DEFAULT 0,
+    version              INT              NOT NULL DEFAULT 0,
+    progress_hook        NVARCHAR(MAX),
+    CONSTRAINT pk_scheduler_batch PRIMARY KEY (batch_id),
+    CONSTRAINT fk_batch_job FOREIGN KEY (batch_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+-- 7. scheduler_batch_metrics
+CREATE TABLE scheduler_batch_metrics
+(
+    batch_id           BINARY(16) NOT NULL,
+    total_duration_ms  BIGINT,
+    child_execution_ms BIGINT,
+    overhead_ms        BIGINT,
+    child_count        INT              NOT NULL DEFAULT 0,
+    success_count      INT              NOT NULL DEFAULT 0,
+    failure_count      INT              NOT NULL DEFAULT 0,
+    started_at         DATETIME2(6),
+    completed_at       DATETIME2(6),
+    version            INT              NOT NULL DEFAULT 0,
+    CONSTRAINT pk_scheduler_batch_metrics PRIMARY KEY (batch_id),
+    CONSTRAINT fk_batch_metrics_job FOREIGN KEY (batch_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+-- 8. scheduler_job_execution
+CREATE TABLE scheduler_job_execution
+(
+    id            BINARY(16) NOT NULL,
+    job_id        BINARY(16) NOT NULL,
+    attempt       INT              NOT NULL,
+    node_id       VARCHAR(64)      NOT NULL,
+    started_at    DATETIME2(6)     NOT NULL,
+    ended_at      DATETIME2(6),
+    status        VARCHAR(16)      NOT NULL DEFAULT 'RUNNING',
+    error_message NVARCHAR(MAX),
+    error_class   VARCHAR(255),
+    duration_ms   BIGINT,
+    CONSTRAINT pk_scheduler_job_execution PRIMARY KEY (id),
+    CONSTRAINT chk_execution_status CHECK (status IN ('RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELED')),
+    CONSTRAINT fk_execution_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_job_execution_job ON scheduler_job_execution (job_id);
+CREATE INDEX idx_job_execution_node ON scheduler_job_execution (node_id, started_at);
+CREATE INDEX idx_job_execution_status ON scheduler_job_execution (status, started_at);
+
+-- 9. scheduler_job_log
+CREATE TABLE scheduler_job_log
+(
+    log_id  BINARY(16) NOT NULL,
+    job_id  BINARY(16) NOT NULL,
+    ts      DATETIME2(6)     NOT NULL,
+    level   VARCHAR(8)       NOT NULL,
+    message NVARCHAR(MAX)    NOT NULL,
+    mdc     NVARCHAR(MAX),
+    CONSTRAINT pk_scheduler_job_log PRIMARY KEY (log_id),
+    CONSTRAINT fk_log_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE,
+    CONSTRAINT chk_log_level CHECK (level IN ('TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR'))
+);
+
+CREATE INDEX idx_joblog_job_ts ON scheduler_job_log (job_id, ts);
+CREATE INDEX idx_joblog_ts ON scheduler_job_log (ts);
+
+-- 10. scheduler_job_archive
+CREATE TABLE scheduler_job_archive
+(
+    archive_id              BINARY(16) NOT NULL,
+    original_job_id         BINARY(16) NOT NULL,
+    final_status            VARCHAR(16)      NOT NULL,
+    job_type                VARCHAR(20)      NOT NULL,
+    priority                INT              NOT NULL,
+    total_attempts          INT              NOT NULL DEFAULT 0,
+    max_retries             INT              NOT NULL DEFAULT 0,
+    backoff_policy          VARCHAR(16)      NOT NULL DEFAULT 'NONE',
+    backoff_param_ms        INT              NOT NULL DEFAULT 0,
+    timeout_sec             INT              NOT NULL DEFAULT 0,
+    target_class            VARCHAR(255),
+    method_name             VARCHAR(128),
+    business_key            VARCHAR(512),
+    cron_expr               VARCHAR(64),
+    zone_id                 VARCHAR(32),
+    original_scheduled_time DATETIME2(6)     NOT NULL,
+    original_created_at     DATETIME2(6)     NOT NULL,
+    first_execution_time    DATETIME2(6),
+    completion_time         DATETIME2(6),
+    total_execution_time_ms BIGINT,
+    queue_wait_ms           BIGINT,
+    archived_at             DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    archived_by             VARCHAR(64),
+    archive_reason          VARCHAR(128),
+    job_result              NVARCHAR(MAX),
+    result_type             VARCHAR(100),
+    final_error             NVARCHAR(MAX),
+    payload_summary         NVARCHAR(MAX),
+    depended_on             BINARY(16),
+    superseded_by           BINARY(16),
+    tags                    VARCHAR(512),
+    CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
+    CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
+    CONSTRAINT chk_archive_job_type CHECK (job_type IN
+                                           ('SINGLE', 'RECURRING', 'BATCH_PARENT', 'BATCH_CHILD',
+                                            'CHAIN_STEP', 'DLQ_ALERT', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
+    CONSTRAINT chk_archive_priority CHECK (priority BETWEEN 0 AND 4),
+    CONSTRAINT chk_archive_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL'))
+);
+
+CREATE INDEX idx_archive_original_id ON scheduler_job_archive (original_job_id);
+CREATE INDEX idx_archive_status ON scheduler_job_archive (final_status);
+CREATE INDEX idx_archive_created_range ON scheduler_job_archive (original_created_at);
+CREATE INDEX idx_archive_completed_range ON scheduler_job_archive (completion_time);
+CREATE INDEX idx_archive_archived_at ON scheduler_job_archive (archived_at);
+CREATE INDEX idx_archive_target_class ON scheduler_job_archive (target_class);
+CREATE INDEX idx_archive_business_key ON scheduler_job_archive (business_key);
+CREATE INDEX idx_archive_job_type ON scheduler_job_archive (job_type);
+CREATE INDEX idx_archive_priority ON scheduler_job_archive (priority);
+
+-- 11. scheduler_workflow_condition
+-- SQL Server forbids two ON DELETE CASCADE foreign keys from one table to the same parent
+-- ("multiple cascade paths"). Both parent_job_id and child_job_id reference scheduler_job, so
+-- neither cascades; the store deletes condition rows explicitly on job removal.
+CREATE TABLE scheduler_workflow_condition
+(
+    id                   BINARY(16) NOT NULL,
+    parent_job_id        BINARY(16) NOT NULL,
+    child_job_id         BINARY(16) NOT NULL,
+    condition_type       VARCHAR(32)      NOT NULL,
+    condition_expression NVARCHAR(MAX),
+    condition_priority   INT              NOT NULL DEFAULT 0,
+    created_at           DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_workflow_condition PRIMARY KEY (id),
+    CONSTRAINT fk_workflow_parent FOREIGN KEY (parent_job_id) REFERENCES scheduler_job (job_id),
+    CONSTRAINT fk_workflow_child FOREIGN KEY (child_job_id) REFERENCES scheduler_job (job_id),
+    CONSTRAINT chk_condition_type CHECK (condition_type IN
+                                         ('SUCCESS', 'FAILURE', 'CUSTOM', 'RESULT_VALUE',
+                                          'BATCH_SUCCESS', 'BATCH_FAILURE', 'BATCH_SUCCESS_RATE',
+                                          'BATCH_FAILURE_COUNT', 'BATCH_CUSTOM'))
+);
+
+CREATE INDEX idx_workflow_parent ON scheduler_workflow_condition (parent_job_id);
+CREATE INDEX idx_workflow_child ON scheduler_workflow_condition (child_job_id);
+CREATE INDEX idx_workflow_priority ON scheduler_workflow_condition (parent_job_id, condition_priority);
+
+-- 12. scheduler_dlq_alerts
+CREATE TABLE scheduler_dlq_alerts
+(
+    id            BINARY(16) NOT NULL,
+    job_id        BINARY(16) NOT NULL,
+    error_hash    VARCHAR(64)      NOT NULL,
+    alert_sent_at DATETIME2(6),
+    alert_channel VARCHAR(100),
+    CONSTRAINT pk_scheduler_dlq_alerts PRIMARY KEY (id),
+    CONSTRAINT uk_job_error_hash UNIQUE (job_id, error_hash),
+    CONSTRAINT fk_dlq_alert_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_dlq_sent_at ON scheduler_dlq_alerts (alert_sent_at);
+
+-- 13. scheduler_resource_permit
+CREATE TABLE scheduler_resource_permit
+(
+    id            BINARY(16) NOT NULL,
+    resource_name VARCHAR(100)     NOT NULL,
+    job_id        BINARY(16) NOT NULL,
+    node_id       VARCHAR(64)      NOT NULL,
+    acquired_at   DATETIME2(6)     NOT NULL DEFAULT SYSUTCDATETIME(),
+    CONSTRAINT pk_scheduler_resource_permit PRIMARY KEY (id),
+    CONSTRAINT fk_resource_permit_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
+CREATE INDEX idx_resource_permit_job ON scheduler_resource_permit (job_id);

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/MssqlContainers.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/MssqlContainers.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Factory for the SQL Server Testcontainer shared by the store's TCK fixtures.
+ *
+ * <p>Defaults to {@code mcr.microsoft.com/mssql/server:2022-latest} (matches the CI/amd64 target;
+ * runs under emulation on Apple Silicon). This is the reference image — the claim path's
+ * boosted-priority ordering uses {@code GREATEST}, which exists only in SQL Server 2022+. The
+ * {@code RATCHET_MSSQL_IMAGE} environment variable can substitute another SQL-Server-compatible
+ * image (accepted as a substitute for the canonical one), but the arm64-native {@code
+ * azure-sql-edge} is a SQL Server 2019 engine and will not pass the claim contracts.
+ *
+ * <p>{@code trustServerCertificate=true} is required because mssql-jdbc 12+ defaults to an
+ * encrypted connection and the container presents a self-signed certificate.
+ *
+ * <p>The shared instance runs against a dedicated {@code ratchet} database with {@code
+ * READ_COMMITTED_SNAPSHOT} enabled. SQL Server's default lock-based READ COMMITTED takes shared
+ * read locks (unlike the MVCC PostgreSQL/MySQL engines Ratchet targets), so concurrent claim/cancel
+ * paths deadlock; row-versioning snapshot reads restore the non-blocking semantics the store
+ * assumes. RCSI cannot be set on {@code master}, hence the dedicated database.
+ */
+final class MssqlContainers {
+
+  private static final String DEFAULT_IMAGE = "mcr.microsoft.com/mssql/server:2022-latest";
+  private static final String DB_NAME = "ratchet";
+  static final String PASSWORD = "Ratchet!Str0ngPwd";
+
+  private MssqlContainers() {}
+
+  static MSSQLServerContainer create() {
+    String image = System.getenv().getOrDefault("RATCHET_MSSQL_IMAGE", DEFAULT_IMAGE);
+    DockerImageName dockerImage =
+        DockerImageName.parse(image).asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server");
+    return new MSSQLServerContainer(dockerImage)
+        .acceptLicense()
+        .withPassword(PASSWORD)
+        .withUrlParam("trustServerCertificate", "true");
+  }
+
+  /** The single schema-loaded SQL Server container shared by every surefire test class. */
+  private static final class Shared {
+    private static final MSSQLServerContainer INSTANCE = create().withReuse(true);
+
+    static {
+      INSTANCE.start();
+      provisionRatchetDatabase(INSTANCE);
+      // Subsequent getJdbcUrl() calls (used by the JPA fixture and the conformance test) now target
+      // the RCSI-enabled ratchet database instead of master.
+      INSTANCE.withUrlParam("databaseName", DB_NAME);
+    }
+  }
+
+  static MSSQLServerContainer shared() {
+    return Shared.INSTANCE;
+  }
+
+  private static void provisionRatchetDatabase(MSSQLServerContainer c) {
+    // Connect to the default database (master) to (re)create the ratchet database with RCSI.
+    try (Connection master =
+            DriverManager.getConnection(c.getJdbcUrl(), c.getUsername(), c.getPassword());
+        Statement st = master.createStatement()) {
+      st.execute(
+          "IF DB_ID('"
+              + DB_NAME
+              + "') IS NOT NULL BEGIN ALTER DATABASE ["
+              + DB_NAME
+              + "] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE ["
+              + DB_NAME
+              + "]; END");
+      st.execute("CREATE DATABASE [" + DB_NAME + "]");
+      st.execute("ALTER DATABASE [" + DB_NAME + "] SET READ_COMMITTED_SNAPSHOT ON");
+      st.execute("ALTER DATABASE [" + DB_NAME + "] SET ALLOW_SNAPSHOT_ISOLATION ON");
+    } catch (SQLException e) {
+      throw new IllegalStateException("Failed to provision the ratchet database", e);
+    }
+    applySchema(c.getJdbcUrl() + ";databaseName=" + DB_NAME, c.getUsername(), c.getPassword());
+  }
+
+  private static void applySchema(String url, String user, String password) {
+    // Strip -- line comments from the whole file BEFORE splitting on ';': some comment lines
+    // contain a semicolon, which would otherwise split a comment and leave a fragment as SQL.
+    String schema = stripComments(readSchema());
+    try (Connection conn = DriverManager.getConnection(url, user, password);
+        Statement st = conn.createStatement()) {
+      for (String raw : schema.split(";")) {
+        String stmt = raw.strip();
+        if (!stmt.isBlank()) {
+          st.execute(stmt);
+        }
+      }
+    } catch (SQLException e) {
+      throw new IllegalStateException("Failed to apply the SQL Server schema", e);
+    }
+  }
+
+  /** Drops every {@code --} line comment so no comment text survives the {@code ;} split. */
+  private static String stripComments(String sql) {
+    return Arrays.stream(sql.split("\n"))
+        .filter(line -> !line.stripLeading().startsWith("--"))
+        .collect(Collectors.joining("\n"));
+  }
+
+  private static String readSchema() {
+    try (InputStream in = MssqlContainers.class.getResourceAsStream("/ddl/sqlserver-schema.sql")) {
+      if (in == null) {
+        throw new IllegalStateException("ddl/sqlserver-schema.sql not found on the test classpath");
+      }
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverActiveBusinessKeyContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverActiveBusinessKeyContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractActiveBusinessKeyContract;
+
+class SqlserverActiveBusinessKeyContractTest extends AbstractActiveBusinessKeyContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverArchiveStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverArchiveStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractArchiveStoreContract;
+
+class SqlserverArchiveStoreContractTest extends AbstractArchiveStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperationsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.ResourceLimitEntity;
+
+class SqlserverAuxiliaryOperationsTest {
+
+  @Test
+  void getPermitRetryDelayUsesDefaultForMissingResource() {
+    SqlserverAuxiliaryOperations operations =
+        new SqlserverAuxiliaryOperations(
+            new SqlserverStoreContext(entityManagerThrowingNoResult()));
+
+    assertEquals(
+        ResourceLimitEntity.DEFAULT_RETRY_DELAY_MS,
+        operations.getPermitRetryDelay("missing-resource"));
+  }
+
+  private static EntityManager entityManagerThrowingNoResult() {
+    Query query =
+        (Query)
+            Proxy.newProxyInstance(
+                Query.class.getClassLoader(),
+                new Class<?>[] {Query.class},
+                (proxy, method, args) -> {
+                  return switch (method.getName()) {
+                    case "setParameter" -> proxy;
+                    case "getSingleResult" -> throw new NoResultException("missing");
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                });
+    return (EntityManager)
+        Proxy.newProxyInstance(
+            EntityManager.class.getClassLoader(),
+            new Class<?>[] {EntityManager.class},
+            (proxy, method, args) -> {
+              if ("createNativeQuery".equals(method.getName())) {
+                return query;
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverBatchOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverBatchOperationsTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.BatchEntity;
+
+class SqlserverBatchOperationsTest {
+
+  private static final UUID BATCH_ID = UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000007");
+
+  @Test
+  void mapIncrementResultRejectsScalarResult() {
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () -> SqlserverBatchOperations.mapIncrementResult(BATCH_ID, 1, ignored -> null));
+
+    assertTrue(thrown.getMessage().contains("Object[]"));
+  }
+
+  @Test
+  void mapIncrementResultRejectsShortRow() {
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                SqlserverBatchOperations.mapIncrementResult(
+                    BATCH_ID, new Object[] {1, 0, 2}, ignored -> null));
+
+    assertTrue(thrown.getMessage().contains("at least 4 columns"));
+  }
+
+  @Test
+  void mapIncrementResultRejectsNonNumericCounters() {
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                SqlserverBatchOperations.mapIncrementResult(
+                    BATCH_ID, new Object[] {"1", 0, 2, null}, ignored -> null));
+
+    assertTrue(thrown.getMessage().contains("completed_items"));
+    assertTrue(thrown.getMessage().contains("numeric"));
+  }
+
+  @Test
+  void mapIncrementResultMapsValidRow() {
+    var progress =
+        SqlserverBatchOperations.mapIncrementResult(
+            BATCH_ID, new Object[] {1L, 2L, 5L, null}, ignored -> null);
+
+    assertEquals(BATCH_ID, progress.batchId());
+    assertEquals(5, progress.totalItems());
+    assertEquals(1, progress.completedItems());
+    assertEquals(2, progress.failedItems());
+  }
+
+  @Test
+  void incrementAtomicThrowsClearErrorWhenBatchIsMissing() {
+    SqlserverBatchOperations operations =
+        new SqlserverBatchOperations(new SqlserverStoreContext(entityManagerThrowingNoResult()));
+
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class, () -> operations.incrementCompletedAtomic(BATCH_ID));
+
+    assertTrue(thrown.getMessage().contains("Batch not found"));
+    assertTrue(thrown.getMessage().contains(BATCH_ID.toString()));
+  }
+
+  @Test
+  void saveBatchUsesReturningRowWithoutFollowUpSelect() {
+    AtomicInteger createNativeQueryCalls = new AtomicInteger();
+    Query query =
+        (Query)
+            Proxy.newProxyInstance(
+                Query.class.getClassLoader(),
+                new Class<?>[] {Query.class},
+                (proxy, method, args) -> {
+                  return switch (method.getName()) {
+                    case "setParameter" -> proxy;
+                    case "getSingleResult" -> new Object[] {BATCH_ID, 4, 1, 2, false, 7, null};
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                });
+    EntityManager em =
+        (EntityManager)
+            Proxy.newProxyInstance(
+                EntityManager.class.getClassLoader(),
+                new Class<?>[] {EntityManager.class},
+                (proxy, method, args) -> {
+                  if ("createNativeQuery".equals(method.getName())) {
+                    createNativeQueryCalls.incrementAndGet();
+                    return query;
+                  }
+                  throw new UnsupportedOperationException(method.getName());
+                });
+    BatchEntity batch = new BatchEntity();
+    batch.setId(BATCH_ID);
+    batch.setTotalItems(4);
+    batch.setCompletedItems(1);
+    batch.setFailedItems(2);
+
+    BatchEntity saved =
+        new SqlserverBatchOperations(new SqlserverStoreContext(em)).saveBatch(batch);
+
+    assertEquals(1, createNativeQueryCalls.get());
+    assertEquals(BATCH_ID, saved.getId());
+    assertEquals(7, saved.getVersion());
+  }
+
+  private static EntityManager entityManagerThrowingNoResult() {
+    Query query =
+        (Query)
+            Proxy.newProxyInstance(
+                Query.class.getClassLoader(),
+                new Class<?>[] {Query.class},
+                (proxy, method, args) -> {
+                  return switch (method.getName()) {
+                    case "setParameter" -> proxy;
+                    case "getSingleResult" -> throw new NoResultException("missing");
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                });
+    return (EntityManager)
+        Proxy.newProxyInstance(
+            EntityManager.class.getClassLoader(),
+            new Class<?>[] {EntityManager.class},
+            (proxy, method, args) -> {
+              if ("createNativeQuery".equals(method.getName())) {
+                return query;
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverBatchStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverBatchStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractBatchStoreContract;
+
+class SqlserverBatchStoreContractTest extends AbstractBatchStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCancelByTagClaimConcurrencyTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCancelByTagClaimConcurrencyTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+
+/**
+ * Regression for the cancel-by-tag / claim race on SQL Server.
+ *
+ * <p>{@code cancelJobsByTag} marks the cold {@code scheduler_job} row CANCELED and then deletes the
+ * hot {@code scheduler_job_queue} row. SQL Server's {@code UPDATE ... FROM} does not lock the
+ * FROM-referenced queue row, so before the fix a poller could claim the tagged job into RUNNING in
+ * the window between the cold update and the hot delete. The hot delete only matched
+ * PENDING/PAUSED/WAITING, so it skipped the now-RUNNING row, stranding it forever — while the
+ * reservation delete still freed the business key, allowing a duplicate to run.
+ *
+ * <p>The window is internal to the cancel method, so this races a real {@code cancelJobsByTag}
+ * against a real {@code claimNextBatchOptimized} on a shared barrier across many repetitions. The
+ * fix locks the candidate queue row {@code FOR UPDATE} as the cancel's first statement, so the
+ * claim's {@code FOR UPDATE SKIP LOCKED} always skips it. The post-invariant after each round is
+ * exact: either the cancel won (job CANCELED, zero queue rows, zero reservations) or the claim won
+ * (job still PENDING-or-RUNNING, exactly one queue row, reservation intact). The broken interleave
+ * produced the forbidden mix — a CANCELED cold row with a surviving RUNNING queue row and a freed
+ * reservation — which trips the assertions below.
+ */
+class SqlserverCancelByTagClaimConcurrencyTest {
+
+  private static final long TIMEOUT_SECONDS = 20;
+  private static final String TAG = "cancel-race-tag";
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    fixture.cleanupStore();
+  }
+
+  @RepeatedTest(40)
+  void cancelAndClaimNeverStrandARunningRow() throws Exception {
+    JobStore store = fixture.store();
+
+    AtomicReference<UUID> jobIdRef = new AtomicReference<>();
+    JobEntity job = fixture.newPendingJob();
+    job.setBusinessKey("cancel-race-key");
+    fixture.runInTransaction(
+        () -> {
+          UUID id = store.create(job).getId();
+          store.insertTags(id, List.of(TAG));
+          jobIdRef.set(id);
+        });
+    UUID jobId = jobIdRef.get();
+
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    CyclicBarrier start = new CyclicBarrier(2);
+    try {
+      Future<?> cancelFuture =
+          executor.submit(
+              () -> {
+                awaitBarrier(start);
+                store.cancelJobsByTag(TAG);
+                return null;
+              });
+      Future<?> claimFuture =
+          executor.submit(
+              () -> {
+                awaitBarrier(start);
+                store.claimNextBatchOptimized(JobExecutionType.SINGLE, 10, "poller-node");
+                return null;
+              });
+      claimFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      cancelFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      assertConsistentOutcome(jobId);
+    } catch (ExecutionException e) {
+      throw new IllegalStateException("worker threw asynchronously", e.getCause());
+    } finally {
+      executor.shutdown();
+      if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  /**
+   * After cancel and claim settle, the job must be in exactly one of two consistent states. The
+   * forbidden state the bug produced — cold row CANCELED, a surviving RUNNING queue row,
+   * reservation freed — fails here.
+   */
+  private void assertConsistentOutcome(UUID jobId) throws Exception {
+    try (Connection conn = fixture.openConnection()) {
+      String terminal = terminalStatus(conn, jobId);
+      String queueStatus = queueStatus(conn, jobId);
+      long reservations = reservationCount(conn, jobId);
+
+      if ("CANCELED".equals(terminal)) {
+        assertEquals(
+            null,
+            queueStatus,
+            "cancel won, so the hot queue row must be gone — a surviving "
+                + queueStatus
+                + " row is the stranded-orphan bug");
+        assertEquals(0, reservations, "cancel won, so the reservation must be freed");
+      } else {
+        assertEquals(null, terminal, "claim won, so the cold row must not be terminal");
+        // claim transitioned PENDING -> RUNNING (or it lost the claim and the row stays PENDING)
+        if (queueStatus == null) {
+          throw new AssertionError("claim won but the queue row vanished");
+        }
+        assertEquals(1, reservations, "claim won, so the reservation must remain held");
+      }
+    }
+  }
+
+  private String terminalStatus(Connection conn, UUID jobId) throws Exception {
+    try (PreparedStatement ps =
+        conn.prepareStatement("SELECT terminal_status FROM scheduler_job WHERE job_id = ?")) {
+      ps.setBytes(1, UuidByteArrayConverter.toBytes(jobId));
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() ? rs.getString(1) : null;
+      }
+    }
+  }
+
+  private String queueStatus(Connection conn, UUID jobId) throws Exception {
+    try (PreparedStatement ps =
+        conn.prepareStatement("SELECT status FROM scheduler_job_queue WHERE job_id = ?")) {
+      ps.setBytes(1, UuidByteArrayConverter.toBytes(jobId));
+      try (ResultSet rs = ps.executeQuery()) {
+        return rs.next() ? rs.getString(1) : null;
+      }
+    }
+  }
+
+  private long reservationCount(Connection conn, UUID jobId) throws Exception {
+    try (PreparedStatement ps =
+        conn.prepareStatement(
+            "SELECT COUNT(*) FROM scheduler_business_key_reservation WHERE owner_job_id = ?")) {
+      ps.setBytes(1, UuidByteArrayConverter.toBytes(jobId));
+      try (ResultSet rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getLong(1);
+      }
+    }
+  }
+
+  private static void awaitBarrier(CyclicBarrier barrier) {
+    try {
+      barrier.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      throw new IllegalStateException("barrier wait failed", e);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCancelByTagClaimConcurrencyTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCancelByTagClaimConcurrencyTest.java
@@ -49,12 +49,12 @@ import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
  *
  * <p>The window is internal to the cancel method, so this races a real {@code cancelJobsByTag}
  * against a real {@code claimNextBatchOptimized} on a shared barrier across many repetitions. The
- * fix locks the candidate queue row {@code FOR UPDATE} as the cancel's first statement, so the
- * claim's {@code FOR UPDATE SKIP LOCKED} always skips it. The post-invariant after each round is
- * exact: either the cancel won (job CANCELED, zero queue rows, zero reservations) or the claim won
- * (job still PENDING-or-RUNNING, exactly one queue row, reservation intact). The broken interleave
- * produced the forbidden mix — a CANCELED cold row with a surviving RUNNING queue row and a freed
- * reservation — which trips the assertions below.
+ * fix locks the candidate queue row with {@code WITH (UPDLOCK, ROWLOCK)} as the cancel's first
+ * statement, so the claim's {@code WITH (UPDLOCK, READPAST, ROWLOCK)} skips it via READPAST. The
+ * post-invariant after each round is exact: either the cancel won (job CANCELED, zero queue rows,
+ * zero reservations) or the claim won (job still PENDING-or-RUNNING, exactly one queue row,
+ * reservation intact). The broken interleave produced the forbidden mix — a CANCELED cold row with
+ * a surviving RUNNING queue row and a freed reservation — which trips the assertions below.
  */
 class SqlserverCancelByTagClaimConcurrencyTest {
 

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverConstraintDetectorTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverConstraintDetectorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.sql.SQLRecoverableException;
+import java.sql.SQLTransientException;
+import org.junit.jupiter.api.Test;
+
+class SqlserverConstraintDetectorTest {
+
+  private final SqlserverConstraintDetector detector = new SqlserverConstraintDetector();
+
+  // SQL Server unique/PK violation: SQLState 23000, vendor error 2627 (constraint) / 2601 (index).
+  private static SQLException uniqueViolation(String constraint) {
+    String name = constraint == null ? "uk_unknown" : constraint;
+    return new SQLException(
+        "Violation of UNIQUE KEY constraint '"
+            + name
+            + "'. Cannot insert duplicate key in object 'dbo.scheduler_job'.",
+        "23000",
+        2627);
+  }
+
+  @Test
+  void extractsConstraintNameThroughWrappers() {
+    Exception wrapped =
+        new RuntimeException("hibernate", uniqueViolation("pk_scheduler_business_key_reservation"));
+
+    assertEquals("pk_scheduler_business_key_reservation", detector.constraintName(wrapped));
+  }
+
+  @Test
+  void returnsNullWhenConstraintNameIsAbsent() {
+    Exception wrapped =
+        new RuntimeException("hibernate", new SQLException("Cannot insert duplicate key", "23000"));
+
+    assertNull(detector.constraintName(wrapped));
+  }
+
+  @Test
+  void detectsDuplicateKeyByErrorCodeThroughWrappers() {
+    Exception wrapped =
+        new RuntimeException("hibernate", new SQLException("duplicate", "23000", 2627));
+
+    assertTrue(detector.isDuplicateKey(wrapped));
+  }
+
+  @Test
+  void detectsDuplicateKeyByUniqueIndexErrorCode() {
+    Exception wrapped =
+        new RuntimeException("hibernate", new SQLException("duplicate", "23000", 2601));
+
+    assertTrue(detector.isDuplicateKey(wrapped));
+  }
+
+  @Test
+  void detectsDuplicateKeyByMessageThroughWrappers() {
+    Exception wrapped = new RuntimeException("hibernate", uniqueViolation("uq_job_key"));
+
+    assertTrue(detector.isDuplicateKey(wrapped));
+  }
+
+  @Test
+  void ignoresNonDuplicateSqlExceptions() {
+    Exception wrapped =
+        new RuntimeException("hibernate", new SQLException("foreign key", "23000", 547));
+
+    assertFalse(detector.isDuplicateKey(wrapped));
+  }
+
+  @Test
+  void detectsDuplicateBusinessKeyFromReservationConstraint() {
+    Exception wrapped =
+        new RuntimeException("hibernate", uniqueViolation("pk_scheduler_business_key_reservation"));
+
+    assertTrue(detector.isDuplicateBusinessKey(wrapped));
+  }
+
+  @Test
+  void ignoresDuplicateKeyFromOtherConstraintAsBusinessKey() {
+    Exception wrapped = new RuntimeException("hibernate", uniqueViolation("uq_job_key"));
+
+    assertFalse(detector.isDuplicateBusinessKey(wrapped));
+  }
+
+  @Test
+  void detectsDeadlockThroughWrappers() {
+    Exception wrapped =
+        new RuntimeException(
+            "hibernate", new SQLException("Transaction was deadlocked", "40001", 1205));
+
+    assertTrue(detector.isDeadlock(wrapped));
+  }
+
+  @Test
+  void detectsSerializationFailureAsRetryableConflict() {
+    Exception wrapped =
+        new RuntimeException("hibernate", new SQLException("serialization failure", "40001"));
+
+    assertTrue(detector.isDeadlock(wrapped));
+  }
+
+  @Test
+  void ignoresNonDeadlockSqlExceptions() {
+    Exception wrapped = new RuntimeException("hibernate", new SQLException("syntax", "42000", 102));
+
+    assertFalse(detector.isDeadlock(wrapped));
+  }
+
+  @Test
+  void detectsConnectionStateThroughWrappers() {
+    Exception wrapped = new RuntimeException("jpa", new SQLException("connection lost", "08006"));
+
+    assertTrue(detector.isTransientConnectionFailure(wrapped));
+  }
+
+  @Test
+  void detectsRecoverableSqlExceptions() {
+    Exception wrapped = new RuntimeException("jpa", new SQLRecoverableException("recoverable"));
+
+    assertTrue(detector.isTransientConnectionFailure(wrapped));
+  }
+
+  @Test
+  void detectsTransientSqlExceptions() {
+    Exception wrapped = new RuntimeException("jpa", new SQLTransientException("transient"));
+
+    assertTrue(detector.isTransientConnectionFailure(wrapped));
+  }
+
+  @Test
+  void ignoresNonTransientSqlExceptions() {
+    Exception wrapped = new RuntimeException("jpa", new SQLException("unique", "23000", 2627));
+
+    assertFalse(detector.isTransientConnectionFailure(wrapped));
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCoreOnlyStoreTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCoreOnlyStoreTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.DlqAlertStore;
+import run.ratchet.store.spi.JobAnalyticsStore;
+import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobQueryStore;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.store.spi.LockStore;
+import run.ratchet.store.spi.NodeStore;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.ResourcePermitStore;
+import run.ratchet.store.spi.SignalStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+/**
+ * Proves a store that advertises only the mandatory core contract still satisfies the engine's
+ * correctness floor. The backing store is a real SQL Server implementation viewed through {@link
+ * run.ratchet.tck.store.CoreOnlyStoreView}, so core lifecycle calls run for real while every
+ * optional capability reports absent.
+ */
+class SqlserverCoreOnlyStoreTest {
+
+  private static final List<Class<?>> OPTIONAL_CAPABILITIES =
+      List.of(
+          RecurringJobStore.class,
+          BatchStore.class,
+          WorkflowConditionStore.class,
+          SignalStore.class,
+          ResourcePermitStore.class,
+          LockStore.class,
+          ArchiveStore.class,
+          JobQueryStore.class,
+          JobAnalyticsStore.class,
+          JobAuditStore.class,
+          DlqAlertStore.class);
+
+  private final SqlserverCoreOnlyTestFixture fixture = new SqlserverCoreOnlyTestFixture();
+
+  @BeforeEach
+  @AfterEach
+  void clean() {
+    fixture.cleanupStore();
+  }
+
+  @Test
+  void capabilityProbe_advertisesCoreAndHidesOptionalCapabilities() {
+    JobStore store = fixture.store();
+
+    assertTrue(
+        store.capability(JobCrudStore.class).isPresent(), "core CRUD must always be advertised");
+    assertTrue(
+        store.capability(NodeStore.class).isPresent(),
+        "node heartbeat / crash recovery must always be advertised");
+    assertTrue(
+        store.capability(TagStore.class).isPresent(), "tag writes must always be advertised");
+
+    for (Class<?> capability : OPTIONAL_CAPABILITIES) {
+      assertTrue(
+          store.capability(capability).isEmpty(),
+          () -> capability.getSimpleName() + " must report absent on a core-only store");
+    }
+  }
+
+  @Test
+  void orphanRecovery_resetsRunningJobsWithoutAnyCapability() {
+    JobEntity job = fixture.persist(fixture.newPendingJob());
+    job.setStatus(JobStatus.RUNNING);
+    job.setPickedBy("phantom-node-" + job.getId());
+    job.setPickedAt(Instant.now().minusSeconds(45));
+    fixture.store().save(job);
+
+    int reset = fixture.store().resetOrphanJobs(Duration.ofSeconds(15));
+
+    assertTrue(reset >= 1, "a job picked 45s ago with a 15s grace should be reclaimed");
+    assertEquals(
+        JobStatus.PENDING,
+        fixture.store().findById(job.getId()).orElseThrow().getStatus(),
+        "crash recovery must run on a store that advertises only core");
+  }
+
+  @Test
+  void capabilityContracts_skipWhenCapabilityAbsent() {
+    // The fixture's capability accessors abort (JUnit skip / conformance N/A) rather than fail when
+    // the store does not advertise the capability.
+    assertThrows(TestAbortedException.class, fixture::batchStore);
+    assertThrows(TestAbortedException.class, fixture::signalStore);
+    assertThrows(TestAbortedException.class, fixture::archiveStore);
+    assertThrows(TestAbortedException.class, fixture::recurringStore);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCoreOnlyTestFixture.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCoreOnlyTestFixture.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.EntityManager;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.CoreOnlyStoreView;
+
+/**
+ * SQL Server fixture whose store advertises only the mandatory core contract. The real SQL Server
+ * store implements every capability; this fixture hides them behind {@link CoreOnlyStoreView} so
+ * the conformance suite sees a store that supports core lifecycle and crash recovery but no
+ * optional capability.
+ */
+public class SqlserverCoreOnlyTestFixture extends SqlserverTestFixture {
+
+  @Override
+  protected JobStore createStore(EntityManager em, MetricsCollector metrics) {
+    return CoreOnlyStoreView.of(super.createStore(em, metrics));
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDialectMapper.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDialectMapper.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.util.Set;
+import run.ratchet.tck.store.schema.DialectTypeMapper;
+import run.ratchet.tck.store.schema.ForeignKey;
+import run.ratchet.tck.store.schema.LogicalType;
+import run.ratchet.tck.store.schema.OnDeleteAction;
+
+/**
+ * SQL Server type/action acceptance for the schema conformance contract.
+ *
+ * <p>Column types are introspected through {@code DatabaseMetaData.getColumns}, which mssql-jdbc
+ * reports as the lowercase native type name ({@code int}, {@code bigint}, {@code binary}, {@code
+ * nvarchar}, {@code datetime2}, {@code bit}, …). The Ratchet SQL Server schema stores UUIDs as
+ * {@code BINARY(16)} (canonical big-endian bytes, not native {@code UNIQUEIDENTIFIER}), JSON and
+ * free TEXT columns as {@code NVARCHAR(MAX)}, and zoneless UTC timestamps as {@code DATETIME2}.
+ *
+ * <p>Like the MySQL mapper, {@link #supportsPartialIndexIntrospection()} stays {@code false}: SQL
+ * Server exposes filtered-index predicates via {@code sys.indexes.filter_definition}, but its
+ * canonical text form ({@code ([status]='PENDING')}) does not line up byte-for-byte with the
+ * catalog's rendered predicate, so the partial-predicate test is skipped while index existence is
+ * still verified.
+ */
+final class SqlserverDialectMapper implements DialectTypeMapper {
+
+  @Override
+  public String dialectName() {
+    return "SQL Server";
+  }
+
+  @Override
+  public Set<String> acceptedTypes(LogicalType logical) {
+    return switch (logical) {
+      case INT32 -> Set.of("int");
+      case INT64 -> Set.of("bigint");
+      case UUID -> Set.of("binary");
+      // Bounded enum/identifier columns are VARCHAR(n); free-text and JSON columns are
+      // NVARCHAR(MAX).
+      case TEXT -> Set.of("varchar", "nvarchar", "char", "nchar");
+      case CHAR_1 -> Set.of("char", "nchar");
+      // Ratchet stores UTC instants in zoneless DATETIME2; DATETIMEOFFSET is also acceptable.
+      case TIMESTAMP_TZ -> Set.of("datetime2", "datetimeoffset");
+      case BOOLEAN -> Set.of("bit");
+      case JSON -> Set.of("nvarchar");
+    };
+  }
+
+  @Override
+  public OnDeleteAction parseOnDelete(String introspectedValue) {
+    if (introspectedValue == null) {
+      return OnDeleteAction.NO_ACTION;
+    }
+    return switch (introspectedValue.toUpperCase()) {
+      case "CASCADE" -> OnDeleteAction.CASCADE;
+      case "RESTRICT" -> OnDeleteAction.RESTRICT;
+      case "SET NULL" -> OnDeleteAction.SET_NULL;
+      case "SET DEFAULT" -> OnDeleteAction.SET_DEFAULT;
+      default -> OnDeleteAction.NO_ACTION;
+    };
+  }
+
+  /**
+   * SQL Server rejects two {@code ON DELETE CASCADE} foreign keys from one table to the same parent
+   * ("multiple cascade paths"). {@code scheduler_workflow_condition} references {@code
+   * scheduler_job} from both {@code parent_job_id} and {@code child_job_id}, so both are declared
+   * {@code NO ACTION} and the store deletes condition rows explicitly. Accept that substitution for
+   * those two FKs; every other FK is compared strictly.
+   */
+  @Override
+  public boolean acceptsOnDelete(ForeignKey expected, OnDeleteAction actual) {
+    boolean isWorkflowConditionFk =
+        expected.name().equals("fk_workflow_parent") || expected.name().equals("fk_workflow_child");
+    if (isWorkflowConditionFk
+        && expected.onDelete() == OnDeleteAction.CASCADE
+        && actual == OnDeleteAction.NO_ACTION) {
+      return true;
+    }
+    return expected.onDelete() == actual;
+  }
+
+  @Override
+  public boolean supportsPartialIndexIntrospection() {
+    return false;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDialectTestSupport.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDialectTestSupport.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.UserTransaction;
+import java.util.UUID;
+import java.util.logging.Logger;
+import run.ratchet.tck.store.SqlDialectTestSupport;
+
+/**
+ * SQL Server {@link SqlDialectTestSupport}: BINARY(16) ids, no foreign-key toggling, and row-level
+ * DELETE.
+ */
+public final class SqlserverDialectTestSupport implements SqlDialectTestSupport {
+
+  private static final Logger log = Logger.getLogger(SqlserverDialectTestSupport.class.getName());
+
+  /** Public no-arg constructor required by {@link java.util.ServiceLoader}. */
+  public SqlserverDialectTestSupport() {}
+
+  @Override
+  public void disableForeignKeyChecks(EntityManager em) {
+    // SQL Server has no session-level foreign-key toggle; the cleanup DELETE respects the
+    // child-before-parent ordering the caller iterates in.
+  }
+
+  @Override
+  public void enableForeignKeyChecks(EntityManager em) {
+    // No-op — see disableForeignKeyChecks.
+  }
+
+  @Override
+  public void clearTable(EntityManager em, String table) {
+    // SQL Server forbids TRUNCATE on a table referenced by an enabled foreign key, and the
+    // scheduler poller keeps ticking through cleanup. Row-level DELETE respects the
+    // child-before-parent ordering the caller iterates in, so it coexists with the live poller.
+    em.createNativeQuery("DELETE FROM " + table).executeUpdate();
+  }
+
+  @Override
+  public Object jobIdParam(UUID jobId) {
+    return SqlDialectTestSupport.uuidToBigEndianBytes(jobId);
+  }
+
+  @Override
+  public void insertTerminalChunk(EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Cold archive rows: terminal_status='SUCCEEDED', no queue row. A recursive CTE generates the
+    // chunk; CONVERT(BINARY(16), NEWID()) is a fresh 16-byte id per row (random is fine — these
+    // rows are never correlated to a queue row). OPTION (MAXRECURSION 0) lifts the default cap of
+    // 100 so large batches insert fully.
+    // language=TSQL
+    String sql =
+        """
+        WITH seq(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %3$d
+        )
+        INSERT INTO scheduler_job
+          (job_id, job_type, payload, idempotency_key, business_key,
+           created_at, terminal_status, terminated_at,
+           execution_start_time, execution_end_time, queue_wait_ms)
+        SELECT CONVERT(BINARY(16), NEWID()), 'SINGLE',
+               '{"target":"run.ratchet.testsuite.app.TimingJob",\
+        "method":"execute","descriptor":"()V",\
+        "isStatic":true,"args":[]}',
+               CONVERT(VARCHAR(36), NEWID()),
+               CONCAT('%2$s-', n + %1$d),
+               SYSUTCDATETIME(), 'SUCCEEDED', DATEADD(HOUR, -1, SYSUTCDATETIME()),
+               DATEADD(HOUR, -1, SYSUTCDATETIME()),
+               DATEADD(MILLISECOND, 10, DATEADD(HOUR, -1, SYSUTCDATETIME())),
+               10
+        FROM seq
+        OPTION (MAXRECURSION 0)
+        """
+            .formatted(offset, keyPrefix, batchCount);
+    em.createNativeQuery(sql).executeUpdate();
+  }
+
+  @Override
+  public void insertPendingQueueChunk(
+      EntityManager em, int batchCount, int offset, String keyPrefix) {
+    // Live PENDING jobs: a cold parent plus a far-future hot queue row. Deterministic BINARY(16)
+    // ids — CAST(CAST(n + offset AS BIGINT) AS BINARY(16)) — let both inserts agree on job_id
+    // without an anti-join. The absolute byte layout is irrelevant here: only that the cold and hot
+    // inserts derive the same value from the same n.
+    // language=TSQL
+    String coldSql =
+        """
+        WITH seq(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %3$d
+        )
+        INSERT INTO scheduler_job
+          (job_id, job_type, payload, idempotency_key, business_key, created_at)
+        SELECT CAST(CAST(n + %1$d AS BIGINT) AS BINARY(16)), 'SINGLE',
+               '{"target":"run.ratchet.testsuite.app.TimingJob",\
+        "method":"execute","descriptor":"()V",\
+        "isStatic":true,"args":[]}',
+               CONCAT('%2$s-key-', n + %1$d),
+               CONCAT('%2$s-', n + %1$d),
+               SYSUTCDATETIME()
+        FROM seq
+        OPTION (MAXRECURSION 0)
+        """
+            .formatted(offset, keyPrefix, batchCount);
+    em.createNativeQuery(coldSql).executeUpdate();
+
+    // language=TSQL
+    String hotSql =
+        """
+        WITH seq(n) AS (
+          SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %2$d
+        )
+        INSERT INTO scheduler_job_queue
+          (job_id, status, job_type, scheduled_time, updated_at)
+        SELECT CAST(CAST(n + %1$d AS BIGINT) AS BINARY(16)),
+               'PENDING', 'SINGLE', DATEADD(DAY, 365, SYSUTCDATETIME()), SYSUTCDATETIME()
+        FROM seq
+        OPTION (MAXRECURSION 0)
+        """
+            .formatted(offset, batchCount);
+    em.createNativeQuery(hotSql).executeUpdate();
+  }
+
+  @Override
+  public void analyzeTable(EntityManager em, String table) {
+    // SQL Server refreshes optimizer statistics with UPDATE STATISTICS. Runs in its own committed
+    // transaction (the caller commits the insert chunks first), so it does not deadlock against
+    // uncommitted DML.
+    em.createNativeQuery("UPDATE STATISTICS " + table).executeUpdate();
+  }
+
+  @Override
+  public void assertNoFullScan(
+      EntityManager em, UserTransaction utx, String table, String label, Runnable storeOperation)
+      throws Exception {
+    // SQL Server's per-table scan counters (sys.dm_db_index_usage_stats) are instance-wide and
+    // reset on restart, so the claim path's index usage is verified by the schema-conformance TCK
+    // and EXPLAIN plans instead. Log for informational purposes only.
+    utx.begin();
+    try {
+      storeOperation.run();
+      utx.commit();
+    } catch (RuntimeException e) {
+      rollbackQuietly(utx);
+      throw e;
+    }
+
+    log.info(
+        String.format(
+            "Scan stats [%s] on %s: SQL Server — per-table scan metrics not available, "
+                + "relying on index definitions and EXPLAIN plans for verification",
+            label, table));
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDlqAlertStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDlqAlertStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractDlqAlertStoreContract;
+
+class SqlserverDlqAlertStoreContractTest extends AbstractDlqAlertStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDualWriteInvariantContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverDualWriteInvariantContractTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractDualWriteInvariantContract;
+
+/**
+ * SQL Server must still honor the active business-key invariants. Running the contract here catches
+ * any regression when Phase 4.4 unifies the bkres model across stores.
+ */
+class SqlserverDualWriteInvariantContractTest extends AbstractDualWriteInvariantContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverExceptionTranslationTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverExceptionTranslationTest.java
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceException;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+
+class SqlserverExceptionTranslationTest {
+
+  private static final UUID JOB_ID = UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000031");
+
+  @Test
+  void archiveJobTranslatesInsertDeadlock() {
+    EntityManager em =
+        entityManager(
+            queryReturning(Collections.singletonList(terminalRow())),
+            queryReturning(List.of()),
+            queryThrowingOnExecute());
+    var ctx = new SqlserverStoreContext(em);
+    var tags = new SqlserverTagOperations(ctx);
+    var reads = new SqlserverJobReadOperations(ctx, tags);
+    var archives = new SqlserverArchiveOperations(ctx, reads);
+    JobEntity input = new JobEntity();
+    input.setId(JOB_ID);
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> archives.archiveJob(input, "retention", "test"));
+  }
+
+  @Test
+  void findJobsForArchivingTranslatesDeadlock() {
+    var archives = archiveOperations(entityManager(queryThrowingOnResults()));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> archives.findJobsForArchiving(Instant.now(), 10));
+  }
+
+  @Test
+  void findJobsForArchivingDoesNotRewrapInnerTagFailure() {
+    var archives =
+        archiveOperations(
+            entityManager(
+                queryReturning(Collections.singletonList(terminalRow())),
+                queryThrowingOnResults()));
+
+    RatchetTransientStoreException thrown =
+        assertThrows(
+            RatchetTransientStoreException.class,
+            () -> archives.findJobsForArchiving(Instant.now(), 10));
+    // The guard rethrows the inner transient as-is; it is not re-translated to the outer op label.
+    assertTrue(thrown.getMessage().contains("hydrate job tags batch"));
+  }
+
+  @Test
+  void findArchivedJobsTranslatesDeadlock() {
+    var archives = archiveOperations(entityManager(queryThrowingOnResults()));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> archives.findArchivedJobs("Job", null, null, null, 10));
+  }
+
+  @Test
+  void purgeArchivedJobsTranslatesDeadlock() {
+    var archives = archiveOperations(entityManager(queryThrowingOnExecute()));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> archives.purgeArchivedJobs(Instant.now()));
+  }
+
+  private static SqlserverArchiveOperations archiveOperations(EntityManager em) {
+    var ctx = new SqlserverStoreContext(em);
+    var tags = new SqlserverTagOperations(ctx);
+    var reads = new SqlserverJobReadOperations(ctx, tags);
+    return new SqlserverArchiveOperations(ctx, reads);
+  }
+
+  @Test
+  void businessKeyReservationsTranslateDeadlock() {
+    var reservations =
+        new SqlserverBusinessKeyReservations(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () ->
+            reservations.insertReservation(
+                "key", JOB_ID, SqlserverBusinessKeyReservations.OWNER_TABLE_QUEUE));
+  }
+
+  @Test
+  void deleteOperationsTranslateDeadlock() {
+    var deletes =
+        new SqlserverJobDeleteOperations(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())),
+            new SqlserverBusinessKeyReservations(
+                new SqlserverStoreContext(entityManager(queryReturningUpdate(1)))));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> deletes.resetOrphanJobsForNode("node"));
+  }
+
+  @Test
+  void readOperationsTranslateDeadlock() {
+    var ctx = new SqlserverStoreContext(entityManager(queryThrowingOnResults()));
+    var reads = new SqlserverJobReadOperations(ctx, new SqlserverTagOperations(ctx));
+
+    assertThrows(RatchetTransientStoreException.class, () -> reads.findById(JOB_ID));
+  }
+
+  @Test
+  void queryOperationsTranslateSearchDeadlock() {
+    var ctx = new SqlserverStoreContext(entityManager(queryThrowingOnResults()));
+    var queries = new SqlserverJobQueryOperations(ctx, new SqlserverTagOperations(ctx));
+
+    assertThrows(RatchetTransientStoreException.class, () -> queries.searchJobs(null, 10, 0));
+  }
+
+  @Test
+  void queryOperationsTranslateCountDeadlock() {
+    var ctx = new SqlserverStoreContext(entityManager(queryThrowingOnSingleResult()));
+    var queries = new SqlserverJobQueryOperations(ctx, new SqlserverTagOperations(ctx));
+
+    assertThrows(RatchetTransientStoreException.class, () -> queries.countJobs(null));
+  }
+
+  @Test
+  void statusTransitionsTranslateDeadlock() {
+    var transitions =
+        new SqlserverJobStatusTransitions(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> transitions.tryPickUpJob(JOB_ID, "node"));
+  }
+
+  @Test
+  void terminalOperationsTranslateDeadlock() {
+    var ctx = new SqlserverStoreContext(entityManager(queryThrowingOnExecute()));
+    var terminals =
+        new SqlserverJobTerminalOperations(
+            ctx, new SqlserverBusinessKeyReservations(ctx), new SqlserverBatchOperations(ctx));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> terminals.scheduleJobRetry(JOB_ID, "boom", Instant.now(), 1));
+  }
+
+  @Test
+  void tagOperationsTranslateDeadlock() {
+    var tags =
+        new SqlserverTagOperations(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(RatchetTransientStoreException.class, () -> tags.deleteTagsByJobId(JOB_ID));
+  }
+
+  @Test
+  void nodeLockOperationsTranslateDeadlock() {
+    var locks =
+        new SqlserverNodeLockOperations(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> locks.tryLock("scheduler", Duration.ofSeconds(30), "node-1"));
+  }
+
+  @Test
+  void signalOperationsTranslateDeadlock() {
+    var signals =
+        new SqlserverSignalOperations(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () ->
+            signals.deliverSignalByKey(
+                "approval", "{}", "json", "APPROVED", null, "node-1", Instant.EPOCH, "delivery-1"));
+  }
+
+  @Test
+  void resourcePermitReleaseTranslatesDeadlock() {
+    var auxiliary =
+        new SqlserverAuxiliaryOperations(
+            new SqlserverStoreContext(entityManager(queryThrowingOnExecute())));
+
+    assertThrows(
+        RatchetTransientStoreException.class, () -> auxiliary.releasePermit("api", JOB_ID));
+  }
+
+  private static EntityManager entityManager(Query... queries) {
+    AtomicInteger nextQuery = new AtomicInteger();
+    return (EntityManager)
+        Proxy.newProxyInstance(
+            EntityManager.class.getClassLoader(),
+            new Class<?>[] {EntityManager.class},
+            (proxy, method, args) -> {
+              if ("createNativeQuery".equals(method.getName())) {
+                return queries[nextQuery.getAndIncrement()];
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+
+  private static Query queryReturning(List<?> rows) {
+    return query(rows, 1, null, null);
+  }
+
+  private static Query queryReturningUpdate(int updated) {
+    return query(List.of(), updated, null, null);
+  }
+
+  private static Query queryThrowingOnExecute() {
+    return query(List.of(), 0, deadlock(), null);
+  }
+
+  private static Query queryThrowingOnResults() {
+    return query(List.of(), 0, null, deadlock());
+  }
+
+  private static Query queryThrowingOnSingleResult() {
+    return query(List.of(), 0, null, null, deadlock());
+  }
+
+  private static Query query(
+      List<?> rows, int updated, RuntimeException executeFailure, RuntimeException resultsFailure) {
+    return query(rows, updated, executeFailure, resultsFailure, null);
+  }
+
+  private static Query query(
+      List<?> rows,
+      int updated,
+      RuntimeException executeFailure,
+      RuntimeException resultsFailure,
+      RuntimeException singleResultFailure) {
+    return (Query)
+        Proxy.newProxyInstance(
+            Query.class.getClassLoader(),
+            new Class<?>[] {Query.class},
+            (proxy, method, args) -> {
+              return switch (method.getName()) {
+                case "setParameter", "setFirstResult", "setMaxResults" -> proxy;
+                case "executeUpdate" -> {
+                  if (executeFailure != null) {
+                    throw executeFailure;
+                  }
+                  yield updated;
+                }
+                case "getResultList" -> {
+                  if (resultsFailure != null) {
+                    throw resultsFailure;
+                  }
+                  yield rows;
+                }
+                case "getSingleResult" -> {
+                  if (singleResultFailure != null) {
+                    throw singleResultFailure;
+                  }
+                  yield rows.isEmpty() ? 0 : rows.get(0);
+                }
+                default -> throw new UnsupportedOperationException(method.getName());
+              };
+            });
+  }
+
+  private static RuntimeException deadlock() {
+    // SQL Server deadlock victim: vendor error 1205, SQLState 40001.
+    return new PersistenceException(
+        "deadlock", new SQLException("Transaction was deadlocked", "40001", 1205));
+  }
+
+  private static Object[] terminalRow() {
+    Object[] row = new Object[SqlserverJobRowMapper.HYDRATION_COL_COUNT];
+    Instant now = Instant.parse("2026-05-12T14:30:00Z");
+    row[0] = JOB_ID;
+    row[1] = JobExecutionType.SINGLE.name();
+    row[2] = JobPriority.NORMAL.ordinal();
+    row[3] = 3;
+    row[4] = BackoffPolicy.NONE.name();
+    row[5] = 0;
+    row[6] = 60;
+    row[11] = "example.Job"; // target_class
+    row[12] = "run"; // method_name
+    row[20] = now; // created_at
+    row[22] = JobStatus.SUCCEEDED.name(); // terminal_status
+    row[24] = 1; // total_attempts
+    row[25] = now; // terminated_at
+    row[26] = now; // execution_start_time
+    row[27] = now; // execution_end_time
+    return row;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverExplainPlanCaptureIT.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverExplainPlanCaptureIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.tck.store.ExplainPlanTestSupport;
+
+class SqlserverExplainPlanCaptureIT {
+
+  private static final SqlserverTestFixture FIXTURE = new SqlserverTestFixture();
+
+  /**
+   * Captures the estimated plan for the optimized executable-claim SELECT via {@code SET
+   * SHOWPLAN_XML ON} (which returns the plan XML without executing the statement). The filtered
+   * index is forced with a hint so the test asserts it remains <em>usable</em> for the claim shape
+   * — SQL Server would reject the hint outright if the filtered index could no longer serve the
+   * query. This mirrors the PostgreSQL test's "disable seqscan to verify the index remains usable"
+   * intent.
+   */
+  private static String showplanXml(Statement statement) throws SQLException {
+    String sql =
+        """
+        SELECT job_id, status, job_type, priority, scheduled_time, version, timeout_sec,
+               picked_by, picked_at, business_key, attempts, max_retries, execution_target
+        FROM scheduler_job_queue WITH (INDEX(idx_claim_executable), UPDLOCK, READPAST, ROWLOCK)
+        WHERE status = 'PENDING'
+          AND scheduled_time <= SYSUTCDATETIME()
+          AND job_type = 'SINGLE'
+        ORDER BY priority DESC, scheduled_time ASC, job_id ASC
+        OFFSET 0 ROWS FETCH NEXT 50 ROWS ONLY
+        """;
+    statement.execute("SET SHOWPLAN_XML ON");
+    try (ResultSet rs = statement.executeQuery(sql)) {
+      assertTrue(rs.next(), "SHOWPLAN_XML should return one plan row");
+      return rs.getString(1);
+    } finally {
+      statement.execute("SET SHOWPLAN_XML OFF");
+    }
+  }
+
+  @BeforeEach
+  void clean() {
+    FIXTURE.cleanupStore();
+  }
+
+  @Test
+  void optimizedExecutableClaimPlan_usesClaimCoveringIndex() throws Exception {
+    ExplainPlanTestSupport.seedPendingJobs(FIXTURE);
+    try (Connection conn = ExplainPlanTestSupport.connection(FIXTURE);
+        Statement statement = conn.createStatement()) {
+      String plan = showplanXml(statement);
+      ExplainPlanTestSupport.writePlan("target/explain-plans/sqlserver-optimized-claim.xml", plan);
+
+      assertTrue(plan.contains("scheduler_job_queue"), plan);
+      assertTrue(plan.contains("idx_claim_executable"), plan);
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverIsolationProbeTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverIsolationProbeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the session-isolation probe driving {@link
+ * SqlserverJobStoreImpl#checkIsolationLevel()} is valid T-SQL that actually returns the level.
+ *
+ * <p>Regression guard: the probe was originally copied verbatim from the PostgreSQL store ({@code
+ * SHOW transaction_isolation}), which is invalid on SQL Server. Because {@code IsolationCheck}
+ * swallows a throwing probe and skips the check, the broken query silently disabled the guard on
+ * every startup without failing any test. Running the probe directly here proves it is live.
+ */
+class SqlserverIsolationProbeTest {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Test
+  void isolationProbeReturnsReadCommitted() throws Exception {
+    try (Connection conn = fixture.openConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery(SqlserverJobStoreImpl.ISOLATION_PROBE_SQL)) {
+      assertTrue(rs.next(), "isolation probe returned no row");
+      String level = rs.getString(1);
+      assertNotNull(level, "isolation probe returned NULL — the CASE did not match a known level");
+      assertEquals(
+          "read committed",
+          level.toLowerCase(Locale.ROOT),
+          "default SQL Server session isolation should be READ COMMITTED (level 2)");
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobAnalyticsStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobAnalyticsStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobAnalyticsStoreContract;
+
+class SqlserverJobAnalyticsStoreContractTest extends AbstractJobAnalyticsStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobAuditStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobAuditStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobAuditStoreContract;
+
+class SqlserverJobAuditStoreContractTest extends AbstractJobAuditStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobBatchStatusStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobBatchStatusStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobBatchStatusStoreContract;
+
+class SqlserverJobBatchStatusStoreContractTest extends AbstractJobBatchStatusStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobBulkStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobBulkStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobBulkStoreContract;
+
+class SqlserverJobBulkStoreContractTest extends AbstractJobBulkStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobClaimStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobClaimStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobClaimStoreContract;
+
+class SqlserverJobClaimStoreContractTest extends AbstractJobClaimStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobCountOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobCountOperationsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import java.lang.reflect.Proxy;
+import org.junit.jupiter.api.Test;
+
+class SqlserverJobCountOperationsTest {
+
+  @Test
+  void queueWaitPercentileRejectsOutOfRangeValueBeforeQuerying() {
+    SqlserverJobCountOperations operations =
+        new SqlserverJobCountOperations(new SqlserverStoreContext(entityManagerThatMustNotRun()));
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> operations.getQueueWaitTimePercentile(1.5));
+
+    assertTrue(thrown.getMessage().contains("[0.0, 1.0]"));
+  }
+
+  private static EntityManager entityManagerThatMustNotRun() {
+    return (EntityManager)
+        Proxy.newProxyInstance(
+            EntityManager.class.getClassLoader(),
+            new Class<?>[] {EntityManager.class},
+            (proxy, method, args) -> {
+              throw new AssertionError("EntityManager should not be called");
+            });
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobCrudStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobCrudStoreContractTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobCrudStoreContract;
+
+class SqlserverJobCrudStoreContractTest extends AbstractJobCrudStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+
+  @Override
+  public boolean supportsTransactionalRollback() {
+    return fixture.supportsTransactionalRollback();
+  }
+
+  @Override
+  public boolean isStaleWriteException(Throwable t) {
+    return fixture.isStaleWriteException(t);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobPauseStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobPauseStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobPauseStoreContract;
+
+class SqlserverJobPauseStoreContractTest extends AbstractJobPauseStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperationsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobFilter;
+import run.ratchet.api.JobQuerySortField;
+import run.ratchet.store.query.JobQueryCursor;
+
+class SqlserverJobQueryOperationsTest {
+
+  @Test
+  void searchJobsIgnoresCursorWithMalformedInstantSortValue() {
+    String cursor =
+        new JobQueryCursor(
+                JobQuerySortField.CREATED_AT,
+                false,
+                "not-an-instant",
+                UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"))
+            .encode();
+    NativeSqlRecorder recorder = new NativeSqlRecorder();
+    SqlserverStoreContext ctx = new SqlserverStoreContext(recorder.entityManager());
+    SqlserverJobQueryOperations operations =
+        new SqlserverJobQueryOperations(ctx, new SqlserverTagOperations(ctx));
+
+    assertDoesNotThrow(
+        () -> operations.searchJobs(JobFilter.builder().cursor(cursor).build(), 10, 7));
+    assertTrue(
+        recorder.lastSql().contains("OFFSET 7"),
+        "Malformed cursors should leave offset pagination in place");
+  }
+
+  @Test
+  void searchJobsIgnoresCursorMintedForADifferentSort() {
+    // Cursor was produced for PRIORITY ascending, but this query sorts by the default
+    // CREATED_AT descending. Applying it would seek on priority while ORDER BY uses created_at,
+    // so the seek must be dropped and offset pagination kept.
+    String cursor =
+        new JobQueryCursor(
+                JobQuerySortField.PRIORITY,
+                true,
+                "3",
+                UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"))
+            .encode();
+    NativeSqlRecorder recorder = new NativeSqlRecorder();
+    SqlserverStoreContext ctx = new SqlserverStoreContext(recorder.entityManager());
+    SqlserverJobQueryOperations operations =
+        new SqlserverJobQueryOperations(ctx, new SqlserverTagOperations(ctx));
+
+    operations.searchJobs(JobFilter.builder().cursor(cursor).build(), 10, 7);
+
+    String sql = recorder.lastSql();
+    assertTrue(
+        sql.contains("OFFSET 7"),
+        "A cursor minted for a different sort must fall back to offset pagination");
+    assertFalse(
+        sql.contains("c.priority >") || sql.contains("c.priority <"),
+        "A mismatched cursor must not contribute a keyset seek predicate");
+  }
+
+  @Test
+  void searchJobsWithArchiveCursorFiltersBothUnionBranches() {
+    String cursor =
+        new JobQueryCursor(
+                JobQuerySortField.CREATED_AT,
+                false,
+                "2026-01-01T00:00:00Z",
+                UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"))
+            .encode();
+    NativeSqlRecorder recorder = new NativeSqlRecorder();
+    SqlserverStoreContext ctx = new SqlserverStoreContext(recorder.entityManager());
+    SqlserverJobQueryOperations operations =
+        new SqlserverJobQueryOperations(ctx, new SqlserverTagOperations(ctx));
+
+    operations.searchJobs(JobFilter.builder().includeArchived(true).cursor(cursor).build(), 10, 25);
+
+    String sql = recorder.lastSql();
+    assertTrue(
+        sql.contains("c.created_at < ? OR (c.created_at = ? AND c.job_id > ?)"),
+        "Live branch should apply the keyset cursor");
+    assertTrue(
+        sql.contains(
+            "a.original_created_at < ? OR (a.original_created_at = ? AND a.original_job_id > ?)"),
+        "Archive branch should apply the keyset cursor");
+    assertFalse(sql.contains("OFFSET 25"), "Cursor pagination should not combine with offset");
+    assertTrue(sql.contains("OFFSET 0"), "Cursor pagination should reset offset");
+  }
+
+  private static final class NativeSqlRecorder {
+    private final List<String> sql = new ArrayList<>();
+
+    EntityManager entityManager() {
+      return (EntityManager)
+          Proxy.newProxyInstance(
+              EntityManager.class.getClassLoader(),
+              new Class<?>[] {EntityManager.class},
+              (proxy, method, args) -> {
+                if ("createNativeQuery".equals(method.getName())) {
+                  sql.add((String) args[0]);
+                  return emptyResultQuery();
+                }
+                throw new UnsupportedOperationException(method.getName());
+              });
+    }
+
+    String lastSql() {
+      assertFalse(sql.isEmpty(), "Expected at least one native query");
+      return sql.get(sql.size() - 1);
+    }
+  }
+
+  private static Query emptyResultQuery() {
+    return (Query)
+        Proxy.newProxyInstance(
+            Query.class.getClassLoader(),
+            new Class<?>[] {Query.class},
+            (proxy, method, args) -> {
+              if ("getResultList".equals(method.getName())) {
+                return List.of();
+              }
+              return switch (method.getName()) {
+                case "setParameter", "setFirstResult", "setMaxResults" -> proxy;
+                default -> throw new UnsupportedOperationException(method.getName());
+              };
+            });
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobQueryStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobQueryStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobQueryStoreContract;
+
+class SqlserverJobQueryStoreContractTest extends AbstractJobQueryStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobReadOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobReadOperationsTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class SqlserverJobReadOperationsTest {
+
+  private static final UUID JOB_ID = UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000469");
+
+  @Test
+  void getJobStatusRejectsRowsWithNoEffectiveStatus() {
+    SqlserverStoreContext ctx =
+        new SqlserverStoreContext(
+            entityManagerReturningRows(Collections.singletonList(new Object[] {null, null})));
+    SqlserverJobReadOperations operations =
+        new SqlserverJobReadOperations(ctx, new SqlserverTagOperations(ctx));
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> operations.getJobStatus(JOB_ID));
+
+    assertTrue(thrown.getMessage().contains("no live or terminal status"));
+  }
+
+  private static EntityManager entityManagerReturningRows(List<?> rows) {
+    Query query =
+        (Query)
+            Proxy.newProxyInstance(
+                Query.class.getClassLoader(),
+                new Class<?>[] {Query.class},
+                (proxy, method, args) -> {
+                  return switch (method.getName()) {
+                    case "setParameter" -> proxy;
+                    case "getResultList" -> rows;
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                });
+    return (EntityManager)
+        Proxy.newProxyInstance(
+            EntityManager.class.getClassLoader(),
+            new Class<?>[] {EntityManager.class},
+            (proxy, method, args) -> {
+              if ("createNativeQuery".equals(method.getName())) {
+                return query;
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobRetryStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobRetryStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobRetryStoreContract;
+
+class SqlserverJobRetryStoreContractTest extends AbstractJobRetryStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobRowMapperTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobRowMapperTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobPriority;
+import run.ratchet.store.entity.JobExecutionType;
+
+class SqlserverJobRowMapperTest {
+
+  private static final UUID JOB_ID = UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000021");
+
+  @Test
+  void hydrateWrapsInvalidEnumWithColumnContext() {
+    Object[] row = liveRow();
+    row[1] = "UNKNOWN_TYPE";
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> SqlserverJobRowMapper.hydrate(row));
+
+    assertTrue(thrown.getMessage().contains(JOB_ID.toString()));
+    assertTrue(thrown.getMessage().contains("job_type"));
+    assertTrue(thrown.getMessage().contains("UNKNOWN_TYPE"));
+    assertInstanceOf(IllegalArgumentException.class, thrown.getCause());
+  }
+
+  @Test
+  void hydrateRejectsRowsWithNoEffectiveStatus() {
+    Object[] row = liveRow();
+    row[SqlserverJobRowMapper.IDX_Q_STATUS] = null;
+
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> SqlserverJobRowMapper.hydrate(row));
+
+    assertTrue(thrown.getMessage().contains("no live or terminal status"));
+  }
+
+  private static Object[] liveRow() {
+    Object[] row = new Object[SqlserverJobRowMapper.HYDRATION_COL_COUNT];
+    Instant now = Instant.parse("2026-05-12T14:30:00Z");
+    row[0] = JOB_ID;
+    row[1] = JobExecutionType.SINGLE.name();
+    row[2] = JobPriority.NORMAL.ordinal();
+    row[3] = 3;
+    row[4] = BackoffPolicy.NONE.name();
+    row[5] = 0;
+    row[6] = 60;
+    row[11] = "example.Job"; // target_class
+    row[12] = "run"; // method_name
+    row[20] = now; // created_at
+    row[SqlserverJobRowMapper.IDX_Q_STATUS] = "PENDING";
+    row[SqlserverJobRowMapper.IDX_Q_STATUS + 1] = now; // q.scheduled_time
+    row[SqlserverJobRowMapper.IDX_Q_STATUS + 2] = 0; // q.attempts
+    row[SqlserverJobRowMapper.IDX_Q_STATUS + 7] = 0; // q.version
+    row[SqlserverJobRowMapper.IDX_Q_STATUS + 8] = now; // q.updated_at
+    return row;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobStoreImplTransactionTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobStoreImplTransactionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobFilter;
+import run.ratchet.tck.store.AbstractJobStoreTransactionBoundaryContract;
+
+class SqlserverJobStoreImplTransactionTest extends AbstractJobStoreTransactionBoundaryContract {
+
+  @Override
+  protected Class<?> jobStoreImplClass() {
+    return SqlserverJobStoreImpl.class;
+  }
+
+  @Test
+  void readMethodsInheritDefaultTransactionBoundary() throws NoSuchMethodException {
+    // Read methods used to carry an explicit @Transactional(SUPPORTS), but on JTA-managed
+    // EclipseLink containers (Payara, GlassFish, OpenLiberty) calling a SUPPORTS method outside
+    // an outer JTA tx leaked the borrowed pool connection with auto-commit disabled, leaving an
+    // open transaction holding metadata locks on subsequent writes. Reverting to the class-level
+    // @Transactional default (REQUIRED) makes each read have a clean tx boundary that commits
+    // before returning the connection to the pool.
+    //
+    // getDatabaseTime is the specific read that triggered the original hang -- it runs during
+    // startup via DefaultNodeIdentityProvider.checkClockSkew before any outer JTA tx exists.
+    assertNoMethodLevelTransactional("getDatabaseTime");
+    assertNoMethodLevelTransactional("searchJobs", JobFilter.class, int.class, int.class);
+    assertNoMethodLevelTransactional("countJobs", JobFilter.class);
+  }
+
+  private static void assertNoMethodLevelTransactional(
+      String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+    Transactional annotation =
+        SqlserverJobStoreImpl.class
+            .getMethod(methodName, parameterTypes)
+            .getAnnotation(Transactional.class);
+    assertNull(annotation);
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobTerminalStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobTerminalStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobTerminalStoreContract;
+
+class SqlserverJobTerminalStoreContractTest extends AbstractJobTerminalStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverLockStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverLockStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractLockStoreContract;
+
+class SqlserverLockStoreContractTest extends AbstractLockStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverNodeLockOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverNodeLockOperationsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class SqlserverNodeLockOperationsTest {
+
+  @Test
+  void upsertHeartbeatRejectsNullArgumentsBeforeSqlExecution() {
+    SqlserverNodeLockOperations operations =
+        new SqlserverNodeLockOperations(new SqlserverStoreContext(noopEntityManager()));
+
+    NullPointerException nodeId =
+        assertThrows(
+            NullPointerException.class, () -> operations.upsertHeartbeat(null, Instant.EPOCH));
+    NullPointerException timestamp =
+        assertThrows(NullPointerException.class, () -> operations.upsertHeartbeat("node-1", null));
+
+    assertEquals("nodeId", nodeId.getMessage());
+    assertEquals("ts", timestamp.getMessage());
+  }
+
+  private static EntityManager noopEntityManager() {
+    return (EntityManager)
+        Proxy.newProxyInstance(
+            EntityManager.class.getClassLoader(),
+            new Class<?>[] {EntityManager.class},
+            (proxy, method, args) -> {
+              if ("createNativeQuery".equals(method.getName())) {
+                return noopQuery();
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+
+  private static Query noopQuery() {
+    return (Query)
+        Proxy.newProxyInstance(
+            Query.class.getClassLoader(),
+            new Class<?>[] {Query.class},
+            (proxy, method, args) -> {
+              if ("executeUpdate".equals(method.getName())) {
+                return 1;
+              }
+              if ("setParameter".equals(method.getName())) {
+                return proxy;
+              }
+              throw new UnsupportedOperationException(method.getName());
+            });
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverNodeStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverNodeStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractNodeStoreContract;
+
+class SqlserverNodeStoreContractTest extends AbstractNodeStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverPayloadEncryptionContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverPayloadEncryptionContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractPayloadEncryptionStoreContract;
+
+class SqlserverPayloadEncryptionContractTest extends AbstractPayloadEncryptionStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverRecurringClaimConcurrencyContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverRecurringClaimConcurrencyContractTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.util.List;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.tck.store.AbstractJpaRecurringClaimConcurrencyContract;
+import run.ratchet.tck.store.JpaContainerFixture;
+
+class SqlserverRecurringClaimConcurrencyContractTest
+    extends AbstractJpaRecurringClaimConcurrencyContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  protected JpaContainerFixture fixture() {
+    return fixture;
+  }
+
+  @Override
+  protected RecurringJobStore recurringStore() {
+    return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobPayload noopPayload() {
+    return new JobPayload("run.ratchet.tck.store.NoopTask", "run", "()V", true, List.of());
+  }
+
+  @Override
+  protected void cleanupRecurringStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverRecurringJobStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverRecurringJobStoreContractTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.util.List;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.tck.store.AbstractRecurringJobStoreContract;
+import run.ratchet.tck.store.JobStoreContractFixture;
+
+class SqlserverRecurringJobStoreContractTest extends AbstractRecurringJobStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  protected RecurringJobStore recurringStore() {
+    return (RecurringJobStore) fixture.store();
+  }
+
+  @Override
+  protected JobStoreContractFixture jobFixture() {
+    return fixture;
+  }
+
+  @Override
+  protected TagStore tagStore() {
+    return (TagStore) fixture.store();
+  }
+
+  @Override
+  protected JobPayload noopPayload() {
+    return new JobPayload("run.ratchet.tck.store.NoopTask", "run", "()V", true, List.of());
+  }
+
+  @Override
+  protected void cleanupRecurringStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverResourcePermitStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverResourcePermitStoreContractTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractResourcePermitStoreContract;
+
+class SqlserverResourcePermitStoreContractTest extends AbstractResourcePermitStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+
+  @Test
+  void tryAcquirePermit_usesCapacityGatedInsert() throws IOException {
+    String source =
+        Files.readString(
+            Path.of("src/main/java/run/ratchet/store/sqlserver/SqlserverAuxiliaryOperations.java"));
+    int start = source.indexOf("public boolean tryAcquirePermit");
+    int end = source.indexOf("public void releasePermit");
+    assertTrue(start >= 0, "tryAcquirePermit method should exist in source");
+    assertTrue(end > start, "releasePermit should appear after tryAcquirePermit in source");
+    String method = source.substring(start, end);
+
+    assertTrue(
+        method.contains("INSERT INTO scheduler_resource_permit")
+            && method.contains(") < max_concurrent")
+            && !method.contains("String countSql"),
+        "tryAcquirePermit must gate permit insertion with the capacity check");
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaConformanceContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaConformanceContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
+import run.ratchet.tck.store.AbstractSchemaConformanceContract;
+import run.ratchet.tck.store.schema.DialectTypeMapper;
+
+/**
+ * SQL Server conformance test for the canonical Ratchet schema. Owns its own Testcontainer (with
+ * reuse enabled) so the conformance check is independent of the JPA fixture used by the rest of the
+ * TCK suite.
+ */
+class SqlserverSchemaConformanceContractTest extends AbstractSchemaConformanceContract {
+
+  @SuppressWarnings({"resource", "rawtypes"})
+  private static final MSSQLServerContainer CONTAINER = MssqlContainers.shared();
+
+  @Override
+  protected Connection openConnection() throws SQLException {
+    return DriverManager.getConnection(
+        CONTAINER.getJdbcUrl(), CONTAINER.getUsername(), CONTAINER.getPassword());
+  }
+
+  @Override
+  protected DialectTypeMapper mapper() {
+    return new SqlserverDialectMapper();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigrationDialectTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigrationDialectTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.store.migration.SchemaMigrationException;
+
+class SqlserverSchemaMigrationDialectTest {
+
+  private final SqlserverSchemaMigrationDialect dialect = new SqlserverSchemaMigrationDialect();
+  private Connection connection;
+  private Statement statement;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    connection = mock(Connection.class);
+    statement = mock(Statement.class);
+    when(connection.createStatement()).thenReturn(statement);
+  }
+
+  private void stubAppLockResult(int result) throws SQLException {
+    ResultSet resultSet = mock(ResultSet.class);
+    when(statement.executeQuery(anyString())).thenReturn(resultSet);
+    when(resultSet.next()).thenReturn(true);
+    when(resultSet.getInt(1)).thenReturn(result);
+  }
+
+  @Test
+  void advertisesSqlserverIdentityOnSharedConnection() {
+    assertEquals("sqlserver", dialect.id());
+    assertFalse(dialect.usesDedicatedLockConnection());
+  }
+
+  @Test
+  void acquiresApplicationLockViaSpGetAppLock() throws Exception {
+    stubAppLockResult(0);
+
+    dialect.acquireLock(connection);
+
+    verify(statement).executeQuery(contains("sp_getapplock"));
+  }
+
+  @Test
+  void failsWhenAppLockReturnsNegative() throws Exception {
+    stubAppLockResult(-1);
+
+    SchemaMigrationException ex =
+        assertThrows(SchemaMigrationException.class, () -> dialect.acquireLock(connection));
+
+    assertTrue(ex.getMessage().contains("Timed out acquiring SQL Server schema migration lock"));
+  }
+
+  @Test
+  void releasesApplicationLock() throws Exception {
+    dialect.releaseLock(connection);
+
+    verify(statement).execute(contains("sp_releaseapplock"));
+  }
+
+  @Test
+  void versionLedgerSqlIsSqlserverFlavored() {
+    assertTrue(dialect.createVersionTableSql().contains("OBJECT_ID"));
+    assertTrue(dialect.createVersionTableSql().contains("DATETIME2(6)"));
+    assertTrue(dialect.recordVersionSql().startsWith("MERGE ratchet_schema_version"));
+    assertTrue(dialect.recordVersionSql().contains("WHEN MATCHED THEN UPDATE"));
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigratorIT.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigratorIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
+import run.ratchet.store.migration.SchemaMigrationDialect;
+import run.ratchet.store.migration.SchemaMigrator;
+import run.ratchet.tck.store.AbstractSchemaMigratorContract;
+import run.ratchet.tck.store.JdbcDriverDataSource;
+
+/**
+ * Runs {@link SchemaMigrator} against a virgin SQL Server Testcontainer (no init script). Verifies
+ * that the migrator brings the schema up from empty, is idempotent on re-run, and converges under
+ * {@code sp_getapplock} when two threads race.
+ */
+class SqlserverSchemaMigratorIT extends AbstractSchemaMigratorContract {
+
+  @SuppressWarnings({"resource", "rawtypes"})
+  private static final MSSQLServerContainer CONTAINER = MssqlContainers.create();
+
+  @BeforeAll
+  static void start() {
+    CONTAINER.start();
+  }
+
+  @AfterAll
+  static void stop() {
+    CONTAINER.stop();
+  }
+
+  @Override
+  protected DataSource dataSource() {
+    return new JdbcDriverDataSource(
+        CONTAINER.getJdbcUrl(), CONTAINER.getUsername(), CONTAINER.getPassword());
+  }
+
+  @Override
+  protected SchemaMigrationDialect dialect() {
+    return new SqlserverSchemaMigrationDialect();
+  }
+
+  @Override
+  protected Connection newJdbcConnection() throws SQLException {
+    return DriverManager.getConnection(
+        CONTAINER.getJdbcUrl(), CONTAINER.getUsername(), CONTAINER.getPassword());
+  }
+
+  // Drop every Ratchet table child-first so foreign keys never block the drop. SQL Server has no
+  // "DROP SCHEMA ... CASCADE", so the virgin state is restored table by table.
+  private static final List<String> TABLES_CHILD_FIRST =
+      List.of(
+          "scheduler_business_key_reservation",
+          "scheduler_job_queue",
+          "scheduler_job_tag",
+          "scheduler_job_log",
+          "scheduler_job_execution",
+          "scheduler_resource_permit",
+          "scheduler_workflow_condition",
+          "scheduler_dlq_alerts",
+          "scheduler_batch_metrics",
+          "scheduler_batch",
+          "scheduler_job_archive",
+          "scheduler_job",
+          "scheduler_recurring_job_archive",
+          "scheduler_recurring_job",
+          "scheduler_resource_limit",
+          "scheduler_lock",
+          "scheduler_node",
+          "ratchet_schema_version");
+
+  @Override
+  protected void resetDatabase() throws SQLException {
+    try (Connection c = newJdbcConnection();
+        Statement s = c.createStatement()) {
+      for (String table : TABLES_CHILD_FIRST) {
+        s.execute("DROP TABLE IF EXISTS dbo." + table);
+      }
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSignalOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSignalOperationsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobPriority;
+import run.ratchet.store.entity.JobExecutionType;
+
+class SqlserverSignalOperationsTest {
+
+  private static final UUID JOB_ID = UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000011");
+
+  @Test
+  void findTimedOutSignalJobsMapsOffsetDateTimeTimeouts() {
+    OffsetDateTime timeout = OffsetDateTime.of(2026, 5, 12, 14, 30, 0, 0, ZoneOffset.UTC);
+    var operations = new SqlserverSignalOperations(contextReturning(row(timeout, 2)));
+
+    var jobs = operations.findTimedOutSignalJobs(Instant.now(), 10);
+
+    assertEquals(timeout.toInstant(), jobs.get(0).getSignalTimeout());
+  }
+
+  @Test
+  void findTimedOutSignalJobsDefaultsInvalidPriorityOrdinal() {
+    var operations =
+        new SqlserverSignalOperations(
+            contextReturning(row(OffsetDateTime.now(ZoneOffset.UTC), 99)));
+
+    var jobs = operations.findTimedOutSignalJobs(Instant.now(), 10);
+
+    assertEquals(JobPriority.NORMAL, jobs.get(0).getPriority());
+  }
+
+  private static SqlserverStoreContext contextReturning(Object[] row) {
+    Query query =
+        (Query)
+            Proxy.newProxyInstance(
+                Query.class.getClassLoader(),
+                new Class<?>[] {Query.class},
+                (proxy, method, args) -> {
+                  return switch (method.getName()) {
+                    case "setParameter", "setMaxResults" -> proxy;
+                    case "getResultList" -> Collections.singletonList(row);
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                });
+    EntityManager em =
+        (EntityManager)
+            Proxy.newProxyInstance(
+                EntityManager.class.getClassLoader(),
+                new Class<?>[] {EntityManager.class},
+                (proxy, method, args) -> {
+                  if ("createNativeQuery".equals(method.getName())) {
+                    return query;
+                  }
+                  throw new UnsupportedOperationException(method.getName());
+                });
+    return new SqlserverStoreContext(em);
+  }
+
+  private static Object[] row(OffsetDateTime timeout, int priorityOrdinal) {
+    return new Object[] {
+      JOB_ID,
+      "approval",
+      timeout,
+      "WAITING",
+      JobExecutionType.SINGLE.name(),
+      priorityOrdinal,
+      3,
+      "business-key",
+      BackoffPolicy.FIXED.name(),
+      1000,
+      "{}",
+      "application/json",
+      null,
+      null,
+      timeout,
+      "tester",
+      "delivery-1"
+    };
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSignalStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSignalStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractSignalStoreContract;
+
+class SqlserverSignalStoreContractTest extends AbstractSignalStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTagOperationsTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTagOperationsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class SqlserverTagOperationsTest {
+
+  @Test
+  void insertTagsChunksLargeInputsIntoBoundedStatements() {
+    NativeSqlRecorder recorder = new NativeSqlRecorder();
+    SqlserverTagOperations operations =
+        new SqlserverTagOperations(new SqlserverStoreContext(recorder.entityManager()));
+    List<String> tags = IntStream.range(0, 600).mapToObj(i -> "tag-" + i).toList();
+
+    operations.insertTags(UUID.fromString("019ae3d1-3f82-7e18-9f09-a9f000000465"), tags);
+
+    assertEquals(3, recorder.sql.size(), "Large tag lists should be inserted in chunks");
+    assertEquals(List.of(500, 500, 200), recorder.parameterCounts);
+  }
+
+  @Test
+  void countJobsByExecutionNodeForTagUsesAttemptOrderForLatestExecution() {
+    NativeSqlRecorder recorder = new NativeSqlRecorder();
+    SqlserverTagOperations operations =
+        new SqlserverTagOperations(new SqlserverStoreContext(recorder.entityManager()));
+
+    operations.countJobsByExecutionNodeForTag("run-tag");
+
+    String sql = recorder.lastSql();
+    assertFalse(sql.contains("MAX(e2.id::text)"), "Latest execution must not depend on UUID text");
+    assertTrue(sql.contains("ORDER BY e2.attempt DESC"), "Attempt number defines execution order");
+    assertTrue(sql.contains("TOP 1"), "Latest execution lookup should return one row");
+  }
+
+  private static final class NativeSqlRecorder {
+    private final List<String> sql = new ArrayList<>();
+    private final List<Integer> parameterCounts = new ArrayList<>();
+
+    EntityManager entityManager() {
+      return (EntityManager)
+          Proxy.newProxyInstance(
+              EntityManager.class.getClassLoader(),
+              new Class<?>[] {EntityManager.class},
+              (proxy, method, args) -> {
+                if ("createNativeQuery".equals(method.getName())) {
+                  sql.add((String) args[0]);
+                  return query();
+                }
+                throw new UnsupportedOperationException(method.getName());
+              });
+    }
+
+    String lastSql() {
+      assertFalse(sql.isEmpty(), "Expected at least one native query");
+      return sql.get(sql.size() - 1);
+    }
+
+    private Query query() {
+      return (Query)
+          Proxy.newProxyInstance(
+              Query.class.getClassLoader(),
+              new Class<?>[] {Query.class},
+              new java.lang.reflect.InvocationHandler() {
+                private int parameterCount;
+
+                @Override
+                public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+                  return switch (method.getName()) {
+                    case "setParameter" -> {
+                      parameterCount = Math.max(parameterCount, ((Number) args[0]).intValue());
+                      yield proxy;
+                    }
+                    case "executeUpdate" -> {
+                      parameterCounts.add(parameterCount);
+                      yield 1;
+                    }
+                    case "getResultList" -> List.of();
+                    default -> throw new UnsupportedOperationException(method.getName());
+                  };
+                }
+              });
+    }
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTagStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTagStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractTagStoreContract;
+
+class SqlserverTagStoreContractTest extends AbstractTagStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTestFixture.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTestFixture.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import jakarta.persistence.EntityManager;
+import java.util.Map;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
+import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.exception.RatchetOptimisticLockException;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.JpaContainerFixture;
+
+/** Shared Testcontainers + Hibernate fixture for SQL Server TCK tests. */
+public class SqlserverTestFixture extends JpaContainerFixture {
+
+  @SuppressWarnings("resource")
+  private static final MSSQLServerContainer CONTAINER = MssqlContainers.shared();
+
+  @Override
+  public boolean isStaleWriteException(Throwable t) {
+    for (Throwable c = t; c != null; c = c.getCause()) {
+      if (c instanceof RatchetOptimisticLockException) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void cleanupStore() {
+    // Order matters: delete children before parents, bkres before queue, queue before job.
+    executeNativeSql("DELETE FROM scheduler_business_key_reservation");
+    executeNativeSql("DELETE FROM scheduler_job_queue");
+    executeNativeSql("DELETE FROM scheduler_job_tag");
+    executeNativeSql("DELETE FROM scheduler_job_log");
+    executeNativeSql("DELETE FROM scheduler_job_execution");
+    executeNativeSql("DELETE FROM scheduler_resource_permit");
+    executeNativeSql("DELETE FROM scheduler_workflow_condition");
+    executeNativeSql("DELETE FROM scheduler_dlq_alerts");
+    executeNativeSql("DELETE FROM scheduler_batch_metrics");
+    executeNativeSql("DELETE FROM scheduler_job_archive");
+    executeNativeSql("DELETE FROM scheduler_job");
+    executeNativeSql("DELETE FROM scheduler_recurring_job_archive");
+    executeNativeSql("DELETE FROM scheduler_recurring_job");
+    executeNativeSql("DELETE FROM scheduler_batch");
+    executeNativeSql("DELETE FROM scheduler_resource_limit");
+    executeNativeSql("DELETE FROM scheduler_lock");
+    executeNativeSql("DELETE FROM scheduler_node");
+  }
+
+  @Override
+  protected JdbcDatabaseContainer<?> container() {
+    return CONTAINER;
+  }
+
+  @Override
+  protected Map<String, Object> jpaProperties() {
+    // No hibernate.dialect pin — Hibernate 6 auto-detects from the JDBC URL. Remaining keys are
+    // opt-in Hibernate tuning and no-op under any other JPA provider.
+    //
+    // preferred_uuid_jdbc_type=BINARY: UUID columns are BINARY(16) holding canonical big-endian
+    // bytes (matching the RI's native UuidByteArrayConverter.toBytes writes). Hibernate's SQL
+    // Server
+    // dialect otherwise defaults UUID to the uniqueidentifier JDBC type, so the driver writes
+    // .NET-Guid mixed-endian bytes into BINARY(16) — JPA-managed writes (em.persist) and reads
+    // (em.find) would then disagree with the native path, breaking FK joins and lookups. Forcing
+    // the
+    // BINARY type routes UUIDs through Hibernate's canonical UUIDJavaType byte order.
+    return Map.of(
+        "hibernate.hbm2ddl.auto", "none",
+        "hibernate.show_sql", "false",
+        "hibernate.format_sql", "false",
+        "hibernate.connection.provider_disables_autocommit", "false",
+        "hibernate.type.preferred_uuid_jdbc_type", "BINARY");
+  }
+
+  @Override
+  protected String persistenceUnitName() {
+    return "ratchet-sqlserver-tck";
+  }
+
+  @Override
+  protected JobStore createStore(EntityManager em, MetricsCollector metrics) {
+    SqlserverJobStoreImpl store =
+        new SqlserverJobStoreImpl(() -> em, metrics, RatchetOptions.defaults());
+    store.checkIsolationLevel();
+    return store;
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverWorkflowConditionStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverWorkflowConditionStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractWorkflowConditionStoreContract;
+
+class SqlserverWorkflowConditionStoreContractTest extends AbstractWorkflowConditionStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/resources/META-INF/persistence.xml
+++ b/stores/ratchet-store-sqlserver/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+                 https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+  <persistence-unit name="ratchet-sqlserver-tck" transaction-type="RESOURCE_LOCAL">
+    <class>run.ratchet.store.entity.JobEntity</class>
+    <class>run.ratchet.store.entity.JobExecutionEntity</class>
+    <class>run.ratchet.store.entity.ResourceLimitEntity</class>
+    <class>run.ratchet.store.entity.BatchMetricsEntity</class>
+    <class>run.ratchet.store.entity.WorkflowConditionEntity</class>
+    <class>run.ratchet.store.entity.ArchivedJobEntity</class>
+    <class>run.ratchet.store.entity.NodeEntity</class>
+    <class>run.ratchet.store.entity.DlqAlertEntity</class>
+    <class>run.ratchet.store.entity.JobLogEntity</class>
+    <class>run.ratchet.store.entity.ResourcePermitEntity</class>
+    <class>run.ratchet.store.entity.BatchEntity</class>
+    <exclude-unlisted-classes>true</exclude-unlisted-classes>
+  </persistence-unit>
+</persistence>

--- a/stores/ratchet-store-sqlserver/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
+++ b/stores/ratchet-store-sqlserver/src/test/resources/META-INF/services/run.ratchet.tck.store.SqlDialectTestSupport
@@ -1,0 +1,1 @@
+run.ratchet.store.sqlserver.SqlserverDialectTestSupport

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSchemaConformanceContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractSchemaConformanceContract.java
@@ -167,10 +167,15 @@ public abstract class AbstractSchemaConformanceContract {
               expected.refColumn().toLowerCase(Locale.ROOT),
               actual.refColumn().toLowerCase(Locale.ROOT),
               () -> "FK " + expected.name() + " referenced column mismatch");
-          assertEquals(
-              expected.onDelete(),
-              actual.onDelete(),
-              () -> "FK " + expected.name() + " ON DELETE action mismatch");
+          assertTrue(
+              mapper().acceptsOnDelete(expected, actual.onDelete()),
+              () ->
+                  "FK "
+                      + expected.name()
+                      + " ON DELETE action mismatch: expected "
+                      + expected.onDelete()
+                      + " but introspected "
+                      + actual.onDelete());
         }
       }
     }

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
@@ -34,6 +34,7 @@ import run.ratchet.api.BackoffPolicy;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobType;
+import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
@@ -86,6 +87,9 @@ public abstract class JpaContainerFixture implements JobStoreContractFixture {
 
   private static final Map<String, EntityManagerFactory> EMF_CACHE = new ConcurrentHashMap<>();
   private static final MetricsCollector NO_OP_METRICS = new NoOpMetricsCollector();
+  // A method that fails with a transient store exception (e.g. a SQL Server deadlock victim) is
+  // retried on a fresh transaction, emulating a production transient-retry interceptor.
+  private static final int MAX_TRANSACTION_ATTEMPTS = 5;
 
   private final EntityManagerFactory emf;
   private final ThreadLocal<EntityManager> threadEm;
@@ -292,12 +296,20 @@ public abstract class JpaContainerFixture implements JobStoreContractFixture {
               EntityManager em = threadEm.get();
               EntityTransaction tx = em.getTransaction();
               boolean owner = !tx.isActive();
-              if (owner) {
-                tx.begin();
+              // A nested (non-owner) call runs inside the caller's transaction and cannot retry.
+              if (!owner) {
+                return invokeUnwrapping(delegate, method, args);
               }
-              try {
-                Object result = method.invoke(delegate, args);
-                if (owner && tx.isActive()) {
+              // Emulate a production @Transactional method behind a transient-retry interceptor:
+              // each attempt is its own transaction, and a transient store failure (a SQL Server
+              // deadlock victim is the realistic case — lock-based engines can deadlock where the
+              // MVCC stores never do) is retried on a fresh transaction. MVCC stores never throw
+              // this, so the retry loop is a single pass for them.
+              RatchetTransientStoreException lastTransient = null;
+              for (int attempt = 1; attempt <= MAX_TRANSACTION_ATTEMPTS; attempt++) {
+                tx.begin();
+                try {
+                  Object result = invokeUnwrapping(delegate, method, args);
                   tx.commit();
                   // Production @Transactional + container-managed PersistenceContext resets the
                   // L1 cache between method invocations. The thread-local EM used by this proxy
@@ -305,22 +317,32 @@ public abstract class JpaContainerFixture implements JobStoreContractFixture {
                   // subsequent em.find() calls would miss server-side UPDATEs issued via native
                   // SQL. Clear after commit to match production semantics.
                   em.clear();
-                }
-                return result;
-              } catch (InvocationTargetException ite) {
-                if (owner && tx.isActive()) {
-                  tx.rollback();
+                  return result;
+                } catch (RatchetTransientStoreException transient_) {
+                  if (tx.isActive()) {
+                    tx.rollback();
+                  }
                   em.clear();
-                }
-                throw ite.getCause();
-              } catch (Throwable t) {
-                if (owner && tx.isActive()) {
-                  tx.rollback();
+                  lastTransient = transient_;
+                } catch (Throwable t) {
+                  if (tx.isActive()) {
+                    tx.rollback();
+                  }
                   em.clear();
+                  throw t;
                 }
-                throw t;
               }
+              throw lastTransient;
             });
+  }
+
+  private static Object invokeUnwrapping(
+      Object delegate, java.lang.reflect.Method method, Object[] args) throws Throwable {
+    try {
+      return method.invoke(delegate, args);
+    } catch (InvocationTargetException ite) {
+      throw ite.getCause();
+    }
   }
 
   /** No-op metrics collector reused by every JPA fixture instance. */

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/schema/DialectTypeMapper.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/schema/DialectTypeMapper.java
@@ -43,6 +43,17 @@ public interface DialectTypeMapper {
   OnDeleteAction parseOnDelete(String introspectedValue);
 
   /**
+   * Whether the introspected {@code actual} ON DELETE action satisfies the catalog's expectation
+   * for {@code expected}. Defaults to strict equality. A dialect overrides this only where it
+   * cannot express a cataloged action — e.g. SQL Server forbids two {@code ON DELETE CASCADE}
+   * foreign keys from one table to the same parent, so it substitutes {@code NO_ACTION} and deletes
+   * the dependent rows in application code.
+   */
+  default boolean acceptsOnDelete(ForeignKey expected, OnDeleteAction actual) {
+    return expected.onDelete() == actual;
+  }
+
+  /**
    * Whether this dialect can introspect partial-index WHERE predicates. {@code false} when the
    * dialect lacks the concept (MySQL covering indexes) or lacks an introspection path. Tests that
    * verify partial predicates skip when this returns {@code false}.

--- a/testing/ratchet-testsuite/pom.xml
+++ b/testing/ratchet-testsuite/pom.xml
@@ -166,6 +166,18 @@
       <artifactId>testcontainers-mongodb</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- Always on the compile classpath so JdbcContainerExtension's MSSQLServerContainer reference
+         resolves regardless of the active DB profile; the store itself ships only under sqlserver. -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-mssqlserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -373,6 +385,23 @@
                   </artifactItems>
                 </configuration>
               </execution>
+              <execution>
+                <id>copy-sqlserver-driver</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>com.microsoft.sqlserver</groupId>
+                      <artifactId>mssql-jdbc</artifactId>
+                      <version>${mssql-jdbc.version}</version>
+                      <outputDirectory>${wildfly.home}/modules/com/microsoft/sqlserver/main</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>
@@ -428,6 +457,21 @@
     &lt;module name="java.security.jgss"/&gt;
     &lt;module name="java.management"/&gt;
     &lt;module name="java.xml"/&gt;
+    &lt;module name="jakarta.transaction.api"/&gt;
+  &lt;/dependencies&gt;
+&lt;/module&gt;</echo>
+                    <echo file="${wildfly.home}/modules/com/microsoft/sqlserver/main/module.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;module xmlns="urn:jboss:module:1.9" name="com.microsoft.sqlserver"&gt;
+  &lt;resources&gt;
+    &lt;resource-root path="mssql-jdbc-${mssql-jdbc.version}.jar"/&gt;
+  &lt;/resources&gt;
+  &lt;dependencies&gt;
+    &lt;module name="java.sql"/&gt;
+    &lt;module name="java.naming"/&gt;
+    &lt;module name="java.logging"/&gt;
+    &lt;module name="java.management"/&gt;
+    &lt;module name="java.xml"/&gt;
+    &lt;module name="java.security.jgss"/&gt;
     &lt;module name="jakarta.transaction.api"/&gt;
   &lt;/dependencies&gt;
 &lt;/module&gt;</echo>
@@ -552,6 +596,23 @@
                   </artifactItems>
                 </configuration>
               </execution>
+              <execution>
+                <id>copy-sqlserver-driver</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>copy</goal>
+                </goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>com.microsoft.sqlserver</groupId>
+                      <artifactId>mssql-jdbc</artifactId>
+                      <version>${mssql-jdbc.version}</version>
+                      <outputDirectory>${wildfly.home}/modules/com/microsoft/sqlserver/main</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>
@@ -607,6 +668,21 @@
     &lt;module name="java.security.jgss"/&gt;
     &lt;module name="java.management"/&gt;
     &lt;module name="java.xml"/&gt;
+    &lt;module name="jakarta.transaction.api"/&gt;
+  &lt;/dependencies&gt;
+&lt;/module&gt;</echo>
+                    <echo file="${wildfly.home}/modules/com/microsoft/sqlserver/main/module.xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;module xmlns="urn:jboss:module:1.9" name="com.microsoft.sqlserver"&gt;
+  &lt;resources&gt;
+    &lt;resource-root path="mssql-jdbc-${mssql-jdbc.version}.jar"/&gt;
+  &lt;/resources&gt;
+  &lt;dependencies&gt;
+    &lt;module name="java.sql"/&gt;
+    &lt;module name="java.naming"/&gt;
+    &lt;module name="java.logging"/&gt;
+    &lt;module name="java.management"/&gt;
+    &lt;module name="java.xml"/&gt;
+    &lt;module name="java.security.jgss"/&gt;
     &lt;module name="jakarta.transaction.api"/&gt;
   &lt;/dependencies&gt;
 &lt;/module&gt;</echo>
@@ -747,13 +823,20 @@
                                    flags="g"
                                    byline="true"/>
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="\s*&lt;jvm-options&gt;-D(ratchet\.test\.db\.type|testsuite\.profile)=[^&lt;]*&lt;/jvm-options&gt;"
+                                   match="\s*&lt;jvm-options&gt;-D(ratchet\.test\.db\.type|testsuite\.profile|user\.timezone)=[^&lt;]*&lt;/jvm-options&gt;"
                                    replace=""
                                    flags="g"
                                    byline="true"/>
+                    <!--
+                      Pin the Payara server JVM to UTC for the same EclipseLink claim-skew
+                      reason documented on the GlassFish profile. The TZ=UTC failsafe env
+                      currently reaches Payara's adapter JVM, but that propagation is
+                      adapter-specific and fragile; injecting the zone as an explicit
+                      jvm-option makes the cell deterministic on non-UTC developer machines.
+                    -->
                     <replaceregexp file="${payara.home}/glassfish/domains/domain1/config/domain.xml"
                                    match="(\s*)&lt;/java-config&gt;"
-                                   replace="\1  &lt;jvm-options&gt;-Dratchet.test.db.type=${ratchet.test.db.type}&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dtestsuite.profile=${testsuite.profile}&lt;/jvm-options&gt;\1&lt;/java-config&gt;"
+                                   replace="\1  &lt;jvm-options&gt;-Duser.timezone=UTC&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dratchet.test.db.type=${ratchet.test.db.type}&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dtestsuite.profile=${testsuite.profile}&lt;/jvm-options&gt;\1&lt;/java-config&gt;"
                                    flags="g"
                                    byline="true"/>
                     <!--
@@ -1013,13 +1096,22 @@
                       harmless duplication).
                     -->
                     <replaceregexp file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml"
-                                   match="\s*&lt;jvm-options&gt;-D(ratchet\.test\.db\.type|testsuite\.profile)=[^&lt;]*&lt;/jvm-options&gt;"
+                                   match="\s*&lt;jvm-options&gt;-D(ratchet\.test\.db\.type|testsuite\.profile|user\.timezone)=[^&lt;]*&lt;/jvm-options&gt;"
                                    replace=""
                                    flags="g"
                                    byline="true"/>
+                    <!--
+                      Pin the GlassFish server JVM to UTC. EclipseLink writes the
+                      store's zone-less DATETIME/TIMESTAMP columns via JDBC Timestamps
+                      and claims them against the (UTC) database's server-side NOW(3);
+                      a non-UTC server zone skews next_fire/scheduled_time and stalls
+                      claims (jobs stay PENDING). The TZ=UTC failsafe env reaches the
+                      Payara adapter's JVM but NOT omnifish's GlassFish JVM, so inject
+                      the zone here as a proper jvm-option asadmin honors at launch.
+                    -->
                     <replaceregexp file="${glassfish.home}/glassfish/domains/domain1/config/domain.xml"
                                    match="(\s*)&lt;/java-config&gt;"
-                                   replace="\1  &lt;jvm-options&gt;-Dratchet.test.db.type=${ratchet.test.db.type}&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dtestsuite.profile=${testsuite.profile}&lt;/jvm-options&gt;\1&lt;/java-config&gt;"
+                                   replace="\1  &lt;jvm-options&gt;-Duser.timezone=UTC&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dratchet.test.db.type=${ratchet.test.db.type}&lt;/jvm-options&gt;\1  &lt;jvm-options&gt;-Dtestsuite.profile=${testsuite.profile}&lt;/jvm-options&gt;\1&lt;/java-config&gt;"
                                    flags="g"
                                    byline="true"/>
                   </target>
@@ -1236,6 +1328,46 @@
         <dependency>
           <groupId>org.testcontainers</groupId>
           <artifactId>testcontainers-mongodb</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!--
+      SQL Server runs green on all five managed servers (wildfly-managed, wildfly-ee11-managed,
+      payara-managed, openliberty-managed, glassfish-managed). The store stores every UUID as
+      BINARY(16) holding the canonical big-endian bytes rather than the native UNIQUEIDENTIFIER
+      type: UNIQUEIDENTIFIER's .NET-Guid mixed-endian storage is read byte-swapped by EclipseLink
+      5.0 (GlassFish 8 / the Jakarta EE 11 RI) from native queries, which stalled every job on that
+      cell. Raw BINARY(16) bytes read identically across every JPA provider, so GlassFish is now
+      supported alongside the other four. Mirrors the BINARY(16) approach of ratchet-store-mysql.
+    -->
+    <profile>
+      <id>sqlserver</id>
+      <properties>
+        <ratchet.test.db.type>sqlserver</ratchet.test.db.type>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>run.ratchet</groupId>
+          <artifactId>ratchet-store-sqlserver</artifactId>
+        </dependency>
+        <!-- Test-jar carries SqlserverDialectTestSupport (ServiceLoader-discovered by the testsuite). -->
+        <dependency>
+          <groupId>run.ratchet</groupId>
+          <artifactId>ratchet-store-sqlserver</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>com.microsoft.sqlserver</groupId>
+          <artifactId>mssql-jdbc</artifactId>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.testcontainers</groupId>
+          <artifactId>testcontainers-mssqlserver</artifactId>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/infra/JdbcContainerExtension.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/infra/JdbcContainerExtension.java
@@ -15,11 +15,22 @@
  */
 package run.ratchet.testsuite.infra;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.oracle.OracleContainer;
 import org.testcontainers.postgresql.PostgreSQLContainer;
@@ -28,10 +39,10 @@ import org.testcontainers.postgresql.PostgreSQLContainer;
  * JUnit 5 extension that starts a shared Testcontainers SQL database before all tests.
  *
  * <p>The database type is determined by the {@code ratchet.test.db.type} system property. The
- * extension starts a container only for {@code mysql}, {@code postgresql}, or {@code oracle}; other
- * values leave the extension inactive, and {@link #getConfig()} will fail until a SQL-backed run
- * initializes it. The container is started once and shared across all test classes via the JUnit
- * {@link ExtensionContext.Store} with GLOBAL namespace.
+ * extension starts a container only for {@code mysql}, {@code postgresql}, {@code oracle}, or
+ * {@code sqlserver}; other values leave the extension inactive, and {@link #getConfig()} will fail
+ * until a SQL-backed run initializes it. The container is started once and shared across all test
+ * classes via the JUnit {@link ExtensionContext.Store} with GLOBAL namespace.
  */
 public class JdbcContainerExtension
     implements BeforeAllCallback, ExtensionContext.Store.CloseableResource {
@@ -52,6 +63,9 @@ public class JdbcContainerExtension
     }
     return config;
   }
+
+  private static final String SQLSERVER_DB = "ratchet";
+  private static final String SQLSERVER_PASSWORD = "Ratchet!Str0ngPwd";
 
   @SuppressWarnings({"resource"})
   private static JdbcDatabaseContainer<?> createContainer(String dbType) {
@@ -78,6 +92,13 @@ public class JdbcContainerExtension
               .withSharedMemorySize(2L * 1024 * 1024 * 1024)
               .withStartupTimeout(Duration.ofMinutes(5))
               .withInitScript("ddl/oracle-schema.sql");
+      case "sqlserver" ->
+          // No withInitScript: the schema is applied to a dedicated RCSI database after start
+          // (see provisionSqlServer). MSSQLServerContainer is sa-only and has no withDatabaseName.
+          new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2022-latest")
+              .acceptLicense()
+              .withPassword(SQLSERVER_PASSWORD)
+              .withUrlParam("trustServerCertificate", "true");
       default -> throw new IllegalArgumentException("Unsupported database type: " + dbType);
     };
   }
@@ -85,7 +106,10 @@ public class JdbcContainerExtension
   @Override
   public void beforeAll(ExtensionContext context) {
     String dbType = System.getProperty("ratchet.test.db.type");
-    if (!"mysql".equals(dbType) && !"postgresql".equals(dbType) && !"oracle".equals(dbType)) {
+    if (!"mysql".equals(dbType)
+        && !"postgresql".equals(dbType)
+        && !"oracle".equals(dbType)
+        && !"sqlserver".equals(dbType)) {
       return;
     }
 
@@ -138,6 +162,14 @@ public class JdbcContainerExtension
           jdbcUrl = jdbcUrl.substring(0, queryStart);
         }
         jdbcUrl += "?connectionTimeZone=UTC";
+      } else if ("sqlserver".equals(dbType)) {
+        // SQL Server's default lock-based READ COMMITTED takes shared read locks (unlike the MVCC
+        // engines Ratchet targets), so concurrent claim/cancel paths deadlock. Provision a
+        // dedicated
+        // database with READ_COMMITTED_SNAPSHOT (which cannot be set on master) and apply the
+        // schema
+        // there. SQL Server JDBC URLs use ';' separators, which are XML-safe in arquillian.xml.
+        jdbcUrl = provisionSqlServer(container);
       }
 
       config =
@@ -160,12 +192,76 @@ public class JdbcContainerExtension
             case "mysql" -> "mysql";
             case "postgresql" -> "postgresql";
             case "oracle" -> "oracle";
+            case "sqlserver" -> "sqlserver";
             default -> "h2";
           };
       System.setProperty("ratchet.test.db.driver.name", driverName);
 
       started = true;
       log.info("Database container ready: " + config.url());
+    }
+  }
+
+  /**
+   * Creates the dedicated {@code ratchet} database with {@code READ_COMMITTED_SNAPSHOT} enabled,
+   * applies the SQL Server schema there, and returns the JDBC URL targeting it. Mirrors the unit
+   * fixture's {@code MssqlContainers}.
+   */
+  private static String provisionSqlServer(JdbcDatabaseContainer<?> mssql) {
+    String master = mssql.getJdbcUrl();
+    try (Connection c =
+            DriverManager.getConnection(master, mssql.getUsername(), mssql.getPassword());
+        Statement s = c.createStatement()) {
+      s.execute(
+          "IF DB_ID('"
+              + SQLSERVER_DB
+              + "') IS NOT NULL BEGIN ALTER DATABASE ["
+              + SQLSERVER_DB
+              + "] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; DROP DATABASE ["
+              + SQLSERVER_DB
+              + "]; END");
+      s.execute("CREATE DATABASE [" + SQLSERVER_DB + "]");
+      s.execute("ALTER DATABASE [" + SQLSERVER_DB + "] SET READ_COMMITTED_SNAPSHOT ON");
+      s.execute("ALTER DATABASE [" + SQLSERVER_DB + "] SET ALLOW_SNAPSHOT_ISOLATION ON");
+    } catch (SQLException e) {
+      throw new IllegalStateException("Failed to provision the SQL Server ratchet database", e);
+    }
+    String ratchetUrl = master + ";databaseName=" + SQLSERVER_DB;
+    applySqlServerSchema(ratchetUrl, mssql.getUsername(), mssql.getPassword());
+    return ratchetUrl;
+  }
+
+  private static void applySqlServerSchema(String url, String user, String password) {
+    String schema = stripSqlComments(readSqlServerSchema());
+    try (Connection conn = DriverManager.getConnection(url, user, password);
+        Statement st = conn.createStatement()) {
+      for (String raw : schema.split(";")) {
+        String stmt = raw.strip();
+        if (!stmt.isBlank()) {
+          st.execute(stmt);
+        }
+      }
+    } catch (SQLException e) {
+      throw new IllegalStateException("Failed to apply the SQL Server schema", e);
+    }
+  }
+
+  private static String stripSqlComments(String sql) {
+    return Arrays.stream(sql.split("\n"))
+        .filter(line -> !line.stripLeading().startsWith("--"))
+        .collect(Collectors.joining("\n"));
+  }
+
+  private static String readSqlServerSchema() {
+    try (InputStream in =
+        JdbcContainerExtension.class.getResourceAsStream("/ddl/sqlserver-schema.sql")) {
+      if (in == null) {
+        throw new IllegalStateException(
+            "ddl/sqlserver-schema.sql not found — is the sqlserver profile active?");
+      }
+      return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/infra/JdbcContainerExtension.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/infra/JdbcContainerExtension.java
@@ -95,10 +95,19 @@ public class JdbcContainerExtension
       case "sqlserver" ->
           // No withInitScript: the schema is applied to a dedicated RCSI database after start
           // (see provisionSqlServer). MSSQLServerContainer is sa-only and has no withDatabaseName.
+          // withReuse keeps the container warm across local matrix runs (reuse is opt-in via
+          // ~/.testcontainers.properties and ignored on ephemeral CI runners), mirroring the
+          // store's
+          // MssqlContainers; a generous startup timeout absorbs the slow cold start of the x86
+          // image
+          // under emulation on Apple Silicon, where the default wait expires before SQL Server is
+          // up.
           new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2022-latest")
               .acceptLicense()
               .withPassword(SQLSERVER_PASSWORD)
-              .withUrlParam("trustServerCertificate", "true");
+              .withUrlParam("trustServerCertificate", "true")
+              .withStartupTimeout(Duration.ofMinutes(5))
+              .withReuse(true);
       default -> throw new IllegalArgumentException("Unsupported database type: " + dbType);
     };
   }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceResources.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceResources.java
@@ -27,6 +27,7 @@ final class DataSourceResources {
       // instantiate datasource-classname directly (Oracle's own GlassFish docs use this class), and
       // an interface there fails to deploy with "Error instantiating class ...".
       case "oracle" -> "oracle.jdbc.pool.OracleDataSource";
+      case "sqlserver" -> "com.microsoft.sqlserver.jdbc.SQLServerDataSource";
       default -> throw new IllegalArgumentException("Unsupported database type: " + dbType);
     };
   }
@@ -36,6 +37,7 @@ final class DataSourceResources {
       case "mysql" -> "com.mysql:mysql-connector-j";
       case "postgresql" -> "org.postgresql:postgresql";
       case "oracle" -> "com.oracle.database.jdbc:ojdbc11";
+      case "sqlserver" -> "com.microsoft.sqlserver:mssql-jdbc";
       default -> throw new IllegalArgumentException("Unsupported database type: " + dbType);
     };
   }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceResourcesTest.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/DataSourceResourcesTest.java
@@ -38,6 +38,9 @@ class DataSourceResourcesTest {
         DataSourceResources.dataSourceClassName("postgresql"));
     assertEquals(
         "oracle.jdbc.pool.OracleDataSource", DataSourceResources.dataSourceClassName("oracle"));
+    assertEquals(
+        "com.microsoft.sqlserver.jdbc.SQLServerDataSource",
+        DataSourceResources.dataSourceClassName("sqlserver"));
   }
 
   @Test
@@ -46,13 +49,18 @@ class DataSourceResourcesTest {
     assertEquals("org.postgresql:postgresql", DataSourceResources.driverCoordinates("postgresql"));
     assertEquals(
         "com.oracle.database.jdbc:ojdbc11", DataSourceResources.driverCoordinates("oracle"));
+    assertEquals(
+        "com.microsoft.sqlserver:mssql-jdbc", DataSourceResources.driverCoordinates("sqlserver"));
   }
 
   @Test
   void unsupportedDatabaseTypeIsRejected() {
+    // "mongodb" is a deliberate sentinel: it is a Ratchet store with no JDBC DataSource, so it is
+    // structurally outside this JDBC resolver and cannot become a supported type here — unlike a
+    // real RDBMS name, which a future store could add and silently un-break this assertion.
     assertThrows(
-        IllegalArgumentException.class, () -> DataSourceResources.dataSourceClassName("sqlserver"));
+        IllegalArgumentException.class, () -> DataSourceResources.dataSourceClassName("mongodb"));
     assertThrows(
-        IllegalArgumentException.class, () -> DataSourceResources.driverCoordinates("sqlserver"));
+        IllegalArgumentException.class, () -> DataSourceResources.driverCoordinates("mongodb"));
   }
 }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/OpenLibertyDataSourceStrategy.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/OpenLibertyDataSourceStrategy.java
@@ -155,7 +155,7 @@ public class OpenLibertyDataSourceStrategy implements DataSourceStrategy {
           <dataSource id="RatchetDS"
                       jndiName="%s"
                       jdbcDriverRef="RatchetJdbcDriver"
-                      transactional="true">
+                      transactional="true"%s>
             <properties URL="%s" user="%s" password="%s"/>
           </dataSource>
         </server>
@@ -164,9 +164,21 @@ public class OpenLibertyDataSourceStrategy implements DataSourceStrategy {
         DataSourceResources.xml(config.dbType()),
         DataSourceResources.dataSourceClassName(config.dbType()),
         JTA_DATASOURCE,
+        isolationLevelAttribute(config.dbType()),
         DataSourceResources.xml(config.url()),
         DataSourceResources.xml(config.username()),
         DataSourceResources.xml(config.password()));
+  }
+
+  private static String isolationLevelAttribute(String dbType) {
+    // Open Liberty's SQL Server data-store helper defaults an unset isolation level to
+    // TRANSACTION_REPEATABLE_READ. Ratchet's claim contract requires READ COMMITTED, so its startup
+    // isolation check throws under that default and the EclipseLink persistence-context connection
+    // it acquired is never returned — leaking one connection per deploy cycle until the
+    // server-level RatchetDS pool (max 50) is exhausted and every later deployment times out.
+    // Pin READ COMMITTED for SQL Server, matching the level WildFly sets via its setup CLI. The
+    // other Liberty cells already run READ COMMITTED, so they are left untouched.
+    return "sqlserver".equals(dbType) ? " isolationLevel=\"TRANSACTION_READ_COMMITTED\"" : "";
   }
 
   private static String driverCoordinates(String dbType) {

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -87,43 +87,55 @@ public class RatchetArchiveBuilder {
   }
 
   public RatchetArchiveBuilder addPersistenceXml(String dbType, String jtaDataSourceName) {
-    if (!dbType.equals("mysql") && !dbType.equals("postgresql") && !dbType.equals("oracle")) {
+    if (!dbType.equals("mysql")
+        && !dbType.equals("postgresql")
+        && !dbType.equals("oracle")
+        && !dbType.equals("sqlserver")) {
       throw new IllegalArgumentException("Unsupported db type: " + dbType);
     }
-    // MySQL stores UUIDs in BINARY(16). EclipseLink's default would send the 36-char hyphenated
-    // string and overflow the column, so EclipseLink deployments route every UUID through
-    // UuidByteArrayConverter via orm-mysql.xml. Hibernate maps UUID -> BINARY(16) natively (its
-    // default on the MySQL dialect), and Hibernate 7 (WildFly 40 / EE 11) rejects an
-    // AttributeConverter on an @Id attribute outright, so Hibernate-7 deployments must NOT
-    // reference orm-mysql.xml — they need no mapping file at all. PostgreSQL stores UUID natively
-    // and must NOT include the converter — it would re-encode native uuid as bytea.
-    //
-    // Oracle mirrors MySQL: RAW(16) UUIDs round-trip through UuidRawConverter via orm-oracle.xml on
-    // EclipseLink and Hibernate 6, while Hibernate 7 omits it (native UUID -> RAW(16)) and instead
-    // auto-quotes the LEVEL reserved word (orm-oracle.xml also carries that "level" column
-    // quoting).
-    boolean hibernate7 = "wildfly-ee11-managed".equals(System.getProperty("arquillian.launch"));
-    String mappingFile;
+    // MySQL and SQL Server store UUIDs in BINARY(16) and Oracle in RAW(16). EclipseLink's default
+    // would send the 36-char hyphenated string and overflow/mistype the column, so EclipseLink
+    // deployments route every UUID through a converter via orm-mysql.xml / orm-oracle.xml /
+    // orm-sqlserver.xml. The WildFly cells run Hibernate (6.6 on wildfly-managed, 7 on
+    // wildfly-ee11-managed); Hibernate maps UUID natively and Hibernate 7 rejects an
+    // AttributeConverter on an @Id outright, so those cells take no UUID mapping file — on MySQL
+    // the
+    // native byte order is already canonical, on SQL Server the preferred_uuid_jdbc_type property
+    // below forces it canonical, and on Oracle the native UUID maps to RAW(16). PostgreSQL stores
+    // UUID natively and must NOT include the converter — it would re-encode native uuid as bytea.
+    String launch = System.getProperty("arquillian.launch", "");
+    boolean hibernate = launch.startsWith("wildfly");
+    boolean hibernate7 = "wildfly-ee11-managed".equals(launch);
+    String mappingFile = "";
     if (dbType.equals("mysql") && !hibernate7) {
       mappingFile = "<mapping-file>META-INF/orm-mysql.xml</mapping-file>";
     } else if (dbType.equals("oracle") && !hibernate7) {
       mappingFile = "<mapping-file>META-INF/orm-oracle.xml</mapping-file>";
-    } else {
-      mappingFile = "";
+    } else if (dbType.equals("sqlserver") && !hibernate) {
+      mappingFile = "<mapping-file>META-INF/orm-sqlserver.xml</mapping-file>";
     }
-    // Oracle-only Hibernate tuning (no-op under EclipseLink, which carries the Instant mapping via
-    // InstantAttributeConverter): map entity Instant to plain TIMESTAMP rather than Hibernate's
-    // default TIMESTAMP WITH TIME ZONE (ORA-18716 on the plain TIMESTAMP columns), and on
-    // Hibernate 7 — where orm-oracle.xml is omitted — auto-quote the LEVEL reserved word so
-    // scheduler_job_log agrees with the shipped DDL.
-    String dialectProps =
-        dbType.equals("oracle")
-            ? """
+    // Per-dialect Hibernate tuning (no-op under EclipseLink). Oracle: map entity Instant to plain
+    // TIMESTAMP rather than Hibernate's default TIMESTAMP WITH TIME ZONE (ORA-18716 on the plain
+    // TIMESTAMP columns), and on Hibernate 7 — where orm-oracle.xml is omitted — auto-quote the
+    // LEVEL reserved word so scheduler_job_log agrees with the shipped DDL. SQL Server: force the
+    // BINARY JDBC type for UUID so Hibernate writes canonical big-endian bytes into BINARY(16)
+    // instead of the uniqueidentifier mixed-endian layout, matching UuidByteArrayConverter.toBytes.
+    String dialectProps;
+    if (dbType.equals("oracle")) {
+      dialectProps =
+          """
                   <property name="hibernate.type.preferred_instant_jdbc_type" value="TIMESTAMP"/>
                   <property name="hibernate.jdbc.time_zone" value="UTC"/>
                   <property name="hibernate.auto_quote_keyword" value="true"/>
-            """
-            : "";
+            """;
+    } else if (dbType.equals("sqlserver")) {
+      dialectProps =
+          """
+                  <property name="hibernate.type.preferred_uuid_jdbc_type" value="BINARY"/>
+            """;
+    } else {
+      dialectProps = "";
+    }
     // No <provider> or hibernate.dialect pin — WildFly auto-discovers via ServiceLoader and the
     // JPA provider auto-detects the dialect from the JDBC URL exposed by RatchetDS. Remaining
     // property keys are opt-in Hibernate tuning and no-op under any other JPA provider.
@@ -200,7 +212,7 @@ public class RatchetArchiveBuilder {
 
     // Store-specific classes
     switch (dbType) {
-      case "mysql", "postgresql", "oracle" -> {
+      case "mysql", "postgresql", "oracle", "sqlserver" -> {
         DataSourceStrategy strategy = DataSourceStrategyFactory.create();
         archive.addClasses(
             JpaTestCleanupStrategy.class,

--- a/testing/ratchet-testsuite/src/test/resources/arquillian.xml
+++ b/testing/ratchet-testsuite/src/test/resources/arquillian.xml
@@ -16,6 +16,7 @@
       <property name="serverConfig">standalone.xml</property>
       <property name="javaVmArguments">
         -Xms512m -Xmx2048m
+        -Duser.timezone=UTC
         -Djboss.socket.binding.port-offset=20000
         ${jacoco.it.argLine}
         -Dratchet.test.db.url=${ratchet.test.db.url}
@@ -55,6 +56,7 @@
       <property name="jbossArguments">--stability=preview</property>
       <property name="javaVmArguments">
         -Xms512m -Xmx2048m
+        -Duser.timezone=UTC
         -Djboss.socket.binding.port-offset=21000
         ${jacoco.it.argLine}
         -Dratchet.test.db.url=${ratchet.test.db.url}
@@ -135,6 +137,7 @@
       <property name="httpPort">${openliberty.http.port}</property>
       <property name="javaVmArguments">
         -Xms512m -Xmx2048m
+        -Duser.timezone=UTC
         ${jacoco.it.argLine}
         -Dratchet.test.db.url=${ratchet.test.db.url}
         -Dratchet.test.db.username=${ratchet.test.db.username}

--- a/testing/ratchet-testsuite/src/test/resources/wildfly-setup.cli
+++ b/testing/ratchet-testsuite/src/test/resources/wildfly-setup.cli
@@ -31,6 +31,15 @@ if (outcome != success) of /subsystem=datasources/jdbc-driver=oracle:read-resour
   )
 end-if
 
+# Add SQL Server JDBC driver (skip if already exists)
+if (outcome != success) of /subsystem=datasources/jdbc-driver=sqlserver:read-resource
+  /subsystem=datasources/jdbc-driver=sqlserver:add( \
+    driver-name=sqlserver, \
+    driver-module-name=com.microsoft.sqlserver, \
+    driver-class-name=com.microsoft.sqlserver.jdbc.SQLServerDriver \
+  )
+end-if
+
 # Add the Ratchet test datasource (skip if already exists)
 if (outcome != success) of /subsystem=datasources/data-source=RatchetDS:read-resource
   data-source add \


### PR DESCRIPTION
Adds `ratchet-store-sqlserver`, a Microsoft SQL Server implementation of the store SPI, alongside the existing MySQL/PostgreSQL/Oracle/MongoDB stores. Branched off the SQL Server port and rebased onto `main` after the Oracle store (#102) and the `0.1.2-SNAPSHOT` bump landed.

## What's here

- New `stores/ratchet-store-sqlserver` module: full store + capability operations, `SqlserverConstraintDetector`, `SqlserverJobRowMapper`, T-SQL dialect translations (two-phase claim, `MERGE` upserts, `sp_getapplock` migration lock), and DDL (`V001` + consolidated schema + debug indexes).
- Taught `SchemaMigrator` the `sqlserver` dialect (product-name detection, lock acquire/release, version-table DDL, `MERGE` record-version).
- Wired into the integration matrix (all 5 servers × `sqlserver`, including GlassFish), TCK schema conformance, and the testsuite Arquillian harness.

## Two SQL Server / GlassFish-specific fixes worth calling out

- **UUIDs stored as `BINARY(16)` (canonical big-endian), not `UNIQUEIDENTIFIER`.** EclipseLink 5.0 on GlassFish 8 reads `UNIQUEIDENTIFIER` via `getBytes`, returning `.NET-Guid` mixed-endian storage bytes that no JPA-layer intercept can redirect. Raw `BINARY(16)` is provider-independent, so EclipseLink 4/5/2.7 and Hibernate all decode it identically — same shape as `ratchet-store-mysql`, and time-sortable for UUIDv7. Hibernate paths set `hibernate.type.preferred_uuid_jdbc_type=BINARY`.
- **`@Recurring` registration deferred to the managed scheduled executor.** EclipseLink 5.0 + mssql-jdbc on a non-XA pool does not autocommit DML run outside JTA, so registration from the mid-deployment `@Initialized(ApplicationScoped)` observer was rolled back. Registration now runs post-deployment with a real component context and retries idempotently until each master is confirmed; SE/plain-CDI still register inline.

## Validation

- `mvn test-compile` green for store-core + sqlserver + full testsuite (`-am`).
- `spotless:check` green.
- `SchemaMigratorTest` passes (13/13).
- Full Arquillian matrix (incl. glassfish+sqlserver) left to CI.
