### PR TITLE
Survive startup when the managed scheduled executor is unresolvable

### DIFF
--- a/ratchet/src/main/java/run/ratchet/ri/cdi/internal/DefaultRatchetLifecycle.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/internal/DefaultRatchetLifecycle.java
@@ -27,6 +27,7 @@ import jakarta.interceptor.Interceptor;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.jboss.logging.Logger;
 import run.ratchet.api.RatchetOptions;
@@ -180,42 +181,65 @@ public class DefaultRatchetLifecycle implements RatchetLifecycle {
     List<SchedulerLifecycleHook> beforeStartSucceeded =
         notifyHooks("beforeStart", hooks(), SchedulerLifecycleHook::beforeStart, true);
 
-    recurringScheduler.configure(
-        options.recurring().pollMs(),
-        options.recurring().maxPollMs(),
-        options.recurring().batchLimit());
-    poller.init();
-    recurringScheduler.init();
+    ScheduledExecutorService scheduledExecutor = resolveScheduledExecutorForStartup();
+    if (scheduledExecutor != null) {
+      recurringScheduler.configure(
+          options.recurring().pollMs(),
+          options.recurring().maxPollMs(),
+          options.recurring().batchLimit());
+      poller.init();
+      recurringScheduler.init();
 
-    orphanRecoveryTimer.start(
-        executorProvider.getScheduledExecutor(), options.node().orphanScanIntervalMinutes());
-    batchRecoveryTimer.start(executorProvider.getScheduledExecutor());
+      orphanRecoveryTimer.start(scheduledExecutor, options.node().orphanScanIntervalMinutes());
+      batchRecoveryTimer.start(scheduledExecutor);
 
-    if (options.maintenance().dlqPurgeEnabled()) {
-      Cron dlqCron = RecurringScheduler.PARSER.parse(options.maintenance().dlqPurgeCron());
-      deadLetterService.init(options.maintenance().dlqPurgeDays(), dlqCron);
-    }
+      if (options.maintenance().dlqPurgeEnabled()) {
+        Cron dlqCron = RecurringScheduler.PARSER.parse(options.maintenance().dlqPurgeCron());
+        deadLetterService.init(options.maintenance().dlqPurgeDays(), dlqCron);
+      }
 
-    if (options.maintenance().jobArchiveEnabled()) {
-      Cron archiveCron = RecurringScheduler.PARSER.parse(options.maintenance().jobArchiveCron());
-      jobArchivingService.init(
-          true,
-          options.maintenance().jobRetentionDays(),
-          options.maintenance().jobArchiveBatchSize(),
-          archiveCron);
-    }
+      if (options.maintenance().jobArchiveEnabled()) {
+        Cron archiveCron = RecurringScheduler.PARSER.parse(options.maintenance().jobArchiveCron());
+        jobArchivingService.init(
+            true,
+            options.maintenance().jobRetentionDays(),
+            options.maintenance().jobArchiveBatchSize(),
+            archiveCron);
+      }
 
-    if (options.maintenance().logPurgeEnabled()) {
-      Cron logCron = RecurringScheduler.PARSER.parse(options.maintenance().logPurgeCron());
-      logPurgeTimer.init(options.maintenance().logRetentionDays(), logCron);
+      if (options.maintenance().logPurgeEnabled()) {
+        Cron logCron = RecurringScheduler.PARSER.parse(options.maintenance().logPurgeCron());
+        logPurgeTimer.init(options.maintenance().logRetentionDays(), logCron);
+      }
+
+      jobExecutionCoordinator.initRetryBufferDrainer();
     }
 
     pollerWakeupListener.init();
-    jobExecutionCoordinator.initRetryBufferDrainer();
 
     startedHooks =
         notifyHooks("afterStart", beforeStartSucceeded, SchedulerLifecycleHook::afterStart, false);
     log.info("Ratchet started");
+  }
+
+  private ScheduledExecutorService resolveScheduledExecutorForStartup() {
+    try {
+      return executorProvider.getScheduledExecutor();
+    } catch (RuntimeException e) {
+      RatchetOptions.ExecutionOptions execution = options.execution();
+      log.errorf(
+          e,
+          "Managed scheduled executor unavailable during Ratchet startup; scheduled background"
+              + " services are disabled: polling, recurring scheduling, orphan recovery, batch"
+              + " recovery, DLQ purge, job archiving, log purge, and retry-buffer draining."
+              + " Configure RatchetOptions.execution().scheduledExecutorJndi(...) to a valid"
+              + " ManagedScheduledExecutorService (current scheduledExecutorJndi=%s,"
+              + " jobExecutorJndi=%s, virtualExecutorJndi=%s).",
+          execution.scheduledExecutorJndi(),
+          execution.jobExecutorJndi(),
+          execution.virtualExecutorJndi());
+      return null;
+    }
   }
 
   @Override

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/internal/DefaultRatchetLifecycleHookTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/internal/DefaultRatchetLifecycleHookTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import jakarta.annotation.Priority;
@@ -224,6 +225,55 @@ class DefaultRatchetLifecycleHookTest {
 
     assertDoesNotThrow(() -> lifecycle.onStartup(new Object()));
     assertDoesNotThrow(lifecycle::onShutdown);
+  }
+
+  @Test
+  void onStartup_whenScheduledExecutorUnavailable_degradesScheduledServicesAndContinues() {
+    Poller poller = mock(Poller.class);
+    RecurringScheduler recurringScheduler = mock(RecurringScheduler.class);
+    OrphanRecoveryTimer orphanRecoveryTimer = mock(OrphanRecoveryTimer.class);
+    BatchRecoveryTimer batchRecoveryTimer = mock(BatchRecoveryTimer.class);
+    DeadLetterService deadLetterService = mock(DeadLetterService.class);
+    JobArchivingService jobArchivingService = mock(JobArchivingService.class);
+    LogPurgeTimer logPurgeTimer = mock(LogPurgeTimer.class);
+    PollerWakeupListener pollerWakeupListener = mock(PollerWakeupListener.class);
+    JobExecutionCoordinator jobExecutionCoordinator = mock(JobExecutionCoordinator.class);
+    ExecutorProvider provider = mock(ExecutorProvider.class);
+    when(provider.getScheduledExecutor()).thenThrow(new IllegalStateException("java:comp unbound"));
+
+    List<String> events = new ArrayList<>();
+    DefaultRatchetLifecycle lifecycle =
+        new DefaultRatchetLifecycle(
+            poller,
+            recurringScheduler,
+            orphanRecoveryTimer,
+            batchRecoveryTimer,
+            deadLetterService,
+            jobArchivingService,
+            logPurgeTimer,
+            pollerWakeupListener,
+            provider,
+            mock(NodeIdentityProvider.class),
+            mock(DrainController.class),
+            RatchetOptions.defaults(),
+            jobExecutionCoordinator,
+            mock(ClusterCoordinator.class),
+            new RecordingInstance<>(List.of(new SuccessfulHook(events))));
+
+    assertDoesNotThrow(() -> lifecycle.onStartup(new Object()));
+
+    assertEquals(List.of("successful.beforeStart", "successful.afterStart"), events);
+    verify(provider).getScheduledExecutor();
+    verify(pollerWakeupListener).init();
+    verifyNoInteractions(
+        poller,
+        recurringScheduler,
+        orphanRecoveryTimer,
+        batchRecoveryTimer,
+        deadLetterService,
+        jobArchivingService,
+        logPurgeTimer,
+        jobExecutionCoordinator);
   }
 
   private DefaultRatchetLifecycle newLifecycle(Instance<SchedulerLifecycleHook> hooks) {


### PR DESCRIPTION
## Summary
- `DefaultRatchetLifecycle.onStartup()` resolves the managed scheduled executor once, up front, instead of calling `executorProvider.getScheduledExecutor()` unguarded mid-startup
- On resolution failure: one `log.errorf(e, ...)` with the full cause chain, naming every disabled service (polling, recurring scheduling, orphan recovery, batch recovery, DLQ purge, archiving, log purge, retry-buffer draining) and the exact `RatchetOptions.execution()` JNDI settings that fix it — then the rest of the lifecycle continues instead of aborting
- New failure-path test: `onStartup_whenScheduledExecutorUnavailable_degradesScheduledServicesAndContinues` (the lifecycle test previously only ever mocked a working executor)

## Why
`DefaultExecutorProvider` intentionally defers JNDI resolution at `@PostConstruct` so an unbound `java:comp` doesn't abort deployment — but the next caller on the same boot-observer thread was `onStartup()`, whose lazy lookup throws `IllegalStateException` uncaught. On a WildFly EAR boot (MSC deployment thread, EAR-lib bean archive — the same environment as #117) the entire scheduler subsystem died at the top of startup. #117 degraded to polling; this aborted everything.

Deliberately no retry loop: there is no managed executor available to schedule a safe EE retry task, and a raw thread would be the wrong portability trade. A degraded node still accepts submissions; nodes with a working executor claim and run the jobs.

## Testing
Red: the new test failed with `Unexpected exception thrown: IllegalStateException: java:comp unbound`. Green after the guard. Full `mvn -pl ratchet -am test` green, Spotless applied. Found via the post-#117 audit (peer-reviewed); no runtime environment reproduces it in the IT matrix because the matrix only deploys WARs — an EAR deployment cell is the durable gap.

Fixes #124