### PR TITLE
Add the JobExtensionStore store capability and supporting extension SPIs

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobFilter.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobFilter.java
@@ -16,9 +16,13 @@
 package run.ratchet.api;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -66,6 +70,13 @@ import java.util.UUID;
  *     layer (for example by widening the policy to omit the principal filter when archive
  *     visibility is required, or by running two queries).
  * @param cursor opaque keyset-pagination cursor, or null to use offset-based pagination
+ * @param propertyFilters per-key extension-property constraints, or null for no property filter.
+ *     Each entry matches jobs that carry a {@code scheduler_job_properties} row whose key equals
+ *     the map key and whose value is one of the entry's values (IN semantics); multiple entries
+ *     combine with AND. Requires a store advertising the {@code JobExtensionStore} capability to
+ *     have written the rows. Property filters match hot rows only: like {@code callerPrincipal} and
+ *     {@code traceCorrelationId}, they are not applied to the archive branch when {@code
+ *     includeArchived} is set.
  * @since 0.1
  */
 @Incubating
@@ -91,13 +102,15 @@ public record JobFilter(
     boolean sortAscending,
     boolean skipCount,
     boolean includeArchived,
-    String cursor) {
+    String cursor,
+    Map<String, Set<String>> propertyFilters) {
 
   public JobFilter {
     statuses = copyOrNull(statuses);
     types = copyOrNull(types);
     priorities = copyOrNull(priorities);
     tags = copyOrNull(tags);
+    propertyFilters = copyPropertyFiltersOrNull(propertyFilters);
   }
 
   public static Builder builder() {
@@ -106,6 +119,16 @@ public record JobFilter(
 
   private static <T> Set<T> copyOrNull(Set<T> values) {
     return values == null ? null : Collections.unmodifiableSet(new HashSet<>(values));
+  }
+
+  private static Map<String, Set<String>> copyPropertyFiltersOrNull(
+      Map<String, Set<String>> values) {
+    if (values == null) {
+      return null;
+    }
+    Map<String, Set<String>> copy = new LinkedHashMap<>();
+    values.forEach((key, allowed) -> copy.put(key, copyOrNull(allowed)));
+    return Collections.unmodifiableMap(copy);
   }
 
   /**
@@ -142,6 +165,7 @@ public record JobFilter(
     b.skipCount = this.skipCount;
     b.includeArchived = this.includeArchived;
     b.cursor = this.cursor;
+    b.propertyFilters = this.propertyFilters == null ? null : new HashMap<>(this.propertyFilters);
     return b;
   }
 
@@ -169,6 +193,7 @@ public record JobFilter(
     private boolean skipCount = false;
     private boolean includeArchived = false;
     private String cursor;
+    private Map<String, Set<String>> propertyFilters;
 
     private Builder() {}
 
@@ -316,6 +341,33 @@ public record JobFilter(
       return this;
     }
 
+    /**
+     * Requires an extension property with the exact key and value. Repeated calls for different
+     * keys combine with AND; a repeated call for the same key replaces the earlier constraint.
+     */
+    public Builder propertyEquals(String key, String value) {
+      return propertyIn(key, Set.of(value));
+    }
+
+    /**
+     * Requires an extension property with the exact key and any of the given values (IN semantics).
+     * Repeated calls for different keys combine with AND; a repeated call for the same key replaces
+     * the earlier constraint.
+     */
+    public Builder propertyIn(String key, Collection<String> values) {
+      if (key == null || key.isBlank()) {
+        throw new IllegalArgumentException("property key must not be null or blank");
+      }
+      if (values == null || values.isEmpty()) {
+        throw new IllegalArgumentException("property values must not be null or empty");
+      }
+      if (this.propertyFilters == null) {
+        this.propertyFilters = new LinkedHashMap<>();
+      }
+      this.propertyFilters.put(key, Set.copyOf(values));
+      return this;
+    }
+
     public JobFilter build() {
       return new JobFilter(
           statuses,
@@ -339,7 +391,8 @@ public record JobFilter(
           sortAscending,
           skipCount,
           includeArchived,
-          cursor);
+          cursor,
+          propertyFilters);
     }
   }
 }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchChunkFailureEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchChunkFailureEvent.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.api.event;
+
+import java.io.Serial;
+import java.time.Instant;
+import java.util.UUID;
+import run.ratchet.api.Incubating;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobType;
+
+/**
+ * Fired when a streaming-batch chunk fails to persist (the chunk's bulk insert threw) on the
+ * invocation-mode submission path.
+ *
+ * <p><b>Best-effort pre-rollback diagnostic.</b> Streaming submission runs in one transaction: a
+ * chunk failure rolls back the batch parent and every previously inserted chunk along with it. The
+ * event therefore fires <em>before</em> that rollback and may reference a batch parent id that
+ * never commits — treat it as an operational signal of the failed submission, not as a pointer to
+ * durable rows. {@link #getJobId()} carries the batch parent id.
+ */
+@Incubating
+public class BatchChunkFailureEvent extends AbstractJobSchedulerEvent {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  private final int chunkIndex;
+  private final int chunkSize;
+  private final String failureReason;
+
+  public BatchChunkFailureEvent(
+      UUID jobId,
+      String businessKey,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId,
+      Instant timestamp,
+      int chunkIndex,
+      int chunkSize,
+      String failureReason) {
+    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    this.chunkIndex = chunkIndex;
+    this.chunkSize = chunkSize;
+    this.failureReason = failureReason;
+  }
+
+  public BatchChunkFailureEvent(
+      UUID jobId,
+      String businessKey,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId,
+      int chunkIndex,
+      int chunkSize,
+      String failureReason) {
+    super(jobId, businessKey, jobType, priority, nodeId);
+    this.chunkIndex = chunkIndex;
+    this.chunkSize = chunkSize;
+    this.failureReason = failureReason;
+  }
+
+  /** Zero-based index of the chunk whose bulk insert failed. */
+  public int getChunkIndex() {
+    return chunkIndex;
+  }
+
+  /** Number of items in the failed chunk. */
+  public int getChunkSize() {
+    return chunkSize;
+  }
+
+  /** Failure description from the underlying store exception. */
+  public String getFailureReason() {
+    return failureReason;
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/InvocationBatchBuilder.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/InvocationBatchBuilder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.function.Function;
+import run.ratchet.api.BatchBuilder;
+import run.ratchet.api.Incubating;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.WorkflowCondition;
+
+/**
+ * Fluent builder for batches whose children are pre-resolved {@link JobInvocation}s — the
+ * invocation-typed mirror of {@link BatchBuilder}.
+ *
+ * <p>Obtained from {@link InvocationSubmissionService#enqueueInvocationBatch}. Child construction
+ * uses a per-item invocation factory instead of a serializable consumer; batch parent semantics
+ * (progress counters, completion processing, branch evaluation) are identical to the lambda
+ * builder.
+ */
+@Incubating
+public interface InvocationBatchBuilder {
+
+  /**
+   * Enqueues one child job per item, each persisting the invocation the factory produces for it.
+   *
+   * @param items batch items; never {@code null}
+   * @param invocationFactory produces the persisted invocation for one item; never {@code null},
+   *     must not return {@code null}
+   */
+  <T extends Serializable> InvocationBatchBuilder forEach(
+      Collection<T> items, Function<T, JobInvocation> invocationFactory);
+
+  /** Adds a conditional branch evaluated against the batch outcome. */
+  InvocationBatchBuilder thenBranch(
+      WorkflowCondition condition, JobInvocation next, String description);
+
+  /** Chains a next step executed when every child succeeds. */
+  InvocationBatchBuilder thenOnBatchSuccess(JobInvocation next);
+
+  /** Chains a next step executed when at least one child fails. */
+  InvocationBatchBuilder thenOnBatchFailure(JobInvocation next);
+
+  /** Requests execution on the virtual-thread executor target. */
+  InvocationBatchBuilder virtual();
+
+  /** Requests execution on the platform-thread executor target. */
+  InvocationBatchBuilder platform();
+
+  /**
+   * Persists the batch parent and all children through the standard creation path.
+   *
+   * <p><b>Transaction attribute:</b> {@code REQUIRED}.
+   */
+  JobHandle submit();
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/InvocationJobBuilder.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/InvocationJobBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.time.Duration;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.Incubating;
+import run.ratchet.api.JobBuilder;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.WorkflowCondition;
+
+/**
+ * Fluent builder for jobs created from pre-resolved {@link JobInvocation}s — the invocation-typed
+ * mirror of {@link JobBuilder}, accepting a {@code JobInvocation} everywhere the public builder
+ * accepts a serializable lambda.
+ *
+ * <p>Obtained from {@link InvocationSubmissionService}. Branch composition reuses {@link
+ * WorkflowCondition} directly, mirroring the lambda side (there is no separate branch builder).
+ * Context-consuming success/failure callbacks are intentionally absent: they take {@code
+ * JobContext}-typed lambdas, not invocations, and trusted extensions compose follow-up work with
+ * {@link #then} / {@link #branch} instead.
+ *
+ * <p>Persistence semantics — validation, class policy, idempotency, tags, wakeup — are identical to
+ * the lambda builder; both converge on the same creation path.
+ */
+@Incubating
+public interface InvocationJobBuilder {
+
+  /** Chains a next step executed after this job completes. */
+  InvocationJobBuilder then(JobInvocation next);
+
+  /** Chains a next step executed only when this job succeeds. */
+  InvocationJobBuilder thenOnSuccess(JobInvocation next);
+
+  /** Chains a next step executed only when this job fails. */
+  InvocationJobBuilder thenOnFailure(JobInvocation next);
+
+  /** Adds a conditional branch evaluated against this job's outcome. */
+  InvocationJobBuilder branch(WorkflowCondition condition, JobInvocation next, String description);
+
+  /** Adds a conditional branch without a description. */
+  InvocationJobBuilder when(WorkflowCondition condition, JobInvocation next);
+
+  /** Schedules the job for immediate execution, overriding any delay. */
+  InvocationJobBuilder immediate();
+
+  /** Parks the job WAITING for an external signal before it becomes executable. */
+  InvocationJobBuilder awaitSignal(String signalKey, Duration timeout);
+
+  /** Sets the idempotency key. */
+  InvocationJobBuilder withIdempotencyKey(String key);
+
+  /** Sets the business key. */
+  InvocationJobBuilder withBusinessKey(String key);
+
+  /** Gates execution on a named resource permit. */
+  InvocationJobBuilder withResource(String resourceName);
+
+  /** Requests execution on the virtual-thread executor target. */
+  InvocationJobBuilder virtual();
+
+  /** Requests execution on the platform-thread executor target. */
+  InvocationJobBuilder platform();
+
+  /** Sets the retry backoff policy. */
+  InvocationJobBuilder withBackoff(BackoffPolicy policy, Duration param);
+
+  /** Sets the maximum retry count. */
+  InvocationJobBuilder withMaxRetries(int retries);
+
+  /** Adds one cleartext key/value parameter. */
+  InvocationJobBuilder withParam(String key, String value);
+
+  /** Sets the priority. */
+  InvocationJobBuilder withPriority(JobPriority priority);
+
+  /** Adds tags. */
+  InvocationJobBuilder withTags(String... tags);
+
+  /** Sets the execution timeout. */
+  InvocationJobBuilder withTimeout(Duration timeout);
+
+  /** Opts this job into payload encryption at rest. */
+  InvocationJobBuilder withEncryptedPayload();
+
+  /**
+   * Persists the job (and any chained steps and branches) through the standard creation path.
+   *
+   * <p><b>Transaction attribute:</b> {@code REQUIRED}.
+   */
+  JobHandle submit();
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/InvocationStreamingBatchBuilder.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/InvocationStreamingBatchBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.io.Serializable;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import run.ratchet.api.Incubating;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.StreamingBatchBuilder;
+import run.ratchet.api.WorkflowCondition;
+
+/**
+ * Fluent builder for streaming batches whose per-item children are pre-resolved {@link
+ * JobInvocation}s — the invocation-typed mirror of {@link StreamingBatchBuilder}.
+ *
+ * <p>Chunking, chunk-boundary persistence, and replay semantics are shared with the lambda builder;
+ * only per-item child construction differs (an invocation factory instead of a serializable
+ * consumer). A chunk whose bulk insert fails emits {@code BatchChunkFailureEvent} and aborts the
+ * submission.
+ */
+@Incubating
+public interface InvocationStreamingBatchBuilder<T extends Serializable> {
+
+  /** Supplies the item stream; consumed once at {@link #start()}. */
+  InvocationStreamingBatchBuilder<T> fromStream(Stream<T> stream);
+
+  /**
+   * Sets the per-item invocation factory.
+   *
+   * @param invocationFactory produces the persisted invocation for one item; never {@code null},
+   *     must not return {@code null}
+   */
+  InvocationStreamingBatchBuilder<T> process(Function<T, JobInvocation> invocationFactory);
+
+  /** Sets the chunk size (default 100, minimum 1). */
+  InvocationStreamingBatchBuilder<T> withChunkSize(int size);
+
+  /** Requests execution on the virtual-thread executor target. */
+  InvocationStreamingBatchBuilder<T> virtual();
+
+  /** Requests execution on the platform-thread executor target. */
+  InvocationStreamingBatchBuilder<T> platform();
+
+  /** Adds a conditional branch evaluated against the batch outcome. */
+  InvocationStreamingBatchBuilder<T> thenBranch(
+      WorkflowCondition condition, JobInvocation next, String description);
+
+  /** Chains a next step executed when every child succeeds. */
+  InvocationStreamingBatchBuilder<T> thenOnBatchSuccess(JobInvocation next);
+
+  /** Chains a next step executed when at least one child fails. */
+  InvocationStreamingBatchBuilder<T> thenOnBatchFailure(JobInvocation next);
+
+  /**
+   * Consumes the stream, persisting children chunk by chunk through the standard creation path.
+   *
+   * <p><b>Transaction attribute:</b> {@code REQUIRED}.
+   */
+  JobHandle start();
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/InvocationSubmissionService.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/InvocationSubmissionService.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.time.Duration;
+import run.ratchet.api.Incubating;
+import run.ratchet.api.WorkflowCondition;
+
+/**
+ * Submission seam for trusted extensions that construct {@link JobInvocation}s directly instead of
+ * serializing lambda calls.
+ *
+ * <p>This SPI is <b>trusted by convention</b>, not a security barrier: anything that can inject it
+ * can persist an arbitrary invocation, exactly as {@link JobInvocationResolver} consumers can
+ * today. Extensions that accept external input (block names, workflow JSON) must validate and
+ * authorize <em>before</em> constructing the invocation they hand to this seam; the framework still
+ * applies payload validation and the deployment's class policy at persistence time, and the worker
+ * re-checks at dispatch time.
+ *
+ * <p>All submissions converge on the same creation path as the public {@code JobSchedulerService}
+ * builders — same validation, idempotency, tags, queue rows, batch metadata, workflow condition
+ * rows, and wakeup behavior. There is no separate persistence path.
+ */
+@Incubating
+public interface InvocationSubmissionService {
+
+  /**
+   * Starts a builder for a job executing the given invocation as soon as possible.
+   *
+   * @param invocation pre-resolved invocation; never {@code null}
+   * @return builder for options, chaining, and submission; never {@code null}
+   */
+  InvocationJobBuilder enqueueInvocation(JobInvocation invocation);
+
+  /**
+   * Starts a builder for a job executing the given invocation after a delay.
+   *
+   * @param delay scheduling delay; never {@code null}
+   * @param invocation pre-resolved invocation; never {@code null}
+   * @return builder for options, chaining, and submission; never {@code null}
+   */
+  InvocationJobBuilder scheduleInvocation(Duration delay, JobInvocation invocation);
+
+  /**
+   * Starts a builder for a batch whose children are produced by per-item invocation factories.
+   *
+   * @param name batch name for diagnostics; never {@code null}
+   * @return batch builder; never {@code null}
+   */
+  InvocationBatchBuilder enqueueInvocationBatch(String name);
+
+  /**
+   * Wraps a pre-resolved invocation as a {@code CUSTOM} workflow condition.
+   *
+   * <p>The invocation's target method is dispatched reflectively at evaluation time with the
+   * parent's {@code JobResult} supplied as the trailing argument (the same coercion the
+   * lambda-predicate path uses) and must return {@code boolean}. No lambda serialization is
+   * involved; the invocation persists as the condition's expression payload and is encrypted under
+   * the parent's predicate surface when payload encryption applies.
+   *
+   * @param invocation predicate invocation; never {@code null}
+   * @return condition composable into branches exactly like the lambda-based factories
+   */
+  WorkflowCondition invocationCondition(JobInvocation invocation);
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/InvocationSubmissionService.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/InvocationSubmissionService.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.spi;
 
+import java.io.Serializable;
 import java.time.Duration;
 import run.ratchet.api.Incubating;
 import run.ratchet.api.WorkflowCondition;
@@ -61,6 +62,14 @@ public interface InvocationSubmissionService {
    * @return batch builder; never {@code null}
    */
   InvocationBatchBuilder enqueueInvocationBatch(String name);
+
+  /**
+   * Starts a builder for a streaming batch whose per-item children come from an invocation factory.
+   *
+   * @param name batch name for diagnostics; never {@code null}
+   * @return streaming batch builder; never {@code null}
+   */
+  <T extends Serializable> InvocationStreamingBatchBuilder<T> invocationStreamingBatch(String name);
 
   /**
    * Wraps a pre-resolved invocation as a {@code CUSTOM} workflow condition.

--- a/ratchet-api/src/main/java/run/ratchet/spi/JobInvocation.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/JobInvocation.java
@@ -15,11 +15,18 @@
  */
 package run.ratchet.spi;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.util.List;
 import run.ratchet.api.Incubating;
 
 /**
  * Serializable description of the target method Ratchet should invoke for a job.
+ *
+ * <p>{@code Serializable} satisfies type bounds such as {@code WorkflowCondition.expression}; the
+ * framework never JDK-serializes an invocation. Persistence converts it to JSON via the payload
+ * factory, so arguments must be JSON-representable (enforced by payload validation at creation),
+ * not {@code Serializable}.
  *
  * @param targetClass fully qualified target class name
  * @param methodName target method name
@@ -33,7 +40,10 @@ public record JobInvocation(
     String methodName,
     String methodDescriptor,
     boolean staticMethod,
-    List<Object> arguments) {
+    List<Object> arguments)
+    implements Serializable {
+
+  @Serial private static final long serialVersionUID = 1L;
 
   public JobInvocation {
     arguments = arguments == null ? List.of() : List.copyOf(arguments);

--- a/ratchet-api/src/main/java/run/ratchet/spi/MaskingContext.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/MaskingContext.java
@@ -16,7 +16,9 @@
 package run.ratchet.spi;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 import run.ratchet.api.Incubating;
 
 /**
@@ -24,18 +26,41 @@ import run.ratchet.api.Incubating;
  * MaskingContext)} overload, so a policy can decide sensitivity per job rather than by field name
  * alone (the same field name can be secret in one job and not in another).
  *
- * <p>{@code jobProperties} carries the job's extension-property rows (read through the {@code
+ * <p>{@code jobProperties()} carries the job's extension-property rows (read through the {@code
  * JobExtensionStore} capability when the store advertises it; empty otherwise). Extensions key
  * their identity here — for example {@code ratchet-blocks.block_name} — so a policy can look up
  * what the job is and which of its fields are declared secret.
  *
- * @param jobId owning job id; never {@code null}
- * @param jobProperties the job's extension properties; never {@code null}, may be empty
+ * <p>Properties are loaded and copied to an immutable map on first access, then memoized. This
+ * context is used single-threaded during masking, so the lazy memoization is intentionally
+ * unsynchronized and instances do not provide record value semantics.
  */
 @Incubating
-public record MaskingContext(UUID jobId, Map<String, String> jobProperties) {
+public final class MaskingContext {
 
-  public MaskingContext {
-    jobProperties = jobProperties == null ? Map.of() : Map.copyOf(jobProperties);
+  private final UUID jobId;
+  private final Supplier<Map<String, String>> jobPropertiesSupplier;
+  private Map<String, String> jobProperties;
+
+  public MaskingContext(UUID jobId, Map<String, String> jobProperties) {
+    this(jobId, () -> jobProperties);
+  }
+
+  public MaskingContext(UUID jobId, Supplier<Map<String, String>> jobPropertiesSupplier) {
+    this.jobId = Objects.requireNonNull(jobId, "jobId");
+    this.jobPropertiesSupplier =
+        Objects.requireNonNull(jobPropertiesSupplier, "jobPropertiesSupplier");
+  }
+
+  public UUID jobId() {
+    return jobId;
+  }
+
+  public Map<String, String> jobProperties() {
+    if (jobProperties == null) {
+      Map<String, String> supplied = jobPropertiesSupplier.get();
+      jobProperties = supplied == null ? Map.of() : Map.copyOf(supplied);
+    }
+    return jobProperties;
   }
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/MaskingContext.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/MaskingContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.util.Map;
+import java.util.UUID;
+import run.ratchet.api.Incubating;
+
+/**
+ * Per-job context handed to the context-aware {@link PayloadMaskingPolicy#isSensitiveField(String,
+ * MaskingContext)} overload, so a policy can decide sensitivity per job rather than by field name
+ * alone (the same field name can be secret in one job and not in another).
+ *
+ * <p>{@code jobProperties} carries the job's extension-property rows (read through the {@code
+ * JobExtensionStore} capability when the store advertises it; empty otherwise). Extensions key
+ * their identity here — for example {@code ratchet-blocks.block_name} — so a policy can look up
+ * what the job is and which of its fields are declared secret.
+ *
+ * @param jobId owning job id; never {@code null}
+ * @param jobProperties the job's extension properties; never {@code null}, may be empty
+ */
+@Incubating
+public record MaskingContext(UUID jobId, Map<String, String> jobProperties) {
+
+  public MaskingContext {
+    jobProperties = jobProperties == null ? Map.of() : Map.copyOf(jobProperties);
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/PayloadMaskingPolicy.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/PayloadMaskingPolicy.java
@@ -39,4 +39,18 @@ public interface PayloadMaskingPolicy {
    *     otherwise
    */
   boolean isSensitiveField(String fieldName);
+
+  /**
+   * Context-aware variant consulted by masking surfaces that know which job a field belongs to. The
+   * default delegates to the name-only check, so existing policies keep working unchanged; a policy
+   * that needs per-job decisions (the same field name secret in one job, public in another)
+   * overrides this and reads the job's identity from {@link MaskingContext#jobProperties()}.
+   *
+   * @param fieldName the field or parameter name as it appears in the payload; never {@code null}
+   * @param context the owning job's masking context; never {@code null}
+   * @return {@code true} if the field's value should be masked, {@code false} otherwise
+   */
+  default boolean isSensitiveField(String fieldName, MaskingContext context) {
+    return isSensitiveField(fieldName);
+  }
 }

--- a/ratchet-api/src/main/java/run/ratchet/spi/PreExecutionArgResolver.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/PreExecutionArgResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.util.UUID;
+import run.ratchet.api.Incubating;
+
+/**
+ * Worker-side hook that can patch a job's invocation arguments at the last moment before reflective
+ * dispatch — after security validation, before argument coercion. Extensions use it for late
+ * binding: resolving placeholder arguments against state that did not exist at submission time (for
+ * example, upstream step results in a workflow).
+ *
+ * <p><b>Arguments only.</b> The dispatched target class, method, and descriptor are pinned by the
+ * payload that security validation cleared; only {@link JobInvocation#arguments()} of the returned
+ * invocation are honored. Returning {@code null} or the input instance leaves the arguments
+ * untouched.
+ *
+ * <p><b>Scope.</b> The hook runs for the job's main invocation. Success/failure callback payloads
+ * and workflow-condition predicates follow their own dispatch paths and are not resolved.
+ *
+ * <p>When no bean of this type is registered, the worker dispatches the persisted arguments
+ * unchanged. A thrown exception fails the executing job through the normal failure path (retry
+ * policy applies).
+ */
+@Incubating
+public interface PreExecutionArgResolver {
+
+  /**
+   * Resolves the arguments to dispatch for one job execution.
+   *
+   * @param jobId the executing job's id; never {@code null}
+   * @param invocation the persisted invocation about to be dispatched; never {@code null}
+   * @return an invocation whose arguments replace the persisted ones, or {@code null} / the input
+   *     instance to dispatch unchanged
+   */
+  JobInvocation resolveArguments(UUID jobId, JobInvocation invocation);
+}

--- a/ratchet-api/src/main/java/run/ratchet/spi/ProtectedSurface.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/ProtectedSurface.java
@@ -67,5 +67,12 @@ public enum ProtectedSurface {
    * and the parent job id, which is in scope at both the write site and the evaluation site, so a
    * predicate lifted to another parent fails the authentication tag.
    */
-  WORKFLOW_CONDITION_PREDICATE
+  WORKFLOW_CONDITION_PREDICATE,
+
+  /**
+   * A per-namespace extension-state blob ({@code scheduler_job_extension_state.state}). AAD binds
+   * the surface, the owning job id, and the namespace, so a blob lifted to another job — or to
+   * another namespace on the same job — fails the authentication tag.
+   */
+  EXTENSION_STATE
 }

--- a/ratchet-api/src/test/java/run/ratchet/api/JobFilterTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/JobFilterTest.java
@@ -139,6 +139,7 @@ class JobFilterTest {
             false,
             false,
             false,
+            null,
             null);
 
     statuses.add(JobStatus.FAILED);

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultBatchBuilder.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultBatchBuilder.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Function;
 import run.ratchet.api.BatchBuilder;
 import run.ratchet.api.BatchContext;
 import run.ratchet.api.ExecutorTargets;
@@ -30,6 +31,7 @@ import run.ratchet.api.WorkflowBranch;
 import run.ratchet.api.WorkflowCondition;
 import run.ratchet.ri.payload.DefaultJobInvocationResolver;
 import run.ratchet.ri.payload.JobPayloadFactory;
+import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.JobInvocationResolver;
 import run.ratchet.store.entity.JobPayload;
 
@@ -150,6 +152,14 @@ public class DefaultBatchBuilder implements BatchBuilder {
 
   String executionTarget() {
     return executionTarget;
+  }
+
+  /** Invocation-typed sibling of {@link #forEach}: each child persists the factory's invocation. */
+  <T extends Serializable> void forEachInvocation(
+      Collection<T> items, Function<T, JobInvocation> invocationFactory) {
+    for (T item : items) {
+      children.add(new ChildSpec(JobPayloadFactory.fromInvocation(invocationFactory.apply(item))));
+    }
   }
 
   private JobPayload payload(Serializable callback) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationBatchBuilder.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationBatchBuilder.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.function.Function;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.spi.InvocationBatchBuilder;
+import run.ratchet.spi.JobInvocation;
+
+/**
+ * Invocation-typed facade over {@link DefaultBatchBuilder}: per-item invocations are converted to
+ * child payloads by the delegate, and branch targets ride through {@link InvocationAdapter}, so
+ * batch persistence stays on the single creation path.
+ */
+final class DefaultInvocationBatchBuilder implements InvocationBatchBuilder {
+
+  private final DefaultBatchBuilder delegate;
+
+  DefaultInvocationBatchBuilder(DefaultBatchBuilder delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public <T extends Serializable> InvocationBatchBuilder forEach(
+      Collection<T> items, Function<T, JobInvocation> invocationFactory) {
+    delegate.forEachInvocation(items, invocationFactory);
+    return this;
+  }
+
+  @Override
+  public InvocationBatchBuilder thenBranch(
+      WorkflowCondition condition, JobInvocation next, String description) {
+    delegate.thenBranch(condition, new InvocationAdapter(next), description);
+    return this;
+  }
+
+  @Override
+  public InvocationBatchBuilder thenOnBatchSuccess(JobInvocation next) {
+    delegate.thenOnBatchSuccess(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public InvocationBatchBuilder thenOnBatchFailure(JobInvocation next) {
+    delegate.thenOnBatchFailure(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public InvocationBatchBuilder virtual() {
+    delegate.virtual();
+    return this;
+  }
+
+  @Override
+  public InvocationBatchBuilder platform() {
+    delegate.platform();
+    return this;
+  }
+
+  @Override
+  public JobHandle submit() {
+    return delegate.submit();
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationJobBuilder.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationJobBuilder.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import java.time.Duration;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobBuilder;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.spi.InvocationJobBuilder;
+import run.ratchet.spi.JobInvocation;
+
+/**
+ * Invocation-typed facade over {@link DefaultJobBuilder}: every {@link JobInvocation} is wrapped in
+ * an {@link InvocationAdapter} so the existing builder state, chain handling, branch handling, and
+ * the single creation path in {@code DefaultJobCreationService} apply unchanged.
+ */
+final class DefaultInvocationJobBuilder implements InvocationJobBuilder {
+
+  private final JobBuilder delegate;
+
+  DefaultInvocationJobBuilder(JobBuilder delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public InvocationJobBuilder then(JobInvocation next) {
+    delegate.then(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder thenOnSuccess(JobInvocation next) {
+    delegate.thenOnSuccess(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder thenOnFailure(JobInvocation next) {
+    delegate.thenOnFailure(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder branch(
+      WorkflowCondition condition, JobInvocation next, String description) {
+    delegate.branch(condition, new InvocationAdapter(next), description);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder when(WorkflowCondition condition, JobInvocation next) {
+    delegate.branch(condition, new InvocationAdapter(next), null);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder immediate() {
+    delegate.immediate();
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder awaitSignal(String signalKey, Duration timeout) {
+    delegate.awaitSignal(signalKey, timeout);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withIdempotencyKey(String key) {
+    delegate.withIdempotencyKey(key);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withBusinessKey(String key) {
+    delegate.withBusinessKey(key);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withResource(String resourceName) {
+    delegate.withResource(resourceName);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder virtual() {
+    delegate.virtual();
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder platform() {
+    delegate.platform();
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withBackoff(BackoffPolicy policy, Duration param) {
+    delegate.withBackoff(policy, param);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withMaxRetries(int retries) {
+    delegate.withMaxRetries(retries);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withParam(String key, String value) {
+    delegate.withParam(key, value);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withPriority(JobPriority priority) {
+    delegate.withPriority(priority);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withTags(String... tags) {
+    delegate.withTags(tags);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withTimeout(Duration timeout) {
+    delegate.withTimeout(timeout);
+    return this;
+  }
+
+  @Override
+  public InvocationJobBuilder withEncryptedPayload() {
+    delegate.withEncryptedPayload();
+    return this;
+  }
+
+  @Override
+  public JobHandle submit() {
+    return delegate.submit();
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationStreamingBatchBuilder.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationStreamingBatchBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import java.io.Serializable;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.WorkflowBranch;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.spi.InvocationStreamingBatchBuilder;
+import run.ratchet.spi.JobInvocation;
+
+/**
+ * Invocation-typed facade over {@link InvocationStreamingState}: branch targets ride through {@link
+ * InvocationAdapter}, and submission converges on the shared streaming chunk loop in {@code
+ * DefaultJobCreationService}.
+ */
+final class DefaultInvocationStreamingBatchBuilder<T extends Serializable>
+    implements InvocationStreamingBatchBuilder<T> {
+
+  private final InvocationStreamingState<T> state;
+
+  DefaultInvocationStreamingBatchBuilder(String name, StreamingBatchSubmitter submitter) {
+    this.state = new InvocationStreamingState<>(name, submitter);
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> fromStream(Stream<T> stream) {
+    state.fromStream(stream);
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> process(Function<T, JobInvocation> invocationFactory) {
+    state.setInvocationFactory(invocationFactory);
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> withChunkSize(int size) {
+    state.withChunkSize(size);
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> virtual() {
+    state.virtual();
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> platform() {
+    state.platform();
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> thenBranch(
+      WorkflowCondition condition, JobInvocation next, String description) {
+    state.addBranch(new WorkflowBranch(condition, new InvocationAdapter(next), description));
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> thenOnBatchSuccess(JobInvocation next) {
+    state.thenOnBatchSuccess(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public InvocationStreamingBatchBuilder<T> thenOnBatchFailure(JobInvocation next) {
+    state.thenOnBatchFailure(new InvocationAdapter(next));
+    return this;
+  }
+
+  @Override
+  public JobHandle start() {
+    return state.start();
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationSubmissionService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationSubmissionService.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Objects;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.spi.InvocationBatchBuilder;
+import run.ratchet.spi.InvocationJobBuilder;
+import run.ratchet.spi.InvocationSubmissionService;
+import run.ratchet.spi.JobInvocation;
+import run.ratchet.spi.JobInvocationResolver;
+
+/**
+ * Reference implementation of {@link InvocationSubmissionService}: thin facades over the existing
+ * builders, converging on {@link DefaultJobCreationService} with no separate persistence path.
+ */
+@ApplicationScoped
+public class DefaultInvocationSubmissionService implements InvocationSubmissionService {
+
+  private final DefaultJobCreationService jobCreationService;
+  private final JobInvocationResolver jobInvocationResolver;
+
+  /** No-arg constructor required by CDI normal-scope proxying. Not for direct use. */
+  protected DefaultInvocationSubmissionService() {
+    this.jobCreationService = null;
+    this.jobInvocationResolver = null;
+  }
+
+  @Inject
+  public DefaultInvocationSubmissionService(
+      DefaultJobCreationService jobCreationService, JobInvocationResolver jobInvocationResolver) {
+    this.jobCreationService = jobCreationService;
+    this.jobInvocationResolver = jobInvocationResolver;
+  }
+
+  @Override
+  public InvocationJobBuilder enqueueInvocation(JobInvocation invocation) {
+    Objects.requireNonNull(invocation, "invocation must not be null");
+    return new DefaultInvocationJobBuilder(
+        DefaultJobBuilder.create(
+            jobCreationService, new InvocationAdapter(invocation), Duration.ZERO));
+  }
+
+  @Override
+  public InvocationJobBuilder scheduleInvocation(Duration delay, JobInvocation invocation) {
+    Objects.requireNonNull(delay, "delay must not be null");
+    Objects.requireNonNull(invocation, "invocation must not be null");
+    return new DefaultInvocationJobBuilder(
+        DefaultJobBuilder.create(jobCreationService, new InvocationAdapter(invocation), delay));
+  }
+
+  @Override
+  public InvocationBatchBuilder enqueueInvocationBatch(String name) {
+    Objects.requireNonNull(name, "name must not be null");
+    return new DefaultInvocationBatchBuilder(
+        new DefaultBatchBuilder(name, jobCreationService, jobInvocationResolver));
+  }
+
+  @Override
+  public WorkflowCondition invocationCondition(JobInvocation invocation) {
+    Objects.requireNonNull(invocation, "invocation must not be null");
+    return new WorkflowCondition(WorkflowCondition.ConditionType.CUSTOM, invocation);
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationSubmissionService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationSubmissionService.java
@@ -17,11 +17,13 @@ package run.ratchet.ri.core;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import java.io.Serializable;
 import java.time.Duration;
 import java.util.Objects;
 import run.ratchet.api.WorkflowCondition;
 import run.ratchet.spi.InvocationBatchBuilder;
 import run.ratchet.spi.InvocationJobBuilder;
+import run.ratchet.spi.InvocationStreamingBatchBuilder;
 import run.ratchet.spi.InvocationSubmissionService;
 import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.JobInvocationResolver;
@@ -70,6 +72,13 @@ public class DefaultInvocationSubmissionService implements InvocationSubmissionS
     Objects.requireNonNull(name, "name must not be null");
     return new DefaultInvocationBatchBuilder(
         new DefaultBatchBuilder(name, jobCreationService, jobInvocationResolver));
+  }
+
+  @Override
+  public <T extends Serializable> InvocationStreamingBatchBuilder<T> invocationStreamingBatch(
+      String name) {
+    Objects.requireNonNull(name, "name must not be null");
+    return new DefaultInvocationStreamingBatchBuilder<>(name, jobCreationService);
   }
 
   @Override

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobBuilder;
 import run.ratchet.api.JobHandle;
@@ -745,35 +746,27 @@ class DefaultJobCreationService
     return createStreamingChildJobs(parentId, builder, chunk);
   }
 
-  /**
-   * Invocation-mode sibling of {@link #createStreamingChildJobs}: per-item payloads come from the
-   * builder's invocation factory instead of lambda resolution. Chunk-level bulk insert, caller
-   * stamping, and authorization checks are identical.
-   */
   private <T extends Serializable> int createInvocationStreamingChildJobs(
       UUID parentId, InvocationStreamingState<T> builder, List<T> items) {
-    List<JobEntity> children = new ArrayList<>(items.size());
-    for (T item : items) {
-      JobEntity child = new JobEntity();
-      child.setJobType(JobExecutionType.BATCH_CHILD);
-      child.setStatus(JobStatus.PENDING);
-      child.setPriority(JobPriority.NORMAL);
-      child.setScheduledTime(effective().instant());
-      child.setPayload(
-          validate(JobPayloadFactory.fromInvocation(builder.invocationFactory().apply(item))));
-      child.setIdempotencyKey(UUID.randomUUID().toString());
-      child.setDependsOn(parentId);
-      child.setExecutionTarget(builder.executionTarget());
-      stampCallerPrincipal(child);
-      checkCreateAuthorization(child);
-      children.add(child);
-    }
-    bulkStore().bulkInsert(children);
-    return children.size();
+    return createStreamingChildJobs(
+        parentId,
+        builder,
+        items,
+        item ->
+            validate(JobPayloadFactory.fromInvocation(builder.invocationFactory().apply(item))));
   }
 
   private <T extends Serializable> int createStreamingChildJobs(
       UUID parentId, DefaultStreamingBatchBuilder<T> builder, List<T> items) {
+    return createStreamingChildJobs(
+        parentId, builder, items, item -> payload(builder.action(), List.of(item)));
+  }
+
+  private <T extends Serializable> int createStreamingChildJobs(
+      UUID parentId,
+      DefaultStreamingBatchBuilder<T> builder,
+      List<T> items,
+      Function<T, JobPayload> payloadFactory) {
     List<JobEntity> children = new ArrayList<>(items.size());
     for (T item : items) {
       JobEntity child = new JobEntity();
@@ -781,7 +774,7 @@ class DefaultJobCreationService
       child.setStatus(JobStatus.PENDING);
       child.setPriority(JobPriority.NORMAL);
       child.setScheduledTime(effective().instant());
-      child.setPayload(payload(builder.action(), List.of(item)));
+      child.setPayload(payloadFactory.apply(item));
       child.setIdempotencyKey(UUID.randomUUID().toString());
       child.setDependsOn(parentId);
       child.setExecutionTarget(builder.executionTarget());
@@ -867,9 +860,6 @@ class DefaultJobCreationService
     // they still run through the same validation and class-policy gate below.
     if (callback instanceof InvocationAdapter adapter) {
       return validate(JobPayloadFactory.fromInvocation(adapter.invocation()));
-    }
-    if (callback instanceof JobInvocation invocation) {
-      return validate(JobPayloadFactory.fromInvocation(invocation));
     }
     return validate(JobPayloadFactory.fromInvocation(jobInvocationResolver.resolve(callback)));
   }

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -39,10 +39,12 @@ import run.ratchet.api.JobOptions;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobSubmitter;
+import run.ratchet.api.JobType;
 import run.ratchet.api.SerializableCheckedRunnable;
 import run.ratchet.api.SerializableFunction;
 import run.ratchet.api.SerializablePredicate;
 import run.ratchet.api.WorkflowBranch;
+import run.ratchet.api.event.BatchChunkFailureEvent;
 import run.ratchet.api.event.JobSignalWaitingEvent;
 import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
 import run.ratchet.api.internal.JobBuilderState;
@@ -519,7 +521,7 @@ class DefaultJobCreationService
       while (iterator.hasNext()) {
         chunk.add(iterator.next());
         if (chunk.size() >= builder.chunkSize()) {
-          totalItems += createStreamingChildJobs(parentId, builder, chunk);
+          totalItems += createChildChunk(parentId, builder, chunk, chunksInserted);
           chunksInserted++;
           builder.invokeLocalProgressHook(parentId, totalItems, chunksInserted);
           chunk.clear();
@@ -527,7 +529,7 @@ class DefaultJobCreationService
       }
 
       if (!chunk.isEmpty()) {
-        totalItems += createStreamingChildJobs(parentId, builder, chunk);
+        totalItems += createChildChunk(parentId, builder, chunk, chunksInserted);
         chunksInserted++;
         builder.invokeLocalProgressHook(parentId, totalItems, chunksInserted);
       }
@@ -712,6 +714,62 @@ class DefaultJobCreationService
       JobEntity savedStep = jobCrudStore.create(step);
       prevId = savedStep.getId();
     }
+  }
+
+  /**
+   * Routes one chunk to the matching child constructor. Invocation-mode chunks emit a best-effort
+   * {@link BatchChunkFailureEvent} before the failure propagates (and the enclosing transaction
+   * rolls the whole submission back).
+   */
+  private <T extends Serializable> int createChildChunk(
+      UUID parentId, DefaultStreamingBatchBuilder<T> builder, List<T> chunk, int chunkIndex) {
+    if (builder instanceof InvocationStreamingState<T> invocationBuilder) {
+      try {
+        return createInvocationStreamingChildJobs(parentId, invocationBuilder, chunk);
+      } catch (RuntimeException e) {
+        if (eventPublisher != null) {
+          eventPublisher.publish(
+              new BatchChunkFailureEvent(
+                  parentId,
+                  null,
+                  JobType.BATCH,
+                  JobPriority.NORMAL,
+                  null,
+                  chunkIndex,
+                  chunk.size(),
+                  e.getMessage()));
+        }
+        throw e;
+      }
+    }
+    return createStreamingChildJobs(parentId, builder, chunk);
+  }
+
+  /**
+   * Invocation-mode sibling of {@link #createStreamingChildJobs}: per-item payloads come from the
+   * builder's invocation factory instead of lambda resolution. Chunk-level bulk insert, caller
+   * stamping, and authorization checks are identical.
+   */
+  private <T extends Serializable> int createInvocationStreamingChildJobs(
+      UUID parentId, InvocationStreamingState<T> builder, List<T> items) {
+    List<JobEntity> children = new ArrayList<>(items.size());
+    for (T item : items) {
+      JobEntity child = new JobEntity();
+      child.setJobType(JobExecutionType.BATCH_CHILD);
+      child.setStatus(JobStatus.PENDING);
+      child.setPriority(JobPriority.NORMAL);
+      child.setScheduledTime(effective().instant());
+      child.setPayload(
+          validate(JobPayloadFactory.fromInvocation(builder.invocationFactory().apply(item))));
+      child.setIdempotencyKey(UUID.randomUUID().toString());
+      child.setDependsOn(parentId);
+      child.setExecutionTarget(builder.executionTarget());
+      stampCallerPrincipal(child);
+      checkCreateAuthorization(child);
+      children.add(child);
+    }
+    bulkStore().bulkInsert(children);
+    return children.size();
   }
 
   private <T extends Serializable> int createStreamingChildJobs(

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -54,6 +54,7 @@ import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.ri.security.JobPayloadInputValidator;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.JobAuthorizationPolicy;
+import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.JobInvocationResolver;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.TracingCollector;
@@ -781,8 +782,13 @@ class DefaultJobCreationService
     condition.setConditionPriority(branch.condition().priority());
     if (branch.condition().expression() != null) {
       Serializable expr = branch.condition().expression();
-      if (expr instanceof SerializablePredicate<?> || expr instanceof SerializableFunction<?, ?>) {
-        JobPayload p = JobPayloadFactory.fromLambda(expr);
+      if (expr instanceof SerializablePredicate<?>
+          || expr instanceof SerializableFunction<?, ?>
+          || expr instanceof JobInvocation) {
+        JobPayload p =
+            expr instanceof JobInvocation invocation
+                ? JobPayloadFactory.fromInvocation(invocation)
+                : JobPayloadFactory.fromLambda(expr);
         // The predicate belongs to the parent job, binds the parent id, and follows the parent's
         // encryption opt-in: an opted-in workflow encrypts its predicate even when the global
         // switch is off.
@@ -799,6 +805,14 @@ class DefaultJobCreationService
   }
 
   private JobPayload payload(Serializable callback) {
+    // Pre-resolved invocations (from InvocationSubmissionService facades) skip lambda resolution;
+    // they still run through the same validation and class-policy gate below.
+    if (callback instanceof InvocationAdapter adapter) {
+      return validate(JobPayloadFactory.fromInvocation(adapter.invocation()));
+    }
+    if (callback instanceof JobInvocation invocation) {
+      return validate(JobPayloadFactory.fromInvocation(invocation));
+    }
     return validate(JobPayloadFactory.fromInvocation(jobInvocationResolver.resolve(callback)));
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -826,7 +826,7 @@ class DefaultJobCreationService
                   null,
                   chunkIndex,
                   chunk.size(),
-                  e.getMessage()));
+                  Objects.requireNonNullElse(e.getMessage(), e.getClass().getName())));
         }
         throw e;
       }

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
@@ -42,6 +42,7 @@ import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.ri.security.PayloadMasker;
 import run.ratchet.spi.JobAuthorizationPolicy;
+import run.ratchet.spi.MaskingContext;
 import run.ratchet.spi.ProtectedSurface;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobPayload;
@@ -49,6 +50,7 @@ import run.ratchet.store.query.JobQueryCursor;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
@@ -68,6 +70,7 @@ class DefaultJobQueryService implements JobQueryService {
   private final CallerPrincipalProvider principalProvider;
   private final Clock clock;
   private final boolean maskPayloads;
+  private final JobExtensionStore extensionStore;
 
   protected DefaultJobQueryService() {
     this.queryStore = null;
@@ -79,6 +82,7 @@ class DefaultJobQueryService implements JobQueryService {
     this.principalProvider = null;
     this.clock = null;
     this.maskPayloads = false;
+    this.extensionStore = null;
   }
 
   public DefaultJobQueryService(
@@ -128,6 +132,7 @@ class DefaultJobQueryService implements JobQueryService {
       Instance<JobAnalyticsStore> analyticsStore,
       Instance<JobAuditStore> executionStore,
       Instance<RecurringJobStore> recurringJobStore,
+      Instance<JobExtensionStore> extensionStore,
       JobAuthorizationPolicy authPolicy,
       CallerPrincipalProvider principalProvider,
       Clock clock,
@@ -141,7 +146,8 @@ class DefaultJobQueryService implements JobQueryService {
         authPolicy,
         principalProvider,
         clock,
-        options);
+        options,
+        extensionStore.isResolvable() ? extensionStore.get() : null);
   }
 
   DefaultJobQueryService(
@@ -154,6 +160,30 @@ class DefaultJobQueryService implements JobQueryService {
       CallerPrincipalProvider principalProvider,
       Clock clock,
       RatchetOptions options) {
+    this(
+        queryStore,
+        crudStore,
+        analyticsStore,
+        executionStore,
+        recurringJobStore,
+        authPolicy,
+        principalProvider,
+        clock,
+        options,
+        null);
+  }
+
+  DefaultJobQueryService(
+      JobQueryStore queryStore,
+      JobCrudStore crudStore,
+      JobAnalyticsStore analyticsStore,
+      JobAuditStore executionStore,
+      RecurringJobStore recurringJobStore,
+      JobAuthorizationPolicy authPolicy,
+      CallerPrincipalProvider principalProvider,
+      Clock clock,
+      RatchetOptions options,
+      JobExtensionStore extensionStore) {
     this.queryStore = queryStore;
     this.crudStore = crudStore;
     this.analyticsStore = analyticsStore;
@@ -163,6 +193,18 @@ class DefaultJobQueryService implements JobQueryService {
     this.principalProvider = principalProvider;
     this.clock = clock;
     this.maskPayloads = options != null && options.security().maskPayloads();
+    this.extensionStore = extensionStore;
+  }
+
+  /**
+   * Builds the per-job masking context: the job's extension properties when the store advertises
+   * the {@code JobExtensionStore} capability, an empty map otherwise. Fetched only when masking is
+   * enabled, once per detail read.
+   */
+  private MaskingContext maskingContext(UUID jobId) {
+    Map<String, String> properties =
+        extensionStore == null ? Map.of() : extensionStore.getPropertiesByPrefix(jobId, "");
+    return new MaskingContext(jobId, properties);
   }
 
   private static String extractSortValue(JobEntity last, JobQuerySortField field) {
@@ -283,17 +325,20 @@ class DefaultJobQueryService implements JobQueryService {
     // through). Free-text fields such as lastError are out of scope — see
     // RatchetOptions.SecurityOptions#maskPayloads.
     // params arrive already decrypted by the row mapper; trace_context is never encrypted.
+    MaskingContext maskingContext = maskPayloads ? maskingContext(e.getId()) : null;
     Map<String, String> params =
-        maskPayloads ? PayloadMasker.maskParams(e.getParams()) : e.getParams();
+        maskPayloads ? PayloadMasker.maskParams(e.getParams(), maskingContext) : e.getParams();
     Map<String, String> traceContext =
-        maskPayloads ? PayloadMasker.maskParams(e.getTraceContext()) : e.getTraceContext();
+        maskPayloads
+            ? PayloadMasker.maskParams(e.getTraceContext(), maskingContext)
+            : e.getTraceContext();
     // job_result is a raw column (no row-mapper decryption), so decrypt at rest first, then mask.
     // Decryption is marker-driven (no-op on plaintext); masking is a no-op when disabled.
     String jobResult =
         PayloadEncryptor.decryptJsonColumn(
             e.getJobResult(), EncryptionTarget.rowBound(ProtectedSurface.RESULT, e.getId()));
     if (maskPayloads) {
-      jobResult = PayloadMasker.maskPayload(jobResult);
+      jobResult = PayloadMasker.maskPayload(jobResult, maskingContext);
     }
 
     JobDetail detail =

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
@@ -197,14 +197,13 @@ class DefaultJobQueryService implements JobQueryService {
   }
 
   /**
-   * Builds the per-job masking context: the job's extension properties when the store advertises
-   * the {@code JobExtensionStore} capability, an empty map otherwise. Fetched only when masking is
-   * enabled, once per detail read.
+   * Builds the per-job masking context: the job's extension properties are fetched only when a
+   * context-aware masking policy reads them.
    */
   private MaskingContext maskingContext(UUID jobId) {
-    Map<String, String> properties =
-        extensionStore == null ? Map.of() : extensionStore.getPropertiesByPrefix(jobId, "");
-    return new MaskingContext(jobId, properties);
+    return new MaskingContext(
+        jobId,
+        () -> extensionStore == null ? Map.of() : extensionStore.getPropertiesByPrefix(jobId, ""));
   }
 
   private static String extractSortValue(JobEntity last, JobQuerySortField field) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultStreamingBatchBuilder.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultStreamingBatchBuilder.java
@@ -153,6 +153,11 @@ class DefaultStreamingBatchBuilder<T extends Serializable> implements StreamingB
     }
   }
 
+  /** Adds an explicit conditional branch (used by the invocation-mode subtype). */
+  void addBranch(WorkflowBranch branch) {
+    workflowBranches.add(branch);
+  }
+
   void validateReady() {
     if (stream == null) {
       throw new IllegalStateException("Stream must be set via fromStream() before calling start()");

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultStreamingBatchBuilder.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultStreamingBatchBuilder.java
@@ -158,10 +158,18 @@ class DefaultStreamingBatchBuilder<T extends Serializable> implements StreamingB
     workflowBranches.add(branch);
   }
 
-  void validateReady() {
+  final void validateReady() {
+    requireStream();
+    validateProcessingReady();
+  }
+
+  private void requireStream() {
     if (stream == null) {
       throw new IllegalStateException("Stream must be set via fromStream() before calling start()");
     }
+  }
+
+  void validateProcessingReady() {
     if (action == null) {
       throw new IllegalStateException(
           "Processing action must be set via process() before calling start()");

--- a/ratchet/src/main/java/run/ratchet/ri/core/InvocationAdapter.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/InvocationAdapter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import java.io.Serial;
+import java.util.Objects;
+import run.ratchet.api.SerializableCheckedRunnable;
+import run.ratchet.spi.JobInvocation;
+
+/**
+ * Carrier that lets a pre-resolved {@link JobInvocation} ride through builder slots typed {@link
+ * SerializableCheckedRunnable} (task, chain steps, branch targets). The creation path unwraps it
+ * before lambda resolution; it is never executed and never serialized.
+ */
+final class InvocationAdapter implements SerializableCheckedRunnable {
+
+  @Serial private static final long serialVersionUID = 1L;
+
+  private final JobInvocation invocation;
+
+  InvocationAdapter(JobInvocation invocation) {
+    this.invocation = Objects.requireNonNull(invocation, "invocation must not be null");
+  }
+
+  JobInvocation invocation() {
+    return invocation;
+  }
+
+  @Override
+  public void run() {
+    throw new IllegalStateException(
+        "InvocationAdapter is a persistence-time carrier and must never be executed");
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/InvocationStreamingState.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/InvocationStreamingState.java
@@ -46,10 +46,7 @@ final class InvocationStreamingState<T extends Serializable>
   }
 
   @Override
-  void validateReady() {
-    if (stream() == null) {
-      throw new IllegalStateException("Stream must be set via fromStream() before calling start()");
-    }
+  void validateProcessingReady() {
     if (invocationFactory == null) {
       throw new IllegalStateException(
           "Invocation factory must be set via process() before calling start()");

--- a/ratchet/src/main/java/run/ratchet/ri/core/InvocationStreamingState.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/InvocationStreamingState.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.function.Function;
+import run.ratchet.spi.JobInvocation;
+
+/**
+ * Invocation-mode streaming batch state: shares the chunk loop, chunk-boundary persistence, and
+ * branch handling with {@link DefaultStreamingBatchBuilder} (which it extends) and carries a
+ * per-item invocation factory instead of a serializable consumer. {@code DefaultJobCreationService}
+ * dispatches each chunk to the invocation-mode child constructor when it sees this subtype; the
+ * public surface is {@code DefaultInvocationStreamingBatchBuilder}.
+ */
+final class InvocationStreamingState<T extends Serializable>
+    extends DefaultStreamingBatchBuilder<T> {
+
+  private Function<T, JobInvocation> invocationFactory;
+
+  InvocationStreamingState(String name, StreamingBatchSubmitter submitter) {
+    super(name, submitter);
+  }
+
+  void setInvocationFactory(Function<T, JobInvocation> invocationFactory) {
+    this.invocationFactory =
+        Objects.requireNonNull(invocationFactory, "invocationFactory must not be null");
+  }
+
+  Function<T, JobInvocation> invocationFactory() {
+    return invocationFactory;
+  }
+
+  @Override
+  void validateReady() {
+    if (stream() == null) {
+      throw new IllegalStateException("Stream must be set via fromStream() before calling start()");
+    }
+    if (invocationFactory == null) {
+      throw new IllegalStateException(
+          "Invocation factory must be set via process() before calling start()");
+    }
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultJobExecutorService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/DefaultJobExecutorService.java
@@ -16,6 +16,7 @@
 package run.ratchet.ri.core.internal;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import java.time.Clock;
 import java.time.Duration;
@@ -48,6 +49,7 @@ import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.JobLoggerFactory;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.PayloadSerializer;
+import run.ratchet.spi.PreExecutionArgResolver;
 import run.ratchet.spi.ResilienceStrategy;
 import run.ratchet.spi.ResultPersistenceStrategy;
 import run.ratchet.spi.RetryPolicy;
@@ -85,6 +87,7 @@ public class DefaultJobExecutorService implements JobExecutorService {
   private final PayloadSerializer payloadSerializer;
   private final PollerScheduler pollerScheduler;
   private final Clock clock;
+  private final PreExecutionArgResolver argResolver;
   private final Object submissionLock = new Object();
   private final AtomicBoolean acceptingExecutions = new AtomicBoolean(true);
   private final Set<TrackingFutureTask> activeFutures = ConcurrentHashMap.newKeySet();
@@ -110,6 +113,7 @@ public class DefaultJobExecutorService implements JobExecutorService {
     this.payloadSerializer = null;
     this.pollerScheduler = null;
     this.clock = null;
+    this.argResolver = null;
   }
 
   @Inject
@@ -133,7 +137,8 @@ public class DefaultJobExecutorService implements JobExecutorService {
       ResultPersistenceStrategy resultPersistenceStrategy,
       JobAuthorizationPolicy authorizationPolicy,
       PayloadSerializer payloadSerializer,
-      Clock clock) {
+      Clock clock,
+      Instance<PreExecutionArgResolver> argResolver) {
     this.poolRegistry = poolRegistry;
     this.timeoutHandler = timeoutHandler;
     this.executorProvider = executorProvider;
@@ -154,6 +159,7 @@ public class DefaultJobExecutorService implements JobExecutorService {
     this.authorizationPolicy = authorizationPolicy;
     this.payloadSerializer = payloadSerializer;
     this.clock = clock;
+    this.argResolver = argResolver != null && argResolver.isResolvable() ? argResolver.get() : null;
   }
 
   private static void cancelTimeoutHandles(
@@ -317,7 +323,8 @@ public class DefaultJobExecutorService implements JobExecutorService {
         authorizationPolicy,
         payloadSerializer,
         timeoutHandler,
-        effective());
+        effective(),
+        argResolver);
   }
 
   private JobTimeoutHandler.TimeoutHandles scheduleWatchdog(

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -57,11 +57,13 @@ import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.ErrorSanitizer;
 import run.ratchet.spi.JobAuthorizationPolicy;
+import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.JobLogger;
 import run.ratchet.spi.JobLoggerContext;
 import run.ratchet.spi.JobLoggerFactory;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.PayloadSerializer;
+import run.ratchet.spi.PreExecutionArgResolver;
 import run.ratchet.spi.ResilienceStrategy;
 import run.ratchet.spi.ResultPersistenceStrategy;
 import run.ratchet.spi.RetryPolicy;
@@ -111,6 +113,7 @@ public class JobTask implements Callable<Void> {
   private final NodeIdentityProvider nodeIdProvider;
   private final ExecutionObserver observabilityFacade;
   private final PreExecutionValidator validationFacade;
+  private final PreExecutionArgResolver argResolver;
   private final BeanResolver beanResolver;
   private final RetryPolicy retryPolicy;
   private final ResilienceStrategy resilienceStrategy;
@@ -152,6 +155,7 @@ public class JobTask implements Callable<Void> {
     this.payloadSerializer = null;
     this.timeoutHandler = null;
     this.clock = null;
+    this.argResolver = null;
   }
 
   @Inject
@@ -173,6 +177,47 @@ public class JobTask implements Callable<Void> {
       PayloadSerializer payloadSerializer,
       JobTimeoutHandler timeoutHandler,
       Clock clock) {
+    this(
+        jobStore,
+        resourcePermitService,
+        lifecycleFacade,
+        nodeIdProvider,
+        observabilityFacade,
+        validationFacade,
+        beanResolver,
+        retryPolicy,
+        resilienceStrategy,
+        errorSanitizer,
+        classPolicy,
+        jobLoggerFactory,
+        resultPersistenceStrategy,
+        authorizationPolicy,
+        payloadSerializer,
+        timeoutHandler,
+        clock,
+        null);
+  }
+
+  public JobTask(
+      JobStore jobStore,
+      ResourcePermitService resourcePermitService,
+      PostExecutionHandler lifecycleFacade,
+      NodeIdentityProvider nodeIdProvider,
+      ExecutionObserver observabilityFacade,
+      PreExecutionValidator validationFacade,
+      BeanResolver beanResolver,
+      RetryPolicy retryPolicy,
+      ResilienceStrategy resilienceStrategy,
+      ErrorSanitizer errorSanitizer,
+      ClassPolicy classPolicy,
+      JobLoggerFactory jobLoggerFactory,
+      ResultPersistenceStrategy resultPersistenceStrategy,
+      JobAuthorizationPolicy authorizationPolicy,
+      PayloadSerializer payloadSerializer,
+      JobTimeoutHandler timeoutHandler,
+      Clock clock,
+      PreExecutionArgResolver argResolver) {
+    this.argResolver = argResolver;
     this.jobStore = jobStore;
     this.resourcePermitService = resourcePermitService;
     this.lifecycleFacade = lifecycleFacade;
@@ -383,9 +428,13 @@ public class JobTask implements Callable<Void> {
         // Validate before breaker scope — config errors must not trip the circuit breaker
         validationFacade.validateSecurity(jobEntity.getPayload());
 
+        // Last-moment argument resolution (late binding), after the security gate cleared the
+        // dispatch target and before the resilience scope so resolver failures don't trip the
+        // breaker. The target identity stays pinned; only arguments can change.
+        JobPayload dispatchPayload = resolveArguments(jobEntity.getPayload(), jobEntity.getId());
+
         jobResult =
-            resilienceStrategy.execute(
-                resilienceServiceName, () -> runPayload(jobEntity.getPayload()));
+            resilienceStrategy.execute(resilienceServiceName, () -> runPayload(dispatchPayload));
 
         if (wasJobCanceledDuringExecution()) {
           handleCanceledDuringExecution(start);
@@ -1190,6 +1239,33 @@ public class JobTask implements Callable<Void> {
   }
 
   @SuppressWarnings("java:S112")
+  /**
+   * Consults the optional {@link PreExecutionArgResolver}: only the returned invocation's arguments
+   * are honored — the dispatch target the security gate validated cannot change.
+   */
+  private JobPayload resolveArguments(JobPayload payload, UUID jobId) {
+    if (argResolver == null) {
+      return payload;
+    }
+    JobInvocation invocation =
+        new JobInvocation(
+            payload.target(),
+            payload.method(),
+            payload.methodDescriptor(),
+            payload.isStatic(),
+            payload.args());
+    JobInvocation resolved = argResolver.resolveArguments(jobId, invocation);
+    if (resolved == null || resolved == invocation) {
+      return payload;
+    }
+    return new JobPayload(
+        payload.target(),
+        payload.method(),
+        payload.methodDescriptor(),
+        payload.isStatic(),
+        resolved.arguments());
+  }
+
   private Object runPayload(JobPayload payload) throws Exception {
     // validateSecurity() is called by call() BEFORE entering the resilience scope.
     // Do not re-validate here — security exceptions inside the breaker would poison it.

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -176,45 +176,6 @@ public class JobTask implements Callable<Void> {
       JobAuthorizationPolicy authorizationPolicy,
       PayloadSerializer payloadSerializer,
       JobTimeoutHandler timeoutHandler,
-      Clock clock) {
-    this(
-        jobStore,
-        resourcePermitService,
-        lifecycleFacade,
-        nodeIdProvider,
-        observabilityFacade,
-        validationFacade,
-        beanResolver,
-        retryPolicy,
-        resilienceStrategy,
-        errorSanitizer,
-        classPolicy,
-        jobLoggerFactory,
-        resultPersistenceStrategy,
-        authorizationPolicy,
-        payloadSerializer,
-        timeoutHandler,
-        clock,
-        null);
-  }
-
-  public JobTask(
-      JobStore jobStore,
-      ResourcePermitService resourcePermitService,
-      PostExecutionHandler lifecycleFacade,
-      NodeIdentityProvider nodeIdProvider,
-      ExecutionObserver observabilityFacade,
-      PreExecutionValidator validationFacade,
-      BeanResolver beanResolver,
-      RetryPolicy retryPolicy,
-      ResilienceStrategy resilienceStrategy,
-      ErrorSanitizer errorSanitizer,
-      ClassPolicy classPolicy,
-      JobLoggerFactory jobLoggerFactory,
-      ResultPersistenceStrategy resultPersistenceStrategy,
-      JobAuthorizationPolicy authorizationPolicy,
-      PayloadSerializer payloadSerializer,
-      JobTimeoutHandler timeoutHandler,
       Clock clock,
       PreExecutionArgResolver argResolver) {
     this.argResolver = argResolver;

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -1238,11 +1238,11 @@ public class JobTask implements Callable<Void> {
     }
   }
 
-  @SuppressWarnings("java:S112")
   /**
    * Consults the optional {@link PreExecutionArgResolver}: only the returned invocation's arguments
    * are honored — the dispatch target the security gate validated cannot change.
    */
+  @SuppressWarnings("java:S112")
   private JobPayload resolveArguments(JobPayload payload, UUID jobId) {
     if (argResolver == null) {
       return payload;

--- a/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
@@ -16,6 +16,7 @@
 package run.ratchet.ri.security;
 
 import java.util.Map;
+import run.ratchet.spi.MaskingContext;
 
 /**
  * Public entry point for masking sensitive fields (passwords, tokens, PII) in job payload data
@@ -34,10 +35,23 @@ public final class PayloadMasker {
   }
 
   /**
+   * Context-aware variant of {@link #maskPayload(String)}: the policy's context-aware overload is
+   * consulted per field. A {@code null} context falls back to name-only matching.
+   */
+  public static String maskPayload(String payloadJson, MaskingContext context) {
+    return run.ratchet.store.util.PayloadMasker.maskPayload(payloadJson, context);
+  }
+
+  /**
    * Serializes {@code payload} to JSON then masks sensitive fields; returns null if input is null.
    */
   public static String maskPayload(Object payload) {
     return run.ratchet.store.util.PayloadMasker.maskPayload(payload);
+  }
+
+  /** Context-aware variant of {@link #maskPayload(Object)}. */
+  public static String maskPayload(Object payload, MaskingContext context) {
+    return run.ratchet.store.util.PayloadMasker.maskPayload(payload, context);
   }
 
   /**
@@ -47,5 +61,10 @@ public final class PayloadMasker {
    */
   public static Map<String, String> maskParams(Map<String, String> params) {
     return run.ratchet.store.util.PayloadMasker.maskParams(params);
+  }
+
+  /** Context-aware variant of {@link #maskParams(Map)}. */
+  public static Map<String, String> maskParams(Map<String, String> params, MaskingContext context) {
+    return run.ratchet.store.util.PayloadMasker.maskParams(params, context);
   }
 }

--- a/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/PayloadMasker.java
@@ -49,11 +49,6 @@ public final class PayloadMasker {
     return run.ratchet.store.util.PayloadMasker.maskPayload(payload);
   }
 
-  /** Context-aware variant of {@link #maskPayload(Object)}. */
-  public static String maskPayload(Object payload, MaskingContext context) {
-    return run.ratchet.store.util.PayloadMasker.maskPayload(payload, context);
-  }
-
   /**
    * Masks the values of sensitive entries in a parameter map; a {@code null} or empty map is
    * returned unchanged. Keys are matched against the active policy, so the original map is never

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.WorkflowCondition;
+import run.ratchet.api.event.BatchChunkFailureEvent;
+import run.ratchet.ri.core.internal.InternalEventPublisher;
 import run.ratchet.ri.core.internal.JobWakeupService;
 import run.ratchet.ri.payload.DefaultJobInvocationResolver;
 import run.ratchet.ri.security.JobPayloadInputValidator;
@@ -98,6 +101,11 @@ class DefaultInvocationSubmissionServiceTest {
   }
 
   private DefaultJobCreationService newCreationService(ClassPolicy classPolicy) {
+    return newCreationService(classPolicy, null);
+  }
+
+  private DefaultJobCreationService newCreationService(
+      ClassPolicy classPolicy, InternalEventPublisher eventPublisher) {
     return new DefaultJobCreationService(
         jobBatchStatusStore,
         jobTerminalStore,
@@ -115,7 +123,7 @@ class DefaultInvocationSubmissionServiceTest {
         null,
         null,
         classPolicy,
-        null,
+        eventPublisher,
         null,
         Clock.fixed(Instant.parse("2026-05-27T12:00:00Z"), ZoneOffset.UTC));
   }
@@ -228,6 +236,61 @@ class DefaultInvocationSubmissionServiceTest {
     assertThrows(
         SecurityException.class,
         () -> gatedService.enqueueInvocation(sendInvoiceInvocation()).submit());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void invocationStreamingBatch_persistsChildrenInChunksFromTheFactory() {
+    service
+        .invocationStreamingBatch("stream")
+        .fromStream(Stream.of("inv_1", "inv_2", "inv_3"))
+        .withChunkSize(2)
+        .process(
+            id ->
+                new JobInvocation(
+                    TARGET, "sendInvoice", "(Ljava/lang/String;)V", true, List.of(id)))
+        .start();
+
+    ArgumentCaptor<List<JobEntity>> captor = ArgumentCaptor.forClass(List.class);
+    verify(jobBulkStore, org.mockito.Mockito.times(2)).bulkInsert(captor.capture());
+    List<List<JobEntity>> chunks = captor.getAllValues();
+    assertEquals(2, chunks.get(0).size());
+    assertEquals(1, chunks.get(1).size());
+    assertEquals(List.of("inv_1"), chunks.get(0).get(0).getPayload().args());
+    assertEquals(List.of("inv_3"), chunks.get(1).get(0).getPayload().args());
+  }
+
+  @Test
+  void chunkFailure_emitsBestEffortEventAndPropagates() {
+    List<Object> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+    InternalEventPublisher publisher = new InternalEventPublisher() {};
+    publisher.addListener(events::add);
+    DefaultInvocationSubmissionService failing =
+        new DefaultInvocationSubmissionService(
+            newCreationService(null, publisher), new DefaultJobInvocationResolver());
+    org.mockito.Mockito.doThrow(new RuntimeException("boom")).when(jobBulkStore).bulkInsert(any());
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            failing
+                .invocationStreamingBatch("stream")
+                .fromStream(Stream.of("inv_1"))
+                .process(
+                    id ->
+                        new JobInvocation(
+                            TARGET, "sendInvoice", "(Ljava/lang/String;)V", true, List.of(id)))
+                .start());
+
+    BatchChunkFailureEvent event =
+        events.stream()
+            .filter(BatchChunkFailureEvent.class::isInstance)
+            .map(BatchChunkFailureEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(0, event.getChunkIndex());
+    assertEquals(1, event.getChunkSize());
+    assertEquals("boom", event.getFailureReason());
   }
 
   private static JobEntity persist(org.mockito.invocation.InvocationOnMock invocation) {

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
@@ -293,6 +293,37 @@ class DefaultInvocationSubmissionServiceTest {
     assertEquals("boom", event.getFailureReason());
   }
 
+  @Test
+  void chunkFailure_withoutMessage_usesExceptionClassNameAsFailureReason() {
+    List<Object> events = new java.util.concurrent.CopyOnWriteArrayList<>();
+    InternalEventPublisher publisher = new InternalEventPublisher() {};
+    publisher.addListener(events::add);
+    DefaultInvocationSubmissionService failing =
+        new DefaultInvocationSubmissionService(
+            newCreationService(null, publisher), new DefaultJobInvocationResolver());
+    org.mockito.Mockito.doThrow(new RuntimeException()).when(jobBulkStore).bulkInsert(any());
+
+    assertThrows(
+        RuntimeException.class,
+        () ->
+            failing
+                .invocationStreamingBatch("stream")
+                .fromStream(Stream.of("inv_1"))
+                .process(
+                    id ->
+                        new JobInvocation(
+                            TARGET, "sendInvoice", "(Ljava/lang/String;)V", true, List.of(id)))
+                .start());
+
+    BatchChunkFailureEvent event =
+        events.stream()
+            .filter(BatchChunkFailureEvent.class::isInstance)
+            .map(BatchChunkFailureEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(RuntimeException.class.getName(), event.getFailureReason());
+  }
+
   private static JobEntity persist(org.mockito.invocation.InvocationOnMock invocation) {
     JobEntity job = invocation.getArgument(0);
     if (job.getId() == null) {

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.WorkflowCondition;
+import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.payload.DefaultJobInvocationResolver;
+import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.spi.ClassPolicy;
+import run.ratchet.spi.JobInvocation;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.JobBulkStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultInvocationSubmissionServiceTest {
+
+  private static final String TARGET = DefaultInvocationSubmissionServiceTest.class.getName();
+
+  @Mock private JobBatchStatusStore jobBatchStatusStore;
+  @Mock private JobTerminalStore jobTerminalStore;
+  @Mock private JobCrudStore jobCrudStore;
+  @Mock private JobBulkStore jobBulkStore;
+  @Mock private BatchStore batchStore;
+  @Mock private TagStore tagStore;
+  @Mock private WorkflowConditionStore workflowConditionStore;
+  @Mock private RecurringJobStore recurringJobStore;
+  @Mock private RecurringScheduler recurringScheduler;
+
+  private DefaultJobCreationService creationService;
+  private DefaultInvocationSubmissionService service;
+
+  public static void sendInvoice(String invoiceId) {}
+
+  public static boolean wasPaid(Object result) {
+    return true;
+  }
+
+  private static class NoopJobWakeupService extends JobWakeupService {
+    @Override
+    public void notify(JobPriority priority, boolean immediate, String executionTarget) {}
+
+    @Override
+    public void notifyIfNeeded(
+        JobExecutionType jobType, JobPriority priority, Duration delay, String executionTarget) {}
+  }
+
+  @BeforeEach
+  void setUp() {
+    creationService = newCreationService(null);
+    service =
+        new DefaultInvocationSubmissionService(creationService, new DefaultJobInvocationResolver());
+    lenient()
+        .when(jobCrudStore.create(any(JobEntity.class)))
+        .thenAnswer(DefaultInvocationSubmissionServiceTest::persist);
+  }
+
+  private DefaultJobCreationService newCreationService(ClassPolicy classPolicy) {
+    return new DefaultJobCreationService(
+        jobBatchStatusStore,
+        jobTerminalStore,
+        jobCrudStore,
+        jobBulkStore,
+        batchStore,
+        tagStore,
+        workflowConditionStore,
+        recurringJobStore,
+        new NoopJobWakeupService(),
+        recurringScheduler,
+        new DefaultJobInvocationResolver(),
+        new JobPayloadInputValidator(),
+        null,
+        null,
+        null,
+        classPolicy,
+        null,
+        null,
+        Clock.fixed(Instant.parse("2026-05-27T12:00:00Z"), ZoneOffset.UTC));
+  }
+
+  private static JobInvocation sendInvoiceInvocation() {
+    return new JobInvocation(
+        TARGET, "sendInvoice", "(Ljava/lang/String;)V", true, List.of("inv_123"));
+  }
+
+  @Test
+  void enqueueInvocation_persistsThePreResolvedInvocation() {
+    service.enqueueInvocation(sendInvoiceInvocation()).submit();
+
+    ArgumentCaptor<JobEntity> captor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).create(captor.capture());
+    JobEntity job = captor.getValue();
+    assertEquals(TARGET, job.getPayload().target());
+    assertEquals("sendInvoice", job.getPayload().method());
+    assertEquals(List.of("inv_123"), job.getPayload().args());
+  }
+
+  @Test
+  void scheduleInvocation_appliesTheDelay() {
+    service.scheduleInvocation(Duration.ofMinutes(5), sendInvoiceInvocation()).submit();
+
+    ArgumentCaptor<JobEntity> captor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).create(captor.capture());
+    assertEquals(Instant.parse("2026-05-27T12:05:00Z"), captor.getValue().getScheduledTime());
+  }
+
+  @Test
+  void builderOptions_delegateToTheLambdaBuilder() {
+    service
+        .enqueueInvocation(sendInvoiceInvocation())
+        .withPriority(JobPriority.HIGH)
+        .withBusinessKey("invoice-42")
+        .withTags("billing")
+        .submit();
+
+    ArgumentCaptor<JobEntity> captor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).create(captor.capture());
+    JobEntity job = captor.getValue();
+    assertEquals(JobPriority.HIGH, job.getPriority());
+    assertEquals("invoice-42", job.getBusinessKey());
+  }
+
+  @Test
+  void then_chainsASecondInvocationStep() {
+    JobInvocation next =
+        new JobInvocation(TARGET, "sendInvoice", "(Ljava/lang/String;)V", true, List.of("inv_2"));
+
+    service.enqueueInvocation(sendInvoiceInvocation()).then(next).submit();
+
+    ArgumentCaptor<JobEntity> captor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore, atLeastOnce()).create(captor.capture());
+    List<JobEntity> created = captor.getAllValues();
+    assertEquals(2, created.size(), "head job plus one chain step");
+    assertEquals(List.of("inv_2"), created.get(1).getPayload().args());
+  }
+
+  @Test
+  void invocationCondition_persistsAsCustomConditionPayload() {
+    JobInvocation predicate =
+        new JobInvocation(TARGET, "wasPaid", "(Ljava/lang/Object;)Z", true, List.of());
+    WorkflowCondition condition = service.invocationCondition(predicate);
+    assertEquals(WorkflowCondition.ConditionType.CUSTOM, condition.type());
+
+    service
+        .enqueueInvocation(sendInvoiceInvocation())
+        .when(condition, sendInvoiceInvocation())
+        .submit();
+
+    ArgumentCaptor<WorkflowConditionEntity> captor =
+        ArgumentCaptor.forClass(WorkflowConditionEntity.class);
+    verify(workflowConditionStore).saveCondition(captor.capture());
+    WorkflowConditionEntity entity = captor.getValue();
+    assertEquals(WorkflowCondition.ConditionType.CUSTOM, entity.getConditionType());
+    assertNotNull(entity.getConditionExpression());
+    org.junit.jupiter.api.Assertions.assertTrue(
+        entity.getConditionExpression().contains("wasPaid"),
+        "condition expression must persist the invocation's payload JSON");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void invocationBatch_persistsOneChildPerItemFromTheFactory() {
+    service
+        .enqueueInvocationBatch("invoices")
+        .forEach(
+            List.of("inv_1", "inv_2"),
+            id ->
+                new JobInvocation(
+                    TARGET, "sendInvoice", "(Ljava/lang/String;)V", true, List.of(id)))
+        .submit();
+
+    ArgumentCaptor<List<JobEntity>> captor = ArgumentCaptor.forClass(List.class);
+    verify(jobBulkStore).bulkInsert(captor.capture());
+    List<JobEntity> children = captor.getValue();
+    assertEquals(2, children.size());
+    assertEquals(List.of("inv_1"), children.get(0).getPayload().args());
+    assertEquals(List.of("inv_2"), children.get(1).getPayload().args());
+  }
+
+  @Test
+  void classPolicy_gatesInvocationSubmissions() {
+    DefaultJobCreationService gated = newCreationService(className -> false);
+    DefaultInvocationSubmissionService gatedService =
+        new DefaultInvocationSubmissionService(gated, new DefaultJobInvocationResolver());
+
+    assertThrows(
+        SecurityException.class,
+        () -> gatedService.enqueueInvocation(sendInvoiceInvocation()).submit());
+  }
+
+  private static JobEntity persist(org.mockito.invocation.InvocationOnMock invocation) {
+    JobEntity job = invocation.getArgument(0);
+    if (job.getId() == null) {
+      job.setId(UUID.randomUUID());
+    }
+    return job;
+  }
+}

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
@@ -58,6 +58,8 @@ import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.spi.JobAuthorizationPolicy;
+import run.ratchet.spi.MaskingContext;
+import run.ratchet.spi.PayloadMaskingPolicy;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionEntity;
 import run.ratchet.store.entity.JobExecutionType;
@@ -66,7 +68,9 @@ import run.ratchet.store.query.JobQueryCursor;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
+import run.ratchet.store.util.PayloadMaskingPolicyHolder;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultJobQueryServiceTest {
@@ -512,27 +516,26 @@ class DefaultJobQueryServiceTest {
     when(crudStore.findDependants(eq(jobId), anyInt(), anyInt()))
         .thenReturn(Collections.emptyList());
 
-    run.ratchet.store.spi.JobExtensionStore extensionStore =
-        org.mockito.Mockito.mock(run.ratchet.store.spi.JobExtensionStore.class);
+    JobExtensionStore extensionStore = Mockito.mock(JobExtensionStore.class);
     when(extensionStore.getPropertiesByPrefix(jobId, ""))
         .thenReturn(Map.of("ratchet-blocks.block_name", "invoice.send"));
 
     // A per-block policy: "channel" is secret only on invoice.send jobs, identified through the
     // job properties carried by the masking context. Name-only matching would never redact it.
-    run.ratchet.spi.PayloadMaskingPolicy perBlockPolicy =
-        new run.ratchet.spi.PayloadMaskingPolicy() {
+    PayloadMaskingPolicy perBlockPolicy =
+        new PayloadMaskingPolicy() {
           @Override
           public boolean isSensitiveField(String fieldName) {
             return false;
           }
 
           @Override
-          public boolean isSensitiveField(String fieldName, run.ratchet.spi.MaskingContext ctx) {
+          public boolean isSensitiveField(String fieldName, MaskingContext ctx) {
             return "channel".equals(fieldName)
                 && "invoice.send".equals(ctx.jobProperties().get("ratchet-blocks.block_name"));
           }
         };
-    run.ratchet.store.util.PayloadMaskingPolicyHolder.set(perBlockPolicy);
+    PayloadMaskingPolicyHolder.set(perBlockPolicy);
     try {
       DefaultJobQueryService masking =
           new DefaultJobQueryService(
@@ -555,7 +558,7 @@ class DefaultJobQueryServiceTest {
           "context-aware policy must see the job's properties and redact per block");
       assertEquals("db", params.get("host"), "non-sensitive key must survive unchanged");
     } finally {
-      run.ratchet.store.util.PayloadMaskingPolicyHolder.set(null);
+      PayloadMaskingPolicyHolder.set(null);
     }
   }
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobQueryServiceTest.java
@@ -502,6 +502,64 @@ class DefaultJobQueryServiceTest {
   }
 
   @Test
+  void getJobDetail_passesJobPropertiesToContextAwarePolicy() {
+    UUID jobId = UUID.randomUUID();
+    JobEntity entity = minimalJobWithId(jobId);
+    entity.setParams(Map.of("channel", "ssn-here", "host", "db"));
+    when(crudStore.findById(jobId)).thenReturn(Optional.of(entity));
+    when(executionStore.findExecutionsByJobId(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+    when(crudStore.findDependants(eq(jobId), anyInt(), anyInt()))
+        .thenReturn(Collections.emptyList());
+
+    run.ratchet.store.spi.JobExtensionStore extensionStore =
+        org.mockito.Mockito.mock(run.ratchet.store.spi.JobExtensionStore.class);
+    when(extensionStore.getPropertiesByPrefix(jobId, ""))
+        .thenReturn(Map.of("ratchet-blocks.block_name", "invoice.send"));
+
+    // A per-block policy: "channel" is secret only on invoice.send jobs, identified through the
+    // job properties carried by the masking context. Name-only matching would never redact it.
+    run.ratchet.spi.PayloadMaskingPolicy perBlockPolicy =
+        new run.ratchet.spi.PayloadMaskingPolicy() {
+          @Override
+          public boolean isSensitiveField(String fieldName) {
+            return false;
+          }
+
+          @Override
+          public boolean isSensitiveField(String fieldName, run.ratchet.spi.MaskingContext ctx) {
+            return "channel".equals(fieldName)
+                && "invoice.send".equals(ctx.jobProperties().get("ratchet-blocks.block_name"));
+          }
+        };
+    run.ratchet.store.util.PayloadMaskingPolicyHolder.set(perBlockPolicy);
+    try {
+      DefaultJobQueryService masking =
+          new DefaultJobQueryService(
+              queryStore,
+              crudStore,
+              analyticsStore,
+              executionStore,
+              recurringJobStore,
+              authPolicy,
+              principalProvider,
+              FIXED_CLOCK,
+              RatchetOptions.builder().security(s -> s.maskPayloads(true)).build(),
+              extensionStore);
+
+      Map<String, String> params = masking.getJobDetail(jobId).orElseThrow().params();
+
+      assertEquals(
+          "***REDACTED***",
+          params.get("channel"),
+          "context-aware policy must see the job's properties and redact per block");
+      assertEquals("db", params.get("host"), "non-sensitive key must survive unchanged");
+    } finally {
+      run.ratchet.store.util.PayloadMaskingPolicyHolder.set(null);
+    }
+  }
+
+  @Test
   void getJobDetail_masksResultAndTraceContext_whenMaskPayloadsEnabled() {
     UUID jobId = UUID.randomUUID();
     JobEntity entity = minimalJobWithId(jobId);

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobExecutorServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobExecutorServiceTest.java
@@ -92,7 +92,8 @@ class JobExecutorServiceTest {
             null,
             null,
             null,
-            FIXED_CLOCK);
+            FIXED_CLOCK,
+            null);
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskAuthorizationTest.java
@@ -114,7 +114,8 @@ class JobTaskAuthorizationTest {
             authorizationPolicy,
             null,
             null,
-            Clock.systemUTC());
+            Clock.systemUTC(),
+            null);
   }
 
   @Test
@@ -258,7 +259,8 @@ class JobTaskAuthorizationTest {
             null,
             serializer,
             null,
-            Clock.systemUTC());
+            Clock.systemUTC(),
+            null);
 
     JobEntity job = createBaseJob();
     nullPolicyTask.init(job);

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskClassCacheBypassTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskClassCacheBypassTest.java
@@ -129,6 +129,7 @@ class JobTaskClassCacheBypassTest {
         null,
         serializer,
         null,
-        Clock.systemUTC());
+        Clock.systemUTC(),
+        null);
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -72,11 +72,13 @@ import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.EncryptionContext;
 import run.ratchet.spi.EncryptionKey;
 import run.ratchet.spi.ErrorSanitizer;
+import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.JobLogger;
 import run.ratchet.spi.KeyProvider;
 import run.ratchet.spi.NodeIdentityProvider;
 import run.ratchet.spi.PayloadEncryption;
 import run.ratchet.spi.PayloadSerializer;
+import run.ratchet.spi.PreExecutionArgResolver;
 import run.ratchet.spi.ResilienceStrategy;
 import run.ratchet.spi.ResultPersistenceStrategy;
 import run.ratchet.spi.RetryPolicy;
@@ -1134,9 +1136,9 @@ class JobTaskTest {
     JsonbTestPayloadSerializer serializer = new JsonbTestPayloadSerializer();
     // The resolver patches the argument AND tries to redirect the target; only the arguments are
     // honored — the dispatch target stays pinned to the payload the security gate validated.
-    run.ratchet.spi.PreExecutionArgResolver resolver =
+    PreExecutionArgResolver resolver =
         (jobId, invocation) ->
-            new run.ratchet.spi.JobInvocation(
+            new JobInvocation(
                 "com.example.Evil",
                 "evil",
                 invocation.methodDescriptor(),

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -1119,6 +1119,73 @@ class JobTaskTest {
     verify(lifecycleFacade).moveToDlq(eq(job), any(PayloadDecryptionException.class));
   }
 
+  private static final java.util.concurrent.atomic.AtomicReference<String> OBSERVED_ARG =
+      new java.util.concurrent.atomic.AtomicReference<>();
+
+  public static String captureArg(String value) {
+    OBSERVED_ARG.set(value);
+    return "done";
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void call_consultsArgResolverAndDispatchesPatchedArguments() throws Exception {
+    OBSERVED_ARG.set(null);
+    JsonbTestPayloadSerializer serializer = new JsonbTestPayloadSerializer();
+    // The resolver patches the argument AND tries to redirect the target; only the arguments are
+    // honored — the dispatch target stays pinned to the payload the security gate validated.
+    run.ratchet.spi.PreExecutionArgResolver resolver =
+        (jobId, invocation) ->
+            new run.ratchet.spi.JobInvocation(
+                "com.example.Evil",
+                "evil",
+                invocation.methodDescriptor(),
+                true,
+                List.of("patched"));
+    JobTask resolving =
+        new JobTask(
+            jobStore,
+            resourcePermitService,
+            lifecycleFacade,
+            nodeIdProvider,
+            observabilityFacade,
+            validationFacade,
+            beanResolver,
+            retryPolicy,
+            resilienceStrategy,
+            errorSanitizer,
+            classPolicy,
+            context -> new JBossLoggingJobLogger(context.jobId(), null),
+            new DefaultResultPersistenceStrategy(RatchetOptions.defaults(), serializer, null),
+            null,
+            serializer,
+            null,
+            Clock.systemUTC(),
+            resolver);
+
+    JobEntity job = createTestJob();
+    job.setPayload(
+        new JobPayload(
+            JobTaskTest.class.getName(),
+            "captureArg",
+            "(Ljava/lang/String;)Ljava/lang/String;",
+            true,
+            List.of("original")));
+    initJobTaskWithDefaultStubs(resolving, job);
+    when(jobStore.getJobStatus(JOB_UUID)).thenReturn(JobStatus.RUNNING);
+    when(resilienceStrategy.isServiceAvailable(anyString())).thenReturn(true);
+    when(resilienceStrategy.execute(anyString(), any(Callable.class)))
+        .thenAnswer(inv -> ((Callable<?>) inv.getArgument(1)).call());
+    when(jobStore.markJobSucceeded(
+            any(UUID.class), any(), any(), any(), any(), anyLong(), anyLong()))
+        .thenReturn(true);
+
+    resolving.call();
+
+    Assertions.assertEquals(
+        "patched", OBSERVED_ARG.get(), "the resolver-patched argument must be dispatched");
+  }
+
   private JobEntity createTestJob() {
     JobEntity job = new JobEntity();
     job.setId(JOB_UUID);

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -156,6 +156,7 @@ class JobTaskTest {
                 null,
                 null,
                 null,
+                null,
                 null));
   }
 
@@ -200,7 +201,8 @@ class JobTaskTest {
             null,
             serializer,
             null,
-            Clock.systemUTC());
+            Clock.systemUTC(),
+            null);
   }
 
   @AfterEach
@@ -1010,7 +1012,8 @@ class JobTaskTest {
             null,
             signalSerializer,
             null,
-            Clock.systemUTC());
+            Clock.systemUTC(),
+            null);
     JobEntity job = createTestJob();
     job.setPayload(
         new JobPayload(
@@ -1064,7 +1067,8 @@ class JobTaskTest {
             null,
             signalSerializer,
             null,
-            Clock.systemUTC());
+            Clock.systemUTC(),
+            null);
     JobEntity job = createTestJob();
     job.setPayload(
         new JobPayload(
@@ -1256,7 +1260,8 @@ class JobTaskTest {
         null,
         null,
         timeoutHandler,
-        FIXED_CLOCK);
+        FIXED_CLOCK,
+        null);
   }
 
   private JobTask newJobTaskWithClock(Clock taskClock) {
@@ -1279,7 +1284,8 @@ class JobTaskTest {
         null,
         null,
         null,
-        taskClock);
+        taskClock,
+        null);
   }
 
   /** Encrypts to a real frame but always fails to decrypt — a tampered/wrong-key analogue. */

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/entity/ArchivedJobEntity.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/entity/ArchivedJobEntity.java
@@ -158,6 +158,12 @@ public class ArchivedJobEntity implements UuidV7EntityListener.UuidV7Assignable 
   @Column(name = "tags", length = 512)
   private String tags;
 
+  @Column(name = "properties", columnDefinition = "TEXT")
+  private String properties;
+
+  @Column(name = "extension_state", columnDefinition = "TEXT")
+  private String extensionState;
+
   public UUID getId() {
     return id;
   }
@@ -411,6 +417,22 @@ public class ArchivedJobEntity implements UuidV7EntityListener.UuidV7Assignable 
 
   public void setTags(String tags) {
     this.tags = tags;
+  }
+
+  public String getProperties() {
+    return properties;
+  }
+
+  public void setProperties(String properties) {
+    this.properties = properties;
+  }
+
+  public String getExtensionState() {
+    return extensionState;
+  }
+
+  public void setExtensionState(String extensionState) {
+    this.extensionState = extensionState;
   }
 
   @Override

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobExtensionStore.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/JobExtensionStore.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.spi;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.api.Incubating;
+
+/**
+ * Optional capability for generic per-job extension storage: write-once indexed scalar properties
+ * and mutable per-namespace structured state.
+ *
+ * <p>Two surfaces back this capability, both keyed by the owning job:
+ *
+ * <ul>
+ *   <li><b>Properties</b> ({@code scheduler_job_properties}) — flat {@code key → value} scalars,
+ *       namespaced by key convention ({@code ratchet-blocks.block_name}, {@code
+ *       ratchet-saga.compensation_target}, ...). Intended to be write-once at submission. Values
+ *       are <b>plaintext by design</b> so the query layer can index-match them; secrets MUST NOT be
+ *       written as properties — secret-capable data belongs in extension state, which is encrypted
+ *       at rest when payload encryption is configured.
+ *   <li><b>Extension state</b> ({@code scheduler_job_extension_state}) — one mutable JSON blob per
+ *       {@code (job, namespace)} with its own per-row version for optimistic CAS. The version is
+ *       independent of every other lock in the schema, so state updates never contend with the
+ *       claim path or status transitions. The stored blob runs through the configured {@code
+ *       PayloadEncryption} engine (encrypt before the CAS write, decrypt after the read); the
+ *       version always covers the stored — possibly ciphertext — bytes.
+ * </ul>
+ *
+ * <p>Both surfaces live in the hot store and follow the owning job through archiving: the archive
+ * path copies them onto the archive row, and the hot rows are removed with the hot job row.
+ *
+ * <p>Stores opt in by implementing this interface; callers probe via {@code
+ * jobStore.capability(JobExtensionStore.class)}.
+ */
+@Incubating
+public interface JobExtensionStore {
+
+  /**
+   * Writes one property for a job, replacing any existing value for the key.
+   *
+   * <p>Properties are intended to be write-once at submission; nothing in this contract prevents
+   * replacement, but values are designed to be stable for the job's lifetime.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}.
+   *
+   * @param jobId owning job id; never {@code null}
+   * @param key property key, namespaced by convention; never {@code null} or blank, at most 255
+   *     characters
+   * @param value property value, plaintext by design (no secrets); may be {@code null}, at most
+   *     1024 characters
+   */
+  void putProperty(UUID jobId, String key, String value);
+
+  /**
+   * Reads one property value for a job.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   *
+   * @param jobId owning job id; never {@code null}
+   * @param key property key; never {@code null}
+   * @return the stored value, or empty when the row is absent or holds a {@code null} value
+   */
+  Optional<String> getProperty(UUID jobId, String key);
+
+  /**
+   * Reads all properties of a job whose key starts with the given prefix.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   *
+   * @param jobId owning job id; never {@code null}
+   * @param prefix key prefix (typically a namespace such as {@code "ratchet-blocks."}); never
+   *     {@code null}, the empty prefix matches every property
+   * @return matching {@code key → value} entries ({@code null} values omitted); never {@code null}
+   */
+  Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix);
+
+  /**
+   * Reads the extension state for one {@code (job, namespace)}.
+   *
+   * <p>Transaction attribute: {@code SUPPORTS}.
+   *
+   * @param jobId owning job id; never {@code null}
+   * @param namespace extension namespace; never {@code null} or blank, at most 64 characters
+   * @return the decrypted state blob and its current version, or empty when absent
+   */
+  Optional<ExtensionState> getState(UUID jobId, String namespace);
+
+  /**
+   * Creates the extension-state row for a {@code (job, namespace)} at version 0.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}.
+   *
+   * @param jobId owning job id; never {@code null}
+   * @param namespace extension namespace; never {@code null} or blank, at most 64 characters
+   * @param initialState serialized JSON blob; never {@code null}
+   * @throws IllegalStateException when a row already exists for the {@code (job, namespace)}
+   */
+  void initState(UUID jobId, String namespace, String initialState);
+
+  /**
+   * Compare-and-set update of the extension state for one {@code (job, namespace)}.
+   *
+   * <p>The write succeeds only when the stored version equals {@code expectedVersion}; on success
+   * the version is incremented by one. Callers retry on a {@code false} return by re-reading the
+   * current state.
+   *
+   * <p>Transaction attribute: {@code REQUIRED}.
+   *
+   * @param jobId owning job id; never {@code null}
+   * @param namespace extension namespace; never {@code null}
+   * @param newState serialized JSON blob replacing the stored one; never {@code null}
+   * @param expectedVersion the version the caller read; must be non-negative
+   * @return {@code true} when the CAS write applied, {@code false} on version conflict or when the
+   *     row is absent
+   */
+  boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion);
+
+  /**
+   * One extension-state read: the decrypted JSON blob and the version that CAS updates must pass
+   * back as {@code expectedVersion}.
+   *
+   * @param json the decrypted state blob; never {@code null}
+   * @param version the row's current version; non-negative
+   */
+  record ExtensionState(String json, int version) {}
+}

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveExtensionData.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveExtensionData.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Function;
+
+public final class ArchiveExtensionData {
+
+  private static final int FIND_BY_IDS_CHUNK_SIZE = 500;
+
+  private final Map<UUID, Map<String, String>> propertiesByJobId;
+  private final Map<UUID, List<ExtensionArchiveJson.StateRow>> statesByJobId;
+
+  private ArchiveExtensionData(
+      Map<UUID, Map<String, String>> propertiesByJobId,
+      Map<UUID, List<ExtensionArchiveJson.StateRow>> statesByJobId) {
+    this.propertiesByJobId = propertiesByJobId;
+    this.statesByJobId = statesByJobId;
+  }
+
+  public static ArchiveExtensionData fetch(
+      EntityManager em,
+      Collection<UUID> jobIds,
+      Function<UUID, Object> idEncoder,
+      Function<Object, UUID> idDecoder) {
+    Objects.requireNonNull(em, "em");
+    Objects.requireNonNull(jobIds, "jobIds");
+    Objects.requireNonNull(idEncoder, "idEncoder");
+    Objects.requireNonNull(idDecoder, "idDecoder");
+    if (jobIds.isEmpty()) {
+      return new ArchiveExtensionData(Map.of(), Map.of());
+    }
+
+    Map<UUID, Map<String, String>> propertiesByJobId = new LinkedHashMap<>();
+    Map<UUID, List<ExtensionArchiveJson.StateRow>> statesByJobId = new LinkedHashMap<>();
+    List<UUID> ids = jobIds.stream().toList();
+    for (int start = 0; start < ids.size(); start += FIND_BY_IDS_CHUNK_SIZE) {
+      List<UUID> chunk = ids.subList(start, Math.min(start + FIND_BY_IDS_CHUNK_SIZE, ids.size()));
+      fetchProperties(em, chunk, idEncoder, idDecoder, propertiesByJobId);
+      fetchStates(em, chunk, idEncoder, idDecoder, statesByJobId);
+    }
+    return new ArchiveExtensionData(propertiesByJobId, statesByJobId);
+  }
+
+  public Map<String, String> properties(UUID jobId) {
+    return propertiesByJobId.getOrDefault(jobId, Map.of());
+  }
+
+  public List<ExtensionArchiveJson.StateRow> states(UUID jobId) {
+    return statesByJobId.getOrDefault(jobId, List.of());
+  }
+
+  private static void fetchProperties(
+      EntityManager em,
+      List<UUID> jobIds,
+      Function<UUID, Object> idEncoder,
+      Function<Object, UUID> idDecoder,
+      Map<UUID, Map<String, String>> propertiesByJobId) {
+    String placeholders = String.join(",", Collections.nCopies(jobIds.size(), "?"));
+    String sql =
+        """
+        SELECT job_id, property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id IN (%s)
+        """
+            .formatted(placeholders);
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = bindIds(em.createNativeQuery(sql), jobIds, idEncoder).getResultList();
+    for (Object[] row : rows) {
+      UUID jobId = idDecoder.apply(row[0]);
+      String value = RowValues.stringOrNull(row[2]);
+      if (value != null) {
+        propertiesByJobId
+            .computeIfAbsent(jobId, ignored -> new LinkedHashMap<>())
+            .put((String) row[1], value);
+      }
+    }
+  }
+
+  private static void fetchStates(
+      EntityManager em,
+      List<UUID> jobIds,
+      Function<UUID, Object> idEncoder,
+      Function<Object, UUID> idDecoder,
+      Map<UUID, List<ExtensionArchiveJson.StateRow>> statesByJobId) {
+    String placeholders = String.join(",", Collections.nCopies(jobIds.size(), "?"));
+    String sql =
+        """
+        SELECT job_id, namespace, state, encrypted_state, encryption_key_id, version, updated_at
+        FROM scheduler_job_extension_state
+        WHERE job_id IN (%s)
+        """
+            .formatted(placeholders);
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows = bindIds(em.createNativeQuery(sql), jobIds, idEncoder).getResultList();
+    for (Object[] row : rows) {
+      UUID jobId = idDecoder.apply(row[0]);
+      statesByJobId
+          .computeIfAbsent(jobId, ignored -> new ArrayList<>())
+          .add(
+              new ExtensionArchiveJson.StateRow(
+                  (String) row[1],
+                  RowValues.stringOrNull(row[2]),
+                  RowValues.booleanOrFalse(row[3]),
+                  RowValues.stringOrNull(row[4]),
+                  ((Number) row[5]).intValue(),
+                  RowValues.instantOrNull(row[6])));
+    }
+  }
+
+  private static Query bindIds(Query query, List<UUID> jobIds, Function<UUID, Object> idEncoder) {
+    int parameter = 1;
+    for (UUID id : jobIds) {
+      query.setParameter(parameter++, idEncoder.apply(id));
+    }
+    return query;
+  }
+}

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveParameterBinder.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveParameterBinder.java
@@ -25,7 +25,7 @@ import run.ratchet.store.entity.ArchivedJobEntity;
 /**
  * Shared archive-insert column list and positional parameter binder for the SQL stores.
  *
- * <p>The column list, the value placeholders, and the 31-parameter binding order are identical
+ * <p>The column list, the value placeholders, and the 33-parameter binding order are identical
  * across dialects; only the four UUID columns differ in encoding (MySQL stores {@code BINARY(16)},
  * PostgreSQL stores native {@code uuid}). Callers pass an {@code idEncoder} that maps a {@link
  * UUID} to its stored form.
@@ -40,16 +40,16 @@ public final class ArchiveParameterBinder {
       original_created_at, first_execution_time, completion_time,
       total_execution_time_ms, queue_wait_ms, archived_at, archived_by, archive_reason,
       job_result, result_type, final_error, payload_summary, depended_on, superseded_by,
-      tags
+      tags, properties, extension_state
       """;
 
   public static final String ARCHIVE_VALUE_PLACEHOLDERS =
-      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+      "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
   private ArchiveParameterBinder() {}
 
   /**
-   * Binds the 31 archive columns in schema order onto {@code query}, starting at positional index
+   * Binds the 33 archive columns in schema order onto {@code query}, starting at positional index
    * {@code parameter}. The four UUID columns ({@code archive_id}, {@code original_job_id}, {@code
    * depended_on}, {@code superseded_by}) are passed through {@code idEncoder}.
    *
@@ -88,6 +88,8 @@ public final class ArchiveParameterBinder {
     query.setParameter(parameter++, idEncoder.apply(archive.getDependedOn()));
     query.setParameter(parameter++, idEncoder.apply(archive.getSupersededBy()));
     query.setParameter(parameter++, archive.getTags());
+    query.setParameter(parameter++, archive.getProperties());
+    query.setParameter(parameter++, archive.getExtensionState());
     return parameter;
   }
 

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveRowMapper.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ArchiveRowMapper.java
@@ -30,7 +30,7 @@ import run.ratchet.store.entity.JobExecutionType;
 /** Maps explicit archive native-query projections into {@link ArchivedJobEntity} instances. */
 public final class ArchiveRowMapper {
 
-  public static final int COLUMN_COUNT = 31;
+  public static final int COLUMN_COUNT = 33;
 
   private ArchiveRowMapper() {}
 
@@ -76,6 +76,8 @@ public final class ArchiveRowMapper {
     archive.setDependedOn(uuidOrNull(cursor.next("depended_on")));
     archive.setSupersededBy(uuidOrNull(cursor.next("superseded_by")));
     archive.setTags(stringOrNull(cursor.next("tags")));
+    archive.setProperties(stringOrNull(cursor.next("properties")));
+    archive.setExtensionState(stringOrNull(cursor.next("extension_state")));
     return archive;
   }
 

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/EncryptionAad.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/EncryptionAad.java
@@ -97,4 +97,25 @@ public final class EncryptionAad {
   public static byte[] binding(String key) {
     return key == null ? new byte[0] : key.getBytes(UTF_8);
   }
+
+  /**
+   * Returns binding bytes for a surface bound to both an id and a string qualifier (the
+   * extension-state surface binds the owning job id and the namespace). Each component is
+   * length-prefixed so {@code (id="A", qualifier="BC")} cannot collide with {@code (id="AB",
+   * qualifier="C")}.
+   *
+   * @param id the binding id, or {@code null}
+   * @param qualifier the binding qualifier, or {@code null}
+   * @return the canonical binding bytes
+   */
+  public static byte[] binding(UUID id, String qualifier) {
+    byte[] idBytes = binding(id);
+    byte[] qualifierBytes = binding(qualifier);
+    return ByteBuffer.allocate(4 + idBytes.length + 4 + qualifierBytes.length)
+        .putInt(idBytes.length)
+        .put(idBytes)
+        .putInt(qualifierBytes.length)
+        .put(qualifierBytes)
+        .array();
+  }
 }

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/EncryptionTarget.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/EncryptionTarget.java
@@ -59,4 +59,13 @@ public record EncryptionTarget(ProtectedSurface surface, UUID jobId, byte[] bind
         parentJobId,
         EncryptionAad.binding(parentJobId));
   }
+
+  /**
+   * The extension-state surface, bound to the owning job id and the namespace so a blob cannot be
+   * relocated between jobs or between namespaces on the same job.
+   */
+  public static EncryptionTarget extensionState(UUID jobId, String namespace) {
+    return new EncryptionTarget(
+        ProtectedSurface.EXTENSION_STATE, jobId, EncryptionAad.binding(jobId, namespace));
+  }
 }

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ExtensionArchiveJson.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ExtensionArchiveJson.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObjectBuilder;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Serializes a job's extension properties and extension-state rows into the denormalized JSON
+ * carried on the archive row ({@code scheduler_job_archive.properties} / {@code .extension_state}).
+ *
+ * <p>The archive copy preserves the rows as stored: extension-state blobs that were encrypted at
+ * rest stay ciphertext (the frame remains bound to the original job id and namespace, so it can be
+ * decrypted later against {@code original_job_id}), and the {@code encrypted_state} / {@code
+ * encryption_key_id} metadata rides along for key-rotation accounting.
+ */
+public final class ExtensionArchiveJson {
+
+  private ExtensionArchiveJson() {}
+
+  /** One extension-state row as stored, copied verbatim into the archive JSON. */
+  public record StateRow(
+      String namespace,
+      String state,
+      boolean encryptedState,
+      String encryptionKeyId,
+      int version,
+      Instant updatedAt) {}
+
+  /**
+   * Serializes the property map to a JSON object, or {@code null} when the job has no properties
+   * (the archive column stays NULL rather than holding {@code {}}).
+   */
+  public static String propertiesJson(Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return null;
+    }
+    JsonObjectBuilder builder = Json.createObjectBuilder();
+    properties.forEach(builder::add);
+    return builder.build().toString();
+  }
+
+  /**
+   * Serializes the extension-state rows to a JSON array, or {@code null} when the job has none (the
+   * archive column stays NULL rather than holding {@code []}).
+   */
+  public static String extensionStateJson(List<StateRow> rows) {
+    if (rows == null || rows.isEmpty()) {
+      return null;
+    }
+    JsonArrayBuilder array = Json.createArrayBuilder();
+    for (StateRow row : rows) {
+      JsonObjectBuilder entry =
+          Json.createObjectBuilder()
+              .add("namespace", row.namespace())
+              .add("state", row.state())
+              .add("encrypted_state", row.encryptedState())
+              .add("version", row.version());
+      if (row.encryptionKeyId() != null) {
+        entry.add("encryption_key_id", row.encryptionKeyId());
+      }
+      if (row.updatedAt() != null) {
+        entry.add("updated_at", row.updatedAt().toString());
+      }
+      array.add(entry);
+    }
+    return array.build().toString();
+  }
+}

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ExtensionValidation.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ExtensionValidation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+/** Shared extension-argument validation used by store extension implementations. */
+public final class ExtensionValidation {
+
+  private ExtensionValidation() {}
+
+  public static void requireKey(String key) {
+    if (key == null || key.isBlank()) {
+      throw new IllegalArgumentException("property key must not be null or blank");
+    }
+  }
+
+  public static void requireNamespace(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+  }
+
+  public static void requireState(String state) {
+    if (state == null) {
+      throw new IllegalArgumentException("state must not be null");
+    }
+  }
+
+  public static String escapeLike(String raw) {
+    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+}

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ExtensionValidation.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/ExtensionValidation.java
@@ -18,17 +18,36 @@ package run.ratchet.store.util;
 /** Shared extension-argument validation used by store extension implementations. */
 public final class ExtensionValidation {
 
+  private static final int MAX_KEY_LENGTH = 255;
+  private static final int MAX_NAMESPACE_LENGTH = 64;
+  private static final int MAX_VALUE_LENGTH = 1024;
+
   private ExtensionValidation() {}
 
   public static void requireKey(String key) {
     if (key == null || key.isBlank()) {
       throw new IllegalArgumentException("property key must not be null or blank");
     }
+    if (key.length() > MAX_KEY_LENGTH) {
+      throw new IllegalArgumentException(
+          "property key must be at most " + MAX_KEY_LENGTH + " characters");
+    }
   }
 
   public static void requireNamespace(String namespace) {
     if (namespace == null || namespace.isBlank()) {
       throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+    if (namespace.length() > MAX_NAMESPACE_LENGTH) {
+      throw new IllegalArgumentException(
+          "namespace must be at most " + MAX_NAMESPACE_LENGTH + " characters");
+    }
+  }
+
+  public static void requireValue(String value) {
+    if (value != null && value.length() > MAX_VALUE_LENGTH) {
+      throw new IllegalArgumentException(
+          "property value must be at most " + MAX_VALUE_LENGTH + " characters");
     }
   }
 

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
@@ -26,6 +26,7 @@ import java.io.StringReader;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jboss.logging.Logger;
+import run.ratchet.spi.MaskingContext;
 import run.ratchet.store.converter.PayloadSerializerHolder;
 
 /**
@@ -42,6 +43,14 @@ public final class PayloadMasker {
 
   /** Masks sensitive fields in a job payload JSON string; returns null if input is null. */
   public static String maskPayload(String payloadJson) {
+    return maskPayload(payloadJson, null);
+  }
+
+  /**
+   * Context-aware variant of {@link #maskPayload(String)}: the active policy's context-aware
+   * overload is consulted per field. A {@code null} context falls back to name-only matching.
+   */
+  public static String maskPayload(String payloadJson, MaskingContext context) {
     if (payloadJson == null || payloadJson.isEmpty()) {
       return null;
     }
@@ -49,7 +58,7 @@ public final class PayloadMasker {
     try (JsonReader reader = Json.createReader(new StringReader(payloadJson))) {
       JsonValue root = reader.readValue();
       if (root.getValueType() == JsonValue.ValueType.OBJECT) {
-        return maskObject(root.asJsonObject()).build().toString();
+        return maskObject(root.asJsonObject(), context).build().toString();
       }
       // Array and scalar roots pass through unchanged: field-level masking only applies
       // when the root is an object.
@@ -64,13 +73,18 @@ public final class PayloadMasker {
    * Serializes {@code payload} to JSON then masks sensitive fields; returns null if input is null.
    */
   public static String maskPayload(Object payload) {
+    return maskPayload(payload, null);
+  }
+
+  /** Context-aware variant of {@link #maskPayload(Object)}. */
+  public static String maskPayload(Object payload, MaskingContext context) {
     if (payload == null) {
       return null;
     }
 
     try {
       String json = PayloadSerializerHolder.get().serialize(payload);
-      return maskPayload(json);
+      return maskPayload(json, context);
     } catch (Exception e) {
       log.warn("Payload serialization error, redacting entire payload", e);
       return MASKED_VALUE;
@@ -85,32 +99,40 @@ public final class PayloadMasker {
    * parameter values are opaque strings, not nested JSON.
    */
   public static Map<String, String> maskParams(Map<String, String> params) {
+    return maskParams(params, null);
+  }
+
+  /** Context-aware variant of {@link #maskParams(Map)}. */
+  public static Map<String, String> maskParams(Map<String, String> params, MaskingContext context) {
     if (params == null || params.isEmpty()) {
       return params;
     }
     Map<String, String> masked = new LinkedHashMap<>(params.size());
     for (var entry : params.entrySet()) {
       masked.put(
-          entry.getKey(), isSensitiveField(entry.getKey()) ? MASKED_VALUE : entry.getValue());
+          entry.getKey(),
+          isSensitiveField(entry.getKey(), context) ? MASKED_VALUE : entry.getValue());
     }
     return masked;
   }
 
-  private static boolean isSensitiveField(String fieldName) {
-    return PayloadMaskingPolicyHolder.get().isSensitiveField(fieldName);
+  private static boolean isSensitiveField(String fieldName, MaskingContext context) {
+    return context == null
+        ? PayloadMaskingPolicyHolder.get().isSensitiveField(fieldName)
+        : PayloadMaskingPolicyHolder.get().isSensitiveField(fieldName, context);
   }
 
-  private static JsonObjectBuilder maskObject(JsonObject object) {
+  private static JsonObjectBuilder maskObject(JsonObject object, MaskingContext context) {
     JsonObjectBuilder builder = Json.createObjectBuilder();
     for (var entry : object.entrySet()) {
       String key = entry.getKey();
       JsonValue value = entry.getValue();
-      if (isSensitiveField(key)) {
+      if (isSensitiveField(key, context)) {
         builder.add(key, MASKED_VALUE);
       } else if (value.getValueType() == JsonValue.ValueType.OBJECT) {
-        builder.add(key, maskObject(value.asJsonObject()));
+        builder.add(key, maskObject(value.asJsonObject(), context));
       } else if (value.getValueType() == JsonValue.ValueType.ARRAY) {
-        builder.add(key, maskArray(value.asJsonArray()));
+        builder.add(key, maskArray(value.asJsonArray(), context));
       } else {
         builder.add(key, value);
       }
@@ -118,13 +140,13 @@ public final class PayloadMasker {
     return builder;
   }
 
-  private static JsonArrayBuilder maskArray(JsonArray array) {
+  private static JsonArrayBuilder maskArray(JsonArray array, MaskingContext context) {
     JsonArrayBuilder builder = Json.createArrayBuilder();
     for (JsonValue item : array) {
       if (item.getValueType() == JsonValue.ValueType.OBJECT) {
-        builder.add(maskObject(item.asJsonObject()));
+        builder.add(maskObject(item.asJsonObject(), context));
       } else if (item.getValueType() == JsonValue.ValueType.ARRAY) {
-        builder.add(maskArray(item.asJsonArray()));
+        builder.add(maskArray(item.asJsonArray(), context));
       } else {
         builder.add(item);
       }

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/PayloadMasker.java
@@ -73,18 +73,13 @@ public final class PayloadMasker {
    * Serializes {@code payload} to JSON then masks sensitive fields; returns null if input is null.
    */
   public static String maskPayload(Object payload) {
-    return maskPayload(payload, null);
-  }
-
-  /** Context-aware variant of {@link #maskPayload(Object)}. */
-  public static String maskPayload(Object payload, MaskingContext context) {
     if (payload == null) {
       return null;
     }
 
     try {
       String json = PayloadSerializerHolder.get().serialize(payload);
-      return maskPayload(json, context);
+      return maskPayload(json);
     } catch (Exception e) {
       log.warn("Payload serialization error, redacting entire payload", e);
       return MASKED_VALUE;

--- a/stores/ratchet-store-core/src/test/java/run/ratchet/store/util/ExtensionValidationTest.java
+++ b/stores/ratchet-store-core/src/test/java/run/ratchet/store/util/ExtensionValidationTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.util;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class ExtensionValidationTest {
+
+  @Test
+  void requireKey_accepts255Characters() {
+    assertDoesNotThrow(() -> ExtensionValidation.requireKey("x".repeat(255)));
+  }
+
+  @Test
+  void requireKey_rejects256Characters() {
+    assertThrows(
+        IllegalArgumentException.class, () -> ExtensionValidation.requireKey("x".repeat(256)));
+  }
+
+  @Test
+  void requireNamespace_accepts64Characters() {
+    assertDoesNotThrow(() -> ExtensionValidation.requireNamespace("x".repeat(64)));
+  }
+
+  @Test
+  void requireNamespace_rejects65Characters() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> ExtensionValidation.requireNamespace("x".repeat(65)));
+  }
+
+  @Test
+  void requireValue_acceptsNull() {
+    assertDoesNotThrow(() -> ExtensionValidation.requireValue(null));
+  }
+
+  @Test
+  void requireValue_accepts1024Characters() {
+    assertDoesNotThrow(() -> ExtensionValidation.requireValue("x".repeat(1024)));
+  }
+
+  @Test
+  void requireValue_rejects1025Characters() {
+    assertThrows(
+        IllegalArgumentException.class, () -> ExtensionValidation.requireValue("x".repeat(1025)));
+  }
+}

--- a/stores/ratchet-store-core/src/test/java/run/ratchet/store/util/ExtensionValidationTest.java
+++ b/stores/ratchet-store-core/src/test/java/run/ratchet/store/util/ExtensionValidationTest.java
@@ -41,8 +41,7 @@ class ExtensionValidationTest {
   @Test
   void requireNamespace_rejects65Characters() {
     assertThrows(
-        IllegalArgumentException.class,
-        () -> ExtensionValidation.requireNamespace("x".repeat(65)));
+        IllegalArgumentException.class, () -> ExtensionValidation.requireNamespace("x".repeat(65)));
   }
 
   @Test

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/DocumentMapper.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/DocumentMapper.java
@@ -487,6 +487,8 @@ public final class DocumentMapper {
     doc.append("depended_on", a.getDependedOn());
     doc.append("superseded_by", a.getSupersededBy());
     doc.append("tags", a.getTags());
+    doc.append("properties", a.getProperties());
+    doc.append("extension_state", a.getExtensionState());
     return doc;
   }
 
@@ -576,6 +578,8 @@ public final class DocumentMapper {
     a.setDependedOn(doc.get("depended_on", UUID.class));
     a.setSupersededBy(doc.get("superseded_by", UUID.class));
     a.setTags(doc.getString("tags"));
+    a.setProperties(doc.getString("properties"));
+    a.setExtensionState(doc.getString("extension_state"));
     return a;
   }
 

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -27,12 +27,19 @@ import static com.mongodb.client.model.Sorts.ascending;
 import static com.mongodb.client.model.Sorts.descending;
 import static run.ratchet.store.mongodb.MongoFieldNames.ARCHIVED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.BUSINESS_KEY;
+import static run.ratchet.store.mongodb.MongoFieldNames.ENCRYPTED_STATE;
+import static run.ratchet.store.mongodb.MongoFieldNames.ENCRYPTION_KEY_ID;
 import static run.ratchet.store.mongodb.MongoFieldNames.ID;
 import static run.ratchet.store.mongodb.MongoFieldNames.JOB_ID;
+import static run.ratchet.store.mongodb.MongoFieldNames.NAMESPACE;
+import static run.ratchet.store.mongodb.MongoFieldNames.PROPERTY_KEY;
+import static run.ratchet.store.mongodb.MongoFieldNames.STATE;
 import static run.ratchet.store.mongodb.MongoFieldNames.STATUS;
 import static run.ratchet.store.mongodb.MongoFieldNames.TARGET_CLASS;
 import static run.ratchet.store.mongodb.MongoFieldNames.TERMINATED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.UPDATED_AT;
+import static run.ratchet.store.mongodb.MongoFieldNames.VALUE;
+import static run.ratchet.store.mongodb.MongoFieldNames.VERSION;
 
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.result.DeleteResult;
@@ -151,11 +158,17 @@ final class MongoArchiveOperations implements ArchiveStore {
     if (jobList.isEmpty()) {
       return 0;
     }
+    List<UUID> jobIds = jobList.stream().map(JobEntity::getId).toList();
+    Map<UUID, Map<String, String>> propertiesByJobId = extensionProperties(session, jobIds);
+    Map<UUID, List<ExtensionArchiveJson.StateRow>> statesByJobId = extensionStates(session, jobIds);
     List<Document> docs = new ArrayList<>(jobList.size());
     for (JobEntity job : jobList) {
       ArchivedJobEntity archive = buildArchive(job, reason, archivedBy);
       archive.setId(UuidV7Factory.create());
-      populateExtensionData(archive, job.getId());
+      populateExtensionData(
+          archive,
+          propertiesByJobId.getOrDefault(job.getId(), Map.of()),
+          statesByJobId.getOrDefault(job.getId(), List.of()));
       docs.add(DocumentMapper.toDocument(archive));
     }
     ctx.archives().insertMany(session, docs);
@@ -266,25 +279,67 @@ final class MongoArchiveOperations implements ArchiveStore {
   private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
     Map<String, String> properties = new LinkedHashMap<>();
     for (Document doc :
-        ctx.jobProperties().find(eq(JOB_ID, jobId)).sort(new Document("property_key", 1))) {
-      String value = doc.getString("value");
+        ctx.jobProperties().find(eq(JOB_ID, jobId)).sort(new Document(PROPERTY_KEY, 1))) {
+      String value = doc.getString(VALUE);
       if (value != null) {
-        properties.put(doc.getString("property_key"), value);
+        properties.put(doc.getString(PROPERTY_KEY), value);
       }
     }
-    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
 
     List<ExtensionArchiveJson.StateRow> states = new ArrayList<>();
     for (Document doc : ctx.jobExtensionState().find(eq(JOB_ID, jobId))) {
       states.add(
           new ExtensionArchiveJson.StateRow(
-              doc.getString("namespace"),
-              doc.getString("state"),
-              doc.getBoolean("encrypted_state", false),
-              doc.getString("encryption_key_id"),
-              doc.getInteger("version", 0),
-              DocumentMapper.toInstant(doc.getDate("updated_at"))));
+              doc.getString(NAMESPACE),
+              doc.getString(STATE),
+              doc.getBoolean(ENCRYPTED_STATE, false),
+              doc.getString(ENCRYPTION_KEY_ID),
+              doc.getInteger(VERSION, 0),
+              DocumentMapper.toInstant(doc.getDate(UPDATED_AT))));
     }
+    populateExtensionData(archive, properties, states);
+  }
+
+  private Map<UUID, Map<String, String>> extensionProperties(
+      ClientSession session, List<UUID> jobIds) {
+    Map<UUID, Map<String, String>> propertiesByJobId = new LinkedHashMap<>();
+    for (Document doc :
+        ctx.jobProperties().find(session, in(JOB_ID, jobIds)).sort(new Document(PROPERTY_KEY, 1))) {
+      String value = doc.getString(VALUE);
+      if (value != null) {
+        UUID jobId = doc.get(JOB_ID, UUID.class);
+        propertiesByJobId
+            .computeIfAbsent(jobId, ignored -> new LinkedHashMap<>())
+            .put(doc.getString(PROPERTY_KEY), value);
+      }
+    }
+    return propertiesByJobId;
+  }
+
+  private Map<UUID, List<ExtensionArchiveJson.StateRow>> extensionStates(
+      ClientSession session, List<UUID> jobIds) {
+    Map<UUID, List<ExtensionArchiveJson.StateRow>> statesByJobId = new LinkedHashMap<>();
+    for (Document doc : ctx.jobExtensionState().find(session, in(JOB_ID, jobIds))) {
+      UUID jobId = doc.get(JOB_ID, UUID.class);
+      statesByJobId
+          .computeIfAbsent(jobId, ignored -> new ArrayList<>())
+          .add(
+              new ExtensionArchiveJson.StateRow(
+                  doc.getString(NAMESPACE),
+                  doc.getString(STATE),
+                  doc.getBoolean(ENCRYPTED_STATE, false),
+                  doc.getString(ENCRYPTION_KEY_ID),
+                  doc.getInteger(VERSION, 0),
+                  DocumentMapper.toInstant(doc.getDate(UPDATED_AT))));
+    }
+    return statesByJobId;
+  }
+
+  private void populateExtensionData(
+      ArchivedJobEntity archive,
+      Map<String, String> properties,
+      List<ExtensionArchiveJson.StateRow> states) {
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
     archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
   }
 

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -28,6 +28,7 @@ import static com.mongodb.client.model.Sorts.descending;
 import static run.ratchet.store.mongodb.MongoFieldNames.ARCHIVED_AT;
 import static run.ratchet.store.mongodb.MongoFieldNames.BUSINESS_KEY;
 import static run.ratchet.store.mongodb.MongoFieldNames.ID;
+import static run.ratchet.store.mongodb.MongoFieldNames.JOB_ID;
 import static run.ratchet.store.mongodb.MongoFieldNames.STATUS;
 import static run.ratchet.store.mongodb.MongoFieldNames.TARGET_CLASS;
 import static run.ratchet.store.mongodb.MongoFieldNames.TERMINATED_AT;
@@ -38,7 +39,9 @@ import com.mongodb.client.result.DeleteResult;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import org.bson.Document;
@@ -48,6 +51,7 @@ import run.ratchet.store.entity.ArchivedJobEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.util.ExtensionArchiveJson;
 
 /**
  * Archive operations over {@code scheduler_job_archive}. Terminal-state jobs matching the retention
@@ -77,6 +81,7 @@ final class MongoArchiveOperations implements ArchiveStore {
   public ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy) {
     ArchivedJobEntity archive = buildArchive(job, reason, archivedBy);
     archive.setId(UuidV7Factory.create());
+    populateExtensionData(archive, job.getId());
     Document doc = DocumentMapper.toDocument(archive);
     try (ClientSession session = ctx.startSession()) {
       session.withTransaction(
@@ -93,6 +98,7 @@ final class MongoArchiveOperations implements ArchiveStore {
               throw new RatchetTransientStoreException(
                   "Archive raced a status change on job " + job.getId() + "; rolling back");
             }
+            deleteExtensionData(session, List.of(job.getId()));
             return Boolean.TRUE;
           });
     } catch (RuntimeException e) {
@@ -131,6 +137,7 @@ final class MongoArchiveOperations implements ArchiveStore {
                         + deleted.getDeletedCount()
                         + "; rolling back");
               }
+              deleteExtensionData(session, ids);
             }
             return archived;
           });
@@ -148,6 +155,7 @@ final class MongoArchiveOperations implements ArchiveStore {
     for (JobEntity job : jobList) {
       ArchivedJobEntity archive = buildArchive(job, reason, archivedBy);
       archive.setId(UuidV7Factory.create());
+      populateExtensionData(archive, job.getId());
       docs.add(DocumentMapper.toDocument(archive));
     }
     ctx.archives().insertMany(session, docs);
@@ -248,5 +256,44 @@ final class MongoArchiveOperations implements ArchiveStore {
       a.setTags(String.join(",", job.getTags()));
     }
     return a;
+  }
+
+  /**
+   * Copies the job's extension properties and extension-state docs onto the archive entity as the
+   * denormalized JSON the archive row carries (state blobs stay as stored — ciphertext when
+   * encrypted at rest).
+   */
+  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
+    Map<String, String> properties = new LinkedHashMap<>();
+    for (Document doc :
+        ctx.jobProperties().find(eq(JOB_ID, jobId)).sort(new Document("property_key", 1))) {
+      String value = doc.getString("value");
+      if (value != null) {
+        properties.put(doc.getString("property_key"), value);
+      }
+    }
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+
+    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>();
+    for (Document doc : ctx.jobExtensionState().find(eq(JOB_ID, jobId))) {
+      states.add(
+          new ExtensionArchiveJson.StateRow(
+              doc.getString("namespace"),
+              doc.getString("state"),
+              doc.getBoolean("encrypted_state", false),
+              doc.getString("encryption_key_id"),
+              doc.getInteger("version", 0),
+              DocumentMapper.toInstant(doc.getDate("updated_at"))));
+    }
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
+  }
+
+  /**
+   * Removes the hot extension docs for archived jobs in the archive session — the Mongo equivalent
+   * of the SQL FK CASCADE that fires when the hot job row is deleted after archiving.
+   */
+  private void deleteExtensionData(ClientSession session, List<UUID> jobIds) {
+    ctx.jobProperties().deleteMany(session, in(JOB_ID, jobIds));
+    ctx.jobExtensionState().deleteMany(session, in(JOB_ID, jobIds));
   }
 }

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoArchiveOperations.java
@@ -88,11 +88,16 @@ final class MongoArchiveOperations implements ArchiveStore {
   public ArchivedJobEntity archiveJob(JobEntity job, String reason, String archivedBy) {
     ArchivedJobEntity archive = buildArchive(job, reason, archivedBy);
     archive.setId(UuidV7Factory.create());
-    populateExtensionData(archive, job.getId());
-    Document doc = DocumentMapper.toDocument(archive);
     try (ClientSession session = ctx.startSession()) {
       session.withTransaction(
           () -> {
+            populateExtensionData(
+                archive,
+                extensionProperties(session, List.of(job.getId()))
+                    .getOrDefault(job.getId(), Map.of()),
+                extensionStates(session, List.of(job.getId()))
+                    .getOrDefault(job.getId(), List.of()));
+            Document doc = DocumentMapper.toDocument(archive);
             ctx.archives().insertOne(session, doc);
             // Only delete a job that is still terminal: a concurrent reset to PENDING must not be
             // archived away. If nothing was deleted, the snapshot is stale, so roll back.
@@ -269,35 +274,6 @@ final class MongoArchiveOperations implements ArchiveStore {
       a.setTags(String.join(",", job.getTags()));
     }
     return a;
-  }
-
-  /**
-   * Copies the job's extension properties and extension-state docs onto the archive entity as the
-   * denormalized JSON the archive row carries (state blobs stay as stored — ciphertext when
-   * encrypted at rest).
-   */
-  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
-    Map<String, String> properties = new LinkedHashMap<>();
-    for (Document doc :
-        ctx.jobProperties().find(eq(JOB_ID, jobId)).sort(new Document(PROPERTY_KEY, 1))) {
-      String value = doc.getString(VALUE);
-      if (value != null) {
-        properties.put(doc.getString(PROPERTY_KEY), value);
-      }
-    }
-
-    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>();
-    for (Document doc : ctx.jobExtensionState().find(eq(JOB_ID, jobId))) {
-      states.add(
-          new ExtensionArchiveJson.StateRow(
-              doc.getString(NAMESPACE),
-              doc.getString(STATE),
-              doc.getBoolean(ENCRYPTED_STATE, false),
-              doc.getString(ENCRYPTION_KEY_ID),
-              doc.getInteger(VERSION, 0),
-              DocumentMapper.toInstant(doc.getDate(UPDATED_AT))));
-    }
-    populateExtensionData(archive, properties, states);
   }
 
   private Map<UUID, Map<String, String>> extensionProperties(

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoCollectionInitializer.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoCollectionInitializer.java
@@ -85,6 +85,35 @@ class MongoCollectionInitializer {
     createDlqAlertIndexes();
     createResourceLimitIndexes();
     createResourcePermitIndexes();
+    createJobPropertiesIndexes();
+    createJobExtensionStateIndexes();
+  }
+
+  private void createJobPropertiesIndexes() {
+    var coll = database.getCollection("scheduler_job_properties");
+    // Uniqueness mirror of the SQL PK (job_id, property_key); claim-correctness is not at stake
+    // but upsert semantics depend on it, so it is required.
+    createRequiredIndex(
+        coll,
+        Indexes.compoundIndex(Indexes.ascending("job_id"), Indexes.ascending("property_key")),
+        new IndexOptions().name("uk_job_property").unique(true));
+    // Cross-job (property_key, value) filter support for the query layer.
+    createRequiredIndex(
+        coll,
+        Indexes.compoundIndex(Indexes.ascending("property_key"), Indexes.ascending("value")),
+        new IndexOptions().name("idx_property_kv"));
+  }
+
+  private void createJobExtensionStateIndexes() {
+    var coll = database.getCollection("scheduler_job_extension_state");
+    // Uniqueness mirror of the SQL PK (job_id, namespace); initState duplicate detection and the
+    // CAS update path both depend on one row per (job, namespace).
+    createRequiredIndex(
+        coll,
+        Indexes.compoundIndex(Indexes.ascending("job_id"), Indexes.ascending("namespace")),
+        new IndexOptions().name("uk_job_extension_namespace").unique(true));
+    // Key-rotation drain check, mirroring idx_job_encryption_key_id on the job table.
+    createIndex(coll, Indexes.ascending("encryption_key_id"), "idx_extension_state_key_id");
   }
 
   private void createJobIndexes() {

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoExtensionOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoExtensionOperations.java
@@ -21,7 +21,18 @@ import static com.mongodb.client.model.Filters.regex;
 import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.inc;
 import static com.mongodb.client.model.Updates.set;
+import static run.ratchet.store.mongodb.MongoFieldNames.ENCRYPTED_STATE;
+import static run.ratchet.store.mongodb.MongoFieldNames.ENCRYPTION_KEY_ID;
 import static run.ratchet.store.mongodb.MongoFieldNames.JOB_ID;
+import static run.ratchet.store.mongodb.MongoFieldNames.NAMESPACE;
+import static run.ratchet.store.mongodb.MongoFieldNames.PROPERTY_KEY;
+import static run.ratchet.store.mongodb.MongoFieldNames.STATE;
+import static run.ratchet.store.mongodb.MongoFieldNames.UPDATED_AT;
+import static run.ratchet.store.mongodb.MongoFieldNames.VALUE;
+import static run.ratchet.store.mongodb.MongoFieldNames.VERSION;
+import static run.ratchet.store.util.ExtensionValidation.requireKey;
+import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
+import static run.ratchet.store.util.ExtensionValidation.requireState;
 
 import com.mongodb.MongoException;
 import com.mongodb.client.model.UpdateOptions;
@@ -53,15 +64,6 @@ import run.ratchet.store.util.PayloadEncryptor;
  * encrypted_state = false}.
  */
 final class MongoExtensionOperations implements JobExtensionStore {
-
-  private static final String PROPERTY_KEY = "property_key";
-  private static final String VALUE = "value";
-  private static final String NAMESPACE = "namespace";
-  private static final String STATE = "state";
-  private static final String ENCRYPTED_STATE = "encrypted_state";
-  private static final String ENCRYPTION_KEY_ID = "encryption_key_id";
-  private static final String VERSION = "version";
-  private static final String UPDATED_AT = "updated_at";
 
   private final MongoStoreContext ctx;
 
@@ -172,23 +174,5 @@ final class MongoExtensionOperations implements JobExtensionStore {
                     inc(VERSION, 1),
                     set(UPDATED_AT, DocumentMapper.toDate(Instant.now()))));
     return result.getModifiedCount() > 0;
-  }
-
-  private static void requireKey(String key) {
-    if (key == null || key.isBlank()) {
-      throw new IllegalArgumentException("property key must not be null or blank");
-    }
-  }
-
-  private static void requireNamespace(String namespace) {
-    if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace must not be null or blank");
-    }
-  }
-
-  private static void requireState(String state) {
-    if (state == null) {
-      throw new IllegalArgumentException("state must not be null");
-    }
   }
 }

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoExtensionOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoExtensionOperations.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.regex;
+import static com.mongodb.client.model.Updates.combine;
+import static com.mongodb.client.model.Updates.inc;
+import static com.mongodb.client.model.Updates.set;
+import static run.ratchet.store.mongodb.MongoFieldNames.JOB_ID;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.result.UpdateResult;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.bson.Document;
+import run.ratchet.store.converter.EncryptionHolder;
+import run.ratchet.store.spi.JobExtensionStore;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.PayloadEncryptor;
+
+/**
+ * MongoDB implementation of {@link JobExtensionStore}.
+ *
+ * <p>Properties and extension state live in their own collections ({@code scheduler_job_properties}
+ * and {@code scheduler_job_extension_state}), NOT as sub-documents on the job document: the job
+ * save path is a whole-document {@code replaceOne}, which would silently wipe embedded extension
+ * data on every job update. Separate collections also mirror the SQL table shape one-to-one.
+ *
+ * <p>Property values are plaintext by design (indexed for the query layer). Extension-state blobs
+ * follow the deployment-wide payload-encryption switch: when it is on, the {@code state} field
+ * holds a ciphertext frame bound to {@code (job_id, namespace)}; otherwise plaintext with {@code
+ * encrypted_state = false}.
+ */
+final class MongoExtensionOperations implements JobExtensionStore {
+
+  private static final String PROPERTY_KEY = "property_key";
+  private static final String VALUE = "value";
+  private static final String NAMESPACE = "namespace";
+  private static final String STATE = "state";
+  private static final String ENCRYPTED_STATE = "encrypted_state";
+  private static final String ENCRYPTION_KEY_ID = "encryption_key_id";
+  private static final String VERSION = "version";
+  private static final String UPDATED_AT = "updated_at";
+
+  private final MongoStoreContext ctx;
+
+  MongoExtensionOperations(MongoStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    requireKey(key);
+    ctx.jobProperties()
+        .updateOne(
+            and(eq(JOB_ID, jobId), eq(PROPERTY_KEY, key)),
+            combine(set(VALUE, value), set(JOB_ID, jobId), set(PROPERTY_KEY, key)),
+            new UpdateOptions().upsert(true));
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    requireKey(key);
+    Document doc = ctx.jobProperties().find(and(eq(JOB_ID, jobId), eq(PROPERTY_KEY, key))).first();
+    if (doc == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(doc.getString(VALUE));
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("prefix must not be null");
+    }
+    Map<String, String> result = new LinkedHashMap<>();
+    var filter =
+        prefix.isEmpty()
+            ? eq(JOB_ID, jobId)
+            : and(eq(JOB_ID, jobId), regex(PROPERTY_KEY, "^" + Pattern.quote(prefix)));
+    for (Document doc : ctx.jobProperties().find(filter).sort(new Document(PROPERTY_KEY, 1))) {
+      String value = doc.getString(VALUE);
+      if (value != null) {
+        result.put(doc.getString(PROPERTY_KEY), value);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    requireNamespace(namespace);
+    Document doc =
+        ctx.jobExtensionState().find(and(eq(JOB_ID, jobId), eq(NAMESPACE, namespace))).first();
+    if (doc == null) {
+      return Optional.empty();
+    }
+    String json =
+        PayloadEncryptor.decryptValue(
+            doc.getString(STATE), EncryptionTarget.extensionState(jobId, namespace));
+    return Optional.of(new ExtensionState(json, doc.getInteger(VERSION, 0)));
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    requireNamespace(namespace);
+    requireState(initialState);
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            initialState, active, EncryptionTarget.extensionState(jobId, namespace));
+    Document doc =
+        new Document(JOB_ID, jobId)
+            .append(NAMESPACE, namespace)
+            .append(STATE, stored)
+            .append(ENCRYPTED_STATE, active)
+            .append(ENCRYPTION_KEY_ID, JobEncryption.keyId(active))
+            .append(VERSION, 0)
+            .append(UPDATED_AT, DocumentMapper.toDate(Instant.now()));
+    try {
+      ctx.jobExtensionState().insertOne(doc);
+    } catch (MongoException e) {
+      if (ctx.constraintDetector().isDuplicateKey(e)) {
+        throw new IllegalStateException(
+            "extension state already initialized for job " + jobId + " namespace " + namespace, e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    requireNamespace(namespace);
+    requireState(newState);
+    if (expectedVersion < 0) {
+      throw new IllegalArgumentException(
+          "expectedVersion must be non-negative: " + expectedVersion);
+    }
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            newState, active, EncryptionTarget.extensionState(jobId, namespace));
+    UpdateResult result =
+        ctx.jobExtensionState()
+            .updateOne(
+                and(eq(JOB_ID, jobId), eq(NAMESPACE, namespace), eq(VERSION, expectedVersion)),
+                combine(
+                    set(STATE, stored),
+                    set(ENCRYPTED_STATE, active),
+                    set(ENCRYPTION_KEY_ID, JobEncryption.keyId(active)),
+                    inc(VERSION, 1),
+                    set(UPDATED_AT, DocumentMapper.toDate(Instant.now()))));
+    return result.getModifiedCount() > 0;
+  }
+
+  private static void requireKey(String key) {
+    if (key == null || key.isBlank()) {
+      throw new IllegalArgumentException("property key must not be null or blank");
+    }
+  }
+
+  private static void requireNamespace(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+  }
+
+  private static void requireState(String state) {
+    if (state == null) {
+      throw new IllegalArgumentException("state must not be null");
+    }
+  }
+}

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoExtensionOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoExtensionOperations.java
@@ -33,6 +33,7 @@ import static run.ratchet.store.mongodb.MongoFieldNames.VERSION;
 import static run.ratchet.store.util.ExtensionValidation.requireKey;
 import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
 import static run.ratchet.store.util.ExtensionValidation.requireState;
+import static run.ratchet.store.util.ExtensionValidation.requireValue;
 
 import com.mongodb.MongoException;
 import com.mongodb.client.model.UpdateOptions;
@@ -74,6 +75,7 @@ final class MongoExtensionOperations implements JobExtensionStore {
   @Override
   public void putProperty(UUID jobId, String key, String value) {
     requireKey(key);
+    requireValue(value);
     ctx.jobProperties()
         .updateOne(
             and(eq(JOB_ID, jobId), eq(PROPERTY_KEY, key)),

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoFieldNames.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoFieldNames.java
@@ -76,6 +76,13 @@ final class MongoFieldNames {
   // Job execution attempt
   static final String JOB_ID = "job_id";
   static final String ATTEMPT = "attempt";
+  // Extension properties / state
+  static final String PROPERTY_KEY = "property_key";
+  static final String VALUE = "value";
+  static final String NAMESPACE = "namespace";
+  static final String STATE = "state";
+  static final String ENCRYPTED_STATE = "encrypted_state";
+  static final String ENCRYPTION_KEY_ID = "encryption_key_id";
   // Job log
   static final String TS = "ts";
   // Archive

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -141,6 +142,28 @@ final class MongoJobQueryOperations {
       return;
     }
     conditions.add(eq(MongoFieldNames.DEPENDS_ON, parentJobId));
+  }
+
+  /**
+   * Compiles property filters against the separate {@code scheduler_job_properties} collection: one
+   * pre-query per key resolving the matching job ids, then an {@code _id IN} condition per key, so
+   * multiple keys intersect (AND semantics) on the main query.
+   */
+  private void appendPropertyConditions(JobFilter filter, List<Bson> conditions) {
+    Map<String, Set<String>> propertyFilters = filter.propertyFilters();
+    if (propertyFilters == null || propertyFilters.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, Set<String>> entry : propertyFilters.entrySet()) {
+      List<UUID> matching =
+          ctx.jobProperties()
+              .distinct(
+                  "job_id",
+                  and(eq("property_key", entry.getKey()), in("value", entry.getValue())),
+                  UUID.class)
+              .into(new ArrayList<>());
+      conditions.add(in(MongoFieldNames.ID, matching));
+    }
   }
 
   private static void appendTagCondition(JobFilter filter, List<Bson> conditions) {
@@ -412,6 +435,7 @@ final class MongoJobQueryOperations {
         MongoFieldNames.TRACE_CONTEXT + ".traceparent", filter.traceCorrelationId(), conditions);
     appendParentJobId(filter, conditions);
     appendTagCondition(filter, conditions);
+    appendPropertyConditions(filter, conditions);
     appendInstantGte(MongoFieldNames.CREATED_AT, filter.createdAfter(), conditions);
     appendInstantLt(MongoFieldNames.CREATED_AT, filter.createdBefore(), conditions);
     appendInstantGte(MongoFieldNames.SCHEDULED_TIME, filter.scheduledAfter(), conditions);

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobQueryOperations.java
@@ -158,8 +158,10 @@ final class MongoJobQueryOperations {
       List<UUID> matching =
           ctx.jobProperties()
               .distinct(
-                  "job_id",
-                  and(eq("property_key", entry.getKey()), in("value", entry.getValue())),
+                  MongoFieldNames.JOB_ID,
+                  and(
+                      eq(MongoFieldNames.PROPERTY_KEY, entry.getKey()),
+                      in(MongoFieldNames.VALUE, entry.getValue())),
                   UUID.class)
               .into(new ArrayList<>());
       conditions.add(in(MongoFieldNames.ID, matching));

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStore.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStore.java
@@ -20,6 +20,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -51,4 +52,5 @@ public interface MongoJobStore
         JobQueryStore,
         JobAnalyticsStore,
         JobAuditStore,
-        DlqAlertStore {}
+        DlqAlertStore,
+        JobExtensionStore {}

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
@@ -77,6 +77,7 @@ class MongoJobStoreImpl implements MongoJobStore {
   private final MongoJobQueryOperations query;
   private final MongoSignalOperations signals;
   private final MongoRecurringJobOperations recurringJobs;
+  private final MongoExtensionOperations extensions;
 
   /**
    * Package-private no-arg constructor required for Weld client-proxy generation (CDI 4.0 §3.15).
@@ -98,6 +99,7 @@ class MongoJobStoreImpl implements MongoJobStore {
     this.query = null;
     this.signals = null;
     this.recurringJobs = null;
+    this.extensions = null;
   }
 
   MongoJobStoreImpl(MongoClient client, MongoDatabase database, RatchetOptions options) {
@@ -127,6 +129,7 @@ class MongoJobStoreImpl implements MongoJobStore {
     this.query = new MongoJobQueryOperations(ctx);
     this.signals = new MongoSignalOperations(ctx);
     this.recurringJobs = new MongoRecurringJobOperations(ctx);
+    this.extensions = new MongoExtensionOperations(ctx);
   }
 
   @Override
@@ -918,5 +921,37 @@ class MongoJobStoreImpl implements MongoJobStore {
   @Override
   public List<run.ratchet.store.spi.RecurringJobDefinition> listAll() {
     return recurringJobs.listAll();
+  }
+
+  // ---------- JobExtensionStore delegates ----------
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    extensions.putProperty(jobId, key, value);
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    return extensions.getProperty(jobId, key);
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    return extensions.getPropertiesByPrefix(jobId, prefix);
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    return extensions.getState(jobId, namespace);
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    extensions.initState(jobId, namespace, initialState);
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    return extensions.updateState(jobId, namespace, newState, expectedVersion);
   }
 }

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoStoreContext.java
@@ -167,4 +167,12 @@ final class MongoStoreContext extends AbstractStoreContext {
   MongoCollection<Document> recurringJobArchive() {
     return database.getCollection("scheduler_recurring_job_archive");
   }
+
+  MongoCollection<Document> jobProperties() {
+    return database.getCollection("scheduler_job_properties");
+  }
+
+  MongoCollection<Document> jobExtensionState() {
+    return database.getCollection("scheduler_job_extension_state");
+  }
 }

--- a/stores/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoJobExtensionStoreContractTest.java
+++ b/stores/ratchet-store-mongodb/src/test/java/run/ratchet/store/mongodb/MongoJobExtensionStoreContractTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mongodb;
+
+import org.junit.jupiter.api.AfterAll;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobExtensionStoreContract;
+
+/** MongoDB contract test for {@code JobExtensionStore} operations. */
+class MongoJobExtensionStoreContractTest extends AbstractJobExtensionStoreContract {
+
+  private static final MongoTestFixture fixture = new MongoTestFixture();
+
+  @AfterAll
+  static void closeFixture() {
+    fixture.close();
+  }
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
@@ -20,7 +20,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,6 +31,7 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
 import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.util.ArchiveExtensionData;
 import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
@@ -87,7 +87,8 @@ final class MysqlArchiveOperations implements ArchiveStore {
       JobEntity hydrated = hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
-      populateExtensionData(archive, hydrated.getId());
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(List.of(hydrated.getId()));
+      populateExtensionData(archive, extensionData, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, UuidByteArrayConverter::toBytes);
       query.executeUpdate();
@@ -115,6 +116,7 @@ final class MysqlArchiveOperations implements ArchiveStore {
           jobs.findByIds(ids).stream()
               .collect(Collectors.toMap(JobEntity::getId, Function.identity()));
       List<ArchivedJobEntity> archives = new ArrayList<>(jobsToArchive.size());
+      List<UUID> archiveIds = new ArrayList<>(jobsToArchive.size());
       for (UUID id : ids) {
         JobEntity hydrated = hydratedById.get(id);
         if (hydrated == null) {
@@ -122,8 +124,12 @@ final class MysqlArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
-        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
+        archiveIds.add(hydrated.getId());
+      }
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(archiveIds);
+      for (int i = 0; i < archives.size(); i++) {
+        populateExtensionData(archives.get(i), extensionData, archiveIds.get(i));
       }
 
       String rows =
@@ -244,53 +250,14 @@ final class MysqlArchiveOperations implements ArchiveStore {
         .orElseThrow(() -> new IllegalStateException("Job not found for archival: " + job.getId()));
   }
 
-  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
-    // language=MySQL
-    String propertySql =
-        """
-        SELECT property_key, value
-        FROM scheduler_job_properties
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> propertyRows =
-        ctx.em()
-            .createNativeQuery(propertySql)
-            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
-            .getResultList();
-    Map<String, String> properties = new LinkedHashMap<>();
-    for (Object[] row : propertyRows) {
-      String value = RowValues.stringOrNull(row[1]);
-      if (value != null) {
-        properties.put((String) row[0], value);
-      }
-    }
-    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+  private ArchiveExtensionData fetchArchiveExtensionData(List<UUID> jobIds) {
+    return ArchiveExtensionData.fetch(
+        ctx.em(), jobIds, UuidByteArrayConverter::toBytes, RowValues::uuidOrNull);
+  }
 
-    // language=MySQL
-    String stateSql =
-        """
-        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
-        FROM scheduler_job_extension_state
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> stateRows =
-        ctx.em()
-            .createNativeQuery(stateSql)
-            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
-            .getResultList();
-    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
-    for (Object[] row : stateRows) {
-      states.add(
-          new ExtensionArchiveJson.StateRow(
-              (String) row[0],
-              RowValues.stringOrNull(row[1]),
-              RowValues.booleanOrFalse(row[2]),
-              RowValues.stringOrNull(row[3]),
-              ((Number) row[4]).intValue(),
-              RowValues.instantOrNull(row[5])));
-    }
-    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
+  private void populateExtensionData(
+      ArchivedJobEntity archive, ArchiveExtensionData extensionData, UUID jobId) {
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(extensionData.properties(jobId)));
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(extensionData.states(jobId)));
   }
 }

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlArchiveOperations.java
@@ -20,6 +20,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -35,6 +36,7 @@ import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.ExtensionArchiveJson;
 import run.ratchet.store.util.RowValues;
 
 final class MysqlArchiveOperations implements ArchiveStore {
@@ -85,6 +87,7 @@ final class MysqlArchiveOperations implements ArchiveStore {
       JobEntity hydrated = hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
+      populateExtensionData(archive, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, UuidByteArrayConverter::toBytes);
       query.executeUpdate();
@@ -119,6 +122,7 @@ final class MysqlArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
+        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
       }
 
@@ -238,5 +242,55 @@ final class MysqlArchiveOperations implements ArchiveStore {
   private JobEntity hydrateForArchive(JobEntity job) {
     return jobs.findById(job.getId())
         .orElseThrow(() -> new IllegalStateException("Job not found for archival: " + job.getId()));
+  }
+
+  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
+    // language=MySQL
+    String propertySql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> propertyRows =
+        ctx.em()
+            .createNativeQuery(propertySql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .getResultList();
+    Map<String, String> properties = new LinkedHashMap<>();
+    for (Object[] row : propertyRows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        properties.put((String) row[0], value);
+      }
+    }
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+
+    // language=MySQL
+    String stateSql =
+        """
+        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
+        FROM scheduler_job_extension_state
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> stateRows =
+        ctx.em()
+            .createNativeQuery(stateSql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .getResultList();
+    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
+    for (Object[] row : stateRows) {
+      states.add(
+          new ExtensionArchiveJson.StateRow(
+              (String) row[0],
+              RowValues.stringOrNull(row[1]),
+              RowValues.booleanOrFalse(row[2]),
+              RowValues.stringOrNull(row[3]),
+              ((Number) row[4]).intValue(),
+              RowValues.instantOrNull(row[5])));
+    }
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
   }
 }

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlExtensionOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlExtensionOperations.java
@@ -19,6 +19,7 @@ import static run.ratchet.store.util.ExtensionValidation.escapeLike;
 import static run.ratchet.store.util.ExtensionValidation.requireKey;
 import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
 import static run.ratchet.store.util.ExtensionValidation.requireState;
+import static run.ratchet.store.util.ExtensionValidation.requireValue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -54,6 +55,7 @@ final class MysqlExtensionOperations implements JobExtensionStore {
   @Override
   public void putProperty(UUID jobId, String key, String value) {
     requireKey(key);
+    requireValue(value);
     // language=MySQL
     String sql =
         """

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlExtensionOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlExtensionOperations.java
@@ -15,6 +15,11 @@
  */
 package run.ratchet.store.mysql;
 
+import static run.ratchet.store.util.ExtensionValidation.escapeLike;
+import static run.ratchet.store.util.ExtensionValidation.requireKey;
+import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
+import static run.ratchet.store.util.ExtensionValidation.requireState;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -210,27 +215,5 @@ final class MysqlExtensionOperations implements JobExtensionStore {
             .setParameter(7, expectedVersion)
             .executeUpdate();
     return updated > 0;
-  }
-
-  private static void requireKey(String key) {
-    if (key == null || key.isBlank()) {
-      throw new IllegalArgumentException("property key must not be null or blank");
-    }
-  }
-
-  private static void requireNamespace(String namespace) {
-    if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace must not be null or blank");
-    }
-  }
-
-  private static void requireState(String state) {
-    if (state == null) {
-      throw new IllegalArgumentException("state must not be null");
-    }
-  }
-
-  private static String escapeLike(String raw) {
-    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
   }
 }

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlExtensionOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlExtensionOperations.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mysql;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.store.converter.EncryptionHolder;
+import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
+import run.ratchet.store.spi.JobExtensionStore;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.PayloadEncryptor;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * MySQL implementation of {@link JobExtensionStore}.
+ *
+ * <p>Property values are plaintext by design (indexed for the query layer). Extension-state blobs
+ * follow the deployment-wide payload-encryption switch: when it is on, the {@code state} column
+ * holds a ciphertext frame bound to {@code (job_id, namespace)}; otherwise plaintext with {@code
+ * encrypted_state = FALSE}.
+ */
+final class MysqlExtensionOperations implements JobExtensionStore {
+
+  private final MysqlStoreContext ctx;
+
+  MysqlExtensionOperations(MysqlStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    requireKey(key);
+    // language=MySQL
+    String sql =
+        """
+        INSERT INTO scheduler_job_properties (job_id, property_key, value)
+        VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE value = VALUES(value)
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+        .setParameter(2, key)
+        .setParameter(3, value)
+        .executeUpdate();
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    requireKey(key);
+    // language=MySQL
+    String sql =
+        """
+        SELECT value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(2, key)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(RowValues.stringOrNull(rows.get(0)));
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("prefix must not be null");
+    }
+    // language=MySQL
+    String sql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key LIKE ? ESCAPE '\\\\'
+        ORDER BY property_key
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(2, escapeLike(prefix) + "%")
+            .getResultList();
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Object[] row : rows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        result.put((String) row[0], value);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    requireNamespace(namespace);
+    // language=MySQL
+    String sql =
+        """
+        SELECT state, version
+        FROM scheduler_job_extension_state
+        WHERE job_id = ? AND namespace = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(2, namespace)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    Object[] row = rows.get(0);
+    String stored = RowValues.stringOrNull(row[0]);
+    String json =
+        PayloadEncryptor.decryptValue(stored, EncryptionTarget.extensionState(jobId, namespace));
+    return Optional.of(new ExtensionState(json, ((Number) row[1]).intValue()));
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    requireNamespace(namespace);
+    requireState(initialState);
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            initialState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=MySQL
+    String sql =
+        """
+        INSERT INTO scheduler_job_extension_state
+          (job_id, namespace, state, encrypted_state, encryption_key_id, version, updated_at)
+        VALUES (?, ?, ?, ?, ?, 0, ?)
+        """;
+    try {
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+          .setParameter(2, namespace)
+          .setParameter(3, stored)
+          .setParameter(4, active)
+          .setParameter(5, JobEncryption.keyId(active))
+          .setParameter(6, Timestamp.from(Instant.now()))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateKey(e)) {
+        throw new IllegalStateException(
+            "extension state already initialized for job " + jobId + " namespace " + namespace, e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    requireNamespace(namespace);
+    requireState(newState);
+    if (expectedVersion < 0) {
+      throw new IllegalArgumentException(
+          "expectedVersion must be non-negative: " + expectedVersion);
+    }
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            newState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=MySQL
+    String sql =
+        """
+        UPDATE scheduler_job_extension_state
+        SET state = ?, encrypted_state = ?, encryption_key_id = ?,
+            version = version + 1, updated_at = ?
+        WHERE job_id = ? AND namespace = ? AND version = ?
+        """;
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, stored)
+            .setParameter(2, active)
+            .setParameter(3, JobEncryption.keyId(active))
+            .setParameter(4, Timestamp.from(Instant.now()))
+            .setParameter(5, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(6, namespace)
+            .setParameter(7, expectedVersion)
+            .executeUpdate();
+    return updated > 0;
+  }
+
+  private static void requireKey(String key) {
+    if (key == null || key.isBlank()) {
+      throw new IllegalArgumentException("property key must not be null or blank");
+    }
+  }
+
+  private static void requireNamespace(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+  }
+
+  private static void requireState(String state) {
+    if (state == null) {
+      throw new IllegalArgumentException("state must not be null");
+    }
+  }
+
+  private static String escapeLike(String raw) {
+    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+}

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobQueryOperations.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -372,6 +373,7 @@ final class MysqlJobQueryOperations {
     appendStringEq("c.trace_id_extracted", filter.traceCorrelationId(), where, params);
     appendParentJobId(filter, where, params);
     appendTagCondition(filter, where, params);
+    appendPropertyConditions(filter, where, params);
     appendInstantGte("c.created_at", filter.createdAfter(), where, params);
     appendInstantLt("c.created_at", filter.createdBefore(), where, params);
     appendInstantGte(
@@ -594,6 +596,26 @@ final class MysqlJobQueryOperations {
     }
     and(where, "a.depended_on = ?");
     params.add(UuidByteArrayConverter.toBytes(parentJobId));
+  }
+
+  private void appendPropertyConditions(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    Map<String, Set<String>> propertyFilters = filter.propertyFilters();
+    if (propertyFilters == null || propertyFilters.isEmpty()) {
+      return;
+    }
+    // One EXISTS per key (AND across keys); IN over the allowed values, served by the
+    // (property_key, value) index on scheduler_job_properties.
+    for (Map.Entry<String, Set<String>> entry : propertyFilters.entrySet()) {
+      and(
+          where,
+          "EXISTS (SELECT 1 FROM scheduler_job_properties p"
+              + " WHERE p.job_id = c.job_id AND p.property_key = ? AND p.value IN ("
+              + placeholders(entry.getValue().size())
+              + "))");
+      params.add(entry.getKey());
+      params.addAll(entry.getValue());
+    }
   }
 
   private void appendTagCondition(JobFilter filter, StringBuilder where, List<Object> params) {

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStore.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStore.java
@@ -20,6 +20,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -51,4 +52,5 @@ public interface MysqlJobStore
         JobQueryStore,
         JobAnalyticsStore,
         JobAuditStore,
-        DlqAlertStore {}
+        DlqAlertStore,
+        JobExtensionStore {}

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
@@ -85,6 +85,7 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   private MysqlTagOperations tags;
   private MysqlSignalOperations signals;
   private MysqlRecurringJobOperations recurringJobs;
+  private MysqlExtensionOperations extensions;
 
   /** No-arg constructor required by CDI normal-scope proxying. Not for direct use. */
   protected MysqlJobStoreImpl() {
@@ -830,6 +831,7 @@ class MysqlJobStoreImpl implements MysqlJobStore {
     auxiliary = new MysqlAuxiliaryOperations(ctx);
     signals = new MysqlSignalOperations(ctx);
     recurringJobs = new MysqlRecurringJobOperations(ctx, reservations);
+    extensions = new MysqlExtensionOperations(ctx);
   }
 
   // ---------- RecurringJobStore delegates ----------
@@ -884,5 +886,37 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   @Override
   public List<run.ratchet.store.spi.RecurringJobDefinition> listAll() {
     return recurringJobs.listAll();
+  }
+
+  // ---------- JobExtensionStore delegates ----------
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    extensions.putProperty(jobId, key, value);
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    return extensions.getProperty(jobId, key);
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    return extensions.getPropertiesByPrefix(jobId, prefix);
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    return extensions.getState(jobId, namespace);
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    extensions.initState(jobId, namespace, initialState);
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    return extensions.updateState(jobId, namespace, newState, expectedVersion);
   }
 }

--- a/stores/ratchet-store-mysql/src/main/resources/ddl/migrations/V001__initial_schema.sql
+++ b/stores/ratchet-store-mysql/src/main/resources/ddl/migrations/V001__initial_schema.sql
@@ -410,6 +410,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_archive
     depended_on             BINARY(16)                                                                                                          NULL,
     superseded_by           BINARY(16)                                                                                                          NULL,
     tags                    VARCHAR(512)                                                                                                        NULL,
+    properties              JSON                                                                                                                NULL,
+    extension_state         JSON                                                                                                                NULL,
     PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_priority CHECK (priority BETWEEN 0 AND 4),
     INDEX idx_archive_original_id (original_job_id),
@@ -477,6 +479,38 @@ CREATE TABLE IF NOT EXISTS scheduler_resource_permit
     INDEX idx_resource_permit_resource (resource_name),
     INDEX idx_resource_permit_job (job_id),
     CONSTRAINT fk_resource_permit_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- 14. Per-job extension properties (write-once indexed scalars; plaintext by design — no secrets)
+CREATE TABLE IF NOT EXISTS scheduler_job_properties
+(
+    job_id       BINARY(16)    NOT NULL,
+    property_key VARCHAR(255)  NOT NULL,
+    value        VARCHAR(1024) NULL,
+    PRIMARY KEY (job_id, property_key),
+    INDEX idx_property_kv (property_key, value(255)),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- 15. Per-job extension state (mutable per-namespace blobs with per-row CAS; encrypted at rest when
+-- payload encryption is configured — state holds ciphertext, encrypted_state/encryption_key_id
+-- mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE IF NOT EXISTS scheduler_job_extension_state
+(
+    job_id            BINARY(16)   NOT NULL,
+    namespace         VARCHAR(64)  NOT NULL,
+    state             TEXT         NOT NULL,
+    encrypted_state   BOOLEAN      NOT NULL DEFAULT FALSE,
+    encryption_key_id VARCHAR(256) NULL,
+    version           INT          NOT NULL DEFAULT 0,
+    updated_at        DATETIME(6)  NOT NULL,
+    PRIMARY KEY (job_id, namespace),
+    INDEX idx_extension_state_key_id (encryption_key_id),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;

--- a/stores/ratchet-store-mysql/src/main/resources/ddl/mysql-schema.sql
+++ b/stores/ratchet-store-mysql/src/main/resources/ddl/mysql-schema.sql
@@ -408,6 +408,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_archive
     depended_on             BINARY(16)                                                                                                          NULL,
     superseded_by           BINARY(16)                                                                                                          NULL,
     tags                    VARCHAR(512)                                                                                                        NULL,
+    properties              JSON                                                                                                                NULL,
+    extension_state         JSON                                                                                                                NULL,
     PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_priority CHECK (priority BETWEEN 0 AND 4),
     INDEX idx_archive_original_id (original_job_id),
@@ -475,6 +477,38 @@ CREATE TABLE IF NOT EXISTS scheduler_resource_permit
     INDEX idx_resource_permit_resource (resource_name),
     INDEX idx_resource_permit_job (job_id),
     CONSTRAINT fk_resource_permit_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- 14. Per-job extension properties (write-once indexed scalars; plaintext by design — no secrets)
+CREATE TABLE IF NOT EXISTS scheduler_job_properties
+(
+    job_id       BINARY(16)    NOT NULL,
+    property_key VARCHAR(255)  NOT NULL,
+    value        VARCHAR(1024) NULL,
+    PRIMARY KEY (job_id, property_key),
+    INDEX idx_property_kv (property_key, value(255)),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- 15. Per-job extension state (mutable per-namespace blobs with per-row CAS; encrypted at rest when
+-- payload encryption is configured — state holds ciphertext, encrypted_state/encryption_key_id
+-- mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE IF NOT EXISTS scheduler_job_extension_state
+(
+    job_id            BINARY(16)   NOT NULL,
+    namespace         VARCHAR(64)  NOT NULL,
+    state             TEXT         NOT NULL,
+    encrypted_state   BOOLEAN      NOT NULL DEFAULT FALSE,
+    encryption_key_id VARCHAR(256) NULL,
+    version           INT          NOT NULL DEFAULT 0,
+    updated_at        DATETIME(6)  NOT NULL,
+    PRIMARY KEY (job_id, namespace),
+    INDEX idx_extension_state_key_id (encryption_key_id),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobExtensionStoreContractTest.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlJobExtensionStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.mysql;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobExtensionStoreContract;
+
+class MysqlJobExtensionStoreContractTest extends AbstractJobExtensionStoreContract {
+
+  private final MysqlTestFixture fixture = new MysqlTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTestFixture.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlTestFixture.java
@@ -71,6 +71,8 @@ public class MysqlTestFixture extends JpaContainerFixture {
     executeNativeSql("DELETE FROM scheduler_dlq_alerts");
     executeNativeSql("DELETE FROM scheduler_batch_metrics");
     executeNativeSql("DELETE FROM scheduler_job_archive");
+    executeNativeSql("DELETE FROM scheduler_job_properties");
+    executeNativeSql("DELETE FROM scheduler_job_extension_state");
     executeNativeSql("DELETE FROM scheduler_job");
     executeNativeSql("DELETE FROM scheduler_recurring_job_archive");
     executeNativeSql("DELETE FROM scheduler_recurring_job");

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleArchiveOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleArchiveOperations.java
@@ -19,7 +19,6 @@ import jakarta.persistence.Query;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -31,6 +30,7 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.oracle.converter.UuidRawConverter;
 import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.util.ArchiveExtensionData;
 import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
@@ -86,7 +86,8 @@ final class OracleArchiveOperations implements ArchiveStore {
       JobEntity hydrated = hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
-      populateExtensionData(archive, hydrated.getId());
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(List.of(hydrated.getId()));
+      populateExtensionData(archive, extensionData, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, UuidRawConverter::toBytes);
       query.executeUpdate();
@@ -114,6 +115,7 @@ final class OracleArchiveOperations implements ArchiveStore {
           jobs.findByIds(ids).stream()
               .collect(Collectors.toMap(JobEntity::getId, Function.identity()));
       List<ArchivedJobEntity> archives = new ArrayList<>(jobsToArchive.size());
+      List<UUID> archiveIds = new ArrayList<>(jobsToArchive.size());
       for (UUID id : ids) {
         JobEntity hydrated = hydratedById.get(id);
         if (hydrated == null) {
@@ -121,8 +123,12 @@ final class OracleArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
-        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
+        archiveIds.add(hydrated.getId());
+      }
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(archiveIds);
+      for (int i = 0; i < archives.size(); i++) {
+        populateExtensionData(archives.get(i), extensionData, archiveIds.get(i));
       }
 
       String rows =
@@ -255,53 +261,14 @@ final class OracleArchiveOperations implements ArchiveStore {
         .orElseThrow(() -> new IllegalStateException("Job not found for archival: " + job.getId()));
   }
 
-  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
-    // language=Oracle
-    String propertySql =
-        """
-        SELECT property_key, value
-        FROM scheduler_job_properties
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> propertyRows =
-        ctx.em()
-            .createNativeQuery(propertySql)
-            .setParameter(1, UuidRawConverter.toBytes(jobId))
-            .getResultList();
-    Map<String, String> properties = new LinkedHashMap<>();
-    for (Object[] row : propertyRows) {
-      String value = RowValues.stringOrNull(row[1]);
-      if (value != null) {
-        properties.put((String) row[0], value);
-      }
-    }
-    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+  private ArchiveExtensionData fetchArchiveExtensionData(List<UUID> jobIds) {
+    return ArchiveExtensionData.fetch(
+        ctx.em(), jobIds, UuidRawConverter::toBytes, RowValues::uuidOrNull);
+  }
 
-    // language=Oracle
-    String stateSql =
-        """
-        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
-        FROM scheduler_job_extension_state
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> stateRows =
-        ctx.em()
-            .createNativeQuery(stateSql)
-            .setParameter(1, UuidRawConverter.toBytes(jobId))
-            .getResultList();
-    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
-    for (Object[] row : stateRows) {
-      states.add(
-          new ExtensionArchiveJson.StateRow(
-              (String) row[0],
-              RowValues.stringOrNull(row[1]),
-              RowValues.booleanOrFalse(row[2]),
-              RowValues.stringOrNull(row[3]),
-              ((Number) row[4]).intValue(),
-              RowValues.instantOrNull(row[5])));
-    }
-    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
+  private void populateExtensionData(
+      ArchivedJobEntity archive, ArchiveExtensionData extensionData, UUID jobId) {
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(extensionData.properties(jobId)));
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(extensionData.states(jobId)));
   }
 }

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleArchiveOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleArchiveOperations.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Query;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +35,7 @@ import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.ExtensionArchiveJson;
 import run.ratchet.store.util.RowValues;
 
 final class OracleArchiveOperations implements ArchiveStore {
@@ -84,6 +86,7 @@ final class OracleArchiveOperations implements ArchiveStore {
       JobEntity hydrated = hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
+      populateExtensionData(archive, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, UuidRawConverter::toBytes);
       query.executeUpdate();
@@ -118,6 +121,7 @@ final class OracleArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
+        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
       }
 
@@ -249,5 +253,55 @@ final class OracleArchiveOperations implements ArchiveStore {
   private JobEntity hydrateForArchive(JobEntity job) {
     return jobs.findById(job.getId())
         .orElseThrow(() -> new IllegalStateException("Job not found for archival: " + job.getId()));
+  }
+
+  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
+    // language=Oracle
+    String propertySql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> propertyRows =
+        ctx.em()
+            .createNativeQuery(propertySql)
+            .setParameter(1, UuidRawConverter.toBytes(jobId))
+            .getResultList();
+    Map<String, String> properties = new LinkedHashMap<>();
+    for (Object[] row : propertyRows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        properties.put((String) row[0], value);
+      }
+    }
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+
+    // language=Oracle
+    String stateSql =
+        """
+        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
+        FROM scheduler_job_extension_state
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> stateRows =
+        ctx.em()
+            .createNativeQuery(stateSql)
+            .setParameter(1, UuidRawConverter.toBytes(jobId))
+            .getResultList();
+    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
+    for (Object[] row : stateRows) {
+      states.add(
+          new ExtensionArchiveJson.StateRow(
+              (String) row[0],
+              RowValues.stringOrNull(row[1]),
+              RowValues.booleanOrFalse(row[2]),
+              RowValues.stringOrNull(row[3]),
+              ((Number) row[4]).intValue(),
+              RowValues.instantOrNull(row[5])));
+    }
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
   }
 }

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleExtensionOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleExtensionOperations.java
@@ -15,6 +15,11 @@
  */
 package run.ratchet.store.oracle;
 
+import static run.ratchet.store.util.ExtensionValidation.escapeLike;
+import static run.ratchet.store.util.ExtensionValidation.requireKey;
+import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
+import static run.ratchet.store.util.ExtensionValidation.requireState;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -214,27 +219,5 @@ final class OracleExtensionOperations implements JobExtensionStore {
             .setParameter(7, expectedVersion)
             .executeUpdate();
     return updated > 0;
-  }
-
-  private static void requireKey(String key) {
-    if (key == null || key.isBlank()) {
-      throw new IllegalArgumentException("property key must not be null or blank");
-    }
-  }
-
-  private static void requireNamespace(String namespace) {
-    if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace must not be null or blank");
-    }
-  }
-
-  private static void requireState(String state) {
-    if (state == null) {
-      throw new IllegalArgumentException("state must not be null");
-    }
-  }
-
-  private static String escapeLike(String raw) {
-    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
   }
 }

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleExtensionOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleExtensionOperations.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.oracle;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.store.converter.EncryptionHolder;
+import run.ratchet.store.oracle.converter.UuidRawConverter;
+import run.ratchet.store.spi.JobExtensionStore;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.PayloadEncryptor;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * Oracle implementation of {@link JobExtensionStore}.
+ *
+ * <p>Property values are plaintext by design (indexed for the query layer). Extension-state blobs
+ * follow the deployment-wide payload-encryption switch: when it is on, the {@code state} column
+ * holds a ciphertext frame bound to {@code (job_id, namespace)}; otherwise plaintext with {@code
+ * encrypted_state = FALSE}.
+ */
+final class OracleExtensionOperations implements JobExtensionStore {
+
+  private final OracleStoreContext ctx;
+
+  OracleExtensionOperations(OracleStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    requireKey(key);
+    // language=Oracle
+    String sql =
+        """
+        MERGE INTO scheduler_job_properties t
+        USING (SELECT ? job_id, ? property_key, ? value FROM dual) s
+        ON (t.job_id = s.job_id AND t.property_key = s.property_key)
+        WHEN MATCHED THEN UPDATE SET t.value = s.value
+        WHEN NOT MATCHED THEN
+          INSERT (job_id, property_key, value)
+          VALUES (s.job_id, s.property_key, s.value)
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidRawConverter.toBytes(jobId))
+        .setParameter(2, key)
+        .setParameter(3, value)
+        .executeUpdate();
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    requireKey(key);
+    // language=Oracle
+    String sql =
+        """
+        SELECT value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidRawConverter.toBytes(jobId))
+            .setParameter(2, key)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(RowValues.stringOrNull(rows.get(0)));
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("prefix must not be null");
+    }
+    // language=Oracle
+    String sql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key LIKE ? ESCAPE '\\'
+        ORDER BY property_key
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidRawConverter.toBytes(jobId))
+            .setParameter(2, escapeLike(prefix) + "%")
+            .getResultList();
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Object[] row : rows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        result.put((String) row[0], value);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    requireNamespace(namespace);
+    // language=Oracle
+    String sql =
+        """
+        SELECT state, version
+        FROM scheduler_job_extension_state
+        WHERE job_id = ? AND namespace = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidRawConverter.toBytes(jobId))
+            .setParameter(2, namespace)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    Object[] row = rows.get(0);
+    String stored = RowValues.stringOrNull(row[0]);
+    String json =
+        PayloadEncryptor.decryptValue(stored, EncryptionTarget.extensionState(jobId, namespace));
+    return Optional.of(new ExtensionState(json, ((Number) row[1]).intValue()));
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    requireNamespace(namespace);
+    requireState(initialState);
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            initialState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=Oracle
+    String sql =
+        """
+        INSERT INTO scheduler_job_extension_state
+          (job_id, namespace, state, encrypted_state, encryption_key_id, version, updated_at)
+        VALUES (?, ?, ?, ?, ?, 0, ?)
+        """;
+    try {
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidRawConverter.toBytes(jobId))
+          .setParameter(2, namespace)
+          .setParameter(3, stored)
+          .setParameter(4, active)
+          .setParameter(5, JobEncryption.keyId(active))
+          .setParameter(6, Timestamp.from(Instant.now()))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateKey(e)) {
+        throw new IllegalStateException(
+            "extension state already initialized for job " + jobId + " namespace " + namespace, e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    requireNamespace(namespace);
+    requireState(newState);
+    if (expectedVersion < 0) {
+      throw new IllegalArgumentException(
+          "expectedVersion must be non-negative: " + expectedVersion);
+    }
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            newState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=Oracle
+    String sql =
+        """
+        UPDATE scheduler_job_extension_state
+        SET state = ?, encrypted_state = ?, encryption_key_id = ?,
+            version = version + 1, updated_at = ?
+        WHERE job_id = ? AND namespace = ? AND version = ?
+        """;
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, stored)
+            .setParameter(2, active)
+            .setParameter(3, JobEncryption.keyId(active))
+            .setParameter(4, Timestamp.from(Instant.now()))
+            .setParameter(5, UuidRawConverter.toBytes(jobId))
+            .setParameter(6, namespace)
+            .setParameter(7, expectedVersion)
+            .executeUpdate();
+    return updated > 0;
+  }
+
+  private static void requireKey(String key) {
+    if (key == null || key.isBlank()) {
+      throw new IllegalArgumentException("property key must not be null or blank");
+    }
+  }
+
+  private static void requireNamespace(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+  }
+
+  private static void requireState(String state) {
+    if (state == null) {
+      throw new IllegalArgumentException("state must not be null");
+    }
+  }
+
+  private static String escapeLike(String raw) {
+    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+}

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleExtensionOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleExtensionOperations.java
@@ -19,6 +19,7 @@ import static run.ratchet.store.util.ExtensionValidation.escapeLike;
 import static run.ratchet.store.util.ExtensionValidation.requireKey;
 import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
 import static run.ratchet.store.util.ExtensionValidation.requireState;
+import static run.ratchet.store.util.ExtensionValidation.requireValue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -54,6 +55,7 @@ final class OracleExtensionOperations implements JobExtensionStore {
   @Override
   public void putProperty(UUID jobId, String key, String value) {
     requireKey(key);
+    requireValue(value);
     // language=Oracle
     String sql =
         """

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobQueryOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobQueryOperations.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -373,6 +374,7 @@ final class OracleJobQueryOperations {
     appendStringEq("c.trace_id_extracted", filter.traceCorrelationId(), where, params);
     appendParentJobId(filter, where, params);
     appendTagCondition(filter, where, params);
+    appendPropertyConditions(filter, where, params);
     appendInstantGte("c.created_at", filter.createdAfter(), where, params);
     appendInstantLt("c.created_at", filter.createdBefore(), where, params);
     appendInstantGte(
@@ -610,6 +612,26 @@ final class OracleJobQueryOperations {
             + placeholders(filterTags.size())
             + "))");
     params.addAll(filterTags);
+  }
+
+  private void appendPropertyConditions(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    Map<String, Set<String>> propertyFilters = filter.propertyFilters();
+    if (propertyFilters == null || propertyFilters.isEmpty()) {
+      return;
+    }
+    // One EXISTS per key (AND across keys); IN over the allowed values, served by the
+    // (property_key, value) index on scheduler_job_properties.
+    for (Map.Entry<String, Set<String>> entry : propertyFilters.entrySet()) {
+      and(
+          where,
+          "EXISTS (SELECT 1 FROM scheduler_job_properties p"
+              + " WHERE p.job_id = c.job_id AND p.property_key = ? AND p.value IN ("
+              + placeholders(entry.getValue().size())
+              + "))");
+      params.add(entry.getKey());
+      params.addAll(entry.getValue());
+    }
   }
 
   private void appendCursorCondition(JobFilter filter, StringBuilder where, List<Object> params) {

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStore.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStore.java
@@ -20,6 +20,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -51,4 +52,5 @@ public interface OracleJobStore
         JobQueryStore,
         JobAnalyticsStore,
         JobAuditStore,
-        DlqAlertStore {}
+        DlqAlertStore,
+        JobExtensionStore {}

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStoreImpl.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStoreImpl.java
@@ -85,6 +85,7 @@ class OracleJobStoreImpl implements OracleJobStore {
   private OracleTagOperations tags;
   private OracleSignalOperations signals;
   private OracleRecurringJobOperations recurringJobs;
+  private OracleExtensionOperations extensions;
 
   /** No-arg constructor required by CDI normal-scope proxying. Not for direct use. */
   protected OracleJobStoreImpl() {
@@ -841,6 +842,7 @@ class OracleJobStoreImpl implements OracleJobStore {
     auxiliary = new OracleAuxiliaryOperations(ctx);
     signals = new OracleSignalOperations(ctx);
     recurringJobs = new OracleRecurringJobOperations(ctx, reservations);
+    extensions = new OracleExtensionOperations(ctx);
   }
 
   // ---------- RecurringJobStore delegates ----------
@@ -895,5 +897,37 @@ class OracleJobStoreImpl implements OracleJobStore {
   @Override
   public List<run.ratchet.store.spi.RecurringJobDefinition> listAll() {
     return recurringJobs.listAll();
+  }
+
+  // ---------- JobExtensionStore delegates ----------
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    extensions.putProperty(jobId, key, value);
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    return extensions.getProperty(jobId, key);
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    return extensions.getPropertiesByPrefix(jobId, prefix);
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    return extensions.getState(jobId, namespace);
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    extensions.initState(jobId, namespace, initialState);
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    return extensions.updateState(jobId, namespace, newState, expectedVersion);
   }
 }

--- a/stores/ratchet-store-oracle/src/main/resources/ddl/migrations/V001__initial_schema.sql
+++ b/stores/ratchet-store-oracle/src/main/resources/ddl/migrations/V001__initial_schema.sql
@@ -360,6 +360,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_archive
     depended_on             RAW(16),
     superseded_by           RAW(16),
     tags                    VARCHAR2(512),
+    properties              CLOB,
+    extension_state         CLOB,
     CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
     CONSTRAINT chk_archive_job_type CHECK (job_type IN
@@ -431,3 +433,33 @@ CREATE TABLE IF NOT EXISTS scheduler_resource_permit
 
 CREATE INDEX IF NOT EXISTS idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
 CREATE INDEX IF NOT EXISTS idx_resource_permit_job ON scheduler_resource_permit (job_id);
+
+-- 14. Per-job extension properties (write-once indexed scalars; plaintext by design — no secrets)
+CREATE TABLE IF NOT EXISTS scheduler_job_properties
+(
+    job_id       RAW(16)        NOT NULL,
+    property_key VARCHAR2(255)  NOT NULL,
+    value        VARCHAR2(1024),
+    CONSTRAINT pk_scheduler_job_properties PRIMARY KEY (job_id, property_key),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_property_kv ON scheduler_job_properties (property_key, value);
+
+-- 15. Per-job extension state (mutable per-namespace blobs with per-row CAS; encrypted at rest when
+-- payload encryption is configured — state holds ciphertext, encrypted_state/encryption_key_id
+-- mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE IF NOT EXISTS scheduler_job_extension_state
+(
+    job_id            RAW(16)      NOT NULL,
+    namespace         VARCHAR2(64) NOT NULL,
+    state             CLOB         NOT NULL,
+    encrypted_state   BOOLEAN      DEFAULT FALSE NOT NULL,
+    encryption_key_id VARCHAR2(256),
+    version           NUMBER(10)   DEFAULT 0 NOT NULL,
+    updated_at        TIMESTAMP(6) NOT NULL,
+    CONSTRAINT pk_scheduler_job_extension_state PRIMARY KEY (job_id, namespace),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_extension_state_key_id ON scheduler_job_extension_state (encryption_key_id);

--- a/stores/ratchet-store-oracle/src/main/resources/ddl/oracle-schema.sql
+++ b/stores/ratchet-store-oracle/src/main/resources/ddl/oracle-schema.sql
@@ -360,6 +360,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_archive
     depended_on             RAW(16),
     superseded_by           RAW(16),
     tags                    VARCHAR2(512),
+    properties              CLOB,
+    extension_state         CLOB,
     CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
     CONSTRAINT chk_archive_job_type CHECK (job_type IN
@@ -431,3 +433,33 @@ CREATE TABLE IF NOT EXISTS scheduler_resource_permit
 
 CREATE INDEX IF NOT EXISTS idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
 CREATE INDEX IF NOT EXISTS idx_resource_permit_job ON scheduler_resource_permit (job_id);
+
+-- 14. Per-job extension properties (write-once indexed scalars; plaintext by design — no secrets)
+CREATE TABLE IF NOT EXISTS scheduler_job_properties
+(
+    job_id       RAW(16)        NOT NULL,
+    property_key VARCHAR2(255)  NOT NULL,
+    value        VARCHAR2(1024),
+    CONSTRAINT pk_scheduler_job_properties PRIMARY KEY (job_id, property_key),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_property_kv ON scheduler_job_properties (property_key, value);
+
+-- 15. Per-job extension state (mutable per-namespace blobs with per-row CAS; encrypted at rest when
+-- payload encryption is configured — state holds ciphertext, encrypted_state/encryption_key_id
+-- mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE IF NOT EXISTS scheduler_job_extension_state
+(
+    job_id            RAW(16)      NOT NULL,
+    namespace         VARCHAR2(64) NOT NULL,
+    state             CLOB         NOT NULL,
+    encrypted_state   BOOLEAN      DEFAULT FALSE NOT NULL,
+    encryption_key_id VARCHAR2(256),
+    version           NUMBER(10)   DEFAULT 0 NOT NULL,
+    updated_at        TIMESTAMP(6) NOT NULL,
+    CONSTRAINT pk_scheduler_job_extension_state PRIMARY KEY (job_id, namespace),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_extension_state_key_id ON scheduler_job_extension_state (encryption_key_id);

--- a/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleJobExtensionStoreContractTest.java
+++ b/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleJobExtensionStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.oracle;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobExtensionStoreContract;
+
+class OracleJobExtensionStoreContractTest extends AbstractJobExtensionStoreContract {
+
+  private final OracleTestFixture fixture = new OracleTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleTestFixture.java
+++ b/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleTestFixture.java
@@ -71,6 +71,8 @@ public class OracleTestFixture extends JpaContainerFixture {
     executeNativeSql("DELETE FROM scheduler_dlq_alerts");
     executeNativeSql("DELETE FROM scheduler_batch_metrics");
     executeNativeSql("DELETE FROM scheduler_job_archive");
+    executeNativeSql("DELETE FROM scheduler_job_properties");
+    executeNativeSql("DELETE FROM scheduler_job_extension_state");
     executeNativeSql("DELETE FROM scheduler_job");
     executeNativeSql("DELETE FROM scheduler_recurring_job_archive");
     executeNativeSql("DELETE FROM scheduler_recurring_job");

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
@@ -20,6 +20,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,6 +35,7 @@ import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.ExtensionArchiveJson;
 import run.ratchet.store.util.RowValues;
 
 final class PostgresqlArchiveOperations implements ArchiveStore {
@@ -79,6 +81,7 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
       JobEntity hydrated = reads.hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
+      populateExtensionData(archive, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, id -> id);
       query.executeUpdate();
@@ -114,6 +117,7 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
+        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
       }
 
@@ -214,5 +218,49 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("purge archived jobs", e);
     }
+  }
+
+  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
+    // language=PostgreSQL
+    String propertySql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> propertyRows =
+        ctx.em().createNativeQuery(propertySql).setParameter(1, jobId).getResultList();
+    Map<String, String> properties = new LinkedHashMap<>();
+    for (Object[] row : propertyRows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        properties.put((String) row[0], value);
+      }
+    }
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+
+    // language=PostgreSQL
+    String stateSql =
+        """
+        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
+        FROM scheduler_job_extension_state
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> stateRows =
+        ctx.em().createNativeQuery(stateSql).setParameter(1, jobId).getResultList();
+    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
+    for (Object[] row : stateRows) {
+      states.add(
+          new ExtensionArchiveJson.StateRow(
+              (String) row[0],
+              RowValues.stringOrNull(row[1]),
+              RowValues.booleanOrFalse(row[2]),
+              RowValues.stringOrNull(row[3]),
+              ((Number) row[4]).intValue(),
+              RowValues.instantOrNull(row[5])));
+    }
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
   }
 }

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlArchiveOperations.java
@@ -20,7 +20,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -31,6 +30,7 @@ import run.ratchet.store.entity.ArchivedJobEntity;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.util.ArchiveExtensionData;
 import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
@@ -81,7 +81,8 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
       JobEntity hydrated = reads.hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
-      populateExtensionData(archive, hydrated.getId());
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(List.of(hydrated.getId()));
+      populateExtensionData(archive, extensionData, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, id -> id);
       query.executeUpdate();
@@ -110,6 +111,7 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
           reads.findByIds(ids).stream()
               .collect(Collectors.toMap(JobEntity::getId, Function.identity()));
       List<ArchivedJobEntity> archives = new ArrayList<>(jobsToArchive.size());
+      List<UUID> archiveIds = new ArrayList<>(jobsToArchive.size());
       for (UUID id : ids) {
         JobEntity hydrated = hydratedById.get(id);
         if (hydrated == null) {
@@ -117,8 +119,12 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
-        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
+        archiveIds.add(hydrated.getId());
+      }
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(archiveIds);
+      for (int i = 0; i < archives.size(); i++) {
+        populateExtensionData(archives.get(i), extensionData, archiveIds.get(i));
       }
 
       String rows =
@@ -220,47 +226,13 @@ final class PostgresqlArchiveOperations implements ArchiveStore {
     }
   }
 
-  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
-    // language=PostgreSQL
-    String propertySql =
-        """
-        SELECT property_key, value
-        FROM scheduler_job_properties
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> propertyRows =
-        ctx.em().createNativeQuery(propertySql).setParameter(1, jobId).getResultList();
-    Map<String, String> properties = new LinkedHashMap<>();
-    for (Object[] row : propertyRows) {
-      String value = RowValues.stringOrNull(row[1]);
-      if (value != null) {
-        properties.put((String) row[0], value);
-      }
-    }
-    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+  private ArchiveExtensionData fetchArchiveExtensionData(List<UUID> jobIds) {
+    return ArchiveExtensionData.fetch(ctx.em(), jobIds, id -> id, RowValues::uuidOrNull);
+  }
 
-    // language=PostgreSQL
-    String stateSql =
-        """
-        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
-        FROM scheduler_job_extension_state
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> stateRows =
-        ctx.em().createNativeQuery(stateSql).setParameter(1, jobId).getResultList();
-    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
-    for (Object[] row : stateRows) {
-      states.add(
-          new ExtensionArchiveJson.StateRow(
-              (String) row[0],
-              RowValues.stringOrNull(row[1]),
-              RowValues.booleanOrFalse(row[2]),
-              RowValues.stringOrNull(row[3]),
-              ((Number) row[4]).intValue(),
-              RowValues.instantOrNull(row[5])));
-    }
-    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
+  private void populateExtensionData(
+      ArchivedJobEntity archive, ArchiveExtensionData extensionData, UUID jobId) {
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(extensionData.properties(jobId)));
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(extensionData.states(jobId)));
   }
 }

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlExtensionOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlExtensionOperations.java
@@ -15,6 +15,11 @@
  */
 package run.ratchet.store.postgresql;
 
+import static run.ratchet.store.util.ExtensionValidation.escapeLike;
+import static run.ratchet.store.util.ExtensionValidation.requireKey;
+import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
+import static run.ratchet.store.util.ExtensionValidation.requireState;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -205,27 +210,5 @@ final class PostgresqlExtensionOperations implements JobExtensionStore {
             .setParameter(7, expectedVersion)
             .executeUpdate();
     return updated > 0;
-  }
-
-  private static void requireKey(String key) {
-    if (key == null || key.isBlank()) {
-      throw new IllegalArgumentException("property key must not be null or blank");
-    }
-  }
-
-  private static void requireNamespace(String namespace) {
-    if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace must not be null or blank");
-    }
-  }
-
-  private static void requireState(String state) {
-    if (state == null) {
-      throw new IllegalArgumentException("state must not be null");
-    }
-  }
-
-  private static String escapeLike(String raw) {
-    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
   }
 }

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlExtensionOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlExtensionOperations.java
@@ -19,6 +19,7 @@ import static run.ratchet.store.util.ExtensionValidation.escapeLike;
 import static run.ratchet.store.util.ExtensionValidation.requireKey;
 import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
 import static run.ratchet.store.util.ExtensionValidation.requireState;
+import static run.ratchet.store.util.ExtensionValidation.requireValue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -53,6 +54,7 @@ final class PostgresqlExtensionOperations implements JobExtensionStore {
   @Override
   public void putProperty(UUID jobId, String key, String value) {
     requireKey(key);
+    requireValue(value);
     // language=PostgreSQL
     String sql =
         """

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlExtensionOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlExtensionOperations.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.postgresql;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.store.converter.EncryptionHolder;
+import run.ratchet.store.spi.JobExtensionStore;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.PayloadEncryptor;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * PostgreSQL implementation of {@link JobExtensionStore}.
+ *
+ * <p>Property values are plaintext by design (indexed for the query layer). Extension-state blobs
+ * follow the deployment-wide payload-encryption switch: when it is on, the {@code state} column
+ * holds a ciphertext frame bound to {@code (job_id, namespace)}; otherwise plaintext with {@code
+ * encrypted_state = FALSE}.
+ */
+final class PostgresqlExtensionOperations implements JobExtensionStore {
+
+  private final PostgresqlStoreContext ctx;
+
+  PostgresqlExtensionOperations(PostgresqlStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    requireKey(key);
+    // language=PostgreSQL
+    String sql =
+        """
+        INSERT INTO scheduler_job_properties (job_id, property_key, value)
+        VALUES (?, ?, ?)
+        ON CONFLICT (job_id, property_key) DO UPDATE SET value = EXCLUDED.value
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, jobId)
+        .setParameter(2, key)
+        .setParameter(3, value)
+        .executeUpdate();
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    requireKey(key);
+    // language=PostgreSQL
+    String sql =
+        """
+        SELECT value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object> rows =
+        ctx.em().createNativeQuery(sql).setParameter(1, jobId).setParameter(2, key).getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(RowValues.stringOrNull(rows.get(0)));
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("prefix must not be null");
+    }
+    // language=PostgreSQL
+    String sql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key LIKE ? ESCAPE '\\'
+        ORDER BY property_key
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, jobId)
+            .setParameter(2, escapeLike(prefix) + "%")
+            .getResultList();
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Object[] row : rows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        result.put((String) row[0], value);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    requireNamespace(namespace);
+    // language=PostgreSQL
+    String sql =
+        """
+        SELECT state, version
+        FROM scheduler_job_extension_state
+        WHERE job_id = ? AND namespace = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, jobId)
+            .setParameter(2, namespace)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    Object[] row = rows.get(0);
+    String stored = RowValues.stringOrNull(row[0]);
+    String json =
+        PayloadEncryptor.decryptValue(stored, EncryptionTarget.extensionState(jobId, namespace));
+    return Optional.of(new ExtensionState(json, ((Number) row[1]).intValue()));
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    requireNamespace(namespace);
+    requireState(initialState);
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            initialState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=PostgreSQL
+    String sql =
+        """
+        INSERT INTO scheduler_job_extension_state
+          (job_id, namespace, state, encrypted_state, encryption_key_id, version, updated_at)
+        VALUES (?, ?, ?, ?, ?, 0, ?)
+        """;
+    try {
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, jobId)
+          .setParameter(2, namespace)
+          .setParameter(3, stored)
+          .setParameter(4, active)
+          .setParameter(5, JobEncryption.keyId(active))
+          .setParameter(6, Timestamp.from(Instant.now()))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateKey(e)) {
+        throw new IllegalStateException(
+            "extension state already initialized for job " + jobId + " namespace " + namespace, e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    requireNamespace(namespace);
+    requireState(newState);
+    if (expectedVersion < 0) {
+      throw new IllegalArgumentException(
+          "expectedVersion must be non-negative: " + expectedVersion);
+    }
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            newState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=PostgreSQL
+    String sql =
+        """
+        UPDATE scheduler_job_extension_state
+        SET state = ?, encrypted_state = ?, encryption_key_id = ?,
+            version = version + 1, updated_at = ?
+        WHERE job_id = ? AND namespace = ? AND version = ?
+        """;
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, stored)
+            .setParameter(2, active)
+            .setParameter(3, JobEncryption.keyId(active))
+            .setParameter(4, Timestamp.from(Instant.now()))
+            .setParameter(5, jobId)
+            .setParameter(6, namespace)
+            .setParameter(7, expectedVersion)
+            .executeUpdate();
+    return updated > 0;
+  }
+
+  private static void requireKey(String key) {
+    if (key == null || key.isBlank()) {
+      throw new IllegalArgumentException("property key must not be null or blank");
+    }
+  }
+
+  private static void requireNamespace(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+  }
+
+  private static void requireState(String state) {
+    if (state == null) {
+      throw new IllegalArgumentException("state must not be null");
+    }
+  }
+
+  private static String escapeLike(String raw) {
+    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+}

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobQueryOperations.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -381,6 +382,7 @@ final class PostgresqlJobQueryOperations {
     appendStringEq("c.trace_context->>'traceparent'", filter.traceCorrelationId(), where, params);
     appendParentJobId(filter, where, params);
     appendTagCondition(filter, where, params);
+    appendPropertyConditions(filter, where, params);
     appendInstantGte("c.created_at", filter.createdAfter(), where, params);
     appendInstantLt("c.created_at", filter.createdBefore(), where, params);
     appendInstantGte(
@@ -585,6 +587,26 @@ final class PostgresqlJobQueryOperations {
   private void appendUuidEq(String column, UUID value, StringBuilder where, List<Object> params) {
     and(where, column + " = ?");
     params.add(value);
+  }
+
+  private void appendPropertyConditions(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    Map<String, Set<String>> propertyFilters = filter.propertyFilters();
+    if (propertyFilters == null || propertyFilters.isEmpty()) {
+      return;
+    }
+    // One EXISTS per key (AND across keys); IN over the allowed values, served by the
+    // (property_key, value) index on scheduler_job_properties.
+    for (Map.Entry<String, Set<String>> entry : propertyFilters.entrySet()) {
+      and(
+          where,
+          "EXISTS (SELECT 1 FROM scheduler_job_properties p"
+              + " WHERE p.job_id = c.job_id AND p.property_key = ? AND p.value IN ("
+              + placeholders(entry.getValue().size())
+              + "))");
+      params.add(entry.getKey());
+      params.addAll(entry.getValue());
+    }
   }
 
   private void appendTagCondition(JobFilter filter, StringBuilder where, List<Object> params) {

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStore.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStore.java
@@ -20,6 +20,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -51,4 +52,5 @@ public interface PostgresqlJobStore
         JobQueryStore,
         JobAnalyticsStore,
         JobAuditStore,
-        DlqAlertStore {}
+        DlqAlertStore,
+        JobExtensionStore {}

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
@@ -88,6 +88,7 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   private PostgresqlAuxiliaryOperations auxiliary;
   private PostgresqlSignalOperations signals;
   private PostgresqlRecurringJobOperations recurringJobs;
+  private PostgresqlExtensionOperations extensions;
 
   /** No-arg constructor required by CDI normal-scope proxying. Not for direct use. */
   protected PostgresqlJobStoreImpl() {
@@ -833,6 +834,7 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
     auxiliary = new PostgresqlAuxiliaryOperations(ctx);
     signals = new PostgresqlSignalOperations(ctx);
     recurringJobs = new PostgresqlRecurringJobOperations(ctx, reservations);
+    extensions = new PostgresqlExtensionOperations(ctx);
   }
 
   // ---------- RecurringJobStore delegates ----------
@@ -883,5 +885,37 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   @Override
   public List<run.ratchet.store.spi.RecurringJobDefinition> listAll() {
     return recurringJobs.listAll();
+  }
+
+  // ---------- JobExtensionStore delegates ----------
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    extensions.putProperty(jobId, key, value);
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    return extensions.getProperty(jobId, key);
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    return extensions.getPropertiesByPrefix(jobId, prefix);
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    return extensions.getState(jobId, namespace);
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    extensions.initState(jobId, namespace, initialState);
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    return extensions.updateState(jobId, namespace, newState, expectedVersion);
   }
 }

--- a/stores/ratchet-store-postgresql/src/main/resources/ddl/migrations/V001__initial_schema.sql
+++ b/stores/ratchet-store-postgresql/src/main/resources/ddl/migrations/V001__initial_schema.sql
@@ -417,6 +417,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_archive
     depended_on             uuid,
     superseded_by           uuid,
     tags                    VARCHAR(512),
+    properties              TEXT,
+    extension_state         TEXT,
     CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
     CONSTRAINT chk_archive_job_type CHECK (job_type IN
@@ -488,3 +490,33 @@ CREATE TABLE IF NOT EXISTS scheduler_resource_permit
 
 CREATE INDEX IF NOT EXISTS idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
 CREATE INDEX IF NOT EXISTS idx_resource_permit_job ON scheduler_resource_permit (job_id);
+
+-- 14. scheduler_job_properties — write-once indexed scalars (plaintext by design; no secrets)
+CREATE TABLE IF NOT EXISTS scheduler_job_properties
+(
+    job_id       uuid          NOT NULL,
+    property_key VARCHAR(255)  NOT NULL,
+    value        VARCHAR(1024),
+    CONSTRAINT pk_scheduler_job_properties PRIMARY KEY (job_id, property_key),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_property_kv ON scheduler_job_properties (property_key, value);
+
+-- 15. scheduler_job_extension_state — mutable per-namespace blobs with per-row CAS; encrypted at
+-- rest when payload encryption is configured (state holds ciphertext, encrypted_state /
+-- encryption_key_id mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE IF NOT EXISTS scheduler_job_extension_state
+(
+    job_id            uuid         NOT NULL,
+    namespace         VARCHAR(64)  NOT NULL,
+    state             TEXT         NOT NULL,
+    encrypted_state   BOOLEAN      NOT NULL DEFAULT FALSE,
+    encryption_key_id VARCHAR(256),
+    version           INT          NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_scheduler_job_extension_state PRIMARY KEY (job_id, namespace),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_extension_state_key_id ON scheduler_job_extension_state (encryption_key_id);

--- a/stores/ratchet-store-postgresql/src/main/resources/ddl/postgresql-schema.sql
+++ b/stores/ratchet-store-postgresql/src/main/resources/ddl/postgresql-schema.sql
@@ -409,6 +409,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job_archive
     depended_on             uuid,
     superseded_by           uuid,
     tags                    VARCHAR(512),
+    properties              TEXT,
+    extension_state         TEXT,
     CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
     CONSTRAINT chk_archive_job_type CHECK (job_type IN
@@ -480,3 +482,33 @@ CREATE TABLE IF NOT EXISTS scheduler_resource_permit
 
 CREATE INDEX IF NOT EXISTS idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
 CREATE INDEX IF NOT EXISTS idx_resource_permit_job ON scheduler_resource_permit (job_id);
+
+-- 14. scheduler_job_properties — write-once indexed scalars (plaintext by design; no secrets)
+CREATE TABLE IF NOT EXISTS scheduler_job_properties
+(
+    job_id       uuid          NOT NULL,
+    property_key VARCHAR(255)  NOT NULL,
+    value        VARCHAR(1024),
+    CONSTRAINT pk_scheduler_job_properties PRIMARY KEY (job_id, property_key),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_property_kv ON scheduler_job_properties (property_key, value);
+
+-- 15. scheduler_job_extension_state — mutable per-namespace blobs with per-row CAS; encrypted at
+-- rest when payload encryption is configured (state holds ciphertext, encrypted_state /
+-- encryption_key_id mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE IF NOT EXISTS scheduler_job_extension_state
+(
+    job_id            uuid         NOT NULL,
+    namespace         VARCHAR(64)  NOT NULL,
+    state             TEXT         NOT NULL,
+    encrypted_state   BOOLEAN      NOT NULL DEFAULT FALSE,
+    encryption_key_id VARCHAR(256),
+    version           INT          NOT NULL DEFAULT 0,
+    updated_at TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_scheduler_job_extension_state PRIMARY KEY (job_id, namespace),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_extension_state_key_id ON scheduler_job_extension_state (encryption_key_id);

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlCoreOnlyStoreTest.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlCoreOnlyStoreTest.java
@@ -34,6 +34,7 @@ import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -64,7 +65,8 @@ class PostgresqlCoreOnlyStoreTest {
           JobQueryStore.class,
           JobAnalyticsStore.class,
           JobAuditStore.class,
-          DlqAlertStore.class);
+          DlqAlertStore.class,
+          JobExtensionStore.class);
 
   private final PostgresqlCoreOnlyTestFixture fixture = new PostgresqlCoreOnlyTestFixture();
 

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlExceptionTranslationTest.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlExceptionTranslationTest.java
@@ -47,6 +47,9 @@ class PostgresqlExceptionTranslationTest {
         entityManager(
             queryReturning(Collections.singletonList(terminalRow())),
             queryReturning(List.of()),
+            // archive copy of extension data: properties + extension-state reads
+            queryReturning(List.of()),
+            queryReturning(List.of()),
             queryThrowingOnExecute());
     var ctx = new PostgresqlStoreContext(em);
     var tags = new PostgresqlTagOperations(ctx);

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlJobExtensionStoreContractTest.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlJobExtensionStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.postgresql;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobExtensionStoreContract;
+
+class PostgresqlJobExtensionStoreContractTest extends AbstractJobExtensionStoreContract {
+
+  private final PostgresqlTestFixture fixture = new PostgresqlTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlTestFixture.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlTestFixture.java
@@ -70,6 +70,8 @@ public class PostgresqlTestFixture extends JpaContainerFixture {
     executeNativeSql("DELETE FROM scheduler_dlq_alerts");
     executeNativeSql("DELETE FROM scheduler_batch_metrics");
     executeNativeSql("DELETE FROM scheduler_job_archive");
+    executeNativeSql("DELETE FROM scheduler_job_properties");
+    executeNativeSql("DELETE FROM scheduler_job_extension_state");
     executeNativeSql("DELETE FROM scheduler_job");
     executeNativeSql("DELETE FROM scheduler_recurring_job_archive");
     executeNativeSql("DELETE FROM scheduler_recurring_job");

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverArchiveOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverArchiveOperations.java
@@ -20,6 +20,7 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -35,6 +36,7 @@ import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
 import run.ratchet.store.util.ArchiveRowMapper;
+import run.ratchet.store.util.ExtensionArchiveJson;
 import run.ratchet.store.util.RowValues;
 
 final class SqlserverArchiveOperations implements ArchiveStore {
@@ -45,10 +47,10 @@ final class SqlserverArchiveOperations implements ArchiveStore {
   // superseded_by (30) are nullable BINARY(16) columns, and mssql-jdbc binds an untyped Java null
   // as
   // nvarchar, which SQL Server refuses to implicitly convert to binary. CAST(? AS BINARY(16)) makes
-  // the conversion explicit (a non-null byte[] casts harmlessly). The other 29 placeholders match
-  // the shared binder's positional order exactly.
+  // the conversion explicit (a non-null byte[] casts harmlessly). The other 31 placeholders match
+  // the shared binder's positional order exactly (tags 31, properties 32, extension_state 33).
   private static final String SQLSERVER_ARCHIVE_VALUE_PLACEHOLDERS =
-      "(" + "?, ".repeat(28) + "CAST(? AS BINARY(16)), CAST(? AS BINARY(16)), ?)";
+      "(" + "?, ".repeat(28) + "CAST(? AS BINARY(16)), CAST(? AS BINARY(16)), ?, ?, ?)";
 
   // language=SQL Server
   private static final String INSERT_ARCHIVE_SQL =
@@ -87,6 +89,7 @@ final class SqlserverArchiveOperations implements ArchiveStore {
       JobEntity hydrated = reads.hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
+      populateExtensionData(archive, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, UuidByteArrayConverter::toBytes);
       query.executeUpdate();
@@ -122,6 +125,7 @@ final class SqlserverArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
+        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
       }
 
@@ -229,5 +233,55 @@ final class SqlserverArchiveOperations implements ArchiveStore {
     } catch (RuntimeException e) {
       throw ctx.translateTransientStoreException("purge archived jobs", e);
     }
+  }
+
+  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
+    // language=SQL Server
+    String propertySql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> propertyRows =
+        ctx.em()
+            .createNativeQuery(propertySql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .getResultList();
+    Map<String, String> properties = new LinkedHashMap<>();
+    for (Object[] row : propertyRows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        properties.put((String) row[0], value);
+      }
+    }
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+
+    // language=SQL Server
+    String stateSql =
+        """
+        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
+        FROM scheduler_job_extension_state
+        WHERE job_id = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> stateRows =
+        ctx.em()
+            .createNativeQuery(stateSql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .getResultList();
+    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
+    for (Object[] row : stateRows) {
+      states.add(
+          new ExtensionArchiveJson.StateRow(
+              (String) row[0],
+              RowValues.stringOrNull(row[1]),
+              RowValues.booleanOrFalse(row[2]),
+              RowValues.stringOrNull(row[3]),
+              ((Number) row[4]).intValue(),
+              RowValues.instantOrNull(row[5])));
+    }
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
   }
 }

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverArchiveOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverArchiveOperations.java
@@ -20,7 +20,6 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,6 +31,7 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.id.UuidV7Factory;
 import run.ratchet.store.spi.ArchiveStore;
 import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.ArchiveExtensionData;
 import run.ratchet.store.util.ArchiveHelper;
 import run.ratchet.store.util.ArchiveParameterBinder;
 import run.ratchet.store.util.ArchiveQuerySupport;
@@ -89,7 +89,8 @@ final class SqlserverArchiveOperations implements ArchiveStore {
       JobEntity hydrated = reads.hydrateForArchive(job);
       ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
       prepareArchive(archive);
-      populateExtensionData(archive, hydrated.getId());
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(List.of(hydrated.getId()));
+      populateExtensionData(archive, extensionData, hydrated.getId());
       Query query = ctx.em().createNativeQuery(INSERT_ARCHIVE_SQL);
       ArchiveParameterBinder.bind(query, archive, 1, UuidByteArrayConverter::toBytes);
       query.executeUpdate();
@@ -118,6 +119,7 @@ final class SqlserverArchiveOperations implements ArchiveStore {
           reads.findByIds(ids).stream()
               .collect(Collectors.toMap(JobEntity::getId, Function.identity()));
       List<ArchivedJobEntity> archives = new ArrayList<>(jobsToArchive.size());
+      List<UUID> archiveIds = new ArrayList<>(jobsToArchive.size());
       for (UUID id : ids) {
         JobEntity hydrated = hydratedById.get(id);
         if (hydrated == null) {
@@ -125,8 +127,12 @@ final class SqlserverArchiveOperations implements ArchiveStore {
         }
         ArchivedJobEntity archive = ArchiveHelper.buildArchive(hydrated, reason, archivedBy);
         prepareArchive(archive);
-        populateExtensionData(archive, hydrated.getId());
         archives.add(archive);
+        archiveIds.add(hydrated.getId());
+      }
+      ArchiveExtensionData extensionData = fetchArchiveExtensionData(archiveIds);
+      for (int i = 0; i < archives.size(); i++) {
+        populateExtensionData(archives.get(i), extensionData, archiveIds.get(i));
       }
 
       String rows =
@@ -235,53 +241,14 @@ final class SqlserverArchiveOperations implements ArchiveStore {
     }
   }
 
-  private void populateExtensionData(ArchivedJobEntity archive, UUID jobId) {
-    // language=SQL Server
-    String propertySql =
-        """
-        SELECT property_key, value
-        FROM scheduler_job_properties
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> propertyRows =
-        ctx.em()
-            .createNativeQuery(propertySql)
-            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
-            .getResultList();
-    Map<String, String> properties = new LinkedHashMap<>();
-    for (Object[] row : propertyRows) {
-      String value = RowValues.stringOrNull(row[1]);
-      if (value != null) {
-        properties.put((String) row[0], value);
-      }
-    }
-    archive.setProperties(ExtensionArchiveJson.propertiesJson(properties));
+  private ArchiveExtensionData fetchArchiveExtensionData(List<UUID> jobIds) {
+    return ArchiveExtensionData.fetch(
+        ctx.em(), jobIds, UuidByteArrayConverter::toBytes, RowValues::uuidOrNull);
+  }
 
-    // language=SQL Server
-    String stateSql =
-        """
-        SELECT namespace, state, encrypted_state, encryption_key_id, version, updated_at
-        FROM scheduler_job_extension_state
-        WHERE job_id = ?
-        """;
-    @SuppressWarnings("unchecked")
-    List<Object[]> stateRows =
-        ctx.em()
-            .createNativeQuery(stateSql)
-            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
-            .getResultList();
-    List<ExtensionArchiveJson.StateRow> states = new ArrayList<>(stateRows.size());
-    for (Object[] row : stateRows) {
-      states.add(
-          new ExtensionArchiveJson.StateRow(
-              (String) row[0],
-              RowValues.stringOrNull(row[1]),
-              RowValues.booleanOrFalse(row[2]),
-              RowValues.stringOrNull(row[3]),
-              ((Number) row[4]).intValue(),
-              RowValues.instantOrNull(row[5])));
-    }
-    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(states));
+  private void populateExtensionData(
+      ArchivedJobEntity archive, ArchiveExtensionData extensionData, UUID jobId) {
+    archive.setProperties(ExtensionArchiveJson.propertiesJson(extensionData.properties(jobId)));
+    archive.setExtensionState(ExtensionArchiveJson.extensionStateJson(extensionData.states(jobId)));
   }
 }

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverExtensionOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverExtensionOperations.java
@@ -19,6 +19,7 @@ import static run.ratchet.store.util.ExtensionValidation.escapeLike;
 import static run.ratchet.store.util.ExtensionValidation.requireKey;
 import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
 import static run.ratchet.store.util.ExtensionValidation.requireState;
+import static run.ratchet.store.util.ExtensionValidation.requireValue;
 
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -54,6 +55,7 @@ final class SqlserverExtensionOperations implements JobExtensionStore {
   @Override
   public void putProperty(UUID jobId, String key, String value) {
     requireKey(key);
+    requireValue(value);
     // language=SQL Server
     String sql =
         """

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverExtensionOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverExtensionOperations.java
@@ -15,6 +15,11 @@
  */
 package run.ratchet.store.sqlserver;
 
+import static run.ratchet.store.util.ExtensionValidation.escapeLike;
+import static run.ratchet.store.util.ExtensionValidation.requireKey;
+import static run.ratchet.store.util.ExtensionValidation.requireNamespace;
+import static run.ratchet.store.util.ExtensionValidation.requireState;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -213,27 +218,5 @@ final class SqlserverExtensionOperations implements JobExtensionStore {
             .setParameter(7, expectedVersion)
             .executeUpdate();
     return updated > 0;
-  }
-
-  private static void requireKey(String key) {
-    if (key == null || key.isBlank()) {
-      throw new IllegalArgumentException("property key must not be null or blank");
-    }
-  }
-
-  private static void requireNamespace(String namespace) {
-    if (namespace == null || namespace.isBlank()) {
-      throw new IllegalArgumentException("namespace must not be null or blank");
-    }
-  }
-
-  private static void requireState(String state) {
-    if (state == null) {
-      throw new IllegalArgumentException("state must not be null");
-    }
-  }
-
-  private static String escapeLike(String raw) {
-    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
   }
 }

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverExtensionOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverExtensionOperations.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import run.ratchet.store.converter.EncryptionHolder;
+import run.ratchet.store.spi.JobExtensionStore;
+import run.ratchet.store.sqlserver.converter.UuidByteArrayConverter;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.JobEncryption;
+import run.ratchet.store.util.PayloadEncryptor;
+import run.ratchet.store.util.RowValues;
+
+/**
+ * SQL Server implementation of {@link JobExtensionStore}.
+ *
+ * <p>Property values are plaintext by design (indexed for the query layer). Extension-state blobs
+ * follow the deployment-wide payload-encryption switch: when it is on, the {@code state} column
+ * holds a ciphertext frame bound to {@code (job_id, namespace)}; otherwise plaintext with {@code
+ * encrypted_state = 0}.
+ */
+final class SqlserverExtensionOperations implements JobExtensionStore {
+
+  private final SqlserverStoreContext ctx;
+
+  SqlserverExtensionOperations(SqlserverStoreContext ctx) {
+    this.ctx = ctx;
+  }
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    requireKey(key);
+    // language=SQL Server
+    String sql =
+        """
+        MERGE scheduler_job_properties AS t
+        USING (VALUES (?, ?, ?)) AS s(job_id, property_key, value)
+          ON t.job_id = s.job_id AND t.property_key = s.property_key
+        WHEN MATCHED THEN UPDATE SET t.value = s.value
+        WHEN NOT MATCHED THEN INSERT (job_id, property_key, value)
+          VALUES (s.job_id, s.property_key, s.value);
+        """;
+    ctx.em()
+        .createNativeQuery(sql)
+        .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+        .setParameter(2, key)
+        .setParameter(3, value)
+        .executeUpdate();
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    requireKey(key);
+    // language=SQL Server
+    String sql =
+        """
+        SELECT value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(2, key)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(RowValues.stringOrNull(rows.get(0)));
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    if (prefix == null) {
+      throw new IllegalArgumentException("prefix must not be null");
+    }
+    // language=SQL Server
+    String sql =
+        """
+        SELECT property_key, value
+        FROM scheduler_job_properties
+        WHERE job_id = ? AND property_key LIKE ? ESCAPE '\\'
+        ORDER BY property_key
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(2, escapeLike(prefix) + "%")
+            .getResultList();
+    Map<String, String> result = new LinkedHashMap<>();
+    for (Object[] row : rows) {
+      String value = RowValues.stringOrNull(row[1]);
+      if (value != null) {
+        result.put((String) row[0], value);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    requireNamespace(namespace);
+    // language=SQL Server
+    String sql =
+        """
+        SELECT state, version
+        FROM scheduler_job_extension_state
+        WHERE job_id = ? AND namespace = ?
+        """;
+    @SuppressWarnings("unchecked")
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(2, namespace)
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    Object[] row = rows.get(0);
+    String stored = RowValues.stringOrNull(row[0]);
+    String json =
+        PayloadEncryptor.decryptValue(stored, EncryptionTarget.extensionState(jobId, namespace));
+    return Optional.of(new ExtensionState(json, ((Number) row[1]).intValue()));
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    requireNamespace(namespace);
+    requireState(initialState);
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            initialState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=SQL Server
+    String sql =
+        """
+        INSERT INTO scheduler_job_extension_state
+          (job_id, namespace, state, encrypted_state, encryption_key_id, version, updated_at)
+        VALUES (?, ?, ?, ?, ?, 0, ?)
+        """;
+    try {
+      ctx.em()
+          .createNativeQuery(sql)
+          .setParameter(1, UuidByteArrayConverter.toBytes(jobId))
+          .setParameter(2, namespace)
+          .setParameter(3, stored)
+          .setParameter(4, active)
+          .setParameter(5, JobEncryption.keyId(active))
+          .setParameter(6, Timestamp.from(Instant.now()))
+          .executeUpdate();
+    } catch (RuntimeException e) {
+      if (ctx.constraintDetector().isDuplicateKey(e)) {
+        throw new IllegalStateException(
+            "extension state already initialized for job " + jobId + " namespace " + namespace, e);
+      }
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    requireNamespace(namespace);
+    requireState(newState);
+    if (expectedVersion < 0) {
+      throw new IllegalArgumentException(
+          "expectedVersion must be non-negative: " + expectedVersion);
+    }
+    boolean active = EncryptionHolder.encryptionActiveFor(false);
+    String stored =
+        PayloadEncryptor.encryptValue(
+            newState, active, EncryptionTarget.extensionState(jobId, namespace));
+    // language=SQL Server
+    String sql =
+        """
+        UPDATE scheduler_job_extension_state
+        SET state = ?, encrypted_state = ?, encryption_key_id = ?,
+            version = version + 1, updated_at = ?
+        WHERE job_id = ? AND namespace = ? AND version = ?
+        """;
+    int updated =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, stored)
+            .setParameter(2, active)
+            .setParameter(3, JobEncryption.keyId(active))
+            .setParameter(4, Timestamp.from(Instant.now()))
+            .setParameter(5, UuidByteArrayConverter.toBytes(jobId))
+            .setParameter(6, namespace)
+            .setParameter(7, expectedVersion)
+            .executeUpdate();
+    return updated > 0;
+  }
+
+  private static void requireKey(String key) {
+    if (key == null || key.isBlank()) {
+      throw new IllegalArgumentException("property key must not be null or blank");
+    }
+  }
+
+  private static void requireNamespace(String namespace) {
+    if (namespace == null || namespace.isBlank()) {
+      throw new IllegalArgumentException("namespace must not be null or blank");
+    }
+  }
+
+  private static void requireState(String state) {
+    if (state == null) {
+      throw new IllegalArgumentException("state must not be null");
+    }
+  }
+
+  private static String escapeLike(String raw) {
+    return raw.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobQueryOperations.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -383,6 +384,7 @@ final class SqlserverJobQueryOperations {
         "JSON_VALUE(c.trace_context, '$.traceparent')", filter.traceCorrelationId(), where, params);
     appendParentJobId(filter, where, params);
     appendTagCondition(filter, where, params);
+    appendPropertyConditions(filter, where, params);
     appendInstantGte("c.created_at", filter.createdAfter(), where, params);
     appendInstantLt("c.created_at", filter.createdBefore(), where, params);
     appendInstantGte(
@@ -602,6 +604,26 @@ final class SqlserverJobQueryOperations {
             + placeholders(filterTags.size())
             + "))");
     params.addAll(filterTags);
+  }
+
+  private void appendPropertyConditions(
+      JobFilter filter, StringBuilder where, List<Object> params) {
+    Map<String, Set<String>> propertyFilters = filter.propertyFilters();
+    if (propertyFilters == null || propertyFilters.isEmpty()) {
+      return;
+    }
+    // One EXISTS per key (AND across keys); IN over the allowed values, served by the
+    // (property_key, value) index on scheduler_job_properties.
+    for (Map.Entry<String, Set<String>> entry : propertyFilters.entrySet()) {
+      and(
+          where,
+          "EXISTS (SELECT 1 FROM scheduler_job_properties p"
+              + " WHERE p.job_id = c.job_id AND p.property_key = ? AND p.value IN ("
+              + placeholders(entry.getValue().size())
+              + "))");
+      params.add(entry.getKey());
+      params.addAll(entry.getValue());
+    }
   }
 
   private void appendCursorCondition(JobFilter filter, StringBuilder where, List<Object> params) {

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStore.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStore.java
@@ -20,6 +20,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -51,4 +52,5 @@ public interface SqlserverJobStore
         JobQueryStore,
         JobAnalyticsStore,
         JobAuditStore,
-        DlqAlertStore {}
+        DlqAlertStore,
+        JobExtensionStore {}

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
@@ -88,6 +88,7 @@ class SqlserverJobStoreImpl implements SqlserverJobStore {
   private SqlserverAuxiliaryOperations auxiliary;
   private SqlserverSignalOperations signals;
   private SqlserverRecurringJobOperations recurringJobs;
+  private SqlserverExtensionOperations extensions;
 
   /** No-arg constructor required by CDI normal-scope proxying. Not for direct use. */
   protected SqlserverJobStoreImpl() {
@@ -846,6 +847,7 @@ class SqlserverJobStoreImpl implements SqlserverJobStore {
     auxiliary = new SqlserverAuxiliaryOperations(ctx);
     signals = new SqlserverSignalOperations(ctx);
     recurringJobs = new SqlserverRecurringJobOperations(ctx, reservations);
+    extensions = new SqlserverExtensionOperations(ctx);
   }
 
   // ---------- RecurringJobStore delegates ----------
@@ -896,5 +898,37 @@ class SqlserverJobStoreImpl implements SqlserverJobStore {
   @Override
   public List<run.ratchet.store.spi.RecurringJobDefinition> listAll() {
     return recurringJobs.listAll();
+  }
+
+  // ---------- JobExtensionStore delegates ----------
+
+  @Override
+  public void putProperty(UUID jobId, String key, String value) {
+    extensions.putProperty(jobId, key, value);
+  }
+
+  @Override
+  public Optional<String> getProperty(UUID jobId, String key) {
+    return extensions.getProperty(jobId, key);
+  }
+
+  @Override
+  public Map<String, String> getPropertiesByPrefix(UUID jobId, String prefix) {
+    return extensions.getPropertiesByPrefix(jobId, prefix);
+  }
+
+  @Override
+  public Optional<ExtensionState> getState(UUID jobId, String namespace) {
+    return extensions.getState(jobId, namespace);
+  }
+
+  @Override
+  public void initState(UUID jobId, String namespace, String initialState) {
+    extensions.initState(jobId, namespace, initialState);
+  }
+
+  @Override
+  public boolean updateState(UUID jobId, String namespace, String newState, int expectedVersion) {
+    return extensions.updateState(jobId, namespace, newState, expectedVersion);
   }
 }

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/migrations/V001__initial_schema.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/migrations/V001__initial_schema.sql
@@ -350,6 +350,8 @@ CREATE TABLE scheduler_job_archive
     depended_on             BINARY(16),
     superseded_by           BINARY(16),
     tags                    VARCHAR(512),
+    properties              NVARCHAR(MAX),
+    extension_state         NVARCHAR(MAX),
     CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
     CONSTRAINT chk_archive_job_type CHECK (job_type IN
@@ -424,3 +426,35 @@ CREATE TABLE scheduler_resource_permit
 
 CREATE INDEX idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
 CREATE INDEX idx_resource_permit_job ON scheduler_resource_permit (job_id);
+
+-- 14. scheduler_job_properties (write-once indexed scalars; plaintext by design — no secrets)
+-- property_key/value are non-unicode VARCHAR so the (property_key, value) index key fits SQL
+-- Server's 1700-byte nonclustered-index limit (255 + 1024 = 1279 < 1700); block metadata is ASCII.
+CREATE TABLE scheduler_job_properties
+(
+    job_id       BINARY(16)    NOT NULL,
+    property_key VARCHAR(255)  NOT NULL,
+    value        VARCHAR(1024),
+    CONSTRAINT pk_scheduler_job_properties PRIMARY KEY (job_id, property_key),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_property_kv ON scheduler_job_properties (property_key, value);
+
+-- 15. scheduler_job_extension_state (mutable per-namespace blobs with per-row CAS; encrypted at rest
+-- when payload encryption is configured — state holds ciphertext, encrypted_state/encryption_key_id
+-- mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE scheduler_job_extension_state
+(
+    job_id            BINARY(16)    NOT NULL,
+    namespace         VARCHAR(64)   NOT NULL,
+    state             NVARCHAR(MAX) NOT NULL,
+    encrypted_state   BIT           NOT NULL DEFAULT 0,
+    encryption_key_id VARCHAR(256),
+    version           INT           NOT NULL DEFAULT 0,
+    updated_at        DATETIME2(6)  NOT NULL,
+    CONSTRAINT pk_scheduler_job_extension_state PRIMARY KEY (job_id, namespace),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_extension_state_key_id ON scheduler_job_extension_state (encryption_key_id);

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-schema.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-schema.sql
@@ -370,6 +370,8 @@ CREATE TABLE scheduler_job_archive
     depended_on             BINARY(16),
     superseded_by           BINARY(16),
     tags                    VARCHAR(512),
+    properties              NVARCHAR(MAX),
+    extension_state         NVARCHAR(MAX),
     CONSTRAINT pk_scheduler_job_archive PRIMARY KEY (archive_id),
     CONSTRAINT chk_archive_status CHECK (final_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
     CONSTRAINT chk_archive_job_type CHECK (job_type IN
@@ -444,3 +446,35 @@ CREATE TABLE scheduler_resource_permit
 
 CREATE INDEX idx_resource_permit_resource ON scheduler_resource_permit (resource_name);
 CREATE INDEX idx_resource_permit_job ON scheduler_resource_permit (job_id);
+
+-- 14. scheduler_job_properties (write-once indexed scalars; plaintext by design — no secrets)
+-- property_key/value are non-unicode VARCHAR so the (property_key, value) index key fits SQL
+-- Server's 1700-byte nonclustered-index limit (255 + 1024 = 1279 < 1700); block metadata is ASCII.
+CREATE TABLE scheduler_job_properties
+(
+    job_id       BINARY(16)    NOT NULL,
+    property_key VARCHAR(255)  NOT NULL,
+    value        VARCHAR(1024),
+    CONSTRAINT pk_scheduler_job_properties PRIMARY KEY (job_id, property_key),
+    CONSTRAINT fk_job_properties_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_property_kv ON scheduler_job_properties (property_key, value);
+
+-- 15. scheduler_job_extension_state (mutable per-namespace blobs with per-row CAS; encrypted at rest
+-- when payload encryption is configured — state holds ciphertext, encrypted_state/encryption_key_id
+-- mirror the scheduler_job payload-encryption metadata columns)
+CREATE TABLE scheduler_job_extension_state
+(
+    job_id            BINARY(16)    NOT NULL,
+    namespace         VARCHAR(64)   NOT NULL,
+    state             NVARCHAR(MAX) NOT NULL,
+    encrypted_state   BIT           NOT NULL DEFAULT 0,
+    encryption_key_id VARCHAR(256),
+    version           INT           NOT NULL DEFAULT 0,
+    updated_at        DATETIME2(6)  NOT NULL,
+    CONSTRAINT pk_scheduler_job_extension_state PRIMARY KEY (job_id, namespace),
+    CONSTRAINT fk_job_extension_state_job FOREIGN KEY (job_id) REFERENCES scheduler_job (job_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_extension_state_key_id ON scheduler_job_extension_state (encryption_key_id);

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCoreOnlyStoreTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverCoreOnlyStoreTest.java
@@ -34,6 +34,7 @@ import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -64,7 +65,8 @@ class SqlserverCoreOnlyStoreTest {
           JobQueryStore.class,
           JobAnalyticsStore.class,
           JobAuditStore.class,
-          DlqAlertStore.class);
+          DlqAlertStore.class,
+          JobExtensionStore.class);
 
   private final SqlserverCoreOnlyTestFixture fixture = new SqlserverCoreOnlyTestFixture();
 

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverExceptionTranslationTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverExceptionTranslationTest.java
@@ -47,6 +47,9 @@ class SqlserverExceptionTranslationTest {
         entityManager(
             queryReturning(Collections.singletonList(terminalRow())),
             queryReturning(List.of()),
+            // archive copy of extension data: properties + extension-state reads
+            queryReturning(List.of()),
+            queryReturning(List.of()),
             queryThrowingOnExecute());
     var ctx = new SqlserverStoreContext(em);
     var tags = new SqlserverTagOperations(ctx);

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobExtensionStoreContractTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverJobExtensionStoreContractTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.sqlserver;
+
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobStore;
+import run.ratchet.tck.store.AbstractJobExtensionStoreContract;
+
+class SqlserverJobExtensionStoreContractTest extends AbstractJobExtensionStoreContract {
+
+  private final SqlserverTestFixture fixture = new SqlserverTestFixture();
+
+  @Override
+  public JobStore store() {
+    return fixture.store();
+  }
+
+  @Override
+  public JobEntity newPendingJob() {
+    return fixture.newPendingJob();
+  }
+
+  @Override
+  public JobEntity newBatchParentJob() {
+    return fixture.newBatchParentJob();
+  }
+
+  @Override
+  public void cleanupStore() {
+    fixture.cleanupStore();
+  }
+}

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigratorIT.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigratorIT.java
@@ -73,6 +73,8 @@ class SqlserverSchemaMigratorIT extends AbstractSchemaMigratorContract {
           "scheduler_business_key_reservation",
           "scheduler_job_queue",
           "scheduler_job_tag",
+          "scheduler_job_properties",
+          "scheduler_job_extension_state",
           "scheduler_job_log",
           "scheduler_job_execution",
           "scheduler_resource_permit",

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTestFixture.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverTestFixture.java
@@ -54,6 +54,8 @@ public class SqlserverTestFixture extends JpaContainerFixture {
     executeNativeSql("DELETE FROM scheduler_dlq_alerts");
     executeNativeSql("DELETE FROM scheduler_batch_metrics");
     executeNativeSql("DELETE FROM scheduler_job_archive");
+    executeNativeSql("DELETE FROM scheduler_job_properties");
+    executeNativeSql("DELETE FROM scheduler_job_extension_state");
     executeNativeSql("DELETE FROM scheduler_job");
     executeNativeSql("DELETE FROM scheduler_recurring_job_archive");
     executeNativeSql("DELETE FROM scheduler_recurring_job");

--- a/testing/ratchet-arch-tests/src/test/java/run/ratchet/architecture/LayeringArchitectureTest.java
+++ b/testing/ratchet-arch-tests/src/test/java/run/ratchet/architecture/LayeringArchitectureTest.java
@@ -55,6 +55,7 @@ public class LayeringArchitectureTest {
   private static final String STORE_MONGODB = "run.ratchet.store.mongodb..";
   private static final String RI = "run.ratchet.ri..";
   private static final String COORDINATOR = "run.ratchet.coordinator..";
+  private static final String BLOCKS = "run.ratchet.blocks..";
 
   /**
    * Defends against total importer shrinkage. Asserts the importer found classes from every module
@@ -99,6 +100,28 @@ public class LayeringArchitectureTest {
     long count = imported.stream().filter(c -> c.getPackageName().startsWith(packageName)).count();
     assertTrue(count > 0, "expected at least one class in " + packageName + ", found 0");
   }
+
+  // --- Core must never depend on the optional blocks extension ---
+
+  /**
+   * {@code run.ratchet.blocks..} is the optional low-code extension layered ON TOP of the core:
+   * blocks depends on the API and SPI seams ({@code InvocationSubmissionService}, {@code
+   * JobExtensionStore}, {@code PreExecutionArgResolver}), never the reverse. A single core-side
+   * reference into the blocks package would make the optional module mandatory. The rule's subject
+   * packages are non-empty today, so it cannot pass vacuously even while the blocks module itself
+   * does not exist yet.
+   */
+  @ArchTest
+  static final ArchRule coreDoesNotDependOnBlocksExtension =
+      noClasses()
+          .that()
+          .resideInAnyPackage(API, SPI, STORE_CORE, RI, COORDINATOR)
+          .should()
+          .dependOnClassesThat()
+          .resideInAPackage(BLOCKS)
+          .because(
+              "ratchet-blocks is an optional extension; the core must never depend on it"
+                  + " (dependency direction: blocks -> api, never the reverse)");
 
   // --- API + store-core must not depend on the reference implementation ---
 

--- a/testing/ratchet-arch-tests/src/test/java/run/ratchet/architecture/ModuleHygieneArchitectureTest.java
+++ b/testing/ratchet-arch-tests/src/test/java/run/ratchet/architecture/ModuleHygieneArchitectureTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
  * here instead of deep in the server matrix.
  *
  * <ul>
- *   <li>Observability providers stay out of the core (api/spi/ri/stores/coordinators).
+ *   <li>Observability providers stay out of the core (api/spi/ri/stores/coordinators/blocks).
  *   <li>The JPA API is confined to the store layer.
  *   <li>The serializable-lambda deserialization surface stays in {@code ratchet-api}.
  *   <li>Implementation modules never print to stdout/stderr or call {@code printStackTrace}.
@@ -58,6 +58,14 @@ public class ModuleHygieneArchitectureTest {
   private static final String SPI = "run.ratchet.spi..";
   private static final String STORE_CORE = "run.ratchet.store..";
   private static final String RI = "run.ratchet.ri..";
+
+  /**
+   * The optional low-code extension (ratchet-blocks, not yet shipped). Included in the hygiene
+   * rules now so the first blocks class is governed from day one; until the module lands the rules
+   * match it vacuously, which is fine — every rule here also covers non-empty packages.
+   */
+  private static final String BLOCKS = "run.ratchet.blocks..";
+
   private static final String COORDINATOR = "run.ratchet.coordinator..";
   private static final String COORDINATOR_JMS = "run.ratchet.coordinator.jms..";
   private static final String COORDINATOR_POSTGRESQL = "run.ratchet.coordinator.postgresql..";
@@ -97,17 +105,17 @@ public class ModuleHygieneArchitectureTest {
   // --- 1. Observability providers stay out of the core ---
 
   /**
-   * The api/spi/ri/store/coordinator modules must not depend on a concrete observability provider.
-   * Metrics and tracing are reached through the {@code MetricsCollector}/{@code TracingCollector}
-   * SPIs; a direct Micrometer or OpenTelemetry import would hardwire the core to one provider and
-   * break the dependency-free public surface. The provider adapters live in {@code
+   * The api/spi/ri/store/coordinator/blocks modules must not depend on a concrete observability
+   * provider. Metrics and tracing are reached through the {@code MetricsCollector}/{@code
+   * TracingCollector} SPIs; a direct Micrometer or OpenTelemetry import would hardwire the core to
+   * one provider and break the dependency-free public surface. The provider adapters live in {@code
    * ratchet-micrometer}/{@code ratchet-otel}, which are outside these packages.
    */
   @ArchTest
   static final ArchRule coreModulesDoNotDependOnObservabilityProviders =
       noClasses()
           .that()
-          .resideInAnyPackage(API, SPI, RI, STORE_CORE, COORDINATOR)
+          .resideInAnyPackage(API, SPI, RI, STORE_CORE, COORDINATOR, BLOCKS)
           .should()
           .dependOnClassesThat()
           .resideInAnyPackage("io.micrometer..", "io.opentelemetry..")
@@ -119,15 +127,16 @@ public class ModuleHygieneArchitectureTest {
 
   /**
    * The {@code jakarta.persistence} API stays in the store layer. The public API, the reference
-   * implementation, and the coordinators are JPA-free — persistence is reached only through the
-   * store SPI. Scoped to SQL-stores-only is unnecessary: store-core legitimately uses JPA, and the
-   * Mongo store does not, so confining to {@code run.ratchet.store..} subsumes both.
+   * implementation, the coordinators, and the blocks extension are JPA-free — persistence is
+   * reached only through the store SPI. Scoped to SQL-stores-only is unnecessary: store-core
+   * legitimately uses JPA, and the Mongo store does not, so confining to {@code
+   * run.ratchet.store..} subsumes both.
    */
   @ArchTest
   static final ArchRule jpaApiIsConfinedToStoreModules =
       noClasses()
           .that()
-          .resideInAnyPackage(API, SPI, RI, COORDINATOR)
+          .resideInAnyPackage(API, SPI, RI, COORDINATOR, BLOCKS)
           .should()
           .dependOnClassesThat()
           .resideInAPackage("jakarta.persistence..")
@@ -159,16 +168,16 @@ public class ModuleHygieneArchitectureTest {
   // --- 4. No stdout/stderr or printStackTrace in implementation modules ---
 
   /**
-   * Implementation modules (RI, store, coordinator) must not write to {@code System.out}/{@code
-   * System.err} or call any {@code Throwable.printStackTrace} overload. Diagnostics go through
-   * JBoss Logging so EE deployments route them consistently; a stray stack-trace dump bypasses the
-   * configured logger.
+   * Implementation modules (RI, store, coordinator, blocks) must not write to {@code
+   * System.out}/{@code System.err} or call any {@code Throwable.printStackTrace} overload.
+   * Diagnostics go through JBoss Logging so EE deployments route them consistently; a stray
+   * stack-trace dump bypasses the configured logger.
    */
   @ArchTest
   static final ArchRule noStdoutStderrOrPrintStackTrace =
       noClasses()
           .that()
-          .resideInAnyPackage(RI, STORE_CORE, COORDINATOR)
+          .resideInAnyPackage(RI, STORE_CORE, COORDINATOR, BLOCKS)
           .should()
           .accessField(System.class, "out")
           .orShould()

--- a/testing/ratchet-tck/store/pom.xml
+++ b/testing/ratchet-tck/store/pom.xml
@@ -34,6 +34,16 @@
             <scope>provided</scope>
         </dependency>
         <!--
+          jakarta.json-api lets the archive-retention contract parse the denormalized
+          properties/extension_state JSON the archive row carries. Provided scope: the store under
+          test already supplies a JSON-P implementation (ExtensionArchiveJson uses it at runtime).
+        -->
+        <dependency>
+            <groupId>jakarta.json</groupId>
+            <artifactId>jakarta.json-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!--
           jakarta.transaction-api lets the transaction-boundary contract assert the @Transactional
           attribute JPA stores declare on their lock/heartbeat operations. Provided scope: the store
           under test already supplies it.

--- a/testing/ratchet-tck/store/src/main/java/module-info.java
+++ b/testing/ratchet-tck/store/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module run.ratchet.tck.store {
   requires run.ratchet.tck.util;
   requires run.ratchet.api;
   requires run.ratchet.store.core;
+  requires jakarta.json;
   requires jakarta.persistence;
   requires jakarta.transaction;
   requires java.sql;

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobCrudStoreContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobCrudStoreContract.java
@@ -37,6 +37,7 @@ import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.LockStore;
 import run.ratchet.store.spi.RecurringJobStore;
@@ -84,7 +85,8 @@ public abstract class AbstractJobCrudStoreContract implements JobStoreContractFi
             JobQueryStore.class,
             JobAnalyticsStore.class,
             JobAuditStore.class,
-            DlqAlertStore.class);
+            DlqAlertStore.class,
+            JobExtensionStore.class);
     for (Class<?> cap : capabilities) {
       var view = store.capability(cap);
       assertEquals(

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobExtensionStoreContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobExtensionStoreContract.java
@@ -74,6 +74,45 @@ public abstract class AbstractJobExtensionStoreContract implements JobStoreContr
   }
 
   @Test
+  void putProperty_rejectsKeyLongerThan255Characters() {
+    var job = persist(newPendingJob());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extensionStore().putProperty(job.getId(), "x".repeat(256), "value"));
+  }
+
+  @Test
+  void putProperty_rejectsValueLongerThan1024Characters() {
+    var job = persist(newPendingJob());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extensionStore().putProperty(job.getId(), "ratchet-tck.value", "x".repeat(1025)));
+  }
+
+  @Test
+  void putProperty_roundTrips255CharacterKey() {
+    var job = persist(newPendingJob());
+    String key = "x".repeat(255);
+
+    extensionStore().putProperty(job.getId(), key, "value");
+
+    assertEquals("value", extensionStore().getProperty(job.getId(), key).orElseThrow());
+  }
+
+  @Test
+  void putProperty_roundTrips1024CharacterValue() {
+    var job = persist(newPendingJob());
+    String value = "x".repeat(1024);
+
+    extensionStore().putProperty(job.getId(), "ratchet-tck.value", value);
+
+    assertEquals(
+        value, extensionStore().getProperty(job.getId(), "ratchet-tck.value").orElseThrow());
+  }
+
+  @Test
   void putProperty_replacesExistingValueForSameKey() {
     var job = persist(newPendingJob());
 
@@ -147,6 +186,15 @@ public abstract class AbstractJobExtensionStoreContract implements JobStoreContr
     ExtensionState state = extensionStore().getState(job.getId(), NAMESPACE).orElseThrow();
     assertEquals("{\"steps\":{}}", state.json());
     assertEquals(0, state.version());
+  }
+
+  @Test
+  void initState_rejectsNamespaceLongerThan64Characters() {
+    var job = persist(newPendingJob());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> extensionStore().initState(job.getId(), "x".repeat(65), "{}"));
   }
 
   @Test

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobExtensionStoreContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobExtensionStoreContract.java
@@ -17,9 +17,13 @@ package run.ratchet.tck.store;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import java.io.StringReader;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +34,9 @@ import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobStatus;
 import run.ratchet.store.converter.EncryptionHolder;
 import run.ratchet.store.spi.JobExtensionStore.ExtensionState;
+import run.ratchet.store.util.EncryptionEnvelope;
+import run.ratchet.store.util.EncryptionTarget;
+import run.ratchet.store.util.PayloadEncryptor;
 import run.ratchet.tck.store.AbstractPayloadEncryptionStoreContract.RecordingEngine;
 import run.ratchet.tck.store.AbstractPayloadEncryptionStoreContract.SingleKeyProvider;
 
@@ -254,6 +261,65 @@ public abstract class AbstractJobExtensionStoreContract implements JobStoreContr
     assertTrue(
         archived.getExtensionState() != null && archived.getExtensionState().contains(NAMESPACE),
         "archive row must carry the job's extension state as JSON");
+  }
+
+  /**
+   * The archive copy preserves encrypted extension state as stored: the archive JSON carries the
+   * ciphertext verbatim (never the plaintext, never a re-encryption), keeps the {@code
+   * encrypted_state} / {@code encryption_key_id} metadata, and the ciphertext stays decryptable
+   * against the original job id and namespace — the AAD binding {@link
+   * EncryptionTarget#extensionState} established on the hot row. The decrypt target is rebuilt from
+   * the archive row alone ({@code original_job_id} + the entry's namespace) to prove the row is
+   * self-sufficient.
+   */
+  @Test
+  void archiveJob_preservesEncryptedExtensionStateAsDecryptableCiphertext() {
+    var job = persist(newPendingJob());
+    RecordingEngine engine = new RecordingEngine();
+    EncryptionHolder.install(
+        List.of(engine), RecordingEngine.ALGORITHM_ID, new SingleKeyProvider(), true);
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"secret\":\"s3cr3t\"}");
+    store().compareAndSwapStatus(job.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store()
+        .markJobSucceeded(
+            job.getId(), null, null, Instant.EPOCH, Instant.EPOCH.plusSeconds(1), 100L, 50L);
+    var completed = store().findById(job.getId()).orElseThrow();
+    int encryptCallsBeforeArchive = engine.encryptedPlaintexts.size();
+    int decryptCallsBeforeArchive = engine.decryptCount.get();
+
+    var archived = archiveStore().archiveJob(completed, "tck", "tck-node");
+
+    // Verbatim copy: archiving must move the ciphertext without routing it through the engine.
+    assertEquals(
+        encryptCallsBeforeArchive,
+        engine.encryptedPlaintexts.size(),
+        "archive copy must not re-encrypt the extension state");
+    assertEquals(
+        decryptCallsBeforeArchive,
+        engine.decryptCount.get(),
+        "archive copy must not decrypt the extension state");
+
+    String json = archived.getExtensionState();
+    assertNotNull(json, "archive row must carry the job's extension state as JSON");
+    assertFalse(json.contains("s3cr3t"), "archive copy must stay ciphertext, never leak plaintext");
+
+    JsonObject entry = Json.createReader(new StringReader(json)).readArray().getJsonObject(0);
+    assertEquals(NAMESPACE, entry.getString("namespace"));
+    assertTrue(entry.getBoolean("encrypted_state"), "archive entry must keep the encrypted flag");
+    assertTrue(
+        EncryptionEnvelope.isFramed(entry.getString("state")),
+        "the copied state must be an envelope-framed ciphertext, not plaintext");
+    assertEquals(
+        "tck-key-1",
+        entry.getString("encryption_key_id"),
+        "archive entry must keep the key id for key-rotation accounting");
+
+    String decrypted =
+        PayloadEncryptor.decryptValue(
+            entry.getString("state"),
+            EncryptionTarget.extensionState(
+                archived.getOriginalJobId(), entry.getString("namespace")));
+    assertEquals("{\"secret\":\"s3cr3t\"}", decrypted);
   }
 
   @Test

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobExtensionStoreContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobExtensionStoreContract.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.tck.store;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobStatus;
+import run.ratchet.store.converter.EncryptionHolder;
+import run.ratchet.store.spi.JobExtensionStore.ExtensionState;
+import run.ratchet.tck.store.AbstractPayloadEncryptionStoreContract.RecordingEngine;
+import run.ratchet.tck.store.AbstractPayloadEncryptionStoreContract.SingleKeyProvider;
+
+/**
+ * Base contract tests for {@code JobExtensionStore}: write-once indexed properties and mutable
+ * per-namespace extension state with optimistic CAS.
+ *
+ * <p>The encryption tests install a recording engine into the static {@link EncryptionHolder} (the
+ * same seam the framework's installer uses at startup) and prove the state blob crosses the
+ * encryption seam on write and round-trips on read; the plaintext tests run with the holder
+ * disabled and assert the plaintext posture.
+ */
+public abstract class AbstractJobExtensionStoreContract implements JobStoreContractFixture {
+
+  private static final String NAMESPACE = "ratchet-tck";
+
+  @BeforeEach
+  @AfterEach
+  void cleanupExtensionFixture() {
+    EncryptionHolder.disable();
+    cleanupStore();
+  }
+
+  // ---- Properties ----
+
+  @Test
+  void putProperty_roundTripsThroughGetProperty() {
+    var job = persist(newPendingJob());
+
+    extensionStore().putProperty(job.getId(), "ratchet-tck.block_name", "invoice.send");
+
+    assertEquals(
+        "invoice.send",
+        extensionStore().getProperty(job.getId(), "ratchet-tck.block_name").orElseThrow());
+  }
+
+  @Test
+  void putProperty_replacesExistingValueForSameKey() {
+    var job = persist(newPendingJob());
+
+    extensionStore().putProperty(job.getId(), "ratchet-tck.block_version", "1");
+    extensionStore().putProperty(job.getId(), "ratchet-tck.block_version", "2");
+
+    assertEquals(
+        "2", extensionStore().getProperty(job.getId(), "ratchet-tck.block_version").orElseThrow());
+  }
+
+  @Test
+  void getProperty_returnsEmptyWhenAbsent() {
+    var job = persist(newPendingJob());
+
+    assertTrue(extensionStore().getProperty(job.getId(), "ratchet-tck.missing").isEmpty());
+    assertTrue(
+        extensionStore().getProperty(new UUID(0L, 424_242L), "ratchet-tck.missing").isEmpty());
+  }
+
+  @Test
+  void getPropertiesByPrefix_returnsOnlyMatchingNamespace() {
+    var job = persist(newPendingJob());
+    extensionStore().putProperty(job.getId(), "ratchet-tck.block_name", "invoice.send");
+    extensionStore().putProperty(job.getId(), "ratchet-tck.block_version", "2");
+    extensionStore().putProperty(job.getId(), "other-ext.key", "ignored");
+
+    Map<String, String> scoped =
+        extensionStore().getPropertiesByPrefix(job.getId(), "ratchet-tck.");
+
+    assertEquals(
+        Map.of("ratchet-tck.block_name", "invoice.send", "ratchet-tck.block_version", "2"), scoped);
+  }
+
+  @Test
+  void getPropertiesByPrefix_emptyPrefixReturnsEverything() {
+    var job = persist(newPendingJob());
+    extensionStore().putProperty(job.getId(), "a.one", "1");
+    extensionStore().putProperty(job.getId(), "b.two", "2");
+
+    assertEquals(2, extensionStore().getPropertiesByPrefix(job.getId(), "").size());
+  }
+
+  @Test
+  void getPropertiesByPrefix_treatsLikeMetacharactersLiterally() {
+    var job = persist(newPendingJob());
+    extensionStore().putProperty(job.getId(), "pct%key.x", "match");
+    extensionStore().putProperty(job.getId(), "pctXkey.x", "no-match");
+
+    Map<String, String> scoped = extensionStore().getPropertiesByPrefix(job.getId(), "pct%");
+
+    assertEquals(Map.of("pct%key.x", "match"), scoped);
+  }
+
+  @Test
+  void properties_areScopedToTheOwningJob() {
+    var first = persist(newPendingJob());
+    var second = persist(newPendingJob());
+    extensionStore().putProperty(first.getId(), "ratchet-tck.block_name", "invoice.send");
+
+    assertTrue(extensionStore().getProperty(second.getId(), "ratchet-tck.block_name").isEmpty());
+  }
+
+  // ---- Extension state ----
+
+  @Test
+  void initState_createsRowAtVersionZero() {
+    var job = persist(newPendingJob());
+
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"steps\":{}}");
+
+    ExtensionState state = extensionStore().getState(job.getId(), NAMESPACE).orElseThrow();
+    assertEquals("{\"steps\":{}}", state.json());
+    assertEquals(0, state.version());
+  }
+
+  @Test
+  void initState_failsLoudWhenAlreadyInitialized() {
+    var job = persist(newPendingJob());
+    extensionStore().initState(job.getId(), NAMESPACE, "{}");
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> extensionStore().initState(job.getId(), NAMESPACE, "{}"));
+  }
+
+  @Test
+  void getState_returnsEmptyWhenAbsent() {
+    var job = persist(newPendingJob());
+
+    assertTrue(extensionStore().getState(job.getId(), NAMESPACE).isEmpty());
+  }
+
+  @Test
+  void updateState_appliesOnMatchingVersionAndIncrements() {
+    var job = persist(newPendingJob());
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"v\":0}");
+
+    assertTrue(extensionStore().updateState(job.getId(), NAMESPACE, "{\"v\":1}", 0));
+
+    ExtensionState state = extensionStore().getState(job.getId(), NAMESPACE).orElseThrow();
+    assertEquals("{\"v\":1}", state.json());
+    assertEquals(1, state.version());
+  }
+
+  @Test
+  void updateState_rejectsStaleVersionAndLeavesStateUntouched() {
+    var job = persist(newPendingJob());
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"v\":0}");
+    assertTrue(extensionStore().updateState(job.getId(), NAMESPACE, "{\"v\":1}", 0));
+
+    assertFalse(
+        extensionStore().updateState(job.getId(), NAMESPACE, "{\"v\":-1}", 0),
+        "a stale expectedVersion must not apply");
+
+    ExtensionState state = extensionStore().getState(job.getId(), NAMESPACE).orElseThrow();
+    assertEquals("{\"v\":1}", state.json());
+    assertEquals(1, state.version());
+  }
+
+  @Test
+  void updateState_returnsFalseWhenRowAbsent() {
+    var job = persist(newPendingJob());
+
+    assertFalse(extensionStore().updateState(job.getId(), NAMESPACE, "{}", 0));
+  }
+
+  @Test
+  void state_isScopedPerNamespace() {
+    var job = persist(newPendingJob());
+    extensionStore().initState(job.getId(), "ns-one", "{\"a\":1}");
+    extensionStore().initState(job.getId(), "ns-two", "{\"b\":2}");
+    assertTrue(extensionStore().updateState(job.getId(), "ns-one", "{\"a\":2}", 0));
+
+    assertEquals(
+        "{\"a\":2}", extensionStore().getState(job.getId(), "ns-one").orElseThrow().json());
+    assertEquals(
+        "{\"b\":2}", extensionStore().getState(job.getId(), "ns-two").orElseThrow().json());
+    assertEquals(0, extensionStore().getState(job.getId(), "ns-two").orElseThrow().version());
+  }
+
+  // ---- Encryption posture ----
+
+  @Test
+  void state_crossesEncryptionSeamWhenEngineInstalled() {
+    var job = persist(newPendingJob());
+    RecordingEngine engine = new RecordingEngine();
+    EncryptionHolder.install(
+        List.of(engine), RecordingEngine.ALGORITHM_ID, new SingleKeyProvider(), true);
+
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"secret\":\"s3cr3t\"}");
+    assertTrue(extensionStore().updateState(job.getId(), NAMESPACE, "{\"secret\":\"upd4ted\"}", 0));
+
+    // Round-trip: decrypted blob and CAS version come back intact.
+    ExtensionState state = extensionStore().getState(job.getId(), NAMESPACE).orElseThrow();
+    assertEquals("{\"secret\":\"upd4ted\"}", state.json());
+    assertEquals(1, state.version());
+
+    // The engine actually saw both writes — the blob was encrypted before it reached the store,
+    // not merely round-tripped as plaintext.
+    assertTrue(engine.encryptedPlaintexts.contains("{\"secret\":\"s3cr3t\"}"));
+    assertTrue(engine.encryptedPlaintexts.contains("{\"secret\":\"upd4ted\"}"));
+    assertTrue(engine.decryptCount.get() > 0, "read path must route through the engine");
+  }
+
+  // ---- Archive retention ----
+
+  @Test
+  void archiveJob_copiesPropertiesAndExtensionStateOntoArchiveRow() {
+    var job = persist(newPendingJob());
+    extensionStore().putProperty(job.getId(), "ratchet-tck.block_name", "invoice.send");
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"steps\":{}}");
+    store().compareAndSwapStatus(job.getId(), JobStatus.PENDING, JobStatus.RUNNING, null);
+    store()
+        .markJobSucceeded(
+            job.getId(), null, null, Instant.EPOCH, Instant.EPOCH.plusSeconds(1), 100L, 50L);
+    var completed = store().findById(job.getId()).orElseThrow();
+
+    var archived = archiveStore().archiveJob(completed, "tck", "tck-node");
+
+    assertTrue(
+        archived.getProperties() != null
+            && archived.getProperties().contains("ratchet-tck.block_name")
+            && archived.getProperties().contains("invoice.send"),
+        "archive row must carry the job's properties as JSON");
+    assertTrue(
+        archived.getExtensionState() != null && archived.getExtensionState().contains(NAMESPACE),
+        "archive row must carry the job's extension state as JSON");
+  }
+
+  @Test
+  void state_isPlaintextWhenEncryptionDisabled() {
+    var job = persist(newPendingJob());
+
+    extensionStore().initState(job.getId(), NAMESPACE, "{\"plain\":true}");
+
+    ExtensionState state = extensionStore().getState(job.getId(), NAMESPACE).orElseThrow();
+    assertEquals("{\"plain\":true}", state.json());
+  }
+}

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractJobQueryStoreContract.java
@@ -842,6 +842,88 @@ public abstract class AbstractJobQueryStoreContract implements JobStoreContractF
     }
   }
 
+  // ── Extension-property filtering ──────────────────────────────────────
+
+  @Test
+  void searchByPropertyEquals_returnsOnlyJobsCarryingTheProperty() {
+    var tagged = persist(newPendingJob());
+    var other = persist(newPendingJob());
+    extensionStore().putProperty(tagged.getId(), "ratchet-tck.block_name", "invoice.send");
+    extensionStore().putProperty(other.getId(), "ratchet-tck.block_name", "invoice.archive");
+
+    List<JobEntity> results =
+        queryStore()
+            .searchJobs(
+                JobFilter.builder()
+                    .propertyEquals("ratchet-tck.block_name", "invoice.send")
+                    .build(),
+                100,
+                0);
+
+    assertEquals(1, results.size(), "propertyEquals must match exactly the tagged job");
+    assertEquals(tagged.getId(), results.get(0).getId());
+  }
+
+  @Test
+  void searchByPropertyIn_matchesAnyListedValue() {
+    var first = persist(newPendingJob());
+    var second = persist(newPendingJob());
+    var third = persist(newPendingJob());
+    extensionStore().putProperty(first.getId(), "ratchet-tck.block_name", "invoice.send");
+    extensionStore().putProperty(second.getId(), "ratchet-tck.block_name", "invoice.archive");
+    extensionStore().putProperty(third.getId(), "ratchet-tck.block_name", "invoice.void");
+
+    List<JobEntity> results =
+        queryStore()
+            .searchJobs(
+                JobFilter.builder()
+                    .propertyIn(
+                        "ratchet-tck.block_name", List.of("invoice.send", "invoice.archive"))
+                    .build(),
+                100,
+                0);
+
+    assertEquals(2, results.size(), "propertyIn must match jobs carrying any listed value");
+  }
+
+  @Test
+  void searchByMultiplePropertyKeys_combinesWithAnd() {
+    var both = persist(newPendingJob());
+    var nameOnly = persist(newPendingJob());
+    extensionStore().putProperty(both.getId(), "ratchet-tck.block_name", "invoice.send");
+    extensionStore().putProperty(both.getId(), "ratchet-tck.block_version", "2");
+    extensionStore().putProperty(nameOnly.getId(), "ratchet-tck.block_name", "invoice.send");
+
+    List<JobEntity> results =
+        queryStore()
+            .searchJobs(
+                JobFilter.builder()
+                    .propertyEquals("ratchet-tck.block_name", "invoice.send")
+                    .propertyEquals("ratchet-tck.block_version", "2")
+                    .build(),
+                100,
+                0);
+
+    assertEquals(1, results.size(), "multiple property keys must intersect");
+    assertEquals(both.getId(), results.get(0).getId());
+  }
+
+  @Test
+  void countJobs_appliesPropertyFilters() {
+    var tagged = persist(newPendingJob());
+    persist(newPendingJob());
+    extensionStore().putProperty(tagged.getId(), "ratchet-tck.block_name", "invoice.send");
+
+    long count =
+        queryStore()
+            .countJobs(
+                JobFilter.builder()
+                    .propertyEquals("ratchet-tck.block_name", "invoice.send")
+                    .build());
+
+    assertEquals(1, count, "countJobs must apply property filters");
+  }
+
   private static void assertDefaultCreatedAtOrder(JobEntity previous, JobEntity current) {
     assertNotNull(previous.getCreatedAt(), "Sorted jobs must expose non-null createdAt values");
     assertNotNull(current.getCreatedAt(), "Sorted jobs must expose non-null createdAt values");

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/ConformanceLevel.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/ConformanceLevel.java
@@ -77,6 +77,7 @@ public enum ConformanceLevel {
       List.of(
           "AbstractArchiveStoreContract",
           "AbstractDlqAlertStoreContract",
+          "AbstractJobExtensionStoreContract",
           "AbstractLockStoreContract",
           "AbstractResourcePermitStoreContract",
           "AbstractSchemaConformanceContract",

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JobStoreContractFixture.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JobStoreContractFixture.java
@@ -25,6 +25,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -115,6 +116,10 @@ public interface JobStoreContractFixture {
 
   default DlqAlertStore dlqAlertStore() {
     return capabilityView(DlqAlertStore.class);
+  }
+
+  default JobExtensionStore extensionStore() {
+    return capabilityView(JobExtensionStore.class);
   }
 
   /**

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/JpaContainerFixture.java
@@ -44,6 +44,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -276,7 +277,8 @@ public abstract class JpaContainerFixture implements JobStoreContractFixture {
               JobQueryStore.class,
               JobAnalyticsStore.class,
               JobAuditStore.class,
-              DlqAlertStore.class
+              DlqAlertStore.class,
+              JobExtensionStore.class
             },
             (proxy, method, args) -> {
               // capability() must return a view that still routes through this transactional proxy,

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/schema/RatchetSchemaCatalog.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/schema/RatchetSchemaCatalog.java
@@ -39,15 +39,16 @@ import run.ratchet.tck.store.schema.DeprecatedArtifact.DroppedIndex;
  * PostgreSQL {@code STORED} expressions are introspection-asymmetric and not part of the
  * conformance contract.
  *
- * <p>Three columns are intentionally omitted because their physical types diverge across stores
- * with no single satisfying {@link LogicalType}: {@code scheduler_batch.progress_hook} (MySQL JSON
- * vs PG TEXT), {@code scheduler_job_log.mdc} (MySQL JSON vs PG TEXT), and {@code
- * scheduler_job_archive.job_result} (MySQL JSON vs PG TEXT). The conformance contract verifies
- * presence and conformance, not exclusivity — omitting these does not weaken the contract.
+ * <p>Five columns are intentionally omitted because their physical types diverge across stores with
+ * no single satisfying {@link LogicalType}: {@code scheduler_batch.progress_hook} (MySQL JSON vs PG
+ * TEXT), {@code scheduler_job_log.mdc} (MySQL JSON vs PG TEXT), and {@code
+ * scheduler_job_archive.job_result} / {@code .properties} / {@code .extension_state} (MySQL JSON vs
+ * PG TEXT). The conformance contract verifies presence and conformance, not exclusivity — omitting
+ * these does not weaken the contract.
  */
 public final class RatchetSchemaCatalog {
 
-  public static final int CURRENT_VERSION = 10;
+  public static final int CURRENT_VERSION = 11;
 
   public static final SchemaSpec CURRENT =
       new SchemaSpec(
@@ -69,7 +70,9 @@ public final class RatchetSchemaCatalog {
               schedulerJobArchive(),
               schedulerWorkflowCondition(),
               schedulerDlqAlerts(),
-              schedulerResourcePermit()),
+              schedulerResourcePermit(),
+              schedulerJobProperties(),
+              schedulerJobExtensionState()),
           v005Drops());
 
   private RatchetSchemaCatalog() {}
@@ -383,7 +386,8 @@ public final class RatchetSchemaCatalog {
         .column(required("archived_at", TIMESTAMP_TZ))
         .column(nullable("archived_by", TEXT))
         .column(nullable("archive_reason", TEXT))
-        // job_result intentionally omitted: MySQL JSON vs PG TEXT type asymmetry.
+        // job_result, properties, and extension_state intentionally omitted: MySQL JSON vs PG
+        // TEXT type asymmetry.
         .column(nullable("result_type", TEXT))
         .column(nullable("final_error", TEXT))
         .column(nullable("payload_summary", TEXT))
@@ -466,6 +470,44 @@ public final class RatchetSchemaCatalog {
                 OnDeleteAction.CASCADE))
         .index(Index.of("idx_resource_permit_resource", "resource_name"))
         .index(Index.of("idx_resource_permit_job", "job_id"))
+        .build();
+  }
+
+  private static Table schedulerJobProperties() {
+    return Table.builder("scheduler_job_properties")
+        .column(required("job_id", UUID))
+        .column(required("property_key", TEXT))
+        .column(nullable("value", TEXT))
+        .primaryKey("job_id", "property_key")
+        .foreignKey(
+            new ForeignKey(
+                "fk_job_properties_job",
+                "job_id",
+                "scheduler_job",
+                "job_id",
+                OnDeleteAction.CASCADE))
+        .index(Index.of("idx_property_kv", "property_key", "value"))
+        .build();
+  }
+
+  private static Table schedulerJobExtensionState() {
+    return Table.builder("scheduler_job_extension_state")
+        .column(required("job_id", UUID))
+        .column(required("namespace", TEXT))
+        .column(required("state", TEXT))
+        .column(required("encrypted_state", BOOLEAN))
+        .column(nullable("encryption_key_id", TEXT))
+        .column(required("version", INT32))
+        .column(required("updated_at", TIMESTAMP_TZ))
+        .primaryKey("job_id", "namespace")
+        .foreignKey(
+            new ForeignKey(
+                "fk_job_extension_state_job",
+                "job_id",
+                "scheduler_job",
+                "job_id",
+                OnDeleteAction.CASCADE))
+        .index(Index.of("idx_extension_state_key_id", "encryption_key_id"))
         .build();
   }
 

--- a/testing/ratchet-tck/store/src/test/java/run/ratchet/tck/store/schema/RatchetSchemaCatalogTest.java
+++ b/testing/ratchet-tck/store/src/test/java/run/ratchet/tck/store/schema/RatchetSchemaCatalogTest.java
@@ -97,10 +97,10 @@ class RatchetSchemaCatalogTest {
   @Test
   void currentVersionMatchesMaxDdlSchemaVersionInsert() {
     assertEquals(
-        10,
+        11,
         RatchetSchemaCatalog.CURRENT_VERSION,
         "CURRENT_VERSION must match the highest ratchet_schema_version insert in the shipped DDL"
-            + " (currently '010'); bump both together when the schema advances so the catalog never"
+            + " (currently '011'); bump both together when the schema advances so the catalog never"
             + " lags the DDL again");
   }
 

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/capability/CoreOnlyStoreDeploymentIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/capability/CoreOnlyStoreDeploymentIT.java
@@ -34,6 +34,7 @@ import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.LockStore;
 import run.ratchet.store.spi.RecurringJobStore;
@@ -74,6 +75,7 @@ class CoreOnlyStoreDeploymentIT extends BaseRatchetIT {
   @Inject private Instance<JobAnalyticsStore> analyticsStore;
   @Inject private Instance<JobAuditStore> auditStore;
   @Inject private Instance<DlqAlertStore> dlqAlertStore;
+  @Inject private Instance<JobExtensionStore> jobExtensionStore;
 
   @Deployment
   public static WebArchive createDeployment() {
@@ -107,6 +109,7 @@ class CoreOnlyStoreDeploymentIT extends BaseRatchetIT {
     assertTrue(analyticsStore.isUnsatisfied(), "JobAnalyticsStore must be unsatisfied");
     assertTrue(auditStore.isUnsatisfied(), "JobAuditStore must be unsatisfied");
     assertTrue(dlqAlertStore.isUnsatisfied(), "DlqAlertStore must be unsatisfied");
+    assertTrue(jobExtensionStore.isUnsatisfied(), "JobExtensionStore must be unsatisfied");
   }
 
   @Test

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/CoreOnlyStoreExtension.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/CoreOnlyStoreExtension.java
@@ -28,6 +28,7 @@ import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.DlqAlertStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
+import run.ratchet.store.spi.JobExtensionStore;
 import run.ratchet.store.spi.JobQueryStore;
 import run.ratchet.store.spi.JobStore;
 import run.ratchet.store.spi.LockStore;
@@ -62,7 +63,8 @@ public class CoreOnlyStoreExtension implements Extension {
           JobQueryStore.class,
           JobAnalyticsStore.class,
           JobAuditStore.class,
-          DlqAlertStore.class);
+          DlqAlertStore.class,
+          JobExtensionStore.class);
 
   <T> void demoteStoreToCore(@Observes ProcessBeanAttributes<T> event) {
     BeanAttributes<T> attributes = event.getBeanAttributes();

--- a/website/docs/adr/0001-payload-encryption-threat-model.md
+++ b/website/docs/adr/0001-payload-encryption-threat-model.md
@@ -84,6 +84,11 @@ silently regress their confidentiality.
 | `ON_FAILURE_PAYLOAD` | `on_failure_payload` | surface ∥ job id |
 | `SIGNAL_PAYLOAD` | `signal_payload` | surface only |
 | `WORKFLOW_CONDITION_PREDICATE` | serialized predicate in `condition_expression` | surface only |
+| `EXTENSION_STATE` | `scheduler_job_extension_state.state` | surface ∥ job id ∥ namespace |
+
+`EXTENSION_STATE` joined the set on 2026-06-11 with the `JobExtensionStore` capability; see
+the amendment of that date for its AAD binding and why it follows the global switch rather
+than per-job opt-in.
 
 ### 3. A per-surface AAD policy, computed by the framework
 
@@ -380,7 +385,9 @@ flag). Broadcast signal delivery cannot read a per-job flag because one cipherte
 rows, so it encrypts whenever an engine is configured rather than gating on the global switch
 alone; over-encrypting a non-opted row is harmless because reads are marker-driven. Recurring
 masters carry their own opt-in flag (`scheduler_recurring_job.encrypted_payload`): the stored
-payload templates are encrypted at rest and every fired child inherits the flag.
+payload templates are encrypted at rest and every fired child inherits the flag. (The
+`EXTENSION_STATE` surface, added 2026-06-11, is outside this per-job set — see that amendment
+for why it follows the global switch only.)
 
 ## Hardening (2026-06-04, post-review)
 
@@ -540,6 +547,29 @@ Both engines pass the same `AbstractPayloadEncryptionEngineContract`, and a regi
 test installs both, makes each the write engine in turn, and confirms a value written by one still
 decrypts after the other takes over writes — read dispatch by algorithm id, working across two
 genuinely different algorithms.
+
+## Amended 2026-06-11: `EXTENSION_STATE` joins the protected set
+
+The `JobExtensionStore` capability (blocks core prereq) adds a mutable, per-namespace
+extension-state blob in `scheduler_job_extension_state`. The blob can carry workflow
+bookkeeping that embeds user data, so it joins the protected-surface enum as
+`EXTENSION_STATE` rather than staying cleartext by default.
+
+- **AAD binding: surface ∥ job id ∥ namespace** (length-prefixed, via
+  `EncryptionTarget.extensionState(jobId, namespace)`). Binding the namespace as well as
+  the job id prevents a ciphertext from being relocated between two namespaces on the
+  same job — two extensions sharing a job must not be able to replay each other's state.
+- **Global switch only, no per-job opt-in.** The per-job `withEncryptedPayload()` flag
+  expresses the *submitter's* choice about the job's own payload surfaces. Extension
+  state is written later, by extension code (the blocks engine), through an SPI whose
+  write sites hold only `(jobId, namespace)` — honoring the per-job flag would add a job
+  row lookup to every CAS write, and the submitter's choice does not govern data the
+  extension owns. A deployment that wants extension state encrypted turns on the global
+  switch; the closed six-surface per-job set above is unchanged.
+- **Archive copy stays ciphertext.** Archiving copies the state rows as stored onto the
+  archive row's denormalized JSON, with the `encrypted_state` / `encryption_key_id`
+  metadata riding along; the AAD remains reconstructable from `original_job_id` and the
+  namespace recorded in each entry.
 
 ## Still open (do not block this ADR)
 

--- a/website/docs/advanced/payload-encryption.md
+++ b/website/docs/advanced/payload-encryption.md
@@ -97,6 +97,14 @@ compliance reviewers about this boundary.
 - A payload column echoed into a log line or diagnostic dump shows ciphertext, not the
   value.
 
+Deployments using framework extensions get one more surface: per-namespace extension
+state (`scheduler_job_extension_state`) is encrypted whenever the **global switch** is on
+— it has no per-job opt-in, because the state is written by extension code after
+submission, not by the submitter. Archiving copies the state rows as stored, so encrypted
+state stays ciphertext on the archive row. See
+[ADR 0001](/adr/0001-payload-encryption-threat-model) for the full protected-surface
+table and rationale.
+
 **Not protected against**
 
 - Live worker memory. A job's arguments are plaintext on the JVM heap while the job runs;

--- a/website/docs/advanced/payload-encryption.md
+++ b/website/docs/advanced/payload-encryption.md
@@ -101,9 +101,9 @@ Deployments using framework extensions get one more surface: per-namespace exten
 state (`scheduler_job_extension_state`) is encrypted whenever the **global switch** is on
 — it has no per-job opt-in, because the state is written by extension code after
 submission, not by the submitter. Archiving copies the state rows as stored, so encrypted
-state stays ciphertext on the archive row. See
-[ADR 0001](/adr/0001-payload-encryption-threat-model) for the full protected-surface
-table and rationale.
+state stays ciphertext on the archive row. The full protected-surface table and rationale
+live in the payload-encryption ADR in the repository
+(`website/docs/adr/0001-payload-encryption-threat-model.md`).
 
 **Not protected against**
 

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -691,6 +691,7 @@ A store advertises each of these by implementing the interface; the engine probe
 | `JobAnalyticsStore` | Aggregate counts, rates, and percentiles | `countJobsByStatus()`, `getQueueWaitTimePercentile()` |
 | `JobAuditStore` | Execution history and per-job logs | `saveExecution()`, `findExecutionsByJobId()`, `appendLog()` |
 | `DlqAlertStore` | DLQ alerting | `saveDlqAlert()`, `existsRecentDlqAlert()` |
+| `JobExtensionStore` | Indexed job properties and per-namespace extension state | `putProperty()`, `getPropertiesByPrefix()`, `initState()`, `updateState()` |
 
 ### Implementing a Custom Store
 

--- a/website/docs/api-reference/batch-builder.md
+++ b/website/docs/api-reference/batch-builder.md
@@ -231,6 +231,8 @@ log.info("Batch submitted with ID {}", handle.id());
 
 Obtained from [`JobSchedulerService.streamingBatch()`](./job-scheduler-service#streamingbatch). Designed for large datasets where items are read from a `Stream` and inserted in configurable chunks.
 
+Framework extensions that build invocations directly (rather than serializing lambdas) have mirrored builders — `InvocationBatchBuilder` and `InvocationStreamingBatchBuilder<T>` — on the [`InvocationSubmissionService`](./spi-interfaces#invocationsubmissionservice) SPI.
+
 ### fromStream
 
 ```java

--- a/website/docs/api-reference/event-system.md
+++ b/website/docs/api-reference/event-system.md
@@ -339,6 +339,27 @@ public void onBatchCompleted(@Observes BatchCompletedEvent event) {
 }
 ```
 
+### BatchChunkFailureEvent {#batchchunkfailureevent}
+
+Fired when a streaming-batch chunk fails to persist (the chunk's bulk insert threw) on the invocation-mode submission path (`InvocationStreamingBatchBuilder`). Lambda-mode streaming batches do not emit it.
+
+```java
+@Incubating
+public class BatchChunkFailureEvent extends AbstractJobSchedulerEvent {
+    public int getChunkIndex()
+    public int getChunkSize()
+    public String getFailureReason()
+}
+```
+
+| Method | Return Type | Description |
+|---|---|---|
+| `getChunkIndex()` | `int` | Zero-based index of the chunk that failed |
+| `getChunkSize()` | `int` | Number of items in the failed chunk |
+| `getFailureReason()` | `String` | Failure description from the underlying store exception |
+
+This is a best-effort, pre-rollback diagnostic. Streaming submission runs in one transaction, so a chunk failure rolls back the batch parent and every previously inserted chunk with it; the event fires before that rollback and may reference a batch parent id (`getJobId()`) that never commits. Treat it as an operational signal of the failed submission, not as a pointer to durable rows.
+
 ## Chain event types {#chainevent-types}
 
 ### ChainStartedEvent

--- a/website/docs/api-reference/job-query-service.md
+++ b/website/docs/api-reference/job-query-service.md
@@ -58,6 +58,17 @@ for (JobSummary job : page.items()) {
 
 `JobFilter` fields are optional. A `null` field means "do not constrain this dimension." Vararg filters such as `statuses()` and `types()` ignore empty argument lists, so a UI can safely pass zero selected statuses to mean "all statuses."
 
+When the store advertises the `JobExtensionStore` capability, jobs can also be filtered by their indexed extension properties:
+
+```java
+JobFilter filter = JobFilter.builder()
+    .propertyEquals("ratchet-blocks.block_name", "invoice.send")
+    .propertyIn("ratchet-blocks.block_version", Set.of("1", "2"))
+    .build();
+```
+
+`propertyEquals(key, value)` requires an exact key/value match; `propertyIn(key, values)` requires the key to hold one of the given values. Constraints on different keys combine with AND; a repeated call for the same key replaces the earlier constraint.
+
 ### getJobDetail
 
 ```java

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -261,6 +261,25 @@ public class PiiSanitizer implements ErrorSanitizer {
 }
 ```
 
+## PayloadMaskingPolicy
+
+Decides which payload fields are masked before a payload leaves the framework on a read or observability path (for example the `params` map on a job detail when `maskPayloads` is enabled). The durable store payload and anything a worker needs to execute are never altered. The built-in policy matches a fixed set of common credential and PII field names (`password`, `token`, `ssn`, ...); deployers produce their own implementation to change the field set.
+
+```java
+@Incubating
+public interface PayloadMaskingPolicy {
+    boolean isSensitiveField(String fieldName);
+
+    default boolean isSensitiveField(String fieldName, MaskingContext context) {
+        return isSensitiveField(fieldName);
+    }
+}
+
+public record MaskingContext(UUID jobId, Map<String, String> jobProperties) {}
+```
+
+The context-aware overload exists for per-job decisions — the same field name can be secret on one job and not on another. `MaskingContext` carries the owning job's id and its extension properties, populated when the store advertises the `JobExtensionStore` capability (empty map otherwise). Existing name-only policies keep working unchanged through the default method.
+
 ## PayloadEncryption
 
 Keyed authenticated-encryption (AEAD) engine that protects sensitive job data at rest. The engine owns its nonce and returns an opaque body carrying everything decryption needs except the key and the additional authenticated data. `algorithmId()` is recorded in each value's envelope so the matching engine is selected at read time. Reference AES-256-GCM and XChaCha20-Poly1305 engines ship in `ratchet-encryption`.
@@ -303,6 +322,42 @@ public interface JobInvocationResolver {
     JobInvocation resolve(Serializable callback, List<Object> runtimeArguments);
 }
 ```
+
+## InvocationSubmissionService
+
+Submission seam for trusted extensions that construct `JobInvocation`s directly instead of going through the lambda-serializing builders on `JobSchedulerService`. Every submission converges on the same creation path as the public builders — same validation, idempotency, tags, batch metadata, workflow condition rows, and wakeup behavior. There is no separate persistence path.
+
+The seam is trusted by convention, not a security barrier: anything that can inject it can persist an arbitrary invocation, exactly as `JobInvocationResolver` consumers can. An extension that accepts external input (block names, workflow definitions) must validate and authorize it before constructing the invocation. Submissions still pass the full standard chain — payload validation, the deployment's class policy, and `JobAuthorizationPolicy.checkCreate()` at persistence time; the worker re-applies the security validation (public-method and signature checks, `checkExecute()`) at dispatch.
+
+```java
+@Incubating
+public interface InvocationSubmissionService {
+    InvocationJobBuilder enqueueInvocation(JobInvocation invocation);
+    InvocationJobBuilder scheduleInvocation(Duration delay, JobInvocation invocation);
+    InvocationBatchBuilder enqueueInvocationBatch(String name);
+    <T extends Serializable> InvocationStreamingBatchBuilder<T> invocationStreamingBatch(String name);
+    WorkflowCondition invocationCondition(JobInvocation invocation);
+}
+```
+
+`JobInvocation` is the serializable description of the dispatch target: fully qualified class name, method name, JVM method descriptor, static flag, and the argument list. Arguments must be JSON-representable — persistence converts the invocation through the payload factory, never JDK serialization.
+
+The three builders mirror their public counterparts. `InvocationJobBuilder` carries the options and chaining surface of [JobBuilder](/api-reference/job-builder) (`then`, `branch`, `awaitSignal`, `withTags`, `withEncryptedPayload`, ...) with a `JobInvocation` in place of each lambda. `InvocationBatchBuilder` and `InvocationStreamingBatchBuilder<T>` mirror [BatchBuilder and StreamingBatchBuilder](/api-reference/batch-builder); the streaming variant expands each stream item into a child job through a `Function<T, JobInvocation>` factory and inherits the chunk-boundary persistence and replay behavior. A streaming chunk whose bulk insert fails emits [`BatchChunkFailureEvent`](/api-reference/event-system#batchchunkfailureevent) before the submission transaction rolls back.
+
+`invocationCondition(...)` wraps a pre-resolved invocation as a `CUSTOM` workflow condition. The target method is dispatched reflectively at evaluation time with the parent's `JobResult` supplied as the trailing argument and must return `boolean`; the invocation persists as the condition's expression payload and is encrypted under the parent's predicate surface when payload encryption applies.
+
+## PreExecutionArgResolver
+
+Worker-side hook that can patch a job's invocation **arguments** at the last moment before reflective dispatch — after security validation, before argument coercion. Extensions use it for late binding: resolving placeholder arguments against state that did not exist at submission time, such as upstream step results in a workflow.
+
+```java
+@Incubating
+public interface PreExecutionArgResolver {
+    JobInvocation resolveArguments(UUID jobId, JobInvocation invocation);
+}
+```
+
+Arguments only: the dispatched target class, method, and descriptor stay pinned to the payload that security validation cleared, and only the returned invocation's arguments are honored. Returning `null` or the input instance dispatches the persisted arguments unchanged, as does leaving the hook unregistered. A thrown exception fails the job through the normal failure path, so the retry policy applies. The hook covers the job's main invocation; success/failure callback payloads and workflow-condition predicates follow their own dispatch paths and are not resolved.
 
 ## ResultPersistenceStrategy
 

--- a/website/docs/concepts/persistence.md
+++ b/website/docs/concepts/persistence.md
@@ -289,6 +289,7 @@ public interface JobStore
 | `JobAnalyticsStore` | Aggregate counts, rate statistics, and percentile metrics |
 | `JobAuditStore` | Execution history recording and structured job log storage |
 | `DlqAlertStore` | DLQ alert audit trail and deduplication |
+| `JobExtensionStore` | Indexed job properties (`scheduler_job_properties`) and mutable per-namespace extension state with optimistic CAS (`scheduler_job_extension_state`), used by framework extensions; archiving copies both onto the archive row as denormalized JSON |
 
 ### Why a Core-Plus-Capabilities Split?
 


### PR DESCRIPTION
## Summary

Adds a set of `@Incubating` extension seams to the scheduler and implements them across all five store backends (MySQL, PostgreSQL, MongoDB, Oracle, SQL Server).

- **`JobExtensionStore`** — a new optional store capability for write-once indexed job properties (`scheduler_job_properties`) and mutable per-namespace state with optimistic CAS (`scheduler_job_extension_state`). State is encrypted at rest when payload encryption is configured, bound to `(job_id, namespace)`; properties are plaintext and indexed for the query layer. Archiving copies both onto the archive row.
- **`InvocationSubmissionService`** — a submission seam for trusted extensions that build `JobInvocation`s directly instead of serializing lambdas, with job/batch/streaming-batch builders that mirror the public API and converge on the same creation path (validation, idempotency, tags, workflow conditions, wakeups).
- **`propertyEquals` / `propertyIn`** filters on `JobFilter`, served by the `(property_key, value)` index.
- A context-aware **`PayloadMaskingPolicy`** overload (`MaskingContext` carries the job id and its properties) so a policy can decide sensitivity per job rather than by field name alone.
- A **`PreExecutionArgResolver`** worker hook for last-moment argument late-binding. Arguments only; the dispatch target stays pinned to what the security gate validated.
- A **`BatchChunkFailureEvent`** (`batch.chunk_failure`) for the invocation-mode streaming path.

New store-TCK contracts cover the capability and the query filters. Architecture-test guardrails keep the optional low-code extension layer's dependency direction and module hygiene honest.

## Testing

- [x] `mvn spotless:check -B` (clean; also ran `spotless:apply`)
- [x] `cd website && npm ci && npm run build`
- [ ] `mvn clean test -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl :ratchet-testsuite,:ratchet-coverage -am`

What actually ran locally:

- Full-reactor `mvn clean test-compile` — green.
- The new `JobExtensionStore` contract (18 tests/store), the `propertyEquals` / `propertyIn` query contract (41 tests/store), and schema conformance pass on all five stores against real Testcontainers databases.
- `mvn clean verify` — green for MySQL, PostgreSQL, and MongoDB, plus the reference implementation, the reactor test suite, the JPMS consumer test, the coordinators (PostgreSQL/JMS/Hazelcast), and the architecture tests.
- Oracle and SQL Server's changed surfaces are green (above), but a complete end-to-end module run for those two was blocked by a local Docker container-startup limit unrelated to the code. Left to CI on fresh runners.

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed (SPI reference, event system, job query service, capability tables, payload encryption; the payload-encryption ADR gained the new protected surface)

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [x] Security-sensitive change
- [ ] Follow-up work remains

All new surface is additive and `@Incubating`. The extension-state column is a new encrypted-at-rest protected surface, so the AAD binding and the global-switch-only posture are worth a look: extension state is written by extension code after submission, so it does not honor the per-job opt-in. See the payload-encryption ADR.

## Additional Context

This branch was brought up to current `main`, which had relocated the store and test modules and added the Oracle and SQL Server stores. The new capability and query filters are implemented for those two stores here as well, so the feature ships on all five backends.

SQL Server uses `VARCHAR` (not `NVARCHAR`) for the `idx_property_kv` key columns to stay within its 1700-byte index-key limit; property keys and values are ASCII extension metadata.
