### PR TITLE
Bump the Netty security pin to 4.1.135.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
     <mssql-jdbc.version>12.8.2.jre11</mssql-jdbc.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
     <artemis.version>2.54.0</artemis.version>
-    <netty.version>4.1.133.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <jackson-core.version>2.18.6</jackson-core.version>
     <infinispan.version>15.1.7.Final</infinispan.version>


### PR DESCRIPTION
## Summary

Dependabot flagged eight alerts (five high, three medium) on `io.netty` artifacts in `ratchet-coordinator-jms`: CVE-2026-44893, CVE-2026-48059, CVE-2026-44249, CVE-2026-45416, CVE-2026-50010, CVE-2026-50020, and CVE-2026-45536 (epoll + kqueue). All are fixed in Netty 4.1.135.Final.

Netty is test scope only — it reaches the module transitively through the embedded Artemis broker used by the ITs, and the root pom already imports `netty-bom` as a security pin for exactly this case. This bumps that one property from 4.1.133.Final to the first patched release. Nothing Netty-related ships in the published artifacts.

## Testing

- [x] `mvn -pl coordinators/ratchet-coordinator-jms -am verify -DskipITs=false` — builds the module and its upstream reactor deps, runs the unit tests and the embedded-Artemis ITs against the bumped Netty; BUILD SUCCESS
- [x] `mvn -pl coordinators/ratchet-coordinator-jms dependency:tree -Dincludes='io.netty:*'` — all 15 resolved Netty artifacts now at 4.1.135.Final, none left on another version

## Docs

- [x] No docs update needed

## Review Notes

- [x] Security-sensitive change

## Additional Context

The remaining two open Dependabot alerts (vite, via VitePress 1.x in `website/`) were dismissed as tolerable risk: both are Windows-only dev-server issues with no vite 5.x backport; revisit when VitePress 2.x is stable.