### PR TITLE
Let @Recurring jobs through restrictive class policies

### DIFF
--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -815,11 +815,14 @@ class DefaultJobCreationService
     // lambda's target class is rejected before reaching the database, not after a worker dequeues
     // it. Framework coordination payloads (the batch-parent noop) target an internal placeholder,
     // never run user code, and so are not subject to the application allowlist — gating them would
-    // break batch submission for any app that allowlists only its own packages.
+    // break batch submission for any app that allowlists only its own packages. @Recurring
+    // annotation payloads similarly target a framework dispatch shim; the shim validates the real
+    // annotated bean class against ClassPolicy before dispatching.
     if (classPolicy != null
         && payload != null
         && payload.target() != null
         && !JobPayloadFactory.isCoordinationPlaceholder(payload)
+        && !JobPayloadFactory.isRecurringDispatchShim(payload)
         && !classPolicy.isAllowed(payload.target())) {
       throw new SecurityException(
           "Class " + payload.target() + " is not allowed for job execution.");

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -53,6 +53,7 @@ import run.ratchet.api.exception.UnsupportedEnvelopeVersionException;
 import run.ratchet.ri.core.DefaultJobSchedulerService;
 import run.ratchet.ri.core.ResourcePermitService;
 import run.ratchet.ri.payload.ArgumentCoercion;
+import run.ratchet.ri.payload.JobPayloadFactory;
 import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.ErrorSanitizer;
@@ -430,7 +431,9 @@ public class JobTask implements Callable<Void> {
     if (className == null || className.isEmpty()) {
       throw new SecurityException("Class name cannot be null or empty");
     }
-    if (classPolicy != null && !classPolicy.isAllowed(className)) {
+    if (classPolicy != null
+        && !JobPayloadFactory.isRecurringDispatchShim(className)
+        && !classPolicy.isAllowed(className)) {
       throw new SecurityException("Class " + className + " is not allowed for job execution.");
     }
     synchronized (REFLECTION_CACHE_LOCK) {

--- a/ratchet/src/main/java/run/ratchet/ri/payload/JobPayloadFactory.java
+++ b/ratchet/src/main/java/run/ratchet/ri/payload/JobPayloadFactory.java
@@ -58,6 +58,15 @@ public final class JobPayloadFactory {
    */
   static final String COORDINATION_PLACEHOLDER_TARGET = "run.ratchet.ri.util.JobPlaceholders";
 
+  /**
+   * Fully-qualified name of the framework's recurring dispatch shim ({@code
+   * run.ratchet.ri.cdi.RecurringMethodInvoker}). Kept as a string so this payload package does not
+   * depend on the CDI package. Payloads pointing here are framework-created by {@code
+   * RecurringJobProcessor}; {@code RecurringMethodInvoker.invoke()} performs its own {@code
+   * ClassPolicy} check against the real annotated bean class before dispatching.
+   */
+  static final String RECURRING_DISPATCH_TARGET = "run.ratchet.ri.cdi.RecurringMethodInvoker";
+
   private static final JobPayload NOOP =
       new JobPayload(COORDINATION_PLACEHOLDER_TARGET, "noop", "()V", true, List.of());
 
@@ -155,6 +164,21 @@ public final class JobPayloadFactory {
    */
   public static boolean isCoordinationPlaceholder(JobPayload payload) {
     return payload != null && COORDINATION_PLACEHOLDER_TARGET.equals(payload.target());
+  }
+
+  /**
+   * Returns true if {@code payload} targets the framework's internal recurring dispatch shim. The
+   * shim is allowed through framework class-policy gates because it never decides the user target
+   * itself: {@code RecurringMethodInvoker.invoke()} validates the real annotated bean class against
+   * the configured {@code ClassPolicy} before invoking it.
+   */
+  public static boolean isRecurringDispatchShim(JobPayload payload) {
+    return payload != null && isRecurringDispatchShim(payload.target());
+  }
+
+  /** String overload for call sites that only have the target class name. */
+  public static boolean isRecurringDispatchShim(String className) {
+    return RECURRING_DISPATCH_TARGET.equals(className);
   }
 
   private static String singleInvocationError(Serializable lambda, int stepCount) {

--- a/ratchet/src/main/java/run/ratchet/ri/security/JobSecurityValidator.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/JobSecurityValidator.java
@@ -20,6 +20,7 @@ import jakarta.inject.Inject;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import org.jboss.logging.Logger;
+import run.ratchet.ri.payload.JobPayloadFactory;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.store.entity.JobPayload;
 
@@ -70,7 +71,8 @@ public class JobSecurityValidator {
       throw new SecurityException("Job payload target class cannot be null or empty");
     }
 
-    if (!classPolicy.isAllowed(targetClass)) {
+    if (!JobPayloadFactory.isRecurringDispatchShim(payload)
+        && !classPolicy.isAllowed(targetClass)) {
       throw new SecurityException("Class " + targetClass + " is not allowed for job execution.");
     }
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceRecurringClassPolicyTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceRecurringClassPolicyTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.Serializable;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import run.ratchet.api.JobPriority;
+import run.ratchet.ri.cdi.RecurringMethodInvoker;
+import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.ri.security.PackagePrefixClassPolicy;
+import run.ratchet.spi.JobInvocation;
+import run.ratchet.spi.JobInvocationResolver;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.JobBulkStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.spi.RecurringJobDefinition;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultJobCreationServiceRecurringClassPolicyTest {
+
+  @Mock private JobBatchStatusStore jobBatchStatusStore;
+  @Mock private JobTerminalStore jobTerminalStore;
+  @Mock private JobCrudStore jobCrudStore;
+  @Mock private JobBulkStore jobBulkStore;
+  @Mock private BatchStore batchStore;
+  @Mock private TagStore tagStore;
+  @Mock private WorkflowConditionStore workflowConditionStore;
+  @Mock private RecurringJobStore recurringJobStore;
+  @Mock private RecurringScheduler recurringScheduler;
+
+  private static class NoopJobWakeupService extends JobWakeupService {
+    @Override
+    public void notify(JobPriority priority, boolean immediate, String executionTarget) {}
+
+    @Override
+    public void notifyIfNeeded(
+        JobExecutionType jobType, JobPriority priority, Duration delay, String executionTarget) {}
+  }
+
+  @Test
+  void recurringDispatchShimPassesEvenWhenItsOwnPackageIsNotAllowlisted() {
+    when(recurringJobStore.createRecurring(any(RecurringJobDefinition.class)))
+        .thenAnswer(invocation -> invocation.<RecurringJobDefinition>getArgument(0).id());
+    DefaultJobCreationService service =
+        new DefaultJobCreationService(
+            jobBatchStatusStore,
+            jobTerminalStore,
+            jobCrudStore,
+            jobBulkStore,
+            batchStore,
+            tagStore,
+            workflowConditionStore,
+            recurringJobStore,
+            new NoopJobWakeupService(),
+            recurringScheduler,
+            recurringDispatchResolver(),
+            new JobPayloadInputValidator(),
+            null,
+            null,
+            null,
+            new PackagePrefixClassPolicy(Set.of("run.ratchet.ri.core.")),
+            null,
+            null,
+            Clock.fixed(Instant.parse("2026-07-01T12:00:00Z"), ZoneOffset.UTC));
+    DefaultRecurringJobBuilder builder =
+        new DefaultRecurringJobBuilder(
+            "0 0 12 * * ?", ZoneId.of("UTC"), AppRecurringBean::doWork, service);
+
+    assertDoesNotThrow(() -> service.submit(builder));
+
+    ArgumentCaptor<RecurringJobDefinition> definitionCaptor =
+        ArgumentCaptor.forClass(RecurringJobDefinition.class);
+    verify(recurringJobStore).createRecurring(definitionCaptor.capture());
+    assertEquals(
+        RecurringMethodInvoker.class.getName(), definitionCaptor.getValue().payload().target());
+  }
+
+  public static class AppRecurringBean {
+    public static void doWork() {}
+  }
+
+  private static JobInvocationResolver recurringDispatchResolver() {
+    return new JobInvocationResolver() {
+      @Override
+      public JobInvocation resolve(Serializable callback) {
+        return recurringDispatchInvocation();
+      }
+
+      @Override
+      public JobInvocation resolve(Serializable callback, List<Object> runtimeArguments) {
+        return recurringDispatchInvocation();
+      }
+    };
+  }
+
+  private static JobInvocation recurringDispatchInvocation() {
+    return new JobInvocation(
+        RecurringMethodInvoker.class.getName(),
+        "invoke",
+        "(Ljava/lang/String;Ljava/lang/String;Z)V",
+        false,
+        List.of(AppRecurringBean.class.getName(), "doWork", Boolean.FALSE));
+  }
+}

--- a/ratchet/src/test/java/run/ratchet/ri/security/JobSecurityValidatorTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/security/JobSecurityValidatorTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import run.ratchet.ri.cdi.RecurringMethodInvoker;
 import run.ratchet.store.entity.JobPayload;
 
 class JobSecurityValidatorTest {
@@ -99,6 +100,20 @@ class JobSecurityValidatorTest {
             "(Ljava/lang/String;)V",
             false,
             List.of("hello"));
+    assertDoesNotThrow(() -> validator.validate(payload));
+  }
+
+  @Test
+  void recurringDispatchShimPassesEvenWhenItsOwnPackageIsNotAllowlisted() {
+    JobSecurityValidator validator = validatorAllowing(THIS_PACKAGE);
+    JobPayload payload =
+        new JobPayload(
+            RecurringMethodInvoker.class.getName(),
+            "invoke",
+            "(Ljava/lang/String;Ljava/lang/String;Z)V",
+            false,
+            List.of(SampleTarget.class.getName(), "doWork", false));
+
     assertDoesNotThrow(() -> validator.validate(payload));
   }
 


### PR DESCRIPTION
## Summary
- `JobPayloadFactory` gains a `RECURRING_DISPATCH_TARGET` string constant plus `isRecurringDispatchShim(JobPayload)` / `isRecurringDispatchShim(String)` helpers, mirroring the existing coordination-placeholder pattern (string constant, not a class literal, so `ri.payload` keeps no dependency on `ri.cdi`)
- All three class-policy gates now exempt the shim: `DefaultJobCreationService` (submit-time), `JobSecurityValidator` (execution-time), `JobTask.loadAllowedClass` (defense-in-depth re-check)
- Regression tests: `DefaultJobCreationServiceRecurringClassPolicyTest` (new) and `JobSecurityValidatorTest.recurringDispatchShimPassesEvenWhenItsOwnPackageIsNotAllowlisted`

## Why
`@Recurring` registration submits a lambda whose captured target is the framework-internal `run.ratchet.ri.cdi.RecurringMethodInvoker`, not the annotated bean. A host that follows the documented hardening posture (a `PackagePrefixClassPolicy` allowlisting only its own packages) had every recurring job rejected with `SecurityException`, surfacing only as an error log and "Completed registration of 0 recurring jobs".

## Why this is not a security hole
`RecurringMethodInvoker.invoke()` already validates the real annotated bean class against the configured `ClassPolicy` before dispatching. The three gates were checking the wrong class; the exemption defers to the one check that was already checking the right one. What a recurring job can execute does not widen.

## Testing
Tests written first and failed with `SecurityException: Class run.ratchet.ri.cdi.RecurringMethodInvoker is not allowed for job execution`; both pass after the fix. Full `mvn -pl ratchet -am test` green, Spotless applied.

Answering the issue's question directly: yes, the invoker's inner-target re-validation is the security boundary, and with this change the host-side policy workaround is no longer needed.

Fixes #118