### PR TITLE
Stop test helpers from tripping Payara's UserTransaction gate

### DIFF
--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestDataManipulator.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestDataManipulator.java
@@ -18,7 +18,7 @@ package run.ratchet.testsuite.app;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.UserTransaction;
+import jakarta.transaction.Transactional;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.UUID;
@@ -27,85 +27,61 @@ import run.ratchet.store.spi.RatchetEntityManagerProvider;
 /**
  * JPA/SQL implementation of {@link TestDataManipulator}.
  *
- * <p>Uses native SQL queries within JTA transactions to manipulate test data. Only packaged in the
- * WAR when a JPA store profile is active.
+ * <p>Uses native SQL queries within interceptor-managed transactions to manipulate test data. Only
+ * packaged in the WAR when a JPA store profile is active.
+ *
+ * <p>These methods deliberately use {@code @Transactional(REQUIRES_NEW)} rather than a direct
+ * {@link jakarta.transaction.UserTransaction}: bare UserTransaction calls are gated by a
+ * TransactionOperationsManager check that a Payara/GlassFish {@code TransactionalInterceptorBase}
+ * race can corrupt under concurrent load, while the interceptor path never consults that gate. See
+ * {@code run.ratchet.testsuite.diagnostics.UtxTomRaceStressIT}.
  */
 @ApplicationScoped
 public class JpaTestDataManipulator implements TestDataManipulator {
 
   @Inject private RatchetEntityManagerProvider entityManagerProvider;
 
-  @Inject private UserTransaction utx;
-
   private static Object jobIdParam(UUID jobId) {
     return SqlDialectTestSupportProvider.get().jobIdParam(jobId);
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public void setJobUpdatedAt(UUID jobId, Instant updatedAt) {
+    Timestamp ts = Timestamp.from(updatedAt);
+
+    // Both JPA stores are now hot/cold-split: cold scheduler_job has no updated_at; the
+    // archive/DLQ-purge cutoff lives on cold.terminated_at, and the live update timestamp
+    // lives on scheduler_job_queue.updated_at. Tests aim this method at one or the other
+    // depending on the row's lifecycle stage.
+    // language=SQL
+    String coldSql =
+        """
+        UPDATE scheduler_job SET terminated_at = ?1
+        WHERE job_id = ?2 AND terminal_status IS NOT NULL
+        """;
+    Object idParam = jobIdParam(jobId);
+    em().createNativeQuery(coldSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
     try {
-      utx.begin();
-      Timestamp ts = Timestamp.from(updatedAt);
-
-      // Both JPA stores are now hot/cold-split: cold scheduler_job has no updated_at; the
-      // archive/DLQ-purge cutoff lives on cold.terminated_at, and the live update timestamp
-      // lives on scheduler_job_queue.updated_at. Tests aim this method at one or the other
-      // depending on the row's lifecycle stage.
       // language=SQL
-      String coldSql =
-          """
-          UPDATE scheduler_job SET terminated_at = ?1
-          WHERE job_id = ?2 AND terminal_status IS NOT NULL
-          """;
-      Object idParam = jobIdParam(jobId);
-      em().createNativeQuery(coldSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
-      try {
-        // language=SQL
-        String hotSql = "UPDATE scheduler_job_queue SET updated_at = ?1 WHERE job_id = ?2";
-        em().createNativeQuery(hotSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
-      } catch (RuntimeException ignored) {
-        // The queue row may not exist once a job has moved to the terminal table.
-      }
-
-      utx.commit();
-    } catch (RuntimeException e) {
-      rollbackQuietly();
-      throw e;
-    } catch (Exception e) {
-      rollbackQuietly();
-      throw new RuntimeException("Failed to set updated_at", e);
+      String hotSql = "UPDATE scheduler_job_queue SET updated_at = ?1 WHERE job_id = ?2";
+      em().createNativeQuery(hotSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
+    } catch (RuntimeException ignored) {
+      // The queue row may not exist once a job has moved to the terminal table.
     }
   }
 
   @Override
+  @Transactional(Transactional.TxType.REQUIRES_NEW)
   public void setArchivedAt(UUID archiveId, Instant archivedAt) {
-    try {
-      utx.begin();
-      Timestamp ts = Timestamp.from(archivedAt);
+    Timestamp ts = Timestamp.from(archivedAt);
 
-      // language=SQL
-      String sql = "UPDATE scheduler_job_archive SET archived_at = ?1 WHERE archive_id = ?2";
-      em().createNativeQuery(sql)
-          .setParameter(1, ts)
-          .setParameter(2, jobIdParam(archiveId))
-          .executeUpdate();
-
-      utx.commit();
-    } catch (RuntimeException e) {
-      rollbackQuietly();
-      throw e;
-    } catch (Exception e) {
-      rollbackQuietly();
-      throw new RuntimeException("Failed to set archived_at", e);
-    }
-  }
-
-  private void rollbackQuietly() {
-    try {
-      utx.rollback();
-    } catch (Exception ignored) {
-      // best-effort rollback
-    }
+    // language=SQL
+    String sql = "UPDATE scheduler_job_archive SET archived_at = ?1 WHERE archive_id = ?2";
+    em().createNativeQuery(sql)
+        .setParameter(1, ts)
+        .setParameter(2, jobIdParam(archiveId))
+        .executeUpdate();
   }
 
   private EntityManager em() {

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestDataManipulator.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/JpaTestDataManipulator.java
@@ -62,13 +62,10 @@ public class JpaTestDataManipulator implements TestDataManipulator {
         """;
     Object idParam = jobIdParam(jobId);
     em().createNativeQuery(coldSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
-    try {
-      // language=SQL
-      String hotSql = "UPDATE scheduler_job_queue SET updated_at = ?1 WHERE job_id = ?2";
-      em().createNativeQuery(hotSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
-    } catch (RuntimeException ignored) {
-      // The queue row may not exist once a job has moved to the terminal table.
-    }
+    // Terminal jobs have no queue row, which makes this a zero-row no-op rather than an error.
+    // language=SQL
+    String hotSql = "UPDATE scheduler_job_queue SET updated_at = ?1 WHERE job_id = ?2";
+    em().createNativeQuery(hotSql).setParameter(1, ts).setParameter(2, idParam).executeUpdate();
   }
 
   @Override

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestTransactionRunner.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestTransactionRunner.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import java.util.function.Supplier;
+
+/**
+ * Runs test setup work inside its own {@code REQUIRES_NEW} transaction.
+ *
+ * <p>Wrapping request-thread store calls in this bean keeps the servlet frame safe from the
+ * Payara/GlassFish {@code TransactionalInterceptorBase} TransactionOperationsManager race: no
+ * background thread ever calls this bean, so its interceptor's save/restore of the frame's
+ * transaction-operations state is reliable regardless of what the store bean's shared interceptor
+ * does underneath. Tests that must drive {@link jakarta.transaction.UserTransaction} directly
+ * should commit their store setup through this runner first.
+ */
+@ApplicationScoped
+@Transactional(Transactional.TxType.REQUIRES_NEW)
+public class TestTransactionRunner {
+
+  public void run(Runnable work) {
+    work.run();
+  }
+
+  public <T> T call(Supplier<T> work) {
+    return work.get();
+  }
+}

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/diagnostics/TomRaceNestedCaller.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/diagnostics/TomRaceNestedCaller.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.diagnostics;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import java.util.UUID;
+import run.ratchet.store.spi.JobCrudStore;
+
+/**
+ * Nested transactional caller for {@link UtxTomRaceStressIT}.
+ *
+ * <p>This bean's class-level {@link Transactional} interceptor sets the executor thread frame's
+ * TransactionOperationsManager to {@code NOT_ALLOWED} before {@link #poke()} calls into the store
+ * bean's own shared {@code @ApplicationScoped} transactional interceptor, producing the nesting
+ * needed by the race described in {@link UtxTomRaceStressIT}.
+ */
+@ApplicationScoped
+@Transactional
+public class TomRaceNestedCaller {
+
+  @Inject JobCrudStore store;
+
+  public void poke() {
+    store.findById(UUID.randomUUID());
+  }
+}

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/diagnostics/UtxTomRaceStressIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/diagnostics/UtxTomRaceStressIT.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.diagnostics;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.enterprise.concurrent.ManagedExecutorService;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.logging.Logger;
+import javax.naming.InitialContext;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobStatus;
+import run.ratchet.ri.payload.JobPayloadFactory;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.entity.JobExecutionType;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.app.TestDataManipulator;
+import run.ratchet.testsuite.util.BaseRatchetIT;
+import run.ratchet.testsuite.util.RatchetArchiveBuilder;
+
+/**
+ * Stress coverage for the GlassFish/Payara {@code TransactionalInterceptorBase}
+ * TransactionOperationsManager race behind an observed {@code Operation not allowed} CI flake.
+ *
+ * <p>The container bug is an unsynchronized {@code preexistingTransactionOperationsManager}
+ * instance field on a CDI interceptor instance shared by concurrent invocations of an
+ * {@code @ApplicationScoped} bean. If one request-thread store call restores another executor
+ * thread's nested {@code NOT_ALLOWED} TransactionOperationsManager, the request frame is poisoned
+ * and the next direct {@link UserTransaction#begin()} fails.
+ *
+ * <p>Two methods, two purposes: the {@link Disabled} diagnostic reproduces the container bug itself
+ * via a bare {@code UserTransaction} (run it manually to check whether a container upgrade fixed
+ * the race); the enabled regression method drives {@link TestDataManipulator} under the same load
+ * and guards ratchet's test infrastructure against reintroducing bare UserTransaction calls on
+ * paths that share beans with background work.
+ */
+class UtxTomRaceStressIT extends BaseRatchetIT {
+
+  private static final Logger log = Logger.getLogger(UtxTomRaceStressIT.class.getName());
+  private static final String DEFAULT_MANAGED_EXECUTOR_JNDI =
+      "java:comp/DefaultManagedExecutorService";
+  private static final int RACER_COUNT = 3;
+  private static final long STRESS_NANOS = TimeUnit.SECONDS.toNanos(20);
+  private static final long REGRESSION_NANOS = TimeUnit.SECONDS.toNanos(6);
+  private static final long STOP_WAIT_MILLIS = 300;
+
+  @Inject private JobCrudStore jobCrudStore;
+
+  @Inject private TomRaceNestedCaller nested;
+
+  @Inject private TestDataManipulator dataManipulator;
+
+  @Inject private UserTransaction utx;
+
+  @Deployment
+  public static WebArchive createDeployment() {
+    String dbType = System.getProperty("ratchet.test.db.type", "mysql");
+    String profile = System.getProperty("testsuite.profile", "wildfly-managed");
+
+    return RatchetArchiveBuilder.create()
+        .addRatchetDependencies(profile, dbType)
+        .addStoreInfrastructure()
+        .addClasses(TomRaceNestedCaller.class)
+        .addBeansXml()
+        .build();
+  }
+
+  @Test
+  void dataManipulatorUnderNestedTransactionalLoad_neverTripsUtxGate() throws Exception {
+    JobEntity job = persistFailedJob();
+    AtomicBoolean running = new AtomicBoolean(true);
+    AtomicLong pokes = new AtomicLong();
+    AtomicLong racerExceptions = new AtomicLong();
+    long iterations = 0;
+    List<Future<?>> futures = new ArrayList<>();
+
+    ManagedExecutorService executor = InitialContext.doLookup(DEFAULT_MANAGED_EXECUTOR_JNDI);
+    for (int i = 0; i < RACER_COUNT; i++) {
+      futures.add(executor.submit(() -> raceUntilStopped(running, pokes, racerExceptions)));
+    }
+
+    try {
+      long deadline = System.nanoTime() + REGRESSION_NANOS;
+      while (System.nanoTime() < deadline) {
+        iterations++;
+        try {
+          dataManipulator.setJobUpdatedAt(job.getId(), Instant.now().minusSeconds(60));
+        } catch (RuntimeException e) {
+          if (hasTomPoisoningCause(e)) {
+            fail(
+                "Manipulator tripped the UserTransaction gate after "
+                    + iterations
+                    + " iterations and "
+                    + pokes.get()
+                    + " background pokes — a bare UserTransaction call is back on a raceable path",
+                e);
+          }
+          throw e;
+        }
+      }
+
+      long finalIterations = iterations;
+      log.info(
+          () ->
+              "Manipulator survived "
+                  + finalIterations
+                  + " iterations under "
+                  + pokes.get()
+                  + " background pokes; swallowed racer exceptions="
+                  + racerExceptions.get());
+    } finally {
+      stopRacers(running, futures);
+    }
+  }
+
+  @Test
+  @Disabled(
+      "Reproduces a Payara/GlassFish TransactionalInterceptorBase TOM race (container bug -"
+          + " upstream report pending); run manually to verify container fixes")
+  void requestThreadUtxBegin_shouldNotInheritNestedExecutorTom() throws Exception {
+    AtomicBoolean running = new AtomicBoolean(true);
+    AtomicLong pokes = new AtomicLong();
+    AtomicLong racerExceptions = new AtomicLong();
+    AtomicLong requestIterations = new AtomicLong();
+    List<Future<?>> futures = new ArrayList<>();
+
+    ManagedExecutorService executor = InitialContext.doLookup(DEFAULT_MANAGED_EXECUTOR_JNDI);
+    for (int i = 0; i < RACER_COUNT; i++) {
+      futures.add(executor.submit(() -> raceUntilStopped(running, pokes, racerExceptions)));
+    }
+
+    try {
+      long deadline = System.nanoTime() + STRESS_NANOS;
+      while (System.nanoTime() < deadline) {
+        long iteration = requestIterations.incrementAndGet();
+        jobCrudStore.findById(UUID.randomUUID());
+
+        try {
+          utx.begin();
+        } catch (IllegalStateException e) {
+          if (isTomPoisoningSymptom(e)) {
+            running.set(false);
+            stopRacers(running, futures);
+            String message =
+                "Reproduced TransactionalInterceptorBase TOM poisoning after "
+                    + iteration
+                    + " request iterations and "
+                    + pokes.get()
+                    + " background pokes; swallowed racer exceptions="
+                    + racerExceptions.get();
+            log.warning(message);
+            fail(message, e);
+          }
+          throw e;
+        }
+
+        utx.commit();
+      }
+
+      log.info(
+          () ->
+              "No TransactionalInterceptorBase TOM poisoning observed after "
+                  + requestIterations.get()
+                  + " request iterations and "
+                  + pokes.get()
+                  + " background pokes; swallowed racer exceptions="
+                  + racerExceptions.get());
+    } finally {
+      stopRacers(running, futures);
+    }
+  }
+
+  private JobEntity persistFailedJob() {
+    JobEntity job = new JobEntity();
+    job.setJobType(JobExecutionType.SINGLE);
+    job.setStatus(JobStatus.FAILED);
+    job.setPriority(JobPriority.NORMAL);
+    job.setScheduledTime(Instant.now().minusSeconds(5));
+    job.setPayload(JobPayloadFactory.noop());
+    job.setIdempotencyKey(UUID.randomUUID().toString());
+    job.setAttempts(0);
+    job.setMaxRetries(0);
+    job.setLastError("boom");
+    return jobCrudStore.save(job);
+  }
+
+  private void raceUntilStopped(
+      AtomicBoolean running, AtomicLong pokes, AtomicLong racerExceptions) {
+    while (running.get()) {
+      try {
+        nested.poke();
+        pokes.incrementAndGet();
+      } catch (Exception e) {
+        racerExceptions.incrementAndGet();
+      }
+    }
+  }
+
+  private static boolean isTomPoisoningSymptom(IllegalStateException e) {
+    return e.getMessage() != null && e.getMessage().contains("Operation not allowed");
+  }
+
+  private static boolean hasTomPoisoningCause(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause instanceof IllegalStateException
+          && cause.getMessage() != null
+          && cause.getMessage().contains("Operation not allowed")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void stopRacers(AtomicBoolean running, List<Future<?>> futures) {
+    running.set(false);
+    for (Future<?> future : futures) {
+      future.cancel(true);
+    }
+    try {
+      Thread.sleep(STOP_WAIT_MILLIS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/diagnostics/UtxTomRaceStressIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/diagnostics/UtxTomRaceStressIT.java
@@ -68,7 +68,7 @@ class UtxTomRaceStressIT extends BaseRatchetIT {
   private static final int RACER_COUNT = 3;
   private static final long STRESS_NANOS = TimeUnit.SECONDS.toNanos(20);
   private static final long REGRESSION_NANOS = TimeUnit.SECONDS.toNanos(6);
-  private static final long STOP_WAIT_MILLIS = 300;
+  private static final long STOP_WAIT_SECONDS = 5;
 
   @Inject private JobCrudStore jobCrudStore;
 
@@ -180,7 +180,16 @@ class UtxTomRaceStressIT extends BaseRatchetIT {
           throw e;
         }
 
-        utx.commit();
+        try {
+          utx.commit();
+        } catch (Exception e) {
+          try {
+            utx.rollback();
+          } catch (Exception ignored) {
+            // The failed commit already resolved the transaction.
+          }
+          throw e;
+        }
       }
 
       log.info(
@@ -240,12 +249,14 @@ class UtxTomRaceStressIT extends BaseRatchetIT {
   private static void stopRacers(AtomicBoolean running, List<Future<?>> futures) {
     running.set(false);
     for (Future<?> future : futures) {
-      future.cancel(true);
-    }
-    try {
-      Thread.sleep(STOP_WAIT_MILLIS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
+      try {
+        future.get(STOP_WAIT_SECONDS, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        future.cancel(true);
+      } catch (Exception e) {
+        future.cancel(true);
+      }
     }
   }
 }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/transaction/PostExecutionRequiresNewIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/transaction/PostExecutionRequiresNewIT.java
@@ -36,6 +36,7 @@ import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.app.TestTransactionRunner;
 import run.ratchet.testsuite.util.BaseRatchetIT;
 import run.ratchet.testsuite.util.RatchetArchiveBuilder;
 
@@ -59,6 +60,8 @@ class PostExecutionRequiresNewIT extends BaseRatchetIT {
 
   @Inject private UserTransaction utx;
 
+  @Inject private TestTransactionRunner txRunner;
+
   @Deployment
   public static WebArchive createDeployment() {
     String dbType = System.getProperty("ratchet.test.db.type", "mysql");
@@ -75,14 +78,23 @@ class PostExecutionRequiresNewIT extends BaseRatchetIT {
   void batchChildAck_commitsInOwnTransaction_andSurvivesCallerRollback() throws Exception {
     // A three-item batch so neither the ack nor the probe below completes it: the only observable
     // effect is the completed-child counter moving, with no completion cascade.
-    JobEntity parent = jobCrudStore.save(batchParentJob());
-    BatchEntity batch = new BatchEntity();
-    batch.setId(parent.getId());
-    batch.setTotalItems(3);
-    batch.setCompletedItems(0);
-    batch.setFailedItems(0);
-    batch.setCompletionProcessed(false);
-    batchStore.saveBatch(batch);
+    // Seeding goes through TestTransactionRunner so the servlet frame cannot be left poisoned by
+    // the store-interceptor TOM race before the deliberate utx.begin() below; the
+    // handleJobSuccess window stays exposed because caller-managed rollback IS the behavior
+    // under test.
+    JobEntity parent =
+        txRunner.call(
+            () -> {
+              JobEntity saved = jobCrudStore.save(batchParentJob());
+              BatchEntity batch = new BatchEntity();
+              batch.setId(saved.getId());
+              batch.setTotalItems(3);
+              batch.setCompletedItems(0);
+              batch.setFailedItems(0);
+              batch.setCompletionProcessed(false);
+              batchStore.saveBatch(batch);
+              return saved;
+            });
 
     // update() reads only getDependsOn() off the child, so an in-memory entity is enough and the
     // poller has no claimable row to touch.

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/util/RatchetArchiveBuilder.java
@@ -39,6 +39,7 @@ import run.ratchet.testsuite.app.TestEntityManagerProvider;
 import run.ratchet.testsuite.app.TestMongoProducer;
 import run.ratchet.testsuite.app.TestRatchetOptionsProducer;
 import run.ratchet.testsuite.app.TestRuntimeConfig;
+import run.ratchet.testsuite.app.TestTransactionRunner;
 import run.ratchet.testsuite.infra.JdbcContainerExtension;
 import run.ratchet.testsuite.infra.JdbcDatabaseConfig;
 
@@ -206,6 +207,7 @@ public class RatchetArchiveBuilder {
         TestClassPolicy.class,
         TestCleanupStrategy.class,
         TestDataManipulator.class,
+        TestTransactionRunner.class,
         PerformanceTestHelper.class,
         TestRatchetOptionsProducer.class,
         TestRuntimeConfig.class);


### PR DESCRIPTION
## What

Fixes the intermittent `Operation not allowed` failures on the payara-managed and glassfish-managed cells (`DlqPurgeIT`, `PostExecutionRequiresNewIT`) — 20 occurrences since June 26, several of them hidden behind green re-runs.

## Root cause

Payara/GlassFish `TransactionalInterceptorBase` saves and restores the invocation's `TransactionOperationsManager` through an unsynchronized instance field. For an `@ApplicationScoped` bean there is one interceptor instance shared by every thread, so a background job-completion call (`PostExecutionHandler` REQUIRES_NEW into a store method) racing a request-thread store call can make the request thread restore "UserTransaction not allowed" onto its own servlet frame. The next bare `utx.begin()` in that request throws `IllegalStateException: Operation not allowed.` from `UserTransactionImpl.checkUserTransactionMethodAccess`.

Only direct `UserTransaction` calls consult that gate; the `@Transactional` interceptor path never does, which is why only the handful of tests driving `UserTransaction` by hand ever failed. Verified against the payara-server-6.2025.11 sources and reproduced live in under a second with the stress test in this PR. WildFly and Liberty are immune (Narayana's interceptor keeps no shared save/restore state), which matches five weeks of CI history: every hit was a payara or glassfish cell, across postgresql, mysql, oracle, and sqlserver.

## Changes

- `JpaTestDataManipulator` uses `@Transactional(REQUIRES_NEW)` methods instead of hand-driven `UserTransaction`, the same idiom as `JpaTestCleanupStrategy`.
- New `TestTransactionRunner` bean commits test seeding in its own transaction. No background thread ever calls it, so its interceptor's save/restore is reliable and the request frame comes back clean.
- `PostExecutionRequiresNewIT` commits its seeding through the runner before the deliberate `utx.begin()`. The begin/rollback sequence itself is untouched; caller-managed rollback is the behavior under test, and its one remaining exposure window during `handleJobSuccess` is accepted.
- New `UtxTomRaceStressIT` + `TomRaceNestedCaller`: the `@Disabled` method reproduces the container bug on demand (fails in under a second on payara + postgresql before this fix) and exists to re-check the container after upgrades. The enabled method drives the fixed manipulator under the same nested-transactional load and passes.

## Left alone, on purpose

- `RollbackNoJobIT` begins its transaction before touching any bean that background threads share, so it cannot be poisoned. It also never failed.
- `JpaPerformanceTestHelper` and the TCK Tx contracts still use `UserTransaction`. The perf ITs are not in the CI matrix, and the TCK contracts begin before touching shared beans. Accepted residual; converting the perf helper would also drag the `SqlDialectTestSupport` signature across every store module for a path that has never flaked.

## Verification

On payara-managed + postgresql: `UtxTomRaceStressIT` (regression method), `DlqPurgeIT`, `JobArchivingIT`, `PostExecutionRequiresNewIT`, and `RollbackNoJobIT` all pass. Before the fix, the stress test reproduced the exact CI stack trace on its first iteration.

An upstream report against Payara (and Eclipse GlassFish, which carries the identical code) is the follow-up.
