### PR TITLE
Make coordinator init failures diagnosable and the thread factory configurable

### DIFF
--- a/coordinators/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorSupport.java
+++ b/coordinators/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorSupport.java
@@ -18,6 +18,7 @@ package run.ratchet.coordinator.common;
 import jakarta.enterprise.inject.Instance;
 import java.util.function.Supplier;
 import org.jboss.logging.Logger;
+import run.ratchet.api.RatchetOptions;
 
 /** Shared CDI {@link Instance} resolution helpers for the bundled cluster coordinators. */
 public final class CoordinatorSupport {
@@ -49,5 +50,12 @@ public final class CoordinatorSupport {
     return configInstance != null && configInstance.isResolvable()
         ? configInstance.get()
         : defaults.get();
+  }
+
+  /**
+   * Resolves Ratchet options from CDI, falling back to compiled defaults when no producer exists.
+   */
+  public static RatchetOptions resolveOptionsOrDefault(Instance<RatchetOptions> optionsInstance) {
+    return resolveConfigOrDefault(optionsInstance, RatchetOptions::defaults);
   }
 }

--- a/coordinators/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorThreading.java
+++ b/coordinators/ratchet-coordinator-common/src/main/java/run/ratchet/coordinator/common/CoordinatorThreading.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.coordinator.common;
 
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -81,8 +82,16 @@ public final class CoordinatorThreading {
    * JNDI miss. {@code threadNamePrefix} names the loop threads (the container may rename them).
    */
   public static CoordinatorThreading managed(String threadNamePrefix) {
+    return managed(threadNamePrefix, MANAGED_THREAD_FACTORY_JNDI);
+  }
+
+  /**
+   * Container mode. Resolves the supplied managed thread factory JNDI name lazily and throws on a
+   * JNDI miss. {@code threadNamePrefix} names the loop threads (the container may rename them).
+   */
+  public static CoordinatorThreading managed(String threadNamePrefix, String jndiName) {
     return new CoordinatorThreading(
-        true, threadNamePrefix, MANAGED_THREAD_FACTORY_JNDI, /* presetFactory= */ null);
+        true, threadNamePrefix, requireJndiName(jndiName), /* presetFactory= */ null);
   }
 
   /**
@@ -177,11 +186,20 @@ public final class CoordinatorThreading {
       throw new IllegalStateException(
           "CoordinatorThreading could not resolve "
               + jndiName
-              + " from JNDI. This name is required by Jakarta Concurrency 3.0+; if you are running"
+              + " from JNDI. Configure ratchet.coordinator.thread-factory-jndi if this deployment"
+              + " exposes the managed thread factory under a different name; if you are running"
               + " outside a Jakarta EE 10+ container, build the coordinator with"
               + " CoordinatorThreading.standalone(...).",
           e);
     }
+  }
+
+  private static String requireJndiName(String jndiName) {
+    String value = Objects.requireNonNull(jndiName, "jndiName").trim();
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException("jndiName must not be blank");
+    }
+    return value;
   }
 
   private static ThreadFactory daemonThreadFactory(String prefix) {

--- a/coordinators/ratchet-coordinator-common/src/test/java/run/ratchet/coordinator/common/CoordinatorThreadingTest.java
+++ b/coordinators/ratchet-coordinator-common/src/test/java/run/ratchet/coordinator/common/CoordinatorThreadingTest.java
@@ -22,8 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
@@ -62,8 +65,8 @@ class CoordinatorThreadingTest {
 
     ExecutorService pool = threading.newDispatchPool("dispatch", 1, 8);
     try {
-      pool.submit(() -> {}).get(2, java.util.concurrent.TimeUnit.SECONDS);
-    } catch (java.util.concurrent.ExecutionException | java.util.concurrent.TimeoutException e) {
+      pool.submit(() -> {}).get(2, TimeUnit.SECONDS);
+    } catch (ExecutionException | TimeoutException e) {
       throw new AssertionError(e);
     }
     pool.shutdownNow();
@@ -80,6 +83,19 @@ class CoordinatorThreadingTest {
     assertTrue(
         ex.getMessage().contains("DefaultManagedThreadFactory"),
         "JNDI-miss message should name the well-known factory: " + ex.getMessage());
+  }
+
+  @Test
+  void managedPathUsesConfiguredJndiName() {
+    String jndiName = "java:jboss/ee/concurrency/factory/RatchetCoordinator";
+    CoordinatorThreading threading = CoordinatorThreading.managed("test", jndiName);
+
+    IllegalStateException ex =
+        assertThrows(IllegalStateException.class, () -> threading.newLoopThread("loop", () -> {}));
+
+    assertTrue(
+        ex.getMessage().contains(jndiName),
+        "JNDI-miss message should name the configured factory: " + ex.getMessage());
   }
 
   @Test

--- a/coordinators/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
+++ b/coordinators/ratchet-coordinator-hazelcast/src/main/java/run/ratchet/coordinator/hazelcast/HazelcastClusterCoordinator.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletionStage;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.coordinator.common.AbstractPushCoordinator;
 import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
@@ -83,6 +84,8 @@ public class HazelcastClusterCoordinator extends AbstractPushCoordinator
    */
   @Inject Instance<HazelcastCoordinatorConfig> configInstance;
 
+  @Inject Instance<RatchetOptions> optionsInstance;
+
   @Inject @Any Instance<HazelcastInstanceProvider> providerInstance;
   @Inject MetricsCollector metrics;
 
@@ -123,7 +126,10 @@ public class HazelcastClusterCoordinator extends AbstractPushCoordinator
     if (threading == null) {
       // CDI/production path: route the dispatch pool through the container's managed thread
       // factory. Standalone is an explicit opt-in via the test constructor.
-      threading = CoordinatorThreading.managed("ratchet-coordinator-hazelcast");
+      RatchetOptions options = CoordinatorSupport.resolveOptionsOrDefault(optionsInstance);
+      threading =
+          CoordinatorThreading.managed(
+              "ratchet-coordinator-hazelcast", options.execution().coordinatorThreadFactoryJndi());
     }
     configureDispatch(
         COORDINATOR_KIND,

--- a/coordinators/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
+++ b/coordinators/ratchet-coordinator-infinispan/src/main/java/run/ratchet/coordinator/infinispan/InfinispanClusterCoordinator.java
@@ -32,6 +32,7 @@ import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.coordinator.common.AbstractPushCoordinator;
 import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
@@ -80,6 +81,8 @@ public class InfinispanClusterCoordinator extends AbstractPushCoordinator
    */
   @Inject Instance<InfinispanCoordinatorConfig> configInstance;
 
+  @Inject Instance<RatchetOptions> optionsInstance;
+
   @Inject @Any Instance<InfinispanCacheManagerProvider> providerInstance;
   @Inject MetricsCollector metrics;
 
@@ -121,7 +124,10 @@ public class InfinispanClusterCoordinator extends AbstractPushCoordinator
     if (threading == null) {
       // CDI/production path: route the dispatch pool through the container's managed thread
       // factory. Standalone is an explicit opt-in via the test constructor.
-      threading = CoordinatorThreading.managed("ratchet-coordinator-infinispan");
+      RatchetOptions options = CoordinatorSupport.resolveOptionsOrDefault(optionsInstance);
+      threading =
+          CoordinatorThreading.managed(
+              "ratchet-coordinator-infinispan", options.execution().coordinatorThreadFactoryJndi());
     }
     configureDispatch(
         COORDINATOR_KIND,

--- a/coordinators/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
+++ b/coordinators/ratchet-coordinator-jms/src/main/java/run/ratchet/coordinator/jms/JmsClusterCoordinator.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.coordinator.common.AbstractPushCoordinator;
 import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
@@ -92,6 +93,8 @@ public class JmsClusterCoordinator extends AbstractPushCoordinator
    * deployment validation out of the box.
    */
   @Inject Instance<JmsCoordinatorConfig> configInstance;
+
+  @Inject Instance<RatchetOptions> optionsInstance;
 
   @Inject @Any Instance<JmsConnectionFactoryProvider> providerInstance;
   @Inject MetricsCollector metrics;
@@ -157,7 +160,10 @@ public class JmsClusterCoordinator extends AbstractPushCoordinator
     if (threading == null) {
       // CDI/production path: route loop threads and the dispatch pool through the container's
       // managed thread factory. Standalone is an explicit opt-in via the test constructors.
-      threading = CoordinatorThreading.managed("ratchet-coordinator-jms");
+      RatchetOptions options = CoordinatorSupport.resolveOptionsOrDefault(optionsInstance);
+      threading =
+          CoordinatorThreading.managed(
+              "ratchet-coordinator-jms", options.execution().coordinatorThreadFactoryJndi());
     }
     configureDispatch(
         COORDINATOR_KIND,

--- a/coordinators/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
+++ b/coordinators/ratchet-coordinator-postgresql/src/main/java/run/ratchet/coordinator/postgresql/PostgresqlListenNotifyCoordinator.java
@@ -34,6 +34,7 @@ import javax.sql.DataSource;
 import org.jboss.logging.Logger;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.coordinator.common.AbstractPushCoordinator;
 import run.ratchet.coordinator.common.CoordinatorSupport;
 import run.ratchet.coordinator.common.CoordinatorThreading;
@@ -85,6 +86,8 @@ public class PostgresqlListenNotifyCoordinator extends AbstractPushCoordinator
    * unsatisfied dependency and fail deployment validation out of the box.
    */
   @Inject Instance<PostgresqlCoordinatorConfig> configInstance;
+
+  @Inject Instance<RatchetOptions> optionsInstance;
 
   @Inject @Any Instance<DataSource> dataSourceInstance;
   @Inject MetricsCollector metrics;
@@ -144,7 +147,10 @@ public class PostgresqlListenNotifyCoordinator extends AbstractPushCoordinator
     if (threading == null) {
       // CDI/production path: route the LISTEN loop and the dispatch pool through the container's
       // managed thread factory. Standalone is an explicit opt-in via the test constructors.
-      threading = CoordinatorThreading.managed("ratchet-coordinator-postgresql");
+      RatchetOptions options = CoordinatorSupport.resolveOptionsOrDefault(optionsInstance);
+      threading =
+          CoordinatorThreading.managed(
+              "ratchet-coordinator-postgresql", options.execution().coordinatorThreadFactoryJndi());
     }
     configureDispatch(
         COORDINATOR_KIND,

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -38,6 +38,9 @@ import java.util.function.Consumer;
 @SuppressWarnings("ClassCanBeRecord")
 public class RatchetOptions {
 
+  private static final String DEFAULT_COORDINATOR_THREAD_FACTORY_JNDI =
+      "java:comp/DefaultManagedThreadFactory";
+
   private final PollingOptions polling;
   private final ExecutionOptions execution;
   private final NodeOptions node;
@@ -391,6 +394,8 @@ public class RatchetOptions {
    * @param jobExecutorJndi JNDI name of the {@code ManagedExecutorService} that runs jobs
    * @param scheduledExecutorJndi JNDI name of the {@code ManagedScheduledExecutorService} used for
    *     scheduled work
+   * @param coordinatorThreadFactoryJndi JNDI name of the {@code ManagedThreadFactory} used by
+   *     bundled cluster coordinators for listener loops and dispatch pools
    * @param virtualExecutorJndi JNDI name of the {@code ManagedExecutorService} used for
    *     virtual-thread execution; when blank, virtual-targeted jobs fall back to the platform pool
    * @param virtualCounterAccounting {@code true} to use lock-free counter accounting for the
@@ -404,8 +409,32 @@ public class RatchetOptions {
       Map<String, Integer> rateLimitsPerMinute,
       String jobExecutorJndi,
       String scheduledExecutorJndi,
+      String coordinatorThreadFactoryJndi,
       String virtualExecutorJndi,
       boolean virtualCounterAccounting) {
+
+    public ExecutionOptions(
+        ThreadingMode defaultThreadingMode,
+        int queueSize,
+        Map<String, Integer> maxConcurrency,
+        Map<String, Integer> virtualThreadLimits,
+        Map<String, Integer> rateLimitsPerMinute,
+        String jobExecutorJndi,
+        String scheduledExecutorJndi,
+        String virtualExecutorJndi,
+        boolean virtualCounterAccounting) {
+      this(
+          defaultThreadingMode,
+          queueSize,
+          maxConcurrency,
+          virtualThreadLimits,
+          rateLimitsPerMinute,
+          jobExecutorJndi,
+          scheduledExecutorJndi,
+          DEFAULT_COORDINATOR_THREAD_FACTORY_JNDI,
+          virtualExecutorJndi,
+          virtualCounterAccounting);
+    }
 
     public ExecutionOptions {
       maxConcurrency = Map.copyOf(maxConcurrency);
@@ -413,6 +442,8 @@ public class RatchetOptions {
       rateLimitsPerMinute = Map.copyOf(rateLimitsPerMinute);
       jobExecutorJndi = requireNonBlank("jobExecutorJndi", jobExecutorJndi);
       scheduledExecutorJndi = requireNonBlank("scheduledExecutorJndi", scheduledExecutorJndi);
+      coordinatorThreadFactoryJndi =
+          requireNonBlank("coordinatorThreadFactoryJndi", coordinatorThreadFactoryJndi);
       defaultThreadingMode =
           defaultThreadingMode == null ? ThreadingMode.PLATFORM : defaultThreadingMode;
       virtualExecutorJndi = blankToNull(virtualExecutorJndi);
@@ -864,6 +895,7 @@ public class RatchetOptions {
     private int queueSize = 100;
     private String jobExecutorJndi = "java:comp/DefaultManagedExecutorService";
     private String scheduledExecutorJndi = "java:comp/DefaultManagedScheduledExecutorService";
+    private String coordinatorThreadFactoryJndi = DEFAULT_COORDINATOR_THREAD_FACTORY_JNDI;
     private String virtualExecutorJndi;
     private boolean virtualCounterAccounting;
 
@@ -927,6 +959,18 @@ public class RatchetOptions {
       return this;
     }
 
+    /**
+     * Sets the JNDI name of the {@code ManagedThreadFactory} used by bundled cluster coordinators.
+     * Defaults to the container's {@code java:comp/DefaultManagedThreadFactory}. Some EAR
+     * deployments expose only global concurrency resources during early CDI startup; point this at
+     * that deployment-specific managed factory when {@code java:comp} is not bound yet.
+     */
+    public ExecutionBuilder coordinatorThreadFactoryJndi(String coordinatorThreadFactoryJndi) {
+      this.coordinatorThreadFactoryJndi =
+          requireNonBlank("coordinatorThreadFactoryJndi", coordinatorThreadFactoryJndi);
+      return this;
+    }
+
     public ExecutionBuilder queueSize(int queueSize) {
       this.queueSize = atLeast("queueSize", queueSize, 0);
       return this;
@@ -957,6 +1001,7 @@ public class RatchetOptions {
           rateLimitsPerMinute,
           jobExecutorJndi,
           scheduledExecutorJndi,
+          coordinatorThreadFactoryJndi,
           virtualExecutorJndi,
           virtualCounterAccounting);
     }

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
@@ -190,6 +190,7 @@ public final class RatchetOptionsFactory {
         .defaultThreadingMode(config.get(RatchetConfigKeys.WORKER_DEFAULT_THREADING_MODE))
         .jobExecutorJndi(config.get(RatchetConfigKeys.WORKER_JOB_EXECUTOR_JNDI))
         .scheduledExecutorJndi(config.get(RatchetConfigKeys.WORKER_SCHEDULED_EXECUTOR_JNDI))
+        .coordinatorThreadFactoryJndi(config.get(RatchetConfigKeys.COORDINATOR_THREAD_FACTORY_JNDI))
         .virtualExecutorJndi(config.get(RatchetConfigKeys.WORKER_VIRTUAL_EXECUTOR_JNDI))
         .virtualCounterAccounting(config.get(RatchetConfigKeys.WORKER_VIRTUAL_COUNTER_ACCOUNTING))
         .queueSize(config.get(RatchetConfigKeys.THREAD_POOL_QUEUE_SIZE))

--- a/ratchet-api/src/main/java/run/ratchet/api/internal/RatchetConfigKeys.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/internal/RatchetConfigKeys.java
@@ -68,6 +68,11 @@ public final class RatchetConfigKeys {
           "ratchet.worker.scheduled-executor-jndi",
           "RATCHET_WORKER_SCHEDULED_EXECUTOR_JNDI",
           "java:comp/DefaultManagedScheduledExecutorService");
+  public static final RatchetConfigKey<String> COORDINATOR_THREAD_FACTORY_JNDI =
+      stringKey(
+          "ratchet.coordinator.thread-factory-jndi",
+          "RATCHET_COORDINATOR_THREAD_FACTORY_JNDI",
+          "java:comp/DefaultManagedThreadFactory");
   public static final RatchetConfigKey<String> WORKER_VIRTUAL_EXECUTOR_JNDI =
       stringKey("ratchet.worker.virtual-executor-jndi", "RATCHET_WORKER_VIRTUAL_EXECUTOR_JNDI", "");
   public static final RatchetConfigKey<Boolean> WORKER_VIRTUAL_COUNTER_ACCOUNTING =

--- a/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsFactoryTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsFactoryTest.java
@@ -205,6 +205,43 @@ class RatchetOptionsFactoryTest {
   }
 
   @Test
+  void mapsCoordinatorThreadFactoryJndiFromProperty() {
+    RatchetOptions options =
+        optionsFrom(
+            new MapRatchetConfigSource(
+                Map.of(
+                    "ratchet.coordinator.thread-factory-jndi",
+                    "java:jboss/ee/concurrency/factory/RatchetCoordinator"),
+                Map.of()));
+
+    assertEquals(
+        "java:jboss/ee/concurrency/factory/RatchetCoordinator",
+        options.execution().coordinatorThreadFactoryJndi());
+  }
+
+  @Test
+  void mapsCoordinatorThreadFactoryJndiFromEnvironmentVariable() {
+    RatchetOptions options =
+        optionsFrom(
+            new MapRatchetConfigSource(
+                Map.of(),
+                Map.of(
+                    "RATCHET_COORDINATOR_THREAD_FACTORY_JNDI",
+                    "java:jboss/ee/concurrency/factory/RatchetCoordinator")));
+
+    assertEquals(
+        "java:jboss/ee/concurrency/factory/RatchetCoordinator",
+        options.execution().coordinatorThreadFactoryJndi());
+  }
+
+  @Test
+  void coordinatorThreadFactoryJndiUsesCoordinatorEnvironmentVariableName() {
+    assertEquals(
+        "RATCHET_COORDINATOR_THREAD_FACTORY_JNDI",
+        RatchetConfigKeys.COORDINATOR_THREAD_FACTORY_JNDI.environmentVariable());
+  }
+
+  @Test
   void skipsSourceThatThrowsAndUsesNextSource() {
     RatchetOptions options =
         optionsFrom(

--- a/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
@@ -37,6 +37,9 @@ class RatchetOptionsTest {
     assertEquals(
         "java:comp/DefaultManagedScheduledExecutorService",
         options.execution().scheduledExecutorJndi());
+    assertEquals(
+        "java:comp/DefaultManagedThreadFactory",
+        options.execution().coordinatorThreadFactoryJndi());
     assertEquals(60L, options.recurring().startupGraceSeconds());
     assertEquals(500, options.timeout().signalTimeoutBatchSize());
     assertEquals(RatchetOptions.IsolationCheckMode.FAIL, options.store().isolationCheckMode());
@@ -52,6 +55,8 @@ class RatchetOptionsTest {
                 execution ->
                     execution
                         .defaultThreadingMode(RatchetOptions.ThreadingMode.VIRTUAL)
+                        .coordinatorThreadFactoryJndi(
+                            "java:jboss/ee/concurrency/factory/RatchetCoordinator")
                         .maxConcurrency("dlq-alert", 4)
                         .virtualThreadLimit("workflow-join", 19)
                         .rateLimitPerMinute("single", 50))
@@ -68,6 +73,9 @@ class RatchetOptionsTest {
     assertEquals(100, options.polling().batchSize());
     assertEquals(2, options.polling().claimHeadroomFactor());
     assertEquals(RatchetOptions.ThreadingMode.VIRTUAL, options.execution().defaultThreadingMode());
+    assertEquals(
+        "java:jboss/ee/concurrency/factory/RatchetCoordinator",
+        options.execution().coordinatorThreadFactoryJndi());
     assertEquals(4, options.execution().maxConcurrency("DLQ_ALERT", -1));
     assertEquals(19, options.execution().virtualThreadLimit("WORKFLOW_JOIN", -1));
     assertEquals(50, options.execution().rateLimitPerMinute("SINGLE"));

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/PollerWakeupListener.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/PollerWakeupListener.java
@@ -66,8 +66,7 @@ public class PollerWakeupListener {
       log.info("PollerWakeupListener registered with ClusterCoordinator");
     } catch (Exception e) {
       log.errorf(
-          "Wakeup listener registration error — polling continues without push notifications: %s",
-          e);
+          e, "Wakeup listener registration error — polling continues without push notifications");
     }
   }
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/PollerWakeupListenerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/PollerWakeupListenerTest.java
@@ -16,15 +16,24 @@
 package run.ratchet.ri.core.internal;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -81,6 +90,34 @@ class PollerWakeupListenerTest {
   }
 
   @Test
+  void init_registrationFailureLogsThrowableWithCauseChain() {
+    RuntimeException rootCause = new RuntimeException("jndi missing");
+    IllegalStateException failure = new IllegalStateException("coordinator init failed", rootCause);
+    doThrow(failure).when(clusterCoordinator).registerWakeupListener(any());
+    PollerWakeupListener listener =
+        new PollerWakeupListener(clusterCoordinator, pollerScheduler, metricsCollector);
+
+    try (LogCapture logs = LogCapture.start(PollerWakeupListener.class)) {
+      listener.init();
+
+      LogRecord record =
+          logs.records().stream()
+              .filter(log -> log.getMessage().contains("Wakeup listener registration error"))
+              .findFirst()
+              .orElseThrow();
+      assertSame(failure, record.getThrown());
+      assertSame(rootCause, record.getThrown().getCause());
+      assertEquals(
+          "Wakeup listener registration error — polling continues without push notifications",
+          record.getMessage());
+      assertTrue(
+          record.getParameters() == null || record.getParameters().length == 0,
+          "Throwable must be attached to the log record, not supplied as a formatting parameter");
+      assertTrue(record.getLevel().intValue() >= Level.SEVERE.intValue());
+    }
+  }
+
+  @Test
   void registeredListener_wakeupFailureDoesNotPropagate() {
     AtomicReference<Consumer<JobWakeupHint>> listenerRef = new AtomicReference<>();
     doAnswer(
@@ -104,5 +141,50 @@ class PollerWakeupListenerTest {
 
     verify(metricsCollector).localWakeup("cluster_listener");
     verify(pollerScheduler).wakeup();
+  }
+
+  private static final class LogCapture implements AutoCloseable {
+    private final Logger logger;
+    private final Handler handler;
+    private final Level originalLevel;
+    private final boolean originalUseParentHandlers;
+    private final List<LogRecord> records = new ArrayList<>();
+
+    private LogCapture(Class<?> type) {
+      logger = Logger.getLogger(type.getName());
+      originalLevel = logger.getLevel();
+      originalUseParentHandlers = logger.getUseParentHandlers();
+      handler =
+          new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+              records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+          };
+      logger.setLevel(Level.ALL);
+      logger.setUseParentHandlers(false);
+      logger.addHandler(handler);
+    }
+
+    static LogCapture start(Class<?> type) {
+      return new LogCapture(type);
+    }
+
+    List<LogRecord> records() {
+      return records;
+    }
+
+    @Override
+    public void close() {
+      logger.removeHandler(handler);
+      logger.setLevel(originalLevel);
+      logger.setUseParentHandlers(originalUseParentHandlers);
+    }
   }
 }


### PR DESCRIPTION
## Summary
Parts (a) and (b) of the issue; part (c) (WildFly subsystem-managed getCache semantics) is deliberately not addressed here.

**Part A — logging.** `PollerWakeupListener.init()` logged registration failures via `%s`, printing only the top-level `WeldException` message. It now passes the throwable to the logger so the full stack and cause chain land in the log. Covered by a log-capture test asserting `LogRecord.getThrown()` carries the cause chain.

**Part B — config seam.** `CoordinatorThreading` hardcoded `java:comp/DefaultManagedThreadFactory`, which is often unbound on the MSC deployment thread running an `@Initialized(ApplicationScoped.class)` observer in an EAR-lib bean archive. The name is now configurable through the same idiom as the executor JNDI names:

- Property: `ratchet.coordinator.thread-factory-jndi`
- Env var: `RATCHET_COORDINATOR_THREAD_FACTORY_JNDI`
- Programmatic: `RatchetOptions.builder().execution(e -> e.coordinatorThreadFactoryJndi("java:jboss/ee/concurrency/factory/RatchetCoordinator"))`
- Default unchanged: `java:comp/DefaultManagedThreadFactory`

The option threads through `CoordinatorSupport` into all four coordinator implementations (Infinispan, JMS, Hazelcast, PostgreSQL). The JNDI-miss error message now names the config key, so the next report self-diagnoses.

## Testing
TDD both parts: Part A red on `LogRecord.getThrown() == null`, green after the logger change. Part B red on the missing option accessor and config key, green after implementation. Module suites for `ratchet`, `ratchet-api`, `ratchet-coordinator-common`, and all four coordinator impls pass. Spotless applied.

Fixes #117