### PR TITLE
Copy caller principal onto recurring child jobs

### DIFF
--- a/ratchet/src/main/java/run/ratchet/ri/core/RecurringJobExecutor.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/RecurringJobExecutor.java
@@ -205,6 +205,7 @@ public class RecurringJobExecutor {
     child.setOnFailurePayload(master.onFailurePayload());
     child.setResourceName(master.resourceName());
     child.setExecutionTarget(master.executionTarget());
+    child.setCallerPrincipal(master.callerPrincipal());
     child.setEncryptedPayload(master.encryptedPayload());
     child.setIdempotencyKey(UUID.randomUUID().toString());
     return child;

--- a/ratchet/src/test/java/run/ratchet/ri/core/RecurringJobExecutorGraceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/RecurringJobExecutorGraceTest.java
@@ -127,6 +127,24 @@ class RecurringJobExecutorGraceTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  void childOccurrenceInheritsCallerPrincipalFromMaster() {
+    state.markRegistrationComplete(Set.of("known-key"));
+
+    RecurringJobDefinition known =
+        recurringMasterWithCallerPrincipal(18L, "known-key", "audit-actor");
+    when(recurringJobStore.claimDueRecurring(anyInt(), anyString(), any()))
+        .thenReturn(List.of(known));
+
+    int fired = executor.process(10, "node-A");
+
+    assertEquals(1, fired);
+    ArgumentCaptor<List<JobEntity>> childrenCaptor = ArgumentCaptor.forClass(List.class);
+    verify(jobBulkStore).bulkInsert(childrenCaptor.capture());
+    assertEquals("audit-actor", childrenCaptor.getValue().get(0).getCallerPrincipal());
+  }
+
+  @Test
   void firesAnyMasterAfterGraceExpires() {
     state =
         new RecurringRegistrationState(
@@ -259,6 +277,12 @@ class RecurringJobExecutorGraceTest {
         id, businessKey, "0 0 12 * * ?", FIXED_NOW.plusSeconds(60), executionTarget);
   }
 
+  private static RecurringJobDefinition recurringMasterWithCallerPrincipal(
+      long id, String businessKey, String callerPrincipal) {
+    return recurringMasterWithFire(
+        id, businessKey, "0 0 12 * * ?", FIXED_NOW.plusSeconds(60), null, callerPrincipal);
+  }
+
   private static RecurringJobDefinition recurringMasterWithFire(
       long id, String businessKey, String cron, Instant nextFire) {
     return recurringMasterWithFire(id, businessKey, cron, nextFire, null);
@@ -266,6 +290,16 @@ class RecurringJobExecutorGraceTest {
 
   private static RecurringJobDefinition recurringMasterWithFire(
       long id, String businessKey, String cron, Instant nextFire, String executionTarget) {
+    return recurringMasterWithFire(id, businessKey, cron, nextFire, executionTarget, null);
+  }
+
+  private static RecurringJobDefinition recurringMasterWithFire(
+      long id,
+      String businessKey,
+      String cron,
+      Instant nextFire,
+      String executionTarget,
+      String callerPrincipal) {
     return new RecurringJobDefinition(
         new UUID(0L, id),
         cron,
@@ -285,7 +319,7 @@ class RecurringJobExecutorGraceTest {
         null,
         executionTarget,
         FIXED_NOW,
-        null,
+        callerPrincipal,
         false);
   }
 }


### PR DESCRIPTION
## Summary
- `RecurringJobExecutor.createChildFromMaster` now copies the master's `callerPrincipal` onto each per-firing child entity
- Regression test: `RecurringJobExecutorGraceTest.childOccurrenceInheritsCallerPrincipalFromMaster`

## Why
The master row stores the principal resolved at `@Recurring` registration, but the child factory copied every other execution-relevant field and skipped this one. Every recurring firing therefore executed with a null `caller_principal`, and hosts that attribute work through a replaced `CallerPrincipalProvider` got no attribution for recurring runs.

## Testing
Test written first and failed with `expected: <audit-actor> but was: <null>`, then passed after the one-line fix. Full `mvn -pl ratchet -am test`: 836 tests in the `ratchet` module, 1560 across the dependency chain, all green. Spotless applied.

The issue also floats exposing the creator on the public `JobContext` API. That's left out on purpose; it's a feature discussion, not part of this bug.

Fixes #115