### PR TITLE
Bump the PostgreSQL JDBC driver to 42.7.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <openliberty-arquillian.version>2.1.4</openliberty-arquillian.version>
     <mysql-connector.version>8.4.0</mysql-connector.version>
     <protobuf-java.version>3.25.9</protobuf-java.version>
-    <postgresql-driver.version>42.7.11</postgresql-driver.version>
+    <postgresql-driver.version>42.7.13</postgresql-driver.version>
     <ojdbc.version>23.9.0.25.07</ojdbc.version>
     <mssql-jdbc.version>12.8.2.jre11</mssql-jdbc.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>


### PR DESCRIPTION
## Summary

CVE-2026-54291: pgJDBC 42.7.4 through 42.7.11 can silently downgrade `channelBinding=require` connections from SCRAM-SHA-256-PLUS to plain SCRAM-SHA-256 when the server certificate uses an algorithm the SCRAM client cannot hash. Fixed in 42.7.12; 42.7.13 adds a fail-closed guard on the same path. OWASP dependency-check flags the pinned 42.7.11 at CVSS 8.2.

One-line bump of `postgresql-driver.version` in the root pom.

## Testing

- [x] `mvn dependency:get -Dartifact=org.postgresql:postgresql:42.7.13` — artifact resolves from Central
- [ ] PostgreSQL matrix cells validate the driver live in CI (all five servers x postgresql)

## Docs

- [x] No docs update needed

## Review Notes

- [x] Security-sensitive change

## Additional Context

Same shape as #129 (Netty security pin bump): a managed-version property move to the first patched release, no code changes.