### PR TITLE
Reconcile recurring masters by business key on re-registration

### DIFF
--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
@@ -286,8 +286,9 @@ public class RecurringJobProcessor {
   }
 
   /**
-   * Registers every discovered {@code @Recurring} method, skipping any whose master is already
-   * committed so the call is idempotent across retries and restarts.
+   * Registers every discovered {@code @Recurring} method. The recurring submit path reconciles
+   * existing masters by business key, so registration is idempotent across retries and restarts
+   * while still applying annotation changes.
    *
    * @return {@code true} once every discovered master is confirmed present in the store (or the
    *     store does not advertise the recurring capability), so the caller can stop retrying
@@ -303,9 +304,6 @@ public class RecurringJobProcessor {
             .map(RecurringMethodRegistration::jobId)
             .collect(Collectors.toCollection(LinkedHashSet::new));
     for (RecurringMethodRegistration registration : registrations) {
-      if (store != null && store.findRecurringByBusinessKey(registration.jobId()).isPresent()) {
-        continue; // already committed (a prior attempt or a previous run) — idempotent skip
-      }
       try {
         registerJob(registration);
       } catch (Exception e) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -30,6 +30,7 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.jboss.logging.Logger;
@@ -45,6 +46,7 @@ import run.ratchet.api.SerializablePredicate;
 import run.ratchet.api.WorkflowBranch;
 import run.ratchet.api.event.JobSignalWaitingEvent;
 import run.ratchet.api.exception.DuplicateIdempotencyKeyException;
+import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.api.internal.JobBuilderState;
 import run.ratchet.ri.core.internal.ChainScheduler;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
@@ -626,18 +628,104 @@ class DefaultJobCreationService
             callerPrincipal,
             builder.encryptedPayload());
 
-    UUID saved = recurringJobStore.createRecurring(definition);
-
-    if (!builder.tags().isEmpty()) {
-      tagStore.insertTags(saved, builder.tags());
-    }
+    RecurringJobDefinition saved = createOrReconcileRecurring(definition, builder.tags());
 
     log.infof(
         "Recurring job submitted (id=%s, cron=%s, zone=%s, nextFire=%s)",
-        saved, builder.cronExpr(), builder.zone(), nextFire);
+        saved.id(), saved.cronExpr(), saved.zoneId(), saved.nextFire());
 
     recurringScheduler.kick();
-    return () -> saved;
+    return saved::id;
+  }
+
+  private RecurringJobDefinition createOrReconcileRecurring(
+      RecurringJobDefinition candidate, List<String> tags) {
+    Optional<RecurringJobDefinition> existing = findRecurringByBusinessKey(candidate.businessKey());
+    if (existing.isPresent()) {
+      return reconcileRecurring(existing.get(), candidate);
+    }
+
+    try {
+      UUID saved = recurringJobStore.createRecurring(candidate);
+      if (!tags.isEmpty()) {
+        tagStore.insertTags(saved, tags);
+      }
+      return candidate;
+    } catch (RatchetTransientStoreException e) {
+      Optional<RecurringJobDefinition> raced = findRecurringByBusinessKey(candidate.businessKey());
+      if (raced.isPresent()) {
+        return reconcileRecurring(raced.get(), candidate);
+      }
+      throw e;
+    }
+  }
+
+  private Optional<RecurringJobDefinition> findRecurringByBusinessKey(String businessKey) {
+    if (businessKey == null) {
+      return Optional.empty();
+    }
+    return recurringJobStore.findRecurringByBusinessKey(businessKey);
+  }
+
+  private RecurringJobDefinition reconcileRecurring(
+      RecurringJobDefinition existing, RecurringJobDefinition candidate) {
+    RecurringJobDefinition replacement = reconciledDefinition(existing, candidate);
+    if (recurringDefinitionsMatch(existing, replacement)) {
+      return existing;
+    }
+    if (!recurringJobStore.updateRecurring(existing.id(), replacement)) {
+      throw new IllegalStateException(
+          "Recurring master " + existing.id() + " disappeared during business-key reconciliation");
+    }
+    return replacement;
+  }
+
+  private static RecurringJobDefinition reconciledDefinition(
+      RecurringJobDefinition existing, RecurringJobDefinition candidate) {
+    boolean scheduleChanged =
+        !Objects.equals(existing.cronExpr(), candidate.cronExpr())
+            || !Objects.equals(existing.zoneId(), candidate.zoneId());
+    Instant nextFire = scheduleChanged ? candidate.nextFire() : existing.nextFire();
+    return new RecurringJobDefinition(
+        existing.id(),
+        candidate.cronExpr(),
+        candidate.zoneId(),
+        nextFire,
+        existing.paused(),
+        existing.pausedAt(),
+        candidate.priority(),
+        candidate.maxRetries(),
+        candidate.backoffPolicy(),
+        candidate.backoffParamMs(),
+        candidate.timeoutSec(),
+        candidate.payload(),
+        candidate.onSuccessPayload(),
+        candidate.onFailurePayload(),
+        existing.businessKey(),
+        candidate.resourceName(),
+        candidate.executionTarget(),
+        existing.createdAt(),
+        existing.callerPrincipal(),
+        candidate.encryptedPayload());
+  }
+
+  private static boolean recurringDefinitionsMatch(
+      RecurringJobDefinition existing, RecurringJobDefinition replacement) {
+    return Objects.equals(existing.cronExpr(), replacement.cronExpr())
+        && Objects.equals(existing.zoneId(), replacement.zoneId())
+        && Objects.equals(existing.nextFire(), replacement.nextFire())
+        && existing.priority() == replacement.priority()
+        && existing.maxRetries() == replacement.maxRetries()
+        && existing.backoffPolicy() == replacement.backoffPolicy()
+        && existing.backoffParamMs() == replacement.backoffParamMs()
+        && existing.timeoutSec() == replacement.timeoutSec()
+        && Objects.equals(existing.payload(), replacement.payload())
+        && Objects.equals(existing.onSuccessPayload(), replacement.onSuccessPayload())
+        && Objects.equals(existing.onFailurePayload(), replacement.onFailurePayload())
+        && Objects.equals(existing.businessKey(), replacement.businessKey())
+        && Objects.equals(existing.resourceName(), replacement.resourceName())
+        && Objects.equals(existing.executionTarget(), replacement.executionTarget())
+        && existing.encryptedPayload() == replacement.encryptedPayload();
   }
 
   private void requireBatchCapability() {

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/RecurringJobProcessorLeaderGateTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/RecurringJobProcessorLeaderGateTest.java
@@ -28,27 +28,35 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
+import java.lang.reflect.Field;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobOptions;
 import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.Recurring;
 import run.ratchet.api.RecurringJobBuilder;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.core.internal.RecurringRegistrationState;
+import run.ratchet.ri.payload.JobPayloadFactory;
 import run.ratchet.spi.StartupCoordinator;
 import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.RecurringJobDefinition;
+import run.ratchet.store.spi.RecurringJobStore;
 
 // Verifies startup-lease-gated cleanup and convergence window in RecurringJobProcessor.
 class RecurringJobProcessorLeaderGateTest {
@@ -239,6 +247,46 @@ class RecurringJobProcessorLeaderGateTest {
     verify(maintenance).cancelOrphanedRecurringAnnotationJobs(eq(Set.of("leader-gate-job")), any());
   }
 
+  @Test
+  void registerRecurringJobs_submitsExistingBusinessKeySoDefinitionCanBeReconciled()
+      throws Exception {
+    var maintenance = mock(RecurringAnnotationMaintenanceService.class);
+    var schedulerService = mock(JobSchedulerService.class);
+    var jobBatchStatusStore = mock(JobBatchStatusStore.class);
+    var recurringJobBuilder = mockRecurringJobBuilder();
+    UUID existingId = UUID.randomUUID();
+    when(recurringJobBuilder.submit()).thenReturn((JobHandle) () -> existingId);
+    var beanManager = mock(BeanManager.class);
+    Set<Bean<?>> beans = Set.of(beanFor(LeaderGateBean.class));
+    when(beanManager.getBeans(any(), any())).thenReturn(beans);
+    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+        .thenReturn(recurringJobBuilder);
+    var registrationState = new RecurringRegistrationState();
+
+    var processor =
+        new RecurringJobProcessor(
+            schedulerService,
+            jobBatchStatusStore,
+            maintenance,
+            beanManager,
+            mock(RecurringMethodInvoker.class),
+            null,
+            registrationState);
+    var store = mock(RecurringJobStore.class);
+    when(store.findRecurringByBusinessKey("leader-gate-job"))
+        .thenReturn(Optional.of(recurringDefinition(existingId, "leader-gate-job")));
+    injectRecurringJobStore(processor, store);
+
+    assertTrue(processor.registerRecurringJobs());
+
+    verify(schedulerService).scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(recurringJobBuilder).withBusinessKey("leader-gate-job");
+    verify(recurringJobBuilder).submit();
+    assertRegisteredJobId(processor, "leader-gate-job", existingId);
+    assertTrue(registrationState.shouldFire("leader-gate-job"));
+    verify(maintenance).cancelOrphanedRecurringAnnotationJobs(eq(Set.of("leader-gate-job")), any());
+  }
+
   private static Bean<?> beanFor(Class<?> beanClass) {
     var bean = mock(Bean.class);
     when(bean.getBeanClass()).thenReturn(beanClass);
@@ -252,6 +300,51 @@ class RecurringJobProcessorLeaderGateTest {
     when(builder.withTags(any())).thenReturn(builder);
     when(builder.submit()).thenReturn((JobHandle) () -> UUID.randomUUID());
     return builder;
+  }
+
+  private static RecurringJobDefinition recurringDefinition(UUID id, String businessKey) {
+    JobOptions options = JobOptions.defaults();
+    return new RecurringJobDefinition(
+        id,
+        "0 0/5 * * * ?",
+        "UTC",
+        FIXED_NOW.plusSeconds(60),
+        false,
+        null,
+        options.priority().ordinal(),
+        options.maxRetries(),
+        options.backoffPolicy(),
+        (int) options.backoffParam().toMillis(),
+        options.timeoutSec(),
+        JobPayloadFactory.noop(),
+        null,
+        null,
+        businessKey,
+        null,
+        null,
+        FIXED_NOW,
+        null,
+        false);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void injectRecurringJobStore(
+      RecurringJobProcessor processor, RecurringJobStore recurringJobStore) throws Exception {
+    Instance<RecurringJobStore> instance = mock(Instance.class);
+    when(instance.isResolvable()).thenReturn(true);
+    when(instance.get()).thenReturn(recurringJobStore);
+    Field field = RecurringJobProcessor.class.getDeclaredField("recurringJobStoreInstance");
+    field.setAccessible(true);
+    field.set(processor, instance);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertRegisteredJobId(
+      RecurringJobProcessor processor, String businessKey, UUID jobId) throws Exception {
+    Field field = RecurringJobProcessor.class.getDeclaredField("registeredJobIds");
+    field.setAccessible(true);
+    Map<String, String> registeredJobIds = (Map<String, String>) field.get(processor);
+    assertEquals(jobId.toString(), registeredJobIds.get(businessKey));
   }
 
   static class LeaderGateBean {

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceRecurringReconciliationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceRecurringReconciliationTest.java
@@ -1,0 +1,398 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.BackoffPolicy;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobOptions;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.payload.DefaultJobInvocationResolver;
+import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.BatchStore;
+import run.ratchet.store.spi.JobBatchStatusStore;
+import run.ratchet.store.spi.JobBulkStore;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.spi.RecurringJobDefinition;
+import run.ratchet.store.spi.RecurringJobStore;
+import run.ratchet.store.spi.TagStore;
+import run.ratchet.store.spi.WorkflowConditionStore;
+
+class DefaultJobCreationServiceRecurringReconciliationTest {
+
+  private static final Instant START = Instant.parse("2026-05-27T12:00:00Z");
+  private static final String BUSINESS_KEY = "invoice-rollup";
+
+  public static void noopTask() {}
+
+  @Test
+  void submitRecurring_reusesExistingMaster_whenBusinessKeyIsRegisteredAgain() {
+    FakeRecurringJobStore store = new FakeRecurringJobStore();
+    MutableClock clock = new MutableClock(START);
+    DefaultJobCreationService service = newService(store, clock);
+
+    UUID firstId =
+        submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY).id();
+    clock.advance(Duration.ofMinutes(30));
+
+    UUID secondId =
+        submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY).id();
+
+    assertEquals(firstId, secondId);
+    assertEquals(1, store.size());
+    assertEquals(1, store.createCount());
+  }
+
+  @Test
+  void submitRecurring_preservesNextFire_whenBusinessKeyIsRegisteredAgainUnchanged() {
+    FakeRecurringJobStore store = new FakeRecurringJobStore();
+    MutableClock clock = new MutableClock(START);
+    DefaultJobCreationService service = newService(store, clock);
+
+    submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY);
+    Instant originalNextFire = store.onlyDefinition().nextFire();
+    clock.advance(Duration.ofMinutes(30));
+
+    submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY);
+
+    assertEquals(originalNextFire, store.onlyDefinition().nextFire());
+    assertEquals(0, store.updateCount());
+  }
+
+  @Test
+  void submitRecurring_updatesExistingMaster_whenCronZoneOrOptionsChange() {
+    FakeRecurringJobStore store = new FakeRecurringJobStore();
+    MutableClock clock = new MutableClock(START);
+    DefaultJobCreationService service = newService(store, clock);
+    JobOptions updatedOptions =
+        JobOptions.defaults()
+            .withPriority(JobPriority.HIGH)
+            .withMaxRetries(3)
+            .withBackoff(BackoffPolicy.FIXED, Duration.ofSeconds(5))
+            .withTimeout(Duration.ofSeconds(30));
+
+    UUID firstId =
+        submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY).id();
+    UUID secondId =
+        submit(service, "0 30 9 * * ?", ZoneId.of("America/New_York"), updatedOptions, BUSINESS_KEY)
+            .id();
+
+    RecurringJobDefinition updated = store.onlyDefinition();
+    assertEquals(firstId, secondId);
+    assertEquals(1, store.size());
+    assertEquals(1, store.updateCount());
+    assertEquals("0 30 9 * * ?", updated.cronExpr());
+    assertEquals("America/New_York", updated.zoneId());
+    assertEquals(Instant.parse("2026-05-27T13:30:00Z"), updated.nextFire());
+    assertEquals(JobPriority.HIGH.ordinal(), updated.priority());
+    assertEquals(3, updated.maxRetries());
+    assertEquals(BackoffPolicy.FIXED, updated.backoffPolicy());
+    assertEquals(5_000, updated.backoffParamMs());
+    assertEquals(30, updated.timeoutSec());
+  }
+
+  @Test
+  void submitRecurring_keepsBusinessKeyConflict_whenSingleJobOwnsReservation() {
+    FakeRecurringJobStore store = new FakeRecurringJobStore();
+    store.reserveForSingleJob(BUSINESS_KEY);
+    DefaultJobCreationService service = newService(store, new MutableClock(START));
+
+    assertThrows(
+        RatchetTransientStoreException.class,
+        () -> submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY));
+    assertEquals(0, store.size());
+  }
+
+  @Test
+  void submitRecurring_reconcilesAfterCreateRace_whenBusinessKeyInsertLoses() {
+    FakeRecurringJobStore store = new FakeRecurringJobStore();
+    MutableClock clock = new MutableClock(START);
+    DefaultJobCreationService service = newService(store, clock);
+    RecurringJobDefinition winner =
+        existingDefinition(UUID.randomUUID(), BUSINESS_KEY, "0 0 8 * * ?", START.plusSeconds(120));
+    store.failNextCreateWithRecurringWinner(winner);
+
+    UUID id =
+        submit(service, "0 * * * * ?", ZoneOffset.UTC, JobOptions.defaults(), BUSINESS_KEY).id();
+
+    assertEquals(winner.id(), id);
+    assertEquals(1, store.size());
+    assertEquals(1, store.updateCount());
+    assertEquals("0 * * * * ?", store.onlyDefinition().cronExpr());
+  }
+
+  private static JobHandle submit(
+      DefaultJobCreationService service,
+      String cron,
+      ZoneId zone,
+      JobOptions options,
+      String businessKey) {
+    DefaultRecurringJobBuilder builder =
+        new DefaultRecurringJobBuilder(
+            cron, zone, DefaultJobCreationServiceRecurringReconciliationTest::noopTask, service);
+    builder.withOptions(options);
+    builder.withBusinessKey(businessKey);
+    return builder.submit();
+  }
+
+  private static DefaultJobCreationService newService(
+      RecurringJobStore recurringJobStore, Clock clock) {
+    return new DefaultJobCreationService(
+        mock(JobBatchStatusStore.class),
+        mock(JobTerminalStore.class),
+        mock(JobCrudStore.class),
+        mock(JobBulkStore.class),
+        mock(BatchStore.class),
+        mock(TagStore.class),
+        mock(WorkflowConditionStore.class),
+        recurringJobStore,
+        new NoopJobWakeupService(),
+        mock(RecurringScheduler.class),
+        new DefaultJobInvocationResolver(),
+        new JobPayloadInputValidator(),
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        clock);
+  }
+
+  private static RecurringJobDefinition existingDefinition(
+      UUID id, String businessKey, String cron, Instant nextFire) {
+    JobOptions options = JobOptions.defaults();
+    return new RecurringJobDefinition(
+        id,
+        cron,
+        "UTC",
+        nextFire,
+        false,
+        null,
+        options.priority().ordinal(),
+        options.maxRetries(),
+        options.backoffPolicy(),
+        (int) options.backoffParam().toMillis(),
+        options.timeoutSec(),
+        new JobPayload(
+            DefaultJobCreationServiceRecurringReconciliationTest.class.getName(),
+            "noopTask",
+            "()V",
+            true,
+            List.of()),
+        null,
+        null,
+        businessKey,
+        null,
+        null,
+        START,
+        null,
+        false);
+  }
+
+  private static final class NoopJobWakeupService extends JobWakeupService {
+    @Override
+    public void notify(JobPriority priority, boolean immediate, String executionTarget) {}
+
+    @Override
+    public void notifyIfNeeded(
+        JobExecutionType jobType, JobPriority priority, Duration delay, String executionTarget) {}
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    private void advance(Duration duration) {
+      instant = instant.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return Clock.fixed(instant, zone);
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+
+  private static final class FakeRecurringJobStore implements RecurringJobStore {
+    private final Map<String, RecurringJobDefinition> definitionsByBusinessKey =
+        new LinkedHashMap<>();
+    private final Set<String> singleJobBusinessKeys = new java.util.HashSet<>();
+
+    private RecurringJobDefinition raceWinner;
+    private int createCount;
+    private int updateCount;
+
+    private int size() {
+      return definitionsByBusinessKey.size();
+    }
+
+    private int createCount() {
+      return createCount;
+    }
+
+    private int updateCount() {
+      return updateCount;
+    }
+
+    private RecurringJobDefinition onlyDefinition() {
+      return new ArrayList<>(definitionsByBusinessKey.values()).get(0);
+    }
+
+    private void reserveForSingleJob(String businessKey) {
+      singleJobBusinessKeys.add(businessKey);
+    }
+
+    private void failNextCreateWithRecurringWinner(RecurringJobDefinition definition) {
+      raceWinner = definition;
+    }
+
+    @Override
+    public UUID createRecurring(RecurringJobDefinition definition) {
+      createCount++;
+      String businessKey = definition.businessKey();
+      if (raceWinner != null) {
+        definitionsByBusinessKey.put(raceWinner.businessKey(), raceWinner);
+        raceWinner = null;
+        throw activeBusinessKey(definition.id());
+      }
+      if (singleJobBusinessKeys.contains(businessKey)
+          || definitionsByBusinessKey.containsKey(businessKey)) {
+        throw activeBusinessKey(definition.id());
+      }
+      definitionsByBusinessKey.put(businessKey, definition);
+      return definition.id();
+    }
+
+    @Override
+    public boolean updateRecurring(UUID id, RecurringJobDefinition definition) {
+      Optional<RecurringJobDefinition> existing = getRecurring(id);
+      if (existing.isEmpty()) {
+        return false;
+      }
+      updateCount++;
+      definitionsByBusinessKey.put(definition.businessKey(), definition);
+      return true;
+    }
+
+    @Override
+    public Optional<RecurringJobDefinition> getRecurring(UUID id) {
+      return definitionsByBusinessKey.values().stream()
+          .filter(definition -> definition.id().equals(id))
+          .findFirst();
+    }
+
+    @Override
+    public Optional<RecurringJobDefinition> findRecurringByBusinessKey(String businessKey) {
+      return Optional.ofNullable(definitionsByBusinessKey.get(businessKey));
+    }
+
+    @Override
+    public List<RecurringJobDefinition> listAll() {
+      return List.copyOf(definitionsByBusinessKey.values());
+    }
+
+    @Override
+    public List<RecurringJobDefinition> claimDueRecurring(
+        int limit, String nodeId, run.ratchet.api.NodeTagFilter tagFilter) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void advanceNextFire(UUID id, Instant nextFire) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Instant> findEarliestRecurringNextFire() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean pauseRecurring(UUID id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean resumeRecurring(UUID id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int cancelOrphanedRecurringAnnotationJobs(
+        Set<String> knownBusinessKeys, Instant nodeStartTime) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int cancelRecurringJobsByTag(String tag) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean cancelRecurringJobByBusinessKey(String businessKey) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int cancelRecurringJobsByBusinessKeys(Set<String> businessKeys) {
+      throw new UnsupportedOperationException();
+    }
+
+    private static RatchetTransientStoreException activeBusinessKey(UUID id) {
+      return new RatchetTransientStoreException(
+          "Active business key in use for recurring master " + id, new RuntimeException("dup"));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `DefaultJobCreationService.submit(DefaultRecurringJobBuilder)` now reconciles instead of blindly inserting: an existing recurring master with the same business key is updated in place (cron, zone, options, payload), keeping its id, paused state, `created_at`, `caller_principal`, and — when the schedule is unchanged — its `next_fire`
- An unchanged re-registration writes nothing, so restarts are silent no-ops and never reset the schedule
- A create that loses a concurrent-boot race (`RatchetTransientStoreException` from the reservation) retries once as a reconcile against the winner
- A business key held by a plain single job is not a reconcile target; the existing conflict failure is preserved
- `RecurringJobProcessor` drops its skip-if-present gate so annotation changes actually reach the reconcile path
- No store SPI, store implementation, or schema changes — built on the existing `findRecurringByBusinessKey` and `updateRecurring`

## Why
Every restart after first boot failed re-registration with `Duplicate entry ... scheduler_business_key_reservation.PRIMARY` and reported 0 registered jobs, while the stale master kept firing on its original cron. Cron/zone/option edits to a `@Recurring` annotation were silently never applied.

## Tests (written first, red then green)
`DefaultJobCreationServiceRecurringReconciliationTest`:
- `submitRecurring_reusesExistingMaster_whenBusinessKeyIsRegisteredAgain`
- `submitRecurring_preservesNextFire_whenBusinessKeyIsRegisteredAgainUnchanged`
- `submitRecurring_updatesExistingMaster_whenCronZoneOrOptionsChange`
- `submitRecurring_keepsBusinessKeyConflict_whenSingleJobOwnsReservation`
- `submitRecurring_reconcilesAfterCreateRace_whenBusinessKeyInsertLoses`

`RecurringJobProcessorLeaderGateTest.registerRecurringJobs_submitsExistingBusinessKeySoDefinitionCanBeReconciled`

Full `mvn -pl ratchet -am clean test` green. Spotless applied.

## Known limits
- Tag reconciliation is left out: the tag path is insert-only today, so tag edits on an existing annotation don't propagate. Same scope boundary as the issue (cron/zone/options/payload).
- The issue's doc note about the business-key interplay with one-off jobs ("kick the same work now") still deserves a docs page mention; not part of this change.

Fixes #119