### PR TITLE
Make lifecycle events and resilience telemetry transaction-safe

### DIFF
--- a/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricTagPolicy.java
+++ b/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricTagPolicy.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.micrometer;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -22,6 +23,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import run.ratchet.spi.ProtectedSurface;
 
 /**
  * Allowlist for string-valued Micrometer tags emitted by {@link MicrometerMetricsCollector}.
@@ -84,6 +86,10 @@ public final class MicrometerMetricTagPolicy {
         .allowValue("breaker", "store.claim")
         .allowValues("requested_target", "platform", "virtual")
         .allowValues("effective_target", "platform")
+        .allowValues("version_gap", "next", "multiple_versions_ahead", "not_newer")
+        .allowValues(
+            "surface",
+            Arrays.stream(ProtectedSurface.values()).map(ProtectedSurface::name).toList())
         .build();
   }
 

--- a/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricTagPolicy.java
+++ b/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricTagPolicy.java
@@ -17,12 +17,14 @@ package run.ratchet.micrometer;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import run.ratchet.api.CircuitBreakerProfile;
 import run.ratchet.spi.ProtectedSurface;
 
 /**
@@ -84,6 +86,12 @@ public final class MicrometerMetricTagPolicy {
             "schedule_retry",
             "update_status")
         .allowValue("breaker", "store.claim")
+        .allowValue("service", "store.claim")
+        .allowValues(
+            "profile",
+            EnumSet.allOf(CircuitBreakerProfile.class).stream()
+                .map(CircuitBreakerProfile::name)
+                .toList())
         .allowValues("requested_target", "platform", "virtual")
         .allowValues("effective_target", "platform")
         .allowValues("version_gap", "next", "multiple_versions_ahead", "not_newer")
@@ -139,6 +147,14 @@ public final class MicrometerMetricTagPolicy {
       return rawValue;
     }
     return OTHER;
+  }
+
+  boolean explicitlyAllows(String tagName, String rawValue) {
+    if (rawValue == null || rawValue.isBlank()) {
+      return false;
+    }
+    Set<String> allowed = allowedValues.get(normalizeTagName(tagName));
+    return allowed != null && allowed.contains(rawValue);
   }
 
   private static String normalizeTagName(String tagName) {

--- a/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricsCollector.java
+++ b/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricsCollector.java
@@ -64,6 +64,8 @@ import run.ratchet.spi.MetricsCollector;
  *   <li>{@code ratchet.signal.cancelled} — counter, tagged by type
  *   <li>{@code ratchet.poller.breaker.state} — gauge, tagged by breaker; values are {@code 0} for
  *       closed/unknown, {@code 1} for half-open, and {@code 2} for open
+ *   <li>{@code ratchet.circuit.breaker.state} — gauge, tagged by service and profile, with the same
+ *       numeric state values
  *   <li>{@code ratchet.store.operation} — timer, tagged by store, operation, and outcome
  *   <li>{@code ratchet.encryption.integrity.violations} — counter, tagged by protected surface
  *   <li>{@code ratchet.encryption.envelope.version_skew} — counter, tagged by bounded version gap
@@ -100,6 +102,8 @@ public class MicrometerMetricsCollector implements MetricsCollector {
   private final Map<MeterKey, Counter> counters = new ConcurrentHashMap<>();
   private final Map<MeterKey, Timer> timers = new ConcurrentHashMap<>();
   private final Map<String, AtomicInteger> pollerBreakerStates = new ConcurrentHashMap<>();
+  private final Map<CircuitBreakerMeterKey, AtomicInteger> circuitBreakerStates =
+      new ConcurrentHashMap<>();
 
   // Required by CDI proxy. The CDI proxy never invokes business methods on this instance —
   // every real call goes to the @Inject constructor below. We still guard the field below
@@ -353,14 +357,13 @@ public class MicrometerMetricsCollector implements MetricsCollector {
     if (registry == null || breakerName == null || breakerName.isBlank()) {
       return;
     }
+    String breakerTag = tag("breaker", breakerName);
     AtomicInteger gaugeValue =
         pollerBreakerStates.computeIfAbsent(
-            breakerName,
+            breakerTag,
             key -> {
               AtomicInteger stateValue = new AtomicInteger();
-              Gauge.builder("ratchet.poller.breaker.state", stateValue, AtomicInteger::get)
-                  .tag("breaker", tag("breaker", key))
-                  .register(registry);
+              replaceGauge("ratchet.poller.breaker.state", stateValue, "breaker", key);
               return stateValue;
             });
     gaugeValue.set(toBreakerStateValue(state));
@@ -393,6 +396,45 @@ public class MicrometerMetricsCollector implements MetricsCollector {
       return "next";
     }
     return gap > 1L ? "multiple_versions_ahead" : "not_newer";
+  }
+
+  @Override
+  public void circuitBreakerState(String serviceName, String profile, String state) {
+    if (registry == null
+        || serviceName == null
+        || serviceName.isBlank()
+        || profile == null
+        || profile.isBlank()
+        || !tagPolicy.explicitlyAllows("service", serviceName)
+        || !tagPolicy.explicitlyAllows("profile", profile)) {
+      return;
+    }
+    CircuitBreakerMeterKey key = new CircuitBreakerMeterKey(serviceName, profile);
+    AtomicInteger gaugeValue =
+        circuitBreakerStates.computeIfAbsent(
+            key,
+            ignored -> {
+              AtomicInteger stateValue = new AtomicInteger();
+              replaceGauge(
+                  "ratchet.circuit.breaker.state",
+                  stateValue,
+                  "service",
+                  key.serviceName(),
+                  "profile",
+                  key.profile());
+              return stateValue;
+            });
+    gaugeValue.set(toBreakerStateValue(state));
+  }
+
+  private void replaceGauge(String name, AtomicInteger stateValue, String... tags) {
+    synchronized (registry) {
+      Gauge existing = registry.find(name).tags(tags).gauge();
+      if (existing != null) {
+        registry.remove(existing);
+      }
+      Gauge.builder(name, stateValue, AtomicInteger::get).tags(tags).register(registry);
+    }
   }
 
   private Counter counter(String name, String... tags) {
@@ -470,4 +512,6 @@ public class MicrometerMetricsCollector implements MetricsCollector {
       return new MeterKey(name, List.of(tags));
     }
   }
+
+  private record CircuitBreakerMeterKey(String serviceName, String profile) {}
 }

--- a/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricsCollector.java
+++ b/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricsCollector.java
@@ -104,6 +104,7 @@ public class MicrometerMetricsCollector implements MetricsCollector {
   private final Map<String, AtomicInteger> pollerBreakerStates = new ConcurrentHashMap<>();
   private final Map<CircuitBreakerMeterKey, AtomicInteger> circuitBreakerStates =
       new ConcurrentHashMap<>();
+  private final Object gaugeRegistrationLock = new Object();
 
   // Required by CDI proxy. The CDI proxy never invokes business methods on this instance —
   // every real call goes to the @Inject constructor below. We still guard the field below
@@ -428,7 +429,7 @@ public class MicrometerMetricsCollector implements MetricsCollector {
   }
 
   private void replaceGauge(String name, AtomicInteger stateValue, String... tags) {
-    synchronized (registry) {
+    synchronized (gaugeRegistrationLock) {
       Gauge existing = registry.find(name).tags(tags).gauge();
       if (existing != null) {
         registry.remove(existing);

--- a/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricsCollector.java
+++ b/observability/ratchet-micrometer/src/main/java/run/ratchet/micrometer/MicrometerMetricsCollector.java
@@ -53,6 +53,8 @@ import run.ratchet.spi.MetricsCollector;
  *   <li>{@code ratchet.poller.claimed.jobs} — counter, tagged by execution type
  *   <li>{@code ratchet.submission.gate.rejections} — counter, tagged by execution type and gate
  *   <li>{@code ratchet.wakeup.local} — counter, tagged by source
+ *   <li>{@code ratchet.execution.target.fallback} — counter, tagged by requested and effective
+ *       execution targets
  *   <li>{@code ratchet.wakeup.cluster.publish} — counter, tagged by transport and outcome
  *   <li>{@code ratchet.wakeup.cluster.receive} — counter, tagged by transport and outcome
  *   <li>{@code ratchet.callbacks.failed} — counter, tagged by type and exception family
@@ -63,6 +65,9 @@ import run.ratchet.spi.MetricsCollector;
  *   <li>{@code ratchet.poller.breaker.state} — gauge, tagged by breaker; values are {@code 0} for
  *       closed/unknown, {@code 1} for half-open, and {@code 2} for open
  *   <li>{@code ratchet.store.operation} — timer, tagged by store, operation, and outcome
+ *   <li>{@code ratchet.encryption.integrity.violations} — counter, tagged by protected surface
+ *   <li>{@code ratchet.encryption.envelope.version_skew} — counter, tagged by bounded version gap
+ *       ({@code next}, {@code multiple_versions_ahead}, or {@code not_newer})
  * </ul>
  *
  * <p>The signal counters also carry a {@code signal_key} tag, but the default {@link
@@ -359,6 +364,35 @@ public class MicrometerMetricsCollector implements MetricsCollector {
               return stateValue;
             });
     gaugeValue.set(toBreakerStateValue(state));
+  }
+
+  @Override
+  public void encryptionIntegrityViolation(UUID jobId, String surface) {
+    if (registry == null) {
+      return;
+    }
+    counter("ratchet.encryption.integrity.violations", "surface", tag("surface", surface))
+        .increment();
+  }
+
+  @Override
+  public void encryptionEnvelopeVersionSkew(UUID jobId, int version, int maxSupportedVersion) {
+    if (registry == null) {
+      return;
+    }
+    counter(
+            "ratchet.encryption.envelope.version_skew",
+            "version_gap",
+            tag("version_gap", envelopeVersionGap(version, maxSupportedVersion)))
+        .increment();
+  }
+
+  private static String envelopeVersionGap(int version, int maxSupportedVersion) {
+    long gap = (long) version - maxSupportedVersion;
+    if (gap == 1L) {
+      return "next";
+    }
+    return gap > 1L ? "multiple_versions_ahead" : "not_newer";
   }
 
   private Counter counter(String name, String... tags) {

--- a/observability/ratchet-micrometer/src/test/java/run/ratchet/micrometer/MicrometerMetricsCollectorTest.java
+++ b/observability/ratchet-micrometer/src/test/java/run/ratchet/micrometer/MicrometerMetricsCollectorTest.java
@@ -16,6 +16,7 @@
 package run.ratchet.micrometer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -28,8 +29,108 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
 import run.ratchet.api.SignalDecision;
 import run.ratchet.api.exception.RatchetTransientStoreException;
+import run.ratchet.spi.ProtectedSurface;
 
 class MicrometerMetricsCollectorTest {
+
+  @Test
+  void encryptionIntegrityViolationPublishesEveryProtectedSurface() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry);
+
+    for (ProtectedSurface surface : ProtectedSurface.values()) {
+      collector.encryptionIntegrityViolation(UUID.randomUUID(), surface.name());
+    }
+
+    for (ProtectedSurface surface : ProtectedSurface.values()) {
+      assertEquals(
+          1.0,
+          registry
+              .get("ratchet.encryption.integrity.violations")
+              .tag("surface", surface.name())
+              .counter()
+              .count());
+    }
+  }
+
+  @Test
+  void encryptionIntegrityViolationAppliesSurfaceTagPolicy() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry);
+
+    collector.encryptionIntegrityViolation(UUID.randomUUID(), "customer-secret-column");
+
+    assertEquals(
+        1.0,
+        registry
+            .get("ratchet.encryption.integrity.violations")
+            .tag("surface", "OTHER")
+            .counter()
+            .count());
+    assertNull(
+        registry
+            .find("ratchet.encryption.integrity.violations")
+            .tag("surface", "customer-secret-column")
+            .counter());
+  }
+
+  @Test
+  void encryptionIntegrityViolationAcceptsExplicitlyAllowlistedSurface() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricTagPolicy tagPolicy =
+        MicrometerMetricTagPolicy.builder().allowValue("surface", "CUSTOM_BLOB").build();
+    MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry, tagPolicy);
+
+    collector.encryptionIntegrityViolation(UUID.randomUUID(), "CUSTOM_BLOB");
+
+    assertEquals(
+        1.0,
+        registry
+            .get("ratchet.encryption.integrity.violations")
+            .tag("surface", "CUSTOM_BLOB")
+            .counter()
+            .count());
+  }
+
+  @Test
+  void encryptionEnvelopeVersionSkewPublishesBoundedVersionGap() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry);
+
+    collector.encryptionEnvelopeVersionSkew(UUID.randomUUID(), 2, 1);
+    collector.encryptionEnvelopeVersionSkew(UUID.randomUUID(), 10, 1);
+    collector.encryptionEnvelopeVersionSkew(UUID.randomUUID(), 1, 1);
+
+    var nextVersion =
+        registry
+            .find("ratchet.encryption.envelope.version_skew")
+            .tag("version_gap", "next")
+            .counter();
+    var multipleVersionsAhead =
+        registry
+            .find("ratchet.encryption.envelope.version_skew")
+            .tag("version_gap", "multiple_versions_ahead")
+            .counter();
+    var notNewer =
+        registry
+            .find("ratchet.encryption.envelope.version_skew")
+            .tag("version_gap", "not_newer")
+            .counter();
+    assertNotNull(nextVersion);
+    assertNotNull(multipleVersionsAhead);
+    assertNotNull(notNewer);
+    assertEquals(1.0, nextVersion.count());
+    assertEquals(1.0, multipleVersionsAhead.count());
+    assertEquals(1.0, notNewer.count());
+    assertEquals(3, registry.find("ratchet.encryption.envelope.version_skew").counters().size());
+    assertNull(
+        registry.find("ratchet.encryption.envelope.version_skew").tag("version", "2").counter());
+    assertNull(
+        registry
+            .find("ratchet.encryption.envelope.version_skew")
+            .tag("max_supported_version", "1")
+            .counter());
+  }
 
   @Test
   void jobFailedTagsByBoundedFamily() {

--- a/observability/ratchet-micrometer/src/test/java/run/ratchet/micrometer/MicrometerMetricsCollectorTest.java
+++ b/observability/ratchet-micrometer/src/test/java/run/ratchet/micrometer/MicrometerMetricsCollectorTest.java
@@ -245,6 +245,82 @@ class MicrometerMetricsCollectorTest {
   }
 
   @Test
+  void resilienceCircuitBreakerStatePublishesPerServiceGauge() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricTagPolicy tagPolicy =
+        MicrometerMetricTagPolicy.builder().allowValue("service", "payments").build();
+    MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry, tagPolicy);
+
+    collector.circuitBreakerState("payments", "EXTERNAL_API", "OPEN");
+    assertEquals(
+        2.0,
+        registry
+            .get("ratchet.circuit.breaker.state")
+            .tag("service", "payments")
+            .tag("profile", "EXTERNAL_API")
+            .gauge()
+            .value());
+
+    collector.circuitBreakerState("payments", "EXTERNAL_API", "HALF_OPEN");
+    assertEquals(
+        1.0,
+        registry
+            .get("ratchet.circuit.breaker.state")
+            .tag("service", "payments")
+            .tag("profile", "EXTERNAL_API")
+            .gauge()
+            .value());
+  }
+
+  @Test
+  void resilienceCircuitBreakerStateSkipsServicesOutsideTheAllowlist() throws Exception {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry);
+
+    for (int tenant = 0; tenant < 100; tenant++) {
+      collector.circuitBreakerState("tenant-" + tenant, "EXTERNAL_API", "OPEN");
+    }
+
+    assertEquals(0, registry.find("ratchet.circuit.breaker.state").meters().size());
+    assertEquals(0, cacheSize(collector, "circuitBreakerStates"));
+  }
+
+  @Test
+  void replacementCollectorRebindsBreakerGauges() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricTagPolicy tagPolicy =
+        MicrometerMetricTagPolicy.builder().allowValue("service", "payments").build();
+    MicrometerMetricsCollector first = new MicrometerMetricsCollector(registry, tagPolicy);
+    first.circuitBreakerState("payments", "EXTERNAL_API", "OPEN");
+
+    MicrometerMetricsCollector replacement = new MicrometerMetricsCollector(registry, tagPolicy);
+    replacement.circuitBreakerState("payments", "EXTERNAL_API", "CLOSED");
+
+    assertEquals(
+        0.0,
+        registry
+            .get("ratchet.circuit.breaker.state")
+            .tag("service", "payments")
+            .tag("profile", "EXTERNAL_API")
+            .gauge()
+            .value());
+  }
+
+  @Test
+  void replacementCollectorRebindsPollerBreakerGauges() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    MicrometerMetricsCollector first = new MicrometerMetricsCollector(registry);
+    first.pollerBreakerState("store.claim", "OPEN");
+
+    MicrometerMetricsCollector replacement = new MicrometerMetricsCollector(registry);
+    replacement.pollerBreakerState("store.claim", "CLOSED");
+
+    assertEquals(
+        0.0,
+        registry.get("ratchet.poller.breaker.state").tag("breaker", "store.claim").gauge().value());
+  }
+
+  @Test
   void signalMetricsUseBoundedTypeAndOutcomeTags() {
     SimpleMeterRegistry registry = new SimpleMeterRegistry();
     MicrometerMetricsCollector collector = new MicrometerMetricsCollector(registry);

--- a/observability/ratchet-otel/pom.xml
+++ b/observability/ratchet-otel/pom.xml
@@ -54,5 +54,11 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <version>${opentelemetry.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/observability/ratchet-otel/src/main/java/run/ratchet/otel/OtelTracingCollector.java
+++ b/observability/ratchet-otel/src/main/java/run/ratchet/otel/OtelTracingCollector.java
@@ -48,6 +48,12 @@ import run.ratchet.spi.TracingCollector;
  *   <li>{@code ratchet.job.priority} — job priority at execution time
  *   <li>{@code ratchet.outcome} — {@code success}, {@code failure}, or {@code abandoned}
  *   <li>{@code ratchet.attempt} — attempt number (failure path only)
+ *   <li>{@code ratchet.signal.key} — signal key (signal-waiting jobs only)
+ *   <li>{@code ratchet.signal.outcome} — signal decision when recorded
+ *   <li>{@code ratchet.signal.delivered_by.present} — {@code true} when Ratchet recorded a
+ *       delivering principal, without publishing that identity
+ *   <li>{@code ratchet.signal.wait_ms} — signal wait time in milliseconds when both timestamps are
+ *       available
  * </ul>
  *
  * <p>W3C {@code traceparent} context captured at enqueue time is restored as the parent span when
@@ -79,6 +85,10 @@ public class OtelTracingCollector implements TracingCollector {
         openTelemetryInstance.isResolvable()
             ? openTelemetryInstance.get()
             : GlobalOpenTelemetry.get();
+  }
+
+  OtelTracingCollector(OpenTelemetry openTelemetry) {
+    this.openTelemetry = openTelemetry;
   }
 
   @Override
@@ -115,11 +125,10 @@ public class OtelTracingCollector implements TracingCollector {
    * {@inheritDoc}
    *
    * <p>Entries in {@code attributes} are attached to the span as additional OTel attributes
-   * verbatim. The RI publishes scheduler-side metadata keys here — notably {@code ratchet.node}
-   * (originating node identity), {@code ratchet.tag.affinity} (worker-tag affinity match), and
-   * {@code ratchet.queue.depth} (queue depth at dispatch time). Unknown keys are passed through
-   * unchanged so the framework can extend the published metadata without requiring a collector
-   * change.
+   * verbatim. The RI currently supplies signal metadata when available: {@code ratchet.signal.key},
+   * {@code ratchet.signal.outcome}, {@code ratchet.signal.delivered_by.present}, and {@code
+   * ratchet.signal.wait_ms}. Other keys are passed through unchanged so callers can add metadata
+   * without requiring a collector change.
    */
   @Override
   public ExecutionScope jobExecutionStarted(

--- a/observability/ratchet-otel/src/main/java/run/ratchet/otel/OtelTracingCollector.java
+++ b/observability/ratchet-otel/src/main/java/run/ratchet/otel/OtelTracingCollector.java
@@ -66,9 +66,13 @@ import run.ratchet.spi.TracingCollector;
  * <p>MDC keys {@code traceId} and {@code spanId} are populated by the OTel SDK's MDC context
  * storage provider when a logging bridge (e.g. {@code opentelemetry-logback-appender} or {@code
  * opentelemetry-log4j2-appender}) is on the classpath.
+ *
+ * <p>The priority is intentionally higher than the Micrometer tracing adapter. Deployments may
+ * install both modules to use Micrometer metrics with direct OpenTelemetry tracing without creating
+ * an ambiguous {@link TracingCollector} injection point.
  */
 @Alternative
-@Priority(1000)
+@Priority(1100)
 @ApplicationScoped
 public class OtelTracingCollector implements TracingCollector {
 

--- a/observability/ratchet-otel/src/test/java/run/ratchet/otel/OtelTracingCollectorTest.java
+++ b/observability/ratchet-otel/src/test/java/run/ratchet/otel/OtelTracingCollectorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.otel;
+
+import static io.opentelemetry.api.common.AttributeKey.stringKey;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobType;
+import run.ratchet.spi.TracingCollector;
+
+class OtelTracingCollectorTest {
+
+  @Test
+  void additionalAttributesArePassedThroughUnchanged() {
+    InMemorySpanExporter exporter = InMemorySpanExporter.create();
+    SdkTracerProvider tracerProvider =
+        SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(exporter)).build();
+    OpenTelemetrySdk openTelemetry =
+        OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+    OtelTracingCollector collector = new OtelTracingCollector(openTelemetry);
+
+    try {
+      TracingCollector.ExecutionScope scope =
+          collector.jobExecutionStarted(
+              new UUID(0L, 1L),
+              JobType.SINGLE,
+              JobPriority.NORMAL,
+              Map.of(),
+              Map.of(
+                  "ratchet.signal.key", "approval",
+                  "ratchet.signal.outcome", "APPROVED",
+                  "ratchet.signal.delivered_by.present", "true",
+                  "ratchet.signal.wait_ms", "2000",
+                  "deployment.region", "us-east-1"));
+      scope.success(10L);
+
+      var span = exporter.getFinishedSpanItems().get(0);
+      assertEquals("approval", span.getAttributes().get(stringKey("ratchet.signal.key")));
+      assertEquals("APPROVED", span.getAttributes().get(stringKey("ratchet.signal.outcome")));
+      assertEquals(
+          "true", span.getAttributes().get(stringKey("ratchet.signal.delivered_by.present")));
+      assertEquals("2000", span.getAttributes().get(stringKey("ratchet.signal.wait_ms")));
+      assertEquals("us-east-1", span.getAttributes().get(stringKey("deployment.region")));
+    } finally {
+      tracerProvider.close();
+    }
+  }
+}

--- a/ratchet-api/src/main/java/run/ratchet/api/event/package-info.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/package-info.java
@@ -39,7 +39,10 @@
  *       thread, hand it to your own executor from inside a synchronous observer.
  *   <li><b>After commit.</b> A state-change event raised inside a transaction is delivered after
  *       that transaction commits. A rollback suppresses the event, and an observer cannot roll the
- *       source transaction back. When no transaction is active, delivery is immediate.
+ *       source transaction back. When no transaction is active, delivery is immediate. If Ratchet
+ *       cannot register an after-commit callback for an existing transaction, it logs the failure
+ *       and suppresses the event rather than risk publishing before the transaction outcome is
+ *       known.
  *   <li><b>Contained failures.</b> A programmatic listener runs in its own guard: one that throws
  *       is logged, and the remaining listeners still run. CDI observers follow standard synchronous
  *       {@code fire} semantics — a {@code @Observes} method that throws aborts delivery to the

--- a/ratchet-api/src/main/java/run/ratchet/spi/MetricsCollector.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/MetricsCollector.java
@@ -175,6 +175,22 @@ public interface MetricsCollector {
   }
 
   /**
+   * Called with a built-in resilience circuit breaker's initial state and after each state change.
+   *
+   * <p>Service names come from {@code CircuitBreakerProtected.service()} or the RI's bounded,
+   * class-and-method fallback. Implementations should still apply their normal metric-cardinality
+   * policy before using the value as a tag. Implementations may omit services that are not in an
+   * explicit bounded allowlist.
+   *
+   * @param serviceName logical downstream service protected by the breaker
+   * @param profile circuit-breaker profile enum name
+   * @param state breaker state enum name, e.g. {@code CLOSED}, {@code HALF_OPEN}, or {@code OPEN}
+   */
+  default void circuitBreakerState(String serviceName, String profile, String state) {
+    // default no-op
+  }
+
+  /**
    * Called when a row flagged {@code encrypted_payload} is read back as unframed plaintext (ADR
    * Q-D). An operational-integrity signal — a write-time downgrade, an un-upgraded node, or a bug —
    * never a read failure. The read still succeeds with the plaintext value.

--- a/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
@@ -40,6 +40,7 @@ import run.ratchet.api.event.JobCompletedEvent;
 import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
 import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.ri.core.internal.WorkflowScheduler;
 import run.ratchet.spi.BeanResolver;
 import run.ratchet.spi.ClassPolicy;
@@ -412,7 +413,7 @@ public class BatchService {
   private void publishBatchEvents(
       BatchEntity batch, JobEntity parent, boolean succeeded, Long totalDurationMs) {
     Runnable publish = () -> publishBatchEventsNow(batch, parent, succeeded, totalDurationMs);
-    if (!registerAfterCommit(publish)) {
+    if (registerAfterCommit(publish) == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       publish.run();
     }
   }
@@ -461,12 +462,12 @@ public class BatchService {
             parent.getAttempts()));
   }
 
-  private boolean registerAfterCommit(Runnable action) {
+  private AfterCommitRegistrationResult registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
         resolveTxRegistry(),
         action,
         log,
-        "After-commit batch completing event registration failed; publishing immediately: %s");
+        "After-commit batch completing event registration failed; events suppressed: %s");
   }
 
   private TransactionSynchronizationRegistry resolveTxRegistry() {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -54,6 +54,7 @@ import run.ratchet.api.internal.JobBuilderState;
 import run.ratchet.ri.core.internal.ChainScheduler;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
 import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.ri.payload.JobPayloadFactory;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.ri.security.JobPayloadInputValidator;
@@ -1011,17 +1012,18 @@ class DefaultJobCreationService
             null,
             signalKey,
             signalTimeout);
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
 
-  private boolean registerAfterCommit(Runnable action) {
+  private AfterCommitRegistrationResult registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
         resolveTxRegistry(),
         action,
         log,
-        "After-commit signal waiting event registration failed; publishing immediately: %s");
+        "After-commit signal waiting event registration failed; event suppressed: %s");
   }
 
   private TransactionSynchronizationRegistry resolveTxRegistry() {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -52,6 +52,7 @@ import run.ratchet.api.event.JobsBulkCancelledEvent;
 import run.ratchet.api.event.JobsBulkSignaledEvent;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
 import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.spi.JobAuthorizationPolicy;
@@ -748,7 +749,8 @@ public class DefaultJobSchedulerService
    */
   private void publishBulkCancelledEvent(String tag, int count) {
     JobsBulkCancelledEvent event = new JobsBulkCancelledEvent(tag, count, effective().instant());
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -778,7 +780,8 @@ public class DefaultJobSchedulerService
                 null);
     // Defer publication until after the surrounding TX commits so a rollback does not produce a
     // spurious CANCELLED event. Falls back to immediate publication when no TX is active.
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -795,7 +798,8 @@ public class DefaultJobSchedulerService
             effective().instant(),
             previousStatus.name(),
             null);
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -816,7 +820,8 @@ public class DefaultJobSchedulerService
                   job.getLastError(),
                   1,
                   retryAt);
-      if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+      if (registerAfterCommit(() -> eventPublisher.publish(event))
+          == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
         eventPublisher.publish(event);
       }
     }
@@ -865,7 +870,8 @@ public class DefaultJobSchedulerService
             job.getPriority(),
             job.getPickedBy(),
             effective().instant());
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -879,7 +885,8 @@ public class DefaultJobSchedulerService
             job.getPriority(),
             job.getPickedBy(),
             effective().instant());
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -893,7 +900,8 @@ public class DefaultJobSchedulerService
             JobPriorityMapper.fromOrdinal(def.priority()),
             null,
             effective().instant());
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -907,7 +915,8 @@ public class DefaultJobSchedulerService
             JobPriorityMapper.fromOrdinal(def.priority()),
             null,
             effective().instant());
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -935,12 +944,12 @@ public class DefaultJobSchedulerService
     return reg;
   }
 
-  private boolean registerAfterCommit(Runnable action) {
+  private AfterCommitRegistrationResult registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
         resolveTxRegistry(),
         action,
         log,
-        "After-commit event registration failed; publishing immediately: %s");
+        "After-commit event registration failed; event suppressed: %s");
   }
 
   private int deliverSignalRaw(UUID jobId, Serializable payload) {
@@ -1102,7 +1111,8 @@ public class DefaultJobSchedulerService
       String rejectionReason) {
     JobsBulkSignaledEvent event =
         new JobsBulkSignaledEvent(signalKey, count, principal, outcome, rejectionReason, timestamp);
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
@@ -1129,7 +1139,8 @@ public class DefaultJobSchedulerService
             principal,
             outcome,
             rejectionReason);
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobCascadeService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobCascadeService.java
@@ -36,6 +36,7 @@ import run.ratchet.api.event.JobPausedEvent;
 import run.ratchet.api.event.JobResumedEvent;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
 import run.ratchet.ri.core.internal.JobWakeupService;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobPauseStore;
@@ -235,11 +236,12 @@ class JobCascadeService {
   }
 
   private void publishAfterCommit(Object event) {
-    if (!JobWakeupService.registerAfterCommit(
-        resolveTxRegistry(),
-        () -> eventPublisher.publish(event),
-        log,
-        "After-commit cascade event registration failed; publishing immediately: %s")) {
+    if (JobWakeupService.registerAfterCommit(
+            resolveTxRegistry(),
+            () -> eventPublisher.publish(event),
+            log,
+            "After-commit cascade event registration failed; event suppressed: %s")
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
@@ -205,7 +205,7 @@ public class ChainScheduler {
     if (eventPublisher == null) {
       return;
     }
-    eventPublisher.publish(
+    publishAfterCommit(
         new ChainCompletedEvent(
             finished.getId(),
             finished.getBusinessKey(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.ri.core.internal;
 
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import jakarta.transaction.Transactional;
 import java.time.Clock;
 import java.time.Instant;
@@ -30,6 +31,7 @@ import run.ratchet.api.JobStatus;
 import run.ratchet.api.event.ChainCompletedEvent;
 import run.ratchet.api.event.ChainFailedEvent;
 import run.ratchet.api.event.ChainStartedEvent;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.spi.JobCrudStore;
@@ -57,6 +59,8 @@ public class ChainScheduler {
   protected final JobTerminalStore jobTerminalStore;
   protected final InternalEventPublisher eventPublisher;
   private final Clock clock;
+
+  private volatile TransactionSynchronizationRegistry txRegistry;
 
   protected ChainScheduler() {
     this.jobCrudStore = null;
@@ -187,7 +191,7 @@ public class ChainScheduler {
         || finished.getJobType() == JobExecutionType.CHAIN_STEP) {
       return;
     }
-    eventPublisher.publish(
+    publishAfterCommit(
         new ChainStartedEvent(
             child.getId(),
             child.getBusinessKey(),
@@ -215,7 +219,7 @@ public class ChainScheduler {
     if (eventPublisher == null) {
       return;
     }
-    eventPublisher.publish(
+    publishAfterCommit(
         new ChainFailedEvent(
             failed.getId(),
             failed.getBusinessKey(),
@@ -224,6 +228,44 @@ public class ChainScheduler {
             failed.getPickedBy(),
             findRootJobId(failed),
             failed.getLastError()));
+  }
+
+  /**
+   * Publishes a chain or workflow state-change event only after the surrounding transaction
+   * commits. Subclasses use the same seam so branch events cannot escape a rolled-back chain
+   * mutation.
+   */
+  protected final void publishAfterCommit(Object event) {
+    if (eventPublisher == null) {
+      return;
+    }
+    Runnable publish = () -> eventPublisher.publish(event);
+    if (JobWakeupService.registerAfterCommit(
+            resolveTxRegistry(),
+            publish,
+            log,
+            "After-commit chain/workflow event registration failed; event suppressed: %s")
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
+      publish.run();
+    }
+  }
+
+  private TransactionSynchronizationRegistry resolveTxRegistry() {
+    TransactionSynchronizationRegistry registry = txRegistry;
+    if (registry == null) {
+      synchronized (this) {
+        registry = txRegistry;
+        if (registry == null) {
+          registry = JobWakeupService.lookupTxRegistry(log);
+          txRegistry = registry;
+        }
+      }
+    }
+    return registry;
+  }
+
+  void setTxRegistryForTesting(TransactionSynchronizationRegistry txRegistry) {
+    this.txRegistry = txRegistry;
   }
 
   private UUID findRootJobId(JobEntity job) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
@@ -38,6 +38,7 @@ import run.ratchet.api.event.JobFailedEvent;
 import run.ratchet.api.event.JobSignalTimedOutEvent;
 import run.ratchet.api.exception.SignalTimeoutException;
 import run.ratchet.ri.core.SingletonLease;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.spi.JobBatchStatusStore;
@@ -413,17 +414,18 @@ public class JobTimeoutHandler {
             null,
             job.getSignalKey(),
             configuredTimeout);
-    if (!registerAfterCommit(() -> eventPublisher.publish(event))) {
+    if (registerAfterCommit(() -> eventPublisher.publish(event))
+        == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
       eventPublisher.publish(event);
     }
   }
 
-  private boolean registerAfterCommit(Runnable action) {
+  private AfterCommitRegistrationResult registerAfterCommit(Runnable action) {
     return JobWakeupService.registerAfterCommit(
         resolveTxRegistry(),
         action,
         log,
-        "After-commit signal timeout event registration failed; publishing immediately: %s");
+        "After-commit signal timeout event registration failed; event suppressed: %s");
   }
 
   private TransactionSynchronizationRegistry resolveTxRegistry() {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobWakeupService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobWakeupService.java
@@ -44,6 +44,25 @@ public class JobWakeupService {
 
   private static final Logger log = Logger.getLogger(JobWakeupService.class);
 
+  /**
+   * Outcome of attempting to defer an action until the current transaction commits.
+   *
+   * <p>Callers may run the action immediately only for {@link #NO_ACTIVE_TRANSACTION}. Both {@link
+   * #REGISTERED} and {@link #ACTIVE_TRANSACTION_REGISTRATION_FAILED} require the caller to suppress
+   * immediate execution: the former already owns the action, while the latter cannot safely know
+   * whether the transaction will commit.
+   */
+  public enum AfterCommitRegistrationResult {
+    /** No transaction registry is available, or the registry reports no current transaction. */
+    NO_ACTIVE_TRANSACTION,
+
+    /** The action was registered and will run only if the transaction commits. */
+    REGISTERED,
+
+    /** A transaction exists, but its state prevented registration or registration itself failed. */
+    ACTIVE_TRANSACTION_REGISTRATION_FAILED
+  }
+
   private final ClusterCoordinator clusterCoordinator;
   private final Instance<PollerScheduler> pollerSchedulerInstance;
   private final MetricsCollector metricsCollector;
@@ -113,15 +132,19 @@ public class JobWakeupService {
   }
 
   private void publishNotification(JobPriority priority, String executionTarget) {
-    if (registerAfterCommit(() -> publishNotificationNow(priority, executionTarget))) {
-      return;
+    AfterCommitRegistrationResult result =
+        registerAfterCommit(() -> publishNotificationNow(priority, executionTarget));
+    if (result == AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION) {
+      publishNotificationNow(priority, executionTarget);
     }
-    publishNotificationNow(priority, executionTarget);
   }
 
-  private boolean registerAfterCommit(Runnable action) {
+  private AfterCommitRegistrationResult registerAfterCommit(Runnable action) {
     return registerAfterCommit(
-        resolveTxRegistry(), action, log, "After-commit wakeup registration error; firing now: %s");
+        resolveTxRegistry(),
+        action,
+        log,
+        "After-commit wakeup registration failed; wakeup suppressed: %s");
   }
 
   private TransactionSynchronizationRegistry resolveTxRegistry() {
@@ -149,17 +172,37 @@ public class JobWakeupService {
     }
   }
 
-  public static boolean registerAfterCommit(
+  /**
+   * Registers an action for post-commit execution without allowing an uncertain transaction state
+   * to leak the action early.
+   *
+   * <p>A missing registry and {@link Status#STATUS_NO_TRANSACTION} produce {@link
+   * AfterCommitRegistrationResult#NO_ACTIVE_TRANSACTION}, allowing the caller to execute the action
+   * immediately. An active transaction produces {@link AfterCommitRegistrationResult#REGISTERED}
+   * when synchronization registration succeeds. Any other transaction state, status lookup failure,
+   * or synchronization registration failure produces {@link
+   * AfterCommitRegistrationResult#ACTIVE_TRANSACTION_REGISTRATION_FAILED}; callers must log and
+   * suppress immediate execution because the transaction outcome is unknown.
+   */
+  public static AfterCommitRegistrationResult registerAfterCommit(
       TransactionSynchronizationRegistry txRegistry,
       Runnable action,
       Logger log,
       String failureMessage) {
     if (txRegistry == null) {
-      return false;
+      return AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION;
     }
+
     try {
-      if (txRegistry.getTransactionStatus() != Status.STATUS_ACTIVE) {
-        return false;
+      int transactionStatus = txRegistry.getTransactionStatus();
+      if (transactionStatus == Status.STATUS_NO_TRANSACTION) {
+        return AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION;
+      }
+      if (transactionStatus != Status.STATUS_ACTIVE) {
+        log.warnf(
+            failureMessage,
+            "transaction status " + transactionStatus + " does not allow registration");
+        return AfterCommitRegistrationResult.ACTIVE_TRANSACTION_REGISTRATION_FAILED;
       }
       txRegistry.registerInterposedSynchronization(
           new Synchronization() {
@@ -175,10 +218,10 @@ public class JobWakeupService {
               }
             }
           });
-      return true;
+      return AfterCommitRegistrationResult.REGISTERED;
     } catch (Exception e) {
       log.warnf(e, failureMessage, e.getMessage());
-      return false;
+      return AfterCommitRegistrationResult.ACTIVE_TRANSACTION_REGISTRATION_FAILED;
     }
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/WorkflowScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/WorkflowScheduler.java
@@ -312,7 +312,7 @@ public class WorkflowScheduler extends ChainScheduler {
     if (eventPublisher == null) {
       return;
     }
-    eventPublisher.publish(
+    publishAfterCommit(
         new WorkflowBranchTriggeredEvent(
             parentJob.getId(),
             parentJob.getBusinessKey(),

--- a/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreaker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreaker.java
@@ -64,6 +64,8 @@ public class CircuitBreaker {
   // HALF_OPEN state tracking
   private int halfOpenSuccesses;
   private int halfOpenAttempts;
+  // Identifies the probe round so late completions cannot update a newer round.
+  private long halfOpenGeneration;
   // OPEN state timing
   private volatile long openedAtMs;
 
@@ -90,6 +92,7 @@ public class CircuitBreaker {
       lock.lock();
       try {
         if (state.compareAndSet(State.OPEN, State.HALF_OPEN)) {
+          halfOpenGeneration++;
           halfOpenSuccesses = 0;
           halfOpenAttempts = 0;
         }
@@ -104,7 +107,7 @@ public class CircuitBreaker {
   /**
    * Executes the task with circuit breaker protection.
    *
-   * @throws run.ratchet.api.exception.CircuitBreakerOpenException if the circuit is OPEN
+   * @throws CircuitBreakerOpenException if the circuit is OPEN
    * @throws Exception if the task throws
    */
   public <T> T execute(Callable<T> task) throws Exception {
@@ -126,15 +129,7 @@ public class CircuitBreaker {
   public void transitionToOpen() {
     lock.lock();
     try {
-      State current = state.get();
-      if (current == State.OPEN) {
-        return;
-      }
-      // Write openedAtMs BEFORE the CAS so any thread that sees state==OPEN via getState()
-      // also sees a valid timestamp. The lock prevents a concurrent reset() from clearing
-      // openedAtMs between the write and the CAS.
-      openedAtMs = clock.millis();
-      state.compareAndSet(current, State.OPEN);
+      transitionToOpenLocked();
     } finally {
       lock.unlock();
     }
@@ -149,6 +144,7 @@ public class CircuitBreaker {
       windowIndex = 0;
       halfOpenSuccesses = 0;
       halfOpenAttempts = 0;
+      halfOpenGeneration++;
       Arrays.fill(window, UNINITIALIZED);
       state.set(State.CLOSED);
     } finally {
@@ -179,13 +175,19 @@ public class CircuitBreaker {
   }
 
   private <T> T executeInHalfOpen(Callable<T> task) throws Exception {
+    long admittedGeneration;
     lock.lock();
     try {
+      if (state.get() != State.HALF_OPEN) {
+        throw new CircuitBreakerOpenException(
+            "Circuit breaker '" + name + "' is no longer accepting this HALF_OPEN trial call");
+      }
       int attempt = ++halfOpenAttempts;
       if (attempt > config.permittedCallsInHalfOpen()) {
         throw new CircuitBreakerOpenException(
             "Circuit breaker '" + name + "' is HALF_OPEN — trial calls exhausted");
       }
+      admittedGeneration = halfOpenGeneration;
     } finally {
       lock.unlock();
     }
@@ -194,13 +196,15 @@ public class CircuitBreaker {
       T result = task.call();
       lock.lock();
       try {
-        int successes = ++halfOpenSuccesses;
-        if (successes >= config.permittedCallsInHalfOpen()) {
-          if (state.compareAndSet(State.HALF_OPEN, State.CLOSED)) {
-            totalCalls = 0;
-            failureCount = 0;
-            windowIndex = 0;
-            Arrays.fill(window, UNINITIALIZED);
+        if (isCurrentHalfOpenGeneration(admittedGeneration)) {
+          int successes = ++halfOpenSuccesses;
+          if (successes >= config.permittedCallsInHalfOpen()) {
+            if (state.compareAndSet(State.HALF_OPEN, State.CLOSED)) {
+              totalCalls = 0;
+              failureCount = 0;
+              windowIndex = 0;
+              Arrays.fill(window, UNINITIALIZED);
+            }
           }
         }
       } finally {
@@ -208,9 +212,34 @@ public class CircuitBreaker {
       }
       return result;
     } catch (Exception e) {
-      transitionToOpen();
+      lock.lock();
+      try {
+        if (isCurrentHalfOpenGeneration(admittedGeneration)) {
+          transitionToOpenLocked();
+        }
+      } finally {
+        lock.unlock();
+      }
       throw e;
     }
+  }
+
+  // Must be called with lock held.
+  private boolean isCurrentHalfOpenGeneration(long admittedGeneration) {
+    return state.get() == State.HALF_OPEN && halfOpenGeneration == admittedGeneration;
+  }
+
+  // Must be called with lock held.
+  private void transitionToOpenLocked() {
+    State current = state.get();
+    if (current == State.OPEN) {
+      return;
+    }
+    // Write openedAtMs BEFORE the CAS so any thread that sees state==OPEN via getState()
+    // also sees a valid timestamp. The lock prevents a concurrent reset() from clearing
+    // openedAtMs between the write and the CAS.
+    openedAtMs = clock.millis();
+    state.compareAndSet(current, State.OPEN);
   }
 
   private void recordSuccess() {

--- a/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreaker.java
+++ b/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreaker.java
@@ -18,8 +18,11 @@ package run.ratchet.ri.resilience;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import run.ratchet.api.exception.CircuitBreakerOpenException;
 
 /**
@@ -54,8 +57,12 @@ public class CircuitBreaker {
   private final String name;
   private final CircuitBreakerConfiguration config;
   private final Clock clock;
+  private final Consumer<State> stateListener;
   private final AtomicReference<State> state = new AtomicReference<>(State.CLOSED);
   private final ReentrantLock lock = new ReentrantLock();
+  private final ConcurrentLinkedQueue<State> pendingStateNotifications =
+      new ConcurrentLinkedQueue<>();
+  private final AtomicBoolean publishingStateNotifications = new AtomicBoolean();
   // Sliding window: ring buffer of outcomes (1 = success, 0 = failure, -1 = uninitialized)
   private final int[] window;
   private int windowIndex;
@@ -70,13 +77,23 @@ public class CircuitBreaker {
   private volatile long openedAtMs;
 
   public CircuitBreaker(String name, CircuitBreakerConfiguration config) {
-    this(name, config, Clock.systemUTC());
+    this(name, config, Clock.systemUTC(), ignored -> {});
   }
 
   public CircuitBreaker(String name, CircuitBreakerConfiguration config, Clock clock) {
+    this(name, config, clock, ignored -> {});
+  }
+
+  CircuitBreaker(String name, CircuitBreakerConfiguration config, Consumer<State> stateListener) {
+    this(name, config, Clock.systemUTC(), stateListener);
+  }
+
+  CircuitBreaker(
+      String name, CircuitBreakerConfiguration config, Clock clock, Consumer<State> stateListener) {
     this.name = name;
     this.config = config;
     this.clock = clock != null ? clock : Clock.systemUTC();
+    this.stateListener = stateListener != null ? stateListener : ignored -> {};
     this.window = new int[config.slidingWindowSize()];
     Arrays.fill(this.window, UNINITIALIZED);
   }
@@ -89,15 +106,21 @@ public class CircuitBreaker {
     State current = state.get();
     // Auto-transition from OPEN to HALF_OPEN if wait duration has elapsed
     if (current == State.OPEN && clock.millis() - openedAtMs >= config.waitDurationMs()) {
+      boolean transitioned = false;
       lock.lock();
       try {
         if (state.compareAndSet(State.OPEN, State.HALF_OPEN)) {
           halfOpenGeneration++;
           halfOpenSuccesses = 0;
           halfOpenAttempts = 0;
+          queueStateNotification(State.HALF_OPEN);
+          transitioned = true;
         }
       } finally {
         lock.unlock();
+      }
+      if (transitioned) {
+        publishPendingStateNotifications();
       }
       return state.get();
     }
@@ -127,15 +150,20 @@ public class CircuitBreaker {
   }
 
   public void transitionToOpen() {
+    boolean transitioned;
     lock.lock();
     try {
-      transitionToOpenLocked();
+      transitioned = transitionToOpenUnderLock();
     } finally {
       lock.unlock();
+    }
+    if (transitioned) {
+      publishPendingStateNotifications();
     }
   }
 
   public void reset() {
+    boolean transitioned = false;
     lock.lock();
     try {
       openedAtMs = 0L;
@@ -146,9 +174,16 @@ public class CircuitBreaker {
       halfOpenAttempts = 0;
       halfOpenGeneration++;
       Arrays.fill(window, UNINITIALIZED);
-      state.set(State.CLOSED);
+      State previous = state.getAndSet(State.CLOSED);
+      if (previous != State.CLOSED) {
+        queueStateNotification(State.CLOSED);
+        transitioned = true;
+      }
     } finally {
       lock.unlock();
+    }
+    if (transitioned) {
+      publishPendingStateNotifications();
     }
   }
 
@@ -194,6 +229,7 @@ public class CircuitBreaker {
 
     try {
       T result = task.call();
+      boolean transitioned = false;
       lock.lock();
       try {
         if (isCurrentHalfOpenGeneration(admittedGeneration)) {
@@ -204,21 +240,30 @@ public class CircuitBreaker {
               failureCount = 0;
               windowIndex = 0;
               Arrays.fill(window, UNINITIALIZED);
+              queueStateNotification(State.CLOSED);
+              transitioned = true;
             }
           }
         }
       } finally {
         lock.unlock();
       }
+      if (transitioned) {
+        publishPendingStateNotifications();
+      }
       return result;
     } catch (Exception e) {
+      boolean transitioned = false;
       lock.lock();
       try {
         if (isCurrentHalfOpenGeneration(admittedGeneration)) {
-          transitionToOpenLocked();
+          transitioned = transitionToOpenUnderLock();
         }
       } finally {
         lock.unlock();
+      }
+      if (transitioned) {
+        publishPendingStateNotifications();
       }
       throw e;
     }
@@ -227,19 +272,6 @@ public class CircuitBreaker {
   // Must be called with lock held.
   private boolean isCurrentHalfOpenGeneration(long admittedGeneration) {
     return state.get() == State.HALF_OPEN && halfOpenGeneration == admittedGeneration;
-  }
-
-  // Must be called with lock held.
-  private void transitionToOpenLocked() {
-    State current = state.get();
-    if (current == State.OPEN) {
-      return;
-    }
-    // Write openedAtMs BEFORE the CAS so any thread that sees state==OPEN via getState()
-    // also sees a valid timestamp. The lock prevents a concurrent reset() from clearing
-    // openedAtMs between the write and the CAS.
-    openedAtMs = clock.millis();
-    state.compareAndSet(current, State.OPEN);
   }
 
   private void recordSuccess() {
@@ -252,14 +284,18 @@ public class CircuitBreaker {
   }
 
   private void recordFailure() {
+    boolean transitioned;
     lock.lock();
     try {
       recordOutcome(0);
       int snapshotTotal = Math.min(totalCalls, window.length);
       int snapshotFailures = failureCount;
-      evaluateThreshold(snapshotTotal, snapshotFailures);
+      transitioned = evaluateThreshold(snapshotTotal, snapshotFailures);
     } finally {
       lock.unlock();
+    }
+    if (transitioned) {
+      publishPendingStateNotifications();
     }
   }
 
@@ -287,14 +323,66 @@ public class CircuitBreaker {
     }
   }
 
-  private void evaluateThreshold(int total, int failures) {
+  private boolean evaluateThreshold(int total, int failures) {
     if (total < config.minimumCalls()) {
-      return;
+      return false;
     }
 
     float failureRate = (failures * 100.0f) / total;
     if (failureRate >= config.failureRateThreshold()) {
-      transitionToOpen();
+      return transitionToOpenUnderLock();
+    }
+    return false;
+  }
+
+  // Must be called with lock held.
+  private boolean transitionToOpenUnderLock() {
+    State current = state.get();
+    if (current == State.OPEN) {
+      return false;
+    }
+    // Write openedAtMs BEFORE the CAS so any thread that sees state==OPEN via getState()
+    // also sees a valid timestamp. The lock prevents a concurrent reset() from clearing
+    // openedAtMs between the write and the CAS.
+    openedAtMs = clock.millis();
+    if (state.compareAndSet(current, State.OPEN)) {
+      queueStateNotification(State.OPEN);
+      return true;
+    }
+    return false;
+  }
+
+  // Must be called with lock held so queue order matches state-transition order.
+  private void queueStateNotification(State newState) {
+    pendingStateNotifications.add(newState);
+  }
+
+  private void publishPendingStateNotifications() {
+    if (!publishingStateNotifications.compareAndSet(false, true)) {
+      return;
+    }
+
+    boolean continuePublishing;
+    do {
+      try {
+        State next;
+        while ((next = pendingStateNotifications.poll()) != null) {
+          notifyState(next);
+        }
+      } finally {
+        publishingStateNotifications.set(false);
+      }
+      continuePublishing =
+          !pendingStateNotifications.isEmpty()
+              && publishingStateNotifications.compareAndSet(false, true);
+    } while (continuePublishing);
+  }
+
+  private void notifyState(State newState) {
+    try {
+      stateListener.accept(newState);
+    } catch (RuntimeException ignored) {
+      // Observability must not change circuit-breaker behavior.
     }
   }
 

--- a/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreakerRegistry.java
+++ b/ratchet/src/main/java/run/ratchet/ri/resilience/CircuitBreakerRegistry.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.jboss.logging.Logger;
 import run.ratchet.api.CircuitBreakerProfile;
 import run.ratchet.spi.CircuitBreakerConfigProvider;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NoOpMetricsCollector;
 
 /**
  * Registry for managing circuit breaker instances by service name.
@@ -38,14 +40,22 @@ public class CircuitBreakerRegistry {
   private final Map<CircuitBreakerKey, CircuitBreaker> breakers = new ConcurrentHashMap<>();
   private final Map<String, CircuitBreakerConfiguration> configs = new ConcurrentHashMap<>();
   private final CircuitBreakerConfigProvider configProvider;
+  private final MetricsCollector metricsCollector;
 
   protected CircuitBreakerRegistry() {
     this.configProvider = null;
+    this.metricsCollector = new NoOpMetricsCollector();
+  }
+
+  public CircuitBreakerRegistry(CircuitBreakerConfigProvider configProvider) {
+    this(configProvider, new NoOpMetricsCollector());
   }
 
   @Inject
-  public CircuitBreakerRegistry(CircuitBreakerConfigProvider configProvider) {
+  public CircuitBreakerRegistry(
+      CircuitBreakerConfigProvider configProvider, MetricsCollector metricsCollector) {
     this.configProvider = configProvider;
+    this.metricsCollector = metricsCollector;
     registerDefaultConfigs();
   }
 
@@ -59,7 +69,7 @@ public class CircuitBreakerRegistry {
     CircuitBreakerConfiguration config =
         configs.getOrDefault(
             configKey, CircuitBreakerConfiguration.fromSpi(configProvider.configFor(profile)));
-    return breakers.computeIfAbsent(key, k -> createBreaker(serviceName, config));
+    return breakers.computeIfAbsent(key, k -> createBreaker(k.serviceName(), k.profile(), config));
   }
 
   public CircuitBreaker.State getBreakerState(String serviceName) {
@@ -103,10 +113,23 @@ public class CircuitBreakerRegistry {
     log.debugf("Registered circuit breaker config: %s", name);
   }
 
-  private CircuitBreaker createBreaker(String serviceName, CircuitBreakerConfiguration config) {
-    CircuitBreaker breaker = new CircuitBreaker(serviceName, config);
+  private CircuitBreaker createBreaker(
+      String serviceName, CircuitBreakerProfile profile, CircuitBreakerConfiguration config) {
+    CircuitBreaker breaker =
+        new CircuitBreaker(serviceName, config, state -> reportState(serviceName, profile, state));
+    reportState(serviceName, profile, CircuitBreaker.State.CLOSED);
     log.debugf("Created circuit breaker for service: %s", serviceName);
     return breaker;
+  }
+
+  private void reportState(
+      String serviceName, CircuitBreakerProfile profile, CircuitBreaker.State state) {
+    try {
+      metricsCollector.circuitBreakerState(serviceName, profile.name(), state.name());
+    } catch (RuntimeException e) {
+      log.debugf(
+          e, "Metrics collector rejected circuit breaker state for service: %s", serviceName);
+    }
   }
 
   private void registerDefaultConfigs() {

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
@@ -370,6 +370,50 @@ class DefaultJobCreationServiceAuthorizationTest {
     verify(eventPublisher).publish(any(JobSignalWaitingEvent.class));
   }
 
+  @Test
+  void signalWaitingEventIsSuppressedWhenTransactionRollsBack() {
+    service.setTxRegistryForTesting(txRegistry);
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    ArgumentCaptor<Synchronization> synchronizationCaptor =
+        ArgumentCaptor.forClass(Synchronization.class);
+    JobEntity saved = savedEntity();
+    when(jobCrudStore.findByIdempotencyKey(anyString())).thenReturn(Optional.empty());
+    when(jobCrudStore.create(any(JobEntity.class))).thenReturn(saved);
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                    service, DefaultJobCreationServiceAuthorizationTest::noopTask, Duration.ZERO)
+                .awaitSignal("approval", Duration.ofSeconds(30));
+
+    service.submit(builder);
+    verify(txRegistry).registerInterposedSynchronization(synchronizationCaptor.capture());
+
+    synchronizationCaptor.getValue().afterCompletion(Status.STATUS_ROLLEDBACK);
+
+    verify(eventPublisher, never()).publish(any(JobSignalWaitingEvent.class));
+  }
+
+  @Test
+  void signalWaitingEventIsSuppressedWhenAfterCommitRegistrationFails() {
+    service.setTxRegistryForTesting(txRegistry);
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doThrow(new IllegalStateException("boom"))
+        .when(txRegistry)
+        .registerInterposedSynchronization(any());
+    JobEntity saved = savedEntity();
+    when(jobCrudStore.findByIdempotencyKey(anyString())).thenReturn(Optional.empty());
+    when(jobCrudStore.create(any(JobEntity.class))).thenReturn(saved);
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                    service, DefaultJobCreationServiceAuthorizationTest::noopTask, Duration.ZERO)
+                .awaitSignal("approval", Duration.ofSeconds(30));
+
+    service.submit(builder);
+
+    verify(eventPublisher, never()).publish(any(JobSignalWaitingEvent.class));
+  }
+
   // ---- streaming batch parent ----
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/ChainSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/ChainSchedulerTest.java
@@ -37,6 +37,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
@@ -117,6 +118,49 @@ class ChainSchedulerTest {
     ChainCompletedEvent event = (ChainCompletedEvent) eventCaptor.getValue();
     assertEquals(finished.getId(), event.getJobId());
     assertEquals(root.getId(), event.getParentJobId());
+  }
+
+  @Test
+  void scheduleNext_chainCompletedEventPublishesExactlyOnceAfterCommit() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    scheduler.setTxRegistryForTesting(txRegistry);
+    AtomicReference<Synchronization> synchronization = activeTransaction();
+    JobEntity root = pendingJob();
+    root.setJobType(JobExecutionType.SINGLE);
+    JobEntity finished = pendingJob();
+    finished.setJobType(JobExecutionType.CHAIN_STEP);
+    finished.setDependsOn(root.getId());
+    when(jobCrudStore.findDependants(eq(finished.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of());
+    when(jobCrudStore.findById(root.getId())).thenReturn(Optional.of(root));
+
+    assertFalse(scheduler.scheduleNext(finished));
+
+    verify(eventPublisher, never()).publish(any(ChainCompletedEvent.class));
+
+    synchronization.get().afterCompletion(Status.STATUS_COMMITTED);
+
+    verify(eventPublisher, times(1)).publish(any(ChainCompletedEvent.class));
+  }
+
+  @Test
+  void scheduleNext_chainCompletedEventIsSuppressedOnRollback() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    scheduler.setTxRegistryForTesting(txRegistry);
+    AtomicReference<Synchronization> synchronization = activeTransaction();
+    JobEntity root = pendingJob();
+    root.setJobType(JobExecutionType.SINGLE);
+    JobEntity finished = pendingJob();
+    finished.setJobType(JobExecutionType.CHAIN_STEP);
+    finished.setDependsOn(root.getId());
+    when(jobCrudStore.findDependants(eq(finished.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of());
+    when(jobCrudStore.findById(root.getId())).thenReturn(Optional.of(root));
+
+    assertFalse(scheduler.scheduleNext(finished));
+    synchronization.get().afterCompletion(Status.STATUS_ROLLEDBACK);
+
+    verify(eventPublisher, never()).publish(any(ChainCompletedEvent.class));
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/ChainSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/ChainSchedulerTest.java
@@ -21,17 +21,24 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -57,6 +64,7 @@ class ChainSchedulerTest {
   @Mock private JobCrudStore jobCrudStore;
   @Mock private JobTerminalStore jobTerminalStore;
   @Mock private InternalEventPublisher eventPublisher;
+  @Mock private TransactionSynchronizationRegistry txRegistry;
 
   private ChainScheduler scheduler;
 
@@ -146,6 +154,28 @@ class ChainSchedulerTest {
     ChainStartedEvent event = (ChainStartedEvent) eventCaptor.getValue();
     assertEquals(child.getId(), event.getJobId());
     assertEquals(root.getId(), event.getParentJobId());
+  }
+
+  @Test
+  void scheduleNext_chainStartedEventPublishesExactlyOnceAfterCommit() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    scheduler.setTxRegistryForTesting(txRegistry);
+    AtomicReference<Synchronization> synchronization = activeTransaction();
+    JobEntity root = pendingJob();
+    root.setJobType(JobExecutionType.SINGLE);
+    JobEntity child = pendingJob();
+    child.setJobType(JobExecutionType.CHAIN_STEP);
+    child.setScheduledTime(ChainScheduler.CHAIN_LOCK_TIME);
+    when(jobCrudStore.findDependants(eq(root.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of(child));
+
+    assertTrue(scheduler.scheduleNext(root));
+
+    verify(eventPublisher, never()).publish(any(ChainStartedEvent.class));
+
+    synchronization.get().afterCompletion(Status.STATUS_COMMITTED);
+
+    verify(eventPublisher, times(1)).publish(any(ChainStartedEvent.class));
   }
 
   @Test
@@ -304,6 +334,48 @@ class ChainSchedulerTest {
     assertEquals("boom", event.getErrorMessage());
   }
 
+  @Test
+  void cancelChain_chainFailedEventIsSuppressedOnRollback() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    scheduler.setTxRegistryForTesting(txRegistry);
+    AtomicReference<Synchronization> synchronization = activeTransaction();
+    JobEntity failed = pendingJob();
+    failed.setJobType(JobExecutionType.SINGLE);
+    failed.setLastError("boom");
+    JobEntity child = pendingJob();
+    child.setJobType(JobExecutionType.CHAIN_STEP);
+    when(jobCrudStore.findDependants(eq(failed.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of(child));
+    when(jobCrudStore.findDependants(eq(child.getId()), anyInt(), anyInt())).thenReturn(List.of());
+
+    scheduler.cancelChain(failed);
+    synchronization.get().afterCompletion(Status.STATUS_ROLLEDBACK);
+
+    verify(eventPublisher, never()).publish(any(ChainFailedEvent.class));
+  }
+
+  @Test
+  void cancelChain_chainFailedEventIsSuppressedWhenAfterCommitRegistrationFails() {
+    scheduler = new ChainScheduler(jobCrudStore, jobTerminalStore, FIXED_CLOCK, eventPublisher);
+    scheduler.setTxRegistryForTesting(txRegistry);
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doThrow(new IllegalStateException("boom"))
+        .when(txRegistry)
+        .registerInterposedSynchronization(any());
+    JobEntity failed = pendingJob();
+    failed.setJobType(JobExecutionType.SINGLE);
+    failed.setLastError("boom");
+    JobEntity child = pendingJob();
+    child.setJobType(JobExecutionType.CHAIN_STEP);
+    when(jobCrudStore.findDependants(eq(failed.getId()), anyInt(), anyInt()))
+        .thenReturn(List.of(child));
+    when(jobCrudStore.findDependants(eq(child.getId()), anyInt(), anyInt())).thenReturn(List.of());
+
+    scheduler.cancelChain(failed);
+
+    verify(eventPublisher, never()).publish(any(ChainFailedEvent.class));
+  }
+
   // ── helpers ───────────────────────────────────────────────────────────────
 
   @Test
@@ -344,5 +416,18 @@ class ChainSchedulerTest {
     verify(jobTerminalStore).cancelJob(b.getId());
     verify(jobTerminalStore, never()).cancelJob(c.getId());
     verify(jobTerminalStore, never()).cancelJob(d.getId());
+  }
+
+  private AtomicReference<Synchronization> activeTransaction() {
+    AtomicReference<Synchronization> synchronization = new AtomicReference<>();
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doAnswer(
+            invocation -> {
+              synchronization.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(txRegistry)
+        .registerInterposedSynchronization(any());
+    return synchronization;
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobWakeupServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobWakeupServiceTest.java
@@ -15,6 +15,7 @@
  */
 package run.ratchet.ri.core.internal;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -30,7 +31,9 @@ import jakarta.transaction.Status;
 import jakarta.transaction.Synchronization;
 import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +43,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.NodeIdentity;
 import run.ratchet.ri.core.PollerScheduler;
+import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.spi.ClusterCoordinator;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.NodeIdentityProvider;
@@ -50,6 +54,7 @@ class JobWakeupServiceTest {
 
   private static final String NODE_ID = "node-test";
   private static final NodeIdentity NODE_IDENTITY = new NodeIdentity(NODE_ID);
+  private static final Logger LOG = Logger.getLogger(JobWakeupServiceTest.class);
 
   @Mock private ClusterCoordinator clusterCoordinator;
   @Mock private Instance<PollerScheduler> pollerSchedulerInstance;
@@ -116,6 +121,36 @@ class JobWakeupServiceTest {
   }
 
   @Test
+  void notify_suppressesWakeupWhenTransactionRollsBack() {
+    AtomicReference<Synchronization> synchronization = new AtomicReference<>();
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doAnswer(
+            invocation -> {
+              synchronization.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(txRegistry)
+        .registerInterposedSynchronization(ArgumentMatchers.any());
+    wakeupService =
+        new JobWakeupService(
+            clusterCoordinator,
+            pollerSchedulerInstance,
+            metricsCollector,
+            nodeIdentityProvider,
+            txRegistry);
+
+    wakeupService.notify(JobPriority.CRITICAL, true, null);
+    synchronization.get().afterCompletion(Status.STATUS_ROLLEDBACK);
+
+    verifyNoInteractions(
+        clusterCoordinator,
+        pollerSchedulerInstance,
+        pollerScheduler,
+        metricsCollector,
+        nodeIdentityProvider);
+  }
+
+  @Test
   void notify_doesNothingWhenImmediateFlagIsFalse() {
     wakeupService.notify(JobPriority.NORMAL, false, null);
 
@@ -124,11 +159,7 @@ class JobWakeupServiceTest {
   }
 
   @Test
-  void notify_fallsBackToImmediateWhenAfterCommitRegistrationFails() {
-    when(nodeIdentityProvider.getNodeId()).thenReturn(NODE_ID);
-    when(pollerSchedulerInstance.isResolvable()).thenReturn(true);
-    when(pollerSchedulerInstance.get()).thenReturn(pollerScheduler);
-
+  void notify_suppressesWakeupWhenAfterCommitRegistrationFails() {
     when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
     doThrow(new IllegalStateException("boom"))
         .when(txRegistry)
@@ -143,9 +174,75 @@ class JobWakeupServiceTest {
 
     wakeupService.notify(JobPriority.HIGH, true, null);
 
-    verify(metricsCollector).localWakeup("job_submit");
-    verify(pollerScheduler).wakeup();
-    verify(clusterCoordinator).notifyNewWork(JobPriority.HIGH, NODE_IDENTITY, null);
+    verifyNoInteractions(
+        clusterCoordinator,
+        pollerSchedulerInstance,
+        pollerScheduler,
+        metricsCollector,
+        nodeIdentityProvider);
+  }
+
+  @Test
+  void registerAfterCommit_reportsNoActiveTransactionWithoutRegistry() {
+    AtomicInteger actions = new AtomicInteger();
+
+    AfterCommitRegistrationResult result =
+        JobWakeupService.registerAfterCommit(null, actions::incrementAndGet, LOG, "%s");
+
+    assertEquals(AfterCommitRegistrationResult.NO_ACTIVE_TRANSACTION, result);
+    assertEquals(0, actions.get());
+  }
+
+  @Test
+  void registerAfterCommit_reportsRegisteredAndRunsOnlyAfterCommit() {
+    AtomicInteger actions = new AtomicInteger();
+    AtomicReference<Synchronization> synchronization = new AtomicReference<>();
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doAnswer(
+            invocation -> {
+              synchronization.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(txRegistry)
+        .registerInterposedSynchronization(ArgumentMatchers.any());
+
+    AfterCommitRegistrationResult result =
+        JobWakeupService.registerAfterCommit(txRegistry, actions::incrementAndGet, LOG, "%s");
+
+    assertEquals(AfterCommitRegistrationResult.REGISTERED, result);
+    assertEquals(0, actions.get());
+
+    synchronization.get().afterCompletion(Status.STATUS_COMMITTED);
+
+    assertEquals(1, actions.get());
+  }
+
+  @Test
+  void registerAfterCommit_reportsFailureWhenActiveRegistrationThrows() {
+    AtomicInteger actions = new AtomicInteger();
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doThrow(new IllegalStateException("boom"))
+        .when(txRegistry)
+        .registerInterposedSynchronization(ArgumentMatchers.any());
+
+    AfterCommitRegistrationResult result =
+        JobWakeupService.registerAfterCommit(txRegistry, actions::incrementAndGet, LOG, "%s");
+
+    assertEquals(AfterCommitRegistrationResult.ACTIVE_TRANSACTION_REGISTRATION_FAILED, result);
+    assertEquals(0, actions.get());
+  }
+
+  @Test
+  void registerAfterCommit_suppressesFallbackWhenTransactionIsMarkedRollback() {
+    AtomicInteger actions = new AtomicInteger();
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_MARKED_ROLLBACK);
+
+    AfterCommitRegistrationResult result =
+        JobWakeupService.registerAfterCommit(txRegistry, actions::incrementAndGet, LOG, "%s");
+
+    assertEquals(AfterCommitRegistrationResult.ACTIVE_TRANSACTION_REGISTRATION_FAILED, result);
+    assertEquals(0, actions.get());
+    verify(txRegistry, never()).registerInterposedSynchronization(any());
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/WorkflowSchedulerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/WorkflowSchedulerTest.java
@@ -24,11 +24,17 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -36,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -65,6 +72,7 @@ class WorkflowSchedulerTest {
   @Mock private WorkflowConditionStore conditionStore;
   @Mock private WorkflowConditionEvaluator conditionEvaluator;
   @Mock private InternalEventPublisher eventPublisher;
+  @Mock private TransactionSynchronizationRegistry txRegistry;
 
   private WorkflowScheduler scheduler;
 
@@ -206,6 +214,65 @@ class WorkflowSchedulerTest {
     assertEquals(parent.getId(), event.getJobId());
     assertEquals("result.ok == true", event.getBranchCondition());
     assertEquals(child.getId(), event.getNextJobId());
+  }
+
+  @Test
+  void scheduleNext_workflowBranchEventPublishesExactlyOnceAfterCommit() {
+    scheduler = eventPublishingScheduler();
+    scheduler.setTxRegistryForTesting(txRegistry);
+    AtomicReference<Synchronization> synchronization = activeTransaction();
+    JobEntity parent = job(new UUID(0L, 180L), JobStatus.SUCCEEDED);
+    JobEntity child = job(new UUID(0L, 190L), JobStatus.PENDING);
+    WorkflowConditionEntity condition = condition(parent.getId(), child.getId(), 0);
+    when(conditionStore.findConditionsByParentJobId(parent.getId())).thenReturn(List.of(condition));
+    when(conditionEvaluator.evaluate(condition, parent)).thenReturn(true);
+    when(jobCrudStore.findById(child.getId())).thenReturn(Optional.of(child));
+
+    assertTrue(scheduler.scheduleNext(parent));
+
+    verify(eventPublisher, never()).publish(any(WorkflowBranchTriggeredEvent.class));
+
+    synchronization.get().afterCompletion(Status.STATUS_COMMITTED);
+
+    verify(eventPublisher, times(1)).publish(any(WorkflowBranchTriggeredEvent.class));
+  }
+
+  @Test
+  void scheduleNext_workflowBranchEventIsSuppressedOnRollback() {
+    scheduler = eventPublishingScheduler();
+    scheduler.setTxRegistryForTesting(txRegistry);
+    AtomicReference<Synchronization> synchronization = activeTransaction();
+    JobEntity parent = job(new UUID(0L, 181L), JobStatus.SUCCEEDED);
+    JobEntity child = job(new UUID(0L, 191L), JobStatus.PENDING);
+    WorkflowConditionEntity condition = condition(parent.getId(), child.getId(), 0);
+    when(conditionStore.findConditionsByParentJobId(parent.getId())).thenReturn(List.of(condition));
+    when(conditionEvaluator.evaluate(condition, parent)).thenReturn(true);
+    when(jobCrudStore.findById(child.getId())).thenReturn(Optional.of(child));
+
+    assertTrue(scheduler.scheduleNext(parent));
+    synchronization.get().afterCompletion(Status.STATUS_ROLLEDBACK);
+
+    verify(eventPublisher, never()).publish(any(WorkflowBranchTriggeredEvent.class));
+  }
+
+  @Test
+  void scheduleNext_workflowBranchEventIsSuppressedWhenAfterCommitRegistrationFails() {
+    scheduler = eventPublishingScheduler();
+    scheduler.setTxRegistryForTesting(txRegistry);
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doThrow(new IllegalStateException("boom"))
+        .when(txRegistry)
+        .registerInterposedSynchronization(any());
+    JobEntity parent = job(new UUID(0L, 182L), JobStatus.SUCCEEDED);
+    JobEntity child = job(new UUID(0L, 192L), JobStatus.PENDING);
+    WorkflowConditionEntity condition = condition(parent.getId(), child.getId(), 0);
+    when(conditionStore.findConditionsByParentJobId(parent.getId())).thenReturn(List.of(condition));
+    when(conditionEvaluator.evaluate(condition, parent)).thenReturn(true);
+    when(jobCrudStore.findById(child.getId())).thenReturn(Optional.of(child));
+
+    assertTrue(scheduler.scheduleNext(parent));
+
+    verify(eventPublisher, never()).publish(any(WorkflowBranchTriggeredEvent.class));
   }
 
   @Test
@@ -461,5 +528,28 @@ class WorkflowSchedulerTest {
     scheduler.cancelChain(parent);
 
     verify(jobTerminalStore).cancelJob(child.getId());
+  }
+
+  private WorkflowScheduler eventPublishingScheduler() {
+    return new WorkflowScheduler(
+        jobCrudStore,
+        jobTerminalStore,
+        conditionStore,
+        conditionEvaluator,
+        FIXED_CLOCK,
+        eventPublisher);
+  }
+
+  private AtomicReference<Synchronization> activeTransaction() {
+    AtomicReference<Synchronization> synchronization = new AtomicReference<>();
+    when(txRegistry.getTransactionStatus()).thenReturn(Status.STATUS_ACTIVE);
+    doAnswer(
+            invocation -> {
+              synchronization.set(invocation.getArgument(0));
+              return null;
+            })
+        .when(txRegistry)
+        .registerInterposedSynchronization(any());
+    return synchronization;
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerRegistryTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerRegistryTest.java
@@ -18,10 +18,13 @@ package run.ratchet.ri.resilience;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.CircuitBreakerProfile;
 import run.ratchet.api.RatchetOptions;
+import run.ratchet.spi.NoOpMetricsCollector;
 
 class CircuitBreakerRegistryTest {
 
@@ -67,6 +70,25 @@ class CircuitBreakerRegistryTest {
     assertEquals(CircuitBreaker.State.OPEN, registry.getBreakerState("maintenance-service"));
   }
 
+  @Test
+  void reportsServiceProfileAndInitialStateToMetricsCollector() {
+    RecordingMetricsCollector metrics = new RecordingMetricsCollector();
+    CircuitBreakerRegistry registry =
+        new CircuitBreakerRegistry(
+            new DefaultCircuitBreakerConfigProvider(RatchetOptions.defaults()), metrics);
+
+    registry.getBreaker("payments", CircuitBreakerProfile.EXTERNAL_API);
+    registry.openBreaker("payments", CircuitBreakerProfile.EXTERNAL_API);
+    registry.resetBreaker("payments", CircuitBreakerProfile.EXTERNAL_API);
+
+    assertEquals(
+        List.of(
+            "payments:EXTERNAL_API:CLOSED",
+            "payments:EXTERNAL_API:OPEN",
+            "payments:EXTERNAL_API:CLOSED"),
+        metrics.transitions);
+  }
+
   @SuppressWarnings("unchecked")
   private static Map<Object, CircuitBreaker> registryKeyMap(CircuitBreakerRegistry registry)
       throws NoSuchFieldException, IllegalAccessException {
@@ -78,5 +100,14 @@ class CircuitBreakerRegistryTest {
   private static CircuitBreakerRegistry defaultRegistry() {
     return new CircuitBreakerRegistry(
         new DefaultCircuitBreakerConfigProvider(RatchetOptions.defaults()));
+  }
+
+  private static final class RecordingMetricsCollector extends NoOpMetricsCollector {
+    private final List<String> transitions = new ArrayList<>();
+
+    @Override
+    public void circuitBreakerState(String serviceName, String profile, String state) {
+      transitions.add(serviceName + ":" + profile + ":" + state);
+    }
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
@@ -23,9 +23,11 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.exception.CircuitBreakerOpenException;
@@ -216,7 +218,7 @@ class CircuitBreakerTest {
     try {
       Future<String> first = executor.submit(() -> blockingHalfOpenCall(started, release));
       Future<String> second = executor.submit(() -> blockingHalfOpenCall(started, release));
-      assertTrue(started.await(1, java.util.concurrent.TimeUnit.SECONDS));
+      assertTrue(started.await(1, TimeUnit.SECONDS));
 
       CircuitBreakerOpenException thrown =
           assertThrows(CircuitBreakerOpenException.class, () -> breaker.execute(() -> "extra"));
@@ -228,6 +230,103 @@ class CircuitBreakerTest {
       assertEquals(CircuitBreaker.State.CLOSED, breaker.getState());
     } finally {
       release.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void staleHalfOpenSuccessCannotCloseANewerProbeRound() throws Exception {
+    breaker.transitionToOpen();
+    clock.advance(Duration.ofMillis(100));
+    assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.getState());
+
+    CountDownLatch staleProbeStarted = new CountDownLatch(1);
+    CountDownLatch releaseStaleProbe = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<String> staleSuccess =
+          executor.submit(
+              () ->
+                  breaker.execute(
+                      () -> {
+                        staleProbeStarted.countDown();
+                        releaseStaleProbe.await();
+                        return "round-1-result";
+                      }));
+      assertTrue(staleProbeStarted.await(1, TimeUnit.SECONDS));
+
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              breaker.execute(
+                  () -> {
+                    throw new RuntimeException("round-1-failure");
+                  }));
+      assertEquals(CircuitBreaker.State.OPEN, breaker.getState());
+
+      clock.advance(Duration.ofMillis(100));
+      assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.getState());
+      assertEquals("round-2-result", breaker.execute(() -> "round-2-result"));
+      assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.getState());
+
+      releaseStaleProbe.countDown();
+      assertEquals("round-1-result", staleSuccess.get(1, TimeUnit.SECONDS));
+      assertEquals(
+          CircuitBreaker.State.HALF_OPEN,
+          breaker.getState(),
+          "a success admitted in round 1 must not close round 2");
+    } finally {
+      releaseStaleProbe.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void staleHalfOpenFailureCannotReopenANewerProbeRound() throws Exception {
+    breaker.transitionToOpen();
+    clock.advance(Duration.ofMillis(100));
+    assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.getState());
+
+    CountDownLatch staleProbeStarted = new CountDownLatch(1);
+    CountDownLatch releaseStaleProbe = new CountDownLatch(1);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    RuntimeException staleFailure = new RuntimeException("round-1-stale-failure");
+    try {
+      Future<String> staleResult =
+          executor.submit(
+              () ->
+                  breaker.execute(
+                      () -> {
+                        staleProbeStarted.countDown();
+                        releaseStaleProbe.await();
+                        throw staleFailure;
+                      }));
+      assertTrue(staleProbeStarted.await(1, TimeUnit.SECONDS));
+
+      assertThrows(
+          RuntimeException.class,
+          () ->
+              breaker.execute(
+                  () -> {
+                    throw new RuntimeException("round-1-current-failure");
+                  }));
+      assertEquals(CircuitBreaker.State.OPEN, breaker.getState());
+
+      clock.advance(Duration.ofMillis(100));
+      assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.getState());
+      assertEquals("round-2-result", breaker.execute(() -> "round-2-result"));
+      assertEquals(CircuitBreaker.State.HALF_OPEN, breaker.getState());
+
+      releaseStaleProbe.countDown();
+      ExecutionException thrown =
+          assertThrows(ExecutionException.class, () -> staleResult.get(1, TimeUnit.SECONDS));
+      assertSame(staleFailure, thrown.getCause());
+      assertEquals(
+          CircuitBreaker.State.HALF_OPEN,
+          breaker.getState(),
+          "a failure admitted in round 1 must not reopen round 2");
+    } finally {
+      releaseStaleProbe.countDown();
       executor.shutdownNow();
     }
   }

--- a/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
@@ -93,7 +93,7 @@ class CircuitBreakerTest {
               if (newState == CircuitBreaker.State.OPEN) {
                 listenerEntered.countDown();
                 try {
-                  if (!releaseListener.await(2, java.util.concurrent.TimeUnit.SECONDS)) {
+                  if (!releaseListener.await(2, TimeUnit.SECONDS)) {
                     throw new AssertionError("listener was not released");
                   }
                 } catch (InterruptedException e) {
@@ -105,14 +105,14 @@ class CircuitBreakerTest {
     ExecutorService executor = Executors.newFixedThreadPool(2);
     try {
       Future<?> opening = executor.submit(observed::transitionToOpen);
-      assertTrue(listenerEntered.await(1, java.util.concurrent.TimeUnit.SECONDS));
+      assertTrue(listenerEntered.await(1, TimeUnit.SECONDS));
 
       Future<?> resetting = executor.submit(observed::reset);
-      resetting.get(1, java.util.concurrent.TimeUnit.SECONDS);
+      resetting.get(1, TimeUnit.SECONDS);
       assertEquals(CircuitBreaker.State.CLOSED, observed.getState());
 
       releaseListener.countDown();
-      opening.get(1, java.util.concurrent.TimeUnit.SECONDS);
+      opening.get(1, TimeUnit.SECONDS);
       assertEquals(List.of(CircuitBreaker.State.OPEN, CircuitBreaker.State.CLOSED), transitions);
     } finally {
       releaseListener.countDown();

--- a/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/resilience/CircuitBreakerTest.java
@@ -22,6 +22,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -50,6 +53,71 @@ class CircuitBreakerTest {
   @Test
   void startsInClosedState() {
     assertEquals(CircuitBreaker.State.CLOSED, breaker.getState());
+  }
+
+  @Test
+  void reportsEachStateTransitionOnce() throws Exception {
+    List<CircuitBreaker.State> transitions = new ArrayList<>();
+    CircuitBreaker observed =
+        new CircuitBreaker(
+            "observed-service",
+            new CircuitBreakerConfiguration(50.0f, 4, 100L, 2, 2),
+            clock,
+            transitions::add);
+
+    observed.transitionToOpen();
+    observed.transitionToOpen();
+    clock.advance(Duration.ofMillis(100));
+    assertEquals(CircuitBreaker.State.HALF_OPEN, observed.getState());
+    observed.execute(() -> "ok1");
+    observed.execute(() -> "ok2");
+
+    assertEquals(
+        List.of(
+            CircuitBreaker.State.OPEN, CircuitBreaker.State.HALF_OPEN, CircuitBreaker.State.CLOSED),
+        transitions);
+  }
+
+  @Test
+  void publishesStateChangesAfterReleasingTheStateLock() throws Exception {
+    CountDownLatch listenerEntered = new CountDownLatch(1);
+    CountDownLatch releaseListener = new CountDownLatch(1);
+    List<CircuitBreaker.State> transitions = new CopyOnWriteArrayList<>();
+    CircuitBreaker observed =
+        new CircuitBreaker(
+            "observed-service",
+            new CircuitBreakerConfiguration(50.0f, 4, 100L, 2, 2),
+            clock,
+            newState -> {
+              transitions.add(newState);
+              if (newState == CircuitBreaker.State.OPEN) {
+                listenerEntered.countDown();
+                try {
+                  if (!releaseListener.await(2, java.util.concurrent.TimeUnit.SECONDS)) {
+                    throw new AssertionError("listener was not released");
+                  }
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new AssertionError("listener was interrupted", e);
+                }
+              }
+            });
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    try {
+      Future<?> opening = executor.submit(observed::transitionToOpen);
+      assertTrue(listenerEntered.await(1, java.util.concurrent.TimeUnit.SECONDS));
+
+      Future<?> resetting = executor.submit(observed::reset);
+      resetting.get(1, java.util.concurrent.TimeUnit.SECONDS);
+      assertEquals(CircuitBreaker.State.CLOSED, observed.getState());
+
+      releaseListener.countDown();
+      opening.get(1, java.util.concurrent.TimeUnit.SECONDS);
+      assertEquals(List.of(CircuitBreaker.State.OPEN, CircuitBreaker.State.CLOSED), transitions);
+    } finally {
+      releaseListener.countDown();
+      executor.shutdownNow();
+    }
   }
 
   @Test

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiCombinedObservabilityAlternativesIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiCombinedObservabilityAlternativesIT.java
@@ -15,46 +15,52 @@
  */
 package run.ratchet.testsuite.tck;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.inject.Inject;
+import java.util.UUID;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import run.ratchet.api.JobPriority;
+import run.ratchet.api.JobType;
+import run.ratchet.micrometer.MicrometerMetricsCollector;
 import run.ratchet.otel.OtelTracingCollector;
+import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.TracingCollector;
 
-/**
- * Verifies that {@link OtelTracingCollector} is selected over {@link
- * run.ratchet.ri.cdi.NoOpTracingCollector} when {@code ratchet-otel} is on the deployment
- * classpath.
- *
- * <p>{@code OtelTracingCollector} is annotated {@code @Alternative @Priority(1100)}, which globally
- * enables it per CDI 2.0+ spec without requiring a {@code beans.xml} entry. This test confirms the
- * CDI container honours the priority and selects the OTel implementation.
- *
- * <p>When no {@code OpenTelemetry} CDI bean is available (as in this test container), {@code
- * OtelTracingCollector} falls back to {@link io.opentelemetry.api.GlobalOpenTelemetry#get()}, which
- * returns a no-op instance. The test only verifies selection — not span emission.
- */
+/** Verifies deterministic adapter selection when both observability modules are installed. */
 @ExtendWith(ArquillianExtension.class)
-class RiOtelTracingAlternativeIT {
+class RiCombinedObservabilityAlternativesIT {
 
   @Inject private TracingCollector tracingCollector;
+  @Inject private MetricsCollector metricsCollector;
+  @Inject private MeterRegistry registry;
 
   @Deployment
   public static WebArchive createDeployment() {
-    return RiOptionalModuleDeployment.create("run.ratchet:ratchet-otel");
+    return RiOptionalModuleDeployment.create(
+        "run.ratchet:ratchet-otel", "run.ratchet:ratchet-micrometer");
   }
 
   @Test
-  void otelAlternativeSelectedOverNoOp() {
-    assertInstanceOf(
-        OtelTracingCollector.class,
-        tracingCollector,
-        "When ratchet-otel is on the deployment classpath, the @Alternative @Priority(1100) "
-            + "OtelTracingCollector must be selected over the default NoOpTracingCollector");
+  void otelTracingAndMicrometerMetricsAreSelectedTogether() {
+    assertInstanceOf(OtelTracingCollector.class, tracingCollector);
+    assertInstanceOf(MicrometerMetricsCollector.class, metricsCollector);
+
+    metricsCollector.jobStarted(new UUID(0L, 1L), JobType.SINGLE, JobPriority.NORMAL);
+
+    assertEquals(
+        1.0,
+        registry
+            .get("ratchet.jobs.started")
+            .tag("type", "SINGLE")
+            .tag("priority", "NORMAL")
+            .counter()
+            .count());
   }
 }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiOptionalModuleDeployment.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/RiOptionalModuleDeployment.java
@@ -28,12 +28,20 @@ final class RiOptionalModuleDeployment {
     return create(artifact, new Package[0]);
   }
 
+  static WebArchive create(String firstArtifact, String secondArtifact) {
+    return create(new String[] {firstArtifact, secondArtifact}, new Package[0]);
+  }
+
   static WebArchive create(String artifact, Package[] packages, Class<?>... classes) {
+    return create(new String[] {artifact}, packages, classes);
+  }
+
+  private static WebArchive create(String[] artifacts, Package[] packages, Class<?>... classes) {
     String dbType = System.getProperty("ratchet.test.db.type", "mysql");
     String profile = System.getProperty("testsuite.profile", "wildfly-managed");
 
     File[] optionalModuleJars =
-        Maven.resolver().loadPomFromFile("pom.xml").resolve(artifact).withTransitivity().asFile();
+        Maven.resolver().loadPomFromFile("pom.xml").resolve(artifacts).withTransitivity().asFile();
 
     RatchetArchiveBuilder builder =
         RatchetArchiveBuilder.create()

--- a/website/docs/advanced/circuit-breakers.md
+++ b/website/docs/advanced/circuit-breakers.md
@@ -340,6 +340,11 @@ try {
 
 **Share breakers across related operations.** If multiple methods call the same downstream service, use the same `service` name so failures in any method contribute to tripping the circuit. This prevents sending traffic to a service that is already known to be failing.
 
-**Monitor state transitions.** Inject `CircuitBreakerRegistry` and periodically check breaker states for operational visibility. Consider exposing breaker state via a health check endpoint.
+**Monitor state transitions.** The Micrometer adapter publishes `ratchet.circuit.breaker.state` as
+a gauge tagged by service name and breaker profile (`0` closed, `1` half-open, `2` open). Add each
+application service name to the `service` allowlist in `MicrometerMetricTagPolicy`; unknown service
+names are not exported, because combining independent breaker states under an `OTHER` tag would be
+misleading. A custom `MetricsCollector` can observe the initial state and subsequent transitions
+through `circuitBreakerState(...)`.
 
 **Prefer manual reset sparingly.** The `resetBreaker()` method forces a circuit back to CLOSED. Use this only for operational recovery (e.g., after confirming a downstream service is restored), not as part of normal application flow.

--- a/website/docs/advanced/metrics-collection.md
+++ b/website/docs/advanced/metrics-collection.md
@@ -10,79 +10,23 @@ Ratchet provides a `MetricsCollector` SPI that receives callbacks during the job
 
 ## MetricsCollector SPI
 
-The SPI defines three core lifecycle callbacks plus an optional callback-failure hook:
+`MetricsCollector` covers the job lifecycle and the scheduler paths operators need when work is not progressing normally. It currently declares 22 callbacks:
 
-```java
-package run.ratchet.spi;
+| Area | Callbacks |
+|------|-----------|
+| Job execution | `jobStarted`, `jobCompleted`, `jobFailed` |
+| Success finalization | `successFinalizationRetried`, `successFinalizationMinimal`, `successFinalizationStuck` |
+| Claim and admission | `claimTransientFailure`, `jobsClaimed`, `gateRejected` |
+| Wakeups and routing | `localWakeup`, `executionTargetFallback`, `clusterWakeupPublished`, `clusterWakeupReceived` |
+| Callbacks and signals | `callbackFailed`, `signalWaiting`, `signalDelivered`, `signalTimedOut`, `signalCancelled` |
+| Store health | `storeOperation`, `pollerBreakerState` |
+| Payload encryption | `encryptionIntegrityViolation`, `encryptionEnvelopeVersionSkew` |
 
-@Incubating
-public interface MetricsCollector {
-
-    /**
-     * Notifies that a job has started execution.
-     *
-     * @param jobId    the unique job identifier
-     * @param type     the job type (SINGLE, RECURRING, BATCH, etc.)
-     * @param priority the job priority level
-     */
-    void jobStarted(UUID jobId, JobType type, JobPriority priority);
-
-    /**
-     * Notifies that a job has completed successfully.
-     *
-     * @param jobId           the unique job identifier
-     * @param type            the job type
-     * @param executionTimeMs the execution time of the completed attempt in milliseconds
-     */
-    void jobCompleted(UUID jobId, JobType type, long executionTimeMs);
-
-    /**
-     * Notifies that a job has failed.
-     *
-     * @param jobId   the unique job identifier
-     * @param type    the job type
-     * @param cause   the exception that caused the failure
-     * @param attempt the 1-based attempt number, including the failed attempt
-     */
-    void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt);
-
-    /**
-     * Notifies that an onSuccess/onFailure callback threw an exception.
-     */
-    default void callbackFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
-        // No-op
-    }
-}
-```
-
-This interface is marked `@Incubating` -- additional lifecycle callbacks (retry, timeout, DLQ) may be added in future releases.
+The first ten methods are required for a direct implementation. The remaining methods have default no-op bodies so the incubating SPI can grow without breaking existing implementations. Treat those defaults as a compatibility mechanism, not a claim that the signals are unimportant. A complete monitoring adapter should make an explicit decision about every callback.
 
 ## Default No-Op Collector
 
-When no monitoring integration is configured, the `NoOpMetricsCollector` satisfies the injection point with empty method bodies:
-
-```java
-@ApplicationScoped
-public class NoOpMetricsCollector implements MetricsCollector {
-
-    @Override
-    public void jobStarted(UUID jobId, JobType type, JobPriority priority) {
-        // No-op
-    }
-
-    @Override
-    public void jobCompleted(UUID jobId, JobType type, long executionTimeMs) {
-        // No-op
-    }
-
-    @Override
-    public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
-        // No-op
-    }
-}
-```
-
-Ratchet runs without a metrics dependency on the classpath.
+When no monitoring integration is configured, `NoOpMetricsCollector` satisfies the injection point without publishing anything. It implements the required callbacks and inherits or retains no-op behavior for the optional ones, so Ratchet runs without a metrics dependency on the classpath.
 
 ## Micrometer Integration
 
@@ -130,21 +74,33 @@ public class MetricsProducer {
 
 ### Published Metrics
 
-The Micrometer adapter publishes the following metrics:
+The Micrometer adapter publishes the following 23 meters:
 
-#### Counters
-
-| Metric Name | Tags | Description |
-|-------------|------|-------------|
-| `ratchet.jobs.started` | `type`, `priority` | Incremented each time a job begins execution |
-| `ratchet.jobs.completed` | `type` | Incremented each time a job completes successfully |
-| `ratchet.jobs.failed` | `type`, `family` | Incremented each time a job fails. The `family` tag contains the `ExceptionFamily` classification of the causing exception (`TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, or `UNKNOWN`). |
-
-#### Timers
-
-| Metric Name | Tags | Description |
-|-------------|------|-------------|
-| `ratchet.jobs.duration` | `type` | Records the execution time of completed jobs. Provides count, total time, max, and histogram data. |
+| Metric Name | Type | Tags | Description |
+|-------------|------|------|-------------|
+| `ratchet.jobs.started` | Counter | `type`, `priority` | Job execution attempts started |
+| `ratchet.jobs.completed` | Counter | `type` | Job execution attempts completed successfully |
+| `ratchet.jobs.failed` | Counter | `type`, `family` | Failed attempts, classified as `TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, or `UNKNOWN` |
+| `ratchet.jobs.duration` | Timer | `type` | Wall-clock duration of successful attempts |
+| `ratchet.store.finalization.retries` | Counter | `type` | Transient conflicts while persisting a successful result |
+| `ratchet.store.finalization.minimal_success` | Counter | `type` | Full-result persistence was exhausted and Ratchet used the minimal terminal-success write |
+| `ratchet.store.finalization.stuck` | Counter | `type` | Both full and minimal finalization were exhausted; the job remains `RUNNING` for recovery |
+| `ratchet.store.claim.transient_failures` | Counter | `execution_type` | Transient store conflicts on the claim path |
+| `ratchet.poller.claimed.jobs` | Counter | `execution_type` | Number of jobs claimed, incremented by the claimed batch size |
+| `ratchet.submission.gate.rejections` | Counter | `execution_type`, `gate_status` | Claimed jobs blocked by a local submission gate |
+| `ratchet.wakeup.local` | Counter | `source` | Direct local poller wakeups after new work |
+| `ratchet.execution.target.fallback` | Counter | `requested_target`, `effective_target` | Requested executor target was unavailable and Ratchet used a fallback pool |
+| `ratchet.wakeup.cluster.publish` | Counter | `transport`, `outcome` | Cluster wakeup publish attempts |
+| `ratchet.wakeup.cluster.receive` | Counter | `transport`, `outcome` | Cluster wakeup messages observed by a receiver |
+| `ratchet.callbacks.failed` | Counter | `type`, `family` | `onSuccess` or `onFailure` callback failures; these do not fail the parent job |
+| `ratchet.signal.waiting` | Counter | `type`, `signal_key` | Jobs created in `WAITING` for a signal |
+| `ratchet.signal.delivered` | Counter | `type`, `signal_key`, `outcome` | Signal deliveries that moved a job to `PENDING` |
+| `ratchet.signal.timed_out` | Counter | `type`, `signal_key` | Signal waits that expired |
+| `ratchet.signal.cancelled` | Counter | `type`, `signal_key` | Signal waits cancelled before delivery |
+| `ratchet.store.operation` | Timer | `store`, `operation`, `outcome` | Timed store operations on claim and execution hot paths |
+| `ratchet.poller.breaker.state` | Gauge | `breaker` | Poller claim-breaker state: `0` closed/unknown, `1` half-open, `2` open |
+| `ratchet.encryption.integrity.violations` | Counter | `surface` | A row marked as encrypted contained unframed plaintext. The read succeeds, but this signals a downgrade, lagging writer, or bug. |
+| `ratchet.encryption.envelope.version_skew` | Counter | `version_gap` | A job used a newer envelope than this node can read. `next` is one version ahead, `multiple_versions_ahead` is more than one, and `not_newer` flags an unexpected callback. Ratchet releases valid newer jobs for an upgraded peer; a persistent rate identifies a lagging node. |
 
 #### Tag Values
 
@@ -158,6 +114,8 @@ The `type` tag corresponds to `JobType` enum values:
 - `SYSTEM` -- Scheduler-managed system work, not user-creatable
 
 The `priority` tag corresponds to `JobPriority` enum values (`LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL`).
+
+String-valued tags pass through `MicrometerMetricTagPolicy`. Framework-defined bounded values are retained; blank values become `UNKNOWN`, and unrecognized values become `OTHER`. Protected-surface values are derived from the `ProtectedSurface` enum, so adding a framework surface automatically updates the default policy. Application signal keys are unbounded and therefore collapse to `OTHER` by default. If you deliberately want selected signal keys or extension values as dimensions, provide a policy that allowlists them and account for the extra time series.
 
 ### Prometheus Scrape Endpoint Example
 
@@ -210,14 +168,15 @@ ratchet_jobs_started_total
 
 ## Implementing a Custom MetricsCollector
 
-For monitoring systems without Micrometer support, or when you need custom metric shapes, implement the SPI directly.
+For monitoring systems without Micrometer support, or when you need custom metric shapes, implement the SPI directly. The abbreviated examples below deliberately export only the three basic job outcomes. They are partial collectors, not replacements for the full operational surface listed above. For production parity, handle every callback or delegate the callbacks you do not customize to another complete collector.
 
 ### MicroProfile Metrics Example
 
 ```java
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
-import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.ExceptionFamily;
+import run.ratchet.spi.NoOpMetricsCollector;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
@@ -232,7 +191,7 @@ import java.time.Duration;
 @Alternative
 @Priority(Interceptor.Priority.APPLICATION)
 @ApplicationScoped
-public class MicroProfileMetricsCollector implements MetricsCollector {
+public class MicroProfileMetricsCollector extends NoOpMetricsCollector {
 
     @Inject
     private MetricRegistry registry;
@@ -260,8 +219,8 @@ public class MicroProfileMetricsCollector implements MetricsCollector {
     public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
         Counter counter = registry.counter("ratchet_jobs_failed",
             new org.eclipse.microprofile.metrics.Tag("type", type.name()),
-            new org.eclipse.microprofile.metrics.Tag("exception",
-                cause.getClass().getSimpleName()));
+            new org.eclipse.microprofile.metrics.Tag("family",
+                ExceptionFamily.classify(cause).name()));
         counter.inc();
     }
 }
@@ -274,7 +233,7 @@ For simpler deployments where structured logs feed into a log aggregation system
 ```java
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobType;
-import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NoOpMetricsCollector;
 
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -285,7 +244,7 @@ import java.util.logging.Logger;
 @Alternative
 @Priority(Interceptor.Priority.APPLICATION)
 @ApplicationScoped
-public class LoggingMetricsCollector implements MetricsCollector {
+public class LoggingMetricsCollector extends NoOpMetricsCollector {
 
     private static final Logger log = Logger.getLogger("ratchet.metrics");
 
@@ -323,6 +282,10 @@ Use the metrics to set up alerts for common operational issues:
 | P95 execution time > 2x baseline | Warning: job execution slowdown |
 | No jobs started in 15 minutes (when expected) | Critical: scheduler may be stalled |
 | `ratchet.jobs.failed` with a specific `family` tag spikes | Investigate the failing exception family |
+| `ratchet.store.finalization.stuck` is non-zero | Page an operator; successful work is waiting for recovery |
+| `ratchet.poller.breaker.state` remains `2` | Investigate store availability and claim latency |
+| `ratchet.encryption.integrity.violations` is non-zero | Investigate an encryption downgrade or un-upgraded writer |
+| `ratchet.encryption.envelope.version_skew` persists after a rollout | Find and upgrade the lagging node |
 
 ## Best practices
 
@@ -334,9 +297,9 @@ Prefer `ratchet.jobs.started{type=SINGLE}` over `ratchet.single_jobs.started`. T
 
 The Micrometer adapter classifies failures into the `ExceptionFamily` enum (`TRANSIENT`, `TIMEOUT`, `VALIDATION`, `BUSINESS`, `UNKNOWN`) for the `family` tag, so cardinality stays fixed. A custom collector that tags by exception class name can produce high-cardinality metrics if your application throws many dynamically-generated exception types. Normalize exception names in that case.
 
-### Monitor attempt counts
+### Monitor finalization fallbacks
 
-A spike in `attempt > 1` failures means retries are being consumed. Pair this with retry policy metrics to understand whether jobs are eventually succeeding or exhausting their retry budget.
+Alert on `ratchet.store.finalization.stuck`. Track `ratchet.store.finalization.retries` and `ratchet.store.finalization.minimal_success` as earlier warnings that terminal writes are contending or failing.
 
 ### Set baselines before alerting
 

--- a/website/docs/advanced/metrics-collection.md
+++ b/website/docs/advanced/metrics-collection.md
@@ -10,7 +10,7 @@ Ratchet provides a `MetricsCollector` SPI that receives callbacks during the job
 
 ## MetricsCollector SPI
 
-`MetricsCollector` covers the job lifecycle and the scheduler paths operators need when work is not progressing normally. It currently declares 22 callbacks:
+`MetricsCollector` covers the job lifecycle and the scheduler paths operators need when work is not progressing normally:
 
 | Area | Callbacks |
 |------|-----------|
@@ -19,7 +19,8 @@ Ratchet provides a `MetricsCollector` SPI that receives callbacks during the job
 | Claim and admission | `claimTransientFailure`, `jobsClaimed`, `gateRejected` |
 | Wakeups and routing | `localWakeup`, `executionTargetFallback`, `clusterWakeupPublished`, `clusterWakeupReceived` |
 | Callbacks and signals | `callbackFailed`, `signalWaiting`, `signalDelivered`, `signalTimedOut`, `signalCancelled` |
-| Store health | `storeOperation`, `pollerBreakerState` |
+| Store health | `storeOperation` |
+| Circuit breakers | `pollerBreakerState`, `circuitBreakerState` |
 | Payload encryption | `encryptionIntegrityViolation`, `encryptionEnvelopeVersionSkew` |
 
 The first ten methods are required for a direct implementation. The remaining methods have default no-op bodies so the incubating SPI can grow without breaking existing implementations. Treat those defaults as a compatibility mechanism, not a claim that the signals are unimportant. A complete monitoring adapter should make an explicit decision about every callback.
@@ -74,7 +75,7 @@ public class MetricsProducer {
 
 ### Published Metrics
 
-The Micrometer adapter publishes the following 23 meters:
+The Micrometer adapter publishes the following meters:
 
 | Metric Name | Type | Tags | Description |
 |-------------|------|------|-------------|
@@ -99,6 +100,7 @@ The Micrometer adapter publishes the following 23 meters:
 | `ratchet.signal.cancelled` | Counter | `type`, `signal_key` | Signal waits cancelled before delivery |
 | `ratchet.store.operation` | Timer | `store`, `operation`, `outcome` | Timed store operations on claim and execution hot paths |
 | `ratchet.poller.breaker.state` | Gauge | `breaker` | Poller claim-breaker state: `0` closed/unknown, `1` half-open, `2` open |
+| `ratchet.circuit.breaker.state` | Gauge | `service`, `profile` | Application circuit-breaker state: `0` closed/unknown, `1` half-open, `2` open |
 | `ratchet.encryption.integrity.violations` | Counter | `surface` | A row marked as encrypted contained unframed plaintext. The read succeeds, but this signals a downgrade, lagging writer, or bug. |
 | `ratchet.encryption.envelope.version_skew` | Counter | `version_gap` | A job used a newer envelope than this node can read. `next` is one version ahead, `multiple_versions_ahead` is more than one, and `not_newer` flags an unexpected callback. Ratchet releases valid newer jobs for an upgraded peer; a persistent rate identifies a lagging node. |
 

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -208,7 +208,7 @@ See [Circuit Breakers](./circuit-breakers.md) for detailed guidance.
 **Adapter module:** `ratchet-micrometer` provides `MicrometerMetricsCollector`
 **Annotation:** `@Incubating`
 
-Receives 22 callbacks covering job outcomes, success finalization, claims and submission gates, wakeups and executor routing, callback and signal events, store timing, the poller breaker, and encryption integrity/version signals. The complete callback and meter catalog is in [Metrics Collection](./metrics-collection.md#metricscollector-spi).
+Receives callbacks covering job outcomes, success finalization, claims and submission gates, wakeups and executor routing, callback and signal events, store timing, circuit breakers, and encryption integrity/version signals. The complete callback and meter catalog is in [Metrics Collection](./metrics-collection.md#metricscollector-spi).
 
 **Partial override:**
 

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -208,24 +208,17 @@ See [Circuit Breakers](./circuit-breakers.md) for detailed guidance.
 **Adapter module:** `ratchet-micrometer` provides `MicrometerMetricsCollector`
 **Annotation:** `@Incubating`
 
-Receives job lifecycle callbacks for monitoring.
+Receives 22 callbacks covering job outcomes, success finalization, claims and submission gates, wakeups and executor routing, callback and signal events, store timing, the poller breaker, and encryption integrity/version signals. The complete callback and meter catalog is in [Metrics Collection](./metrics-collection.md#metricscollector-spi).
 
-```java
-@Incubating
-public interface MetricsCollector {
-    void jobStarted(UUID jobId, JobType type, JobPriority priority);
-    void jobCompleted(UUID jobId, JobType type, long executionTimeMs);
-    void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt);
-}
-```
+**Partial override:**
 
-**Override:**
+This abbreviated collector deliberately exports only the three basic job outcomes. Extend `NoOpMetricsCollector` when a partial view is intentional. A complete replacement should handle or delegate every callback listed in the catalog.
 
 ```java
 @Alternative
 @Priority(Interceptor.Priority.APPLICATION)
 @ApplicationScoped
-public class DatadogMetricsCollector implements MetricsCollector {
+public class DatadogMetricsCollector extends NoOpMetricsCollector {
 
     @Inject
     private StatsDClient statsd;
@@ -246,7 +239,7 @@ public class DatadogMetricsCollector implements MetricsCollector {
     @Override
     public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
         statsd.incrementCounter("ratchet.jobs.failed",
-            "type:" + type, "exception:" + cause.getClass().getSimpleName());
+            "type:" + type, "family:" + ExceptionFamily.classify(cause).name());
     }
 }
 ```

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -558,45 +558,26 @@ Emits job lifecycle metrics for integration with monitoring systems (Micrometer,
 This interface is marked `@Incubating` and may change. Additional lifecycle callbacks may be added in future releases.
 :::
 
-```java
-@Incubating
-public interface MetricsCollector {
-    void jobStarted(UUID jobId, JobType type, JobPriority priority);
-    void jobCompleted(UUID jobId, JobType type, long executionTimeMs);
-    void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt);
-}
-```
+| Area | Callbacks |
+|------|-----------|
+| Job execution | `jobStarted(UUID, JobType, JobPriority)`, `jobCompleted(UUID, JobType, long)`, `jobFailed(UUID, JobType, Throwable, int)` |
+| Success finalization | `successFinalizationRetried(UUID, JobType)`, `successFinalizationMinimal(UUID, JobType)`, `successFinalizationStuck(UUID, JobType)` |
+| Claim and admission | `claimTransientFailure(String)`, `jobsClaimed(String, int)`, `gateRejected(String, String)` |
+| Wakeups and routing | `localWakeup(String)`, `executionTargetFallback(String, String)`, `clusterWakeupPublished(String, String)`, `clusterWakeupReceived(String, String)` |
+| Callbacks and signals | `callbackFailed(UUID, JobType, Throwable, int)`, `signalWaiting(UUID, JobType, String)`, `signalDelivered(UUID, JobType, String, SignalDecision.Outcome)`, `signalTimedOut(UUID, JobType, String)`, `signalCancelled(UUID, JobType, String)` |
+| Store health | `storeOperation(String, String, String, long)`, `pollerBreakerState(String, String)` |
+| Payload encryption | `encryptionIntegrityViolation(UUID, String)`, `encryptionEnvelopeVersionSkew(UUID, int, int)` |
 
-### jobStarted
+The first ten callbacks are required for direct implementations; the rest have default no-op bodies for compatibility. See [Metrics Collection](../advanced/metrics-collection.md#metricscollector-spi) for callback semantics and the complete Micrometer meter catalog.
 
-```java
-void jobStarted(UUID jobId, JobType type, JobPriority priority)
-```
+### Partial example
 
-Called when a job begins execution.
-
-### jobCompleted
-
-```java
-void jobCompleted(UUID jobId, JobType type, long executionTimeMs)
-```
-
-Called when a job completes successfully.
-
-### jobFailed
-
-```java
-void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt)
-```
-
-Called when a job fails. The `attempt` parameter is 1-based and includes the failure being reported.
-
-### Example
+This example deliberately records only the three basic job outcomes. It extends `NoOpMetricsCollector` so that omission is explicit and the code remains compatible with the full SPI. A production replacement for the built-in Micrometer adapter should handle or delegate every callback.
 
 ```java
 @Alternative @Priority(APPLICATION)
 @ApplicationScoped
-public class MicrometerMetricsCollector implements MetricsCollector {
+public class PartialMicrometerMetricsCollector extends NoOpMetricsCollector {
 
     @Inject MeterRegistry registry;
 
@@ -616,7 +597,7 @@ public class MicrometerMetricsCollector implements MetricsCollector {
     public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
         registry.counter("ratchet.jobs.failed",
             "type", type.name(),
-            "exception", cause.getClass().getSimpleName()).increment();
+            "family", ExceptionFamily.classify(cause).name()).increment();
     }
 }
 ```

--- a/website/docs/api-reference/spi-interfaces.md
+++ b/website/docs/api-reference/spi-interfaces.md
@@ -565,7 +565,8 @@ This interface is marked `@Incubating` and may change. Additional lifecycle call
 | Claim and admission | `claimTransientFailure(String)`, `jobsClaimed(String, int)`, `gateRejected(String, String)` |
 | Wakeups and routing | `localWakeup(String)`, `executionTargetFallback(String, String)`, `clusterWakeupPublished(String, String)`, `clusterWakeupReceived(String, String)` |
 | Callbacks and signals | `callbackFailed(UUID, JobType, Throwable, int)`, `signalWaiting(UUID, JobType, String)`, `signalDelivered(UUID, JobType, String, SignalDecision.Outcome)`, `signalTimedOut(UUID, JobType, String)`, `signalCancelled(UUID, JobType, String)` |
-| Store health | `storeOperation(String, String, String, long)`, `pollerBreakerState(String, String)` |
+| Store health | `storeOperation(String, String, String, long)` |
+| Circuit breakers | `pollerBreakerState(String, String)`, `circuitBreakerState(String, String, String)` |
 | Payload encryption | `encryptionIntegrityViolation(UUID, String)`, `encryptionEnvelopeVersionSkew(UUID, int, int)` |
 
 The first ten callbacks are required for direct implementations; the rest have default no-op bodies for compatibility. See [Metrics Collection](../advanced/metrics-collection.md#metricscollector-spi) for callback semantics and the complete Micrometer meter catalog.

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -40,12 +40,33 @@ The `MicrometerMetricsCollector` is annotated `@Alternative @Priority(1000)`, so
 
 | Metric | Type | Tags | Description |
 |--------|------|------|-------------|
-| `ratchet.jobs.started` | Counter | `type`, `priority` | Jobs that began execution |
-| `ratchet.jobs.completed` | Counter | `type` | Jobs that finished successfully |
-| `ratchet.jobs.failed` | Counter | `type`, `family` | Jobs that failed (exception-family classification as tag) |
-| `ratchet.jobs.duration` | Timer | `type` | Execution time per job |
+| `ratchet.jobs.started` | Counter | `type`, `priority` | Job execution attempts started |
+| `ratchet.jobs.completed` | Counter | `type` | Job execution attempts completed successfully |
+| `ratchet.jobs.failed` | Counter | `type`, `family` | Failed attempts, grouped by bounded exception family |
+| `ratchet.jobs.duration` | Timer | `type` | Wall-clock duration of successful attempts |
+| `ratchet.store.finalization.retries` | Counter | `type` | Transient conflicts while persisting a successful result |
+| `ratchet.store.finalization.minimal_success` | Counter | `type` | Full-result persistence was exhausted and Ratchet used the minimal success write |
+| `ratchet.store.finalization.stuck` | Counter | `type` | Both finalization paths were exhausted; the job remains `RUNNING` for recovery |
+| `ratchet.store.claim.transient_failures` | Counter | `execution_type` | Transient store conflicts on the claim path |
+| `ratchet.poller.claimed.jobs` | Counter | `execution_type` | Number of jobs claimed |
+| `ratchet.submission.gate.rejections` | Counter | `execution_type`, `gate_status` | Claimed jobs blocked by a local submission gate |
+| `ratchet.wakeup.local` | Counter | `source` | Direct local poller wakeups after new work |
+| `ratchet.execution.target.fallback` | Counter | `requested_target`, `effective_target` | Requested executor target was unavailable and Ratchet used a fallback pool |
+| `ratchet.wakeup.cluster.publish` | Counter | `transport`, `outcome` | Cluster wakeup publish attempts |
+| `ratchet.wakeup.cluster.receive` | Counter | `transport`, `outcome` | Cluster wakeup messages observed by a receiver |
+| `ratchet.callbacks.failed` | Counter | `type`, `family` | `onSuccess` or `onFailure` callback failures; these do not fail the parent job |
+| `ratchet.signal.waiting` | Counter | `type`, `signal_key` | Jobs created in `WAITING` for a signal |
+| `ratchet.signal.delivered` | Counter | `type`, `signal_key`, `outcome` | Signal deliveries that moved a job to `PENDING` |
+| `ratchet.signal.timed_out` | Counter | `type`, `signal_key` | Signal waits that expired |
+| `ratchet.signal.cancelled` | Counter | `type`, `signal_key` | Signal waits cancelled before delivery |
+| `ratchet.store.operation` | Timer | `store`, `operation`, `outcome` | Timed store operations on claim and execution hot paths |
+| `ratchet.poller.breaker.state` | Gauge | `breaker` | Poller claim-breaker state: `0` closed/unknown, `1` half-open, `2` open |
+| `ratchet.encryption.integrity.violations` | Counter | `surface` | A row marked as encrypted contained plaintext. The read succeeds, but the writer or rollout needs investigation. |
+| `ratchet.encryption.envelope.version_skew` | Counter | `version_gap` | A newer envelope reached this node. `next`, `multiple_versions_ahead`, and `not_newer` keep the diagnostic bounded; Ratchet releases valid newer jobs for an upgraded peer. |
 
 The `type` tag corresponds to `JobType` (`SINGLE`, `RECURRING`, `BATCH`, `CHAIN`, `WORKFLOW`, `SYSTEM`). The `priority` tag corresponds to `JobPriority` (`LOWEST`, `LOW`, `NORMAL`, `HIGH`, `CRITICAL`). The `family` tag corresponds to `ExceptionFamily`, a coarse classification of the failure cause rather than the raw exception class name.
+
+`MicrometerMetricTagPolicy` keeps string-valued tags bounded. Framework values pass through, blanks become `UNKNOWN`, and unrecognized values become `OTHER`. Signal keys are application strings and collapse to `OTHER` unless you explicitly allowlist selected keys. See [Metrics Collection](../advanced/metrics-collection.md#published-metrics) for the tag-policy details.
 
 ### Grafana dashboard queries
 
@@ -72,7 +93,9 @@ topk(5, sum by (family) (rate(ratchet_jobs_failed_total[5m])))
 
 ### Custom `MetricsCollector`
 
-If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. Beyond the three core job-lifecycle hooks (`jobStarted`, `jobCompleted`, `jobFailed`), the SPI also declares `successFinalizationRetried`/`successFinalizationMinimal`/`successFinalizationStuck`, `claimTransientFailure`, `jobsClaimed`, `gateRejected`, and `localWakeup`, plus default no-op hooks for cluster wakeup, callback failures, signal events, store operations, and poller circuit-breaker state. The simplest approach is to extend `NoOpMetricsCollector` and override only the callbacks you need:
+If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. Its 22 callbacks cover job outcomes, success finalization, claims and gates, wakeups and executor routing, callback and signal events, store timing, the poller breaker, and encryption integrity/version signals.
+
+The example below is intentionally partial: it records two basic job outcomes and drops every other signal. Extending `NoOpMetricsCollector` is convenient when that is what you want. For a production replacement, review every callback in [Metrics Collection](../advanced/metrics-collection.md#metricscollector-spi) and either export it or delegate it to a complete collector.
 
 ```java
 public class MyMetricsCollector extends NoOpMetricsCollector {
@@ -219,6 +242,10 @@ Wire this into your alerting system. A non-zero DLQ count means something failed
 | Node heartbeat stale > 2min | **Critical** | Node may be down; check process health |
 | Pending CRITICAL jobs > 30s | **Critical** | Cluster may be overloaded |
 | Pending queue depth growing | **Warning** | Scale up nodes or increase thread pool |
+| `ratchet.store.finalization.stuck` > 0 | **Critical** | Check store health; successful work is waiting for recovery |
+| `ratchet.poller.breaker.state` remains `2` | **Critical** | Investigate claim-path store failures |
+| `ratchet.encryption.integrity.violations` > 0 | **Critical** | Investigate a downgrade, lagging writer, or encryption bug |
+| `ratchet.encryption.envelope.version_skew` persists after rollout | **Warning** | Find and upgrade the lagging node |
 
 ## See also
 

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -66,6 +66,7 @@ Micrometer tracing bridge. A custom tracing collector with a priority above 1100
 | `ratchet.signal.cancelled` | Counter | `type`, `signal_key` | Signal waits cancelled before delivery |
 | `ratchet.store.operation` | Timer | `store`, `operation`, `outcome` | Timed store operations on claim and execution hot paths |
 | `ratchet.poller.breaker.state` | Gauge | `breaker` | Poller claim-breaker state: `0` closed/unknown, `1` half-open, `2` open |
+| `ratchet.circuit.breaker.state` | Gauge | `service`, `profile` | Application circuit-breaker state: `0` closed/unknown, `1` half-open, `2` open |
 | `ratchet.encryption.integrity.violations` | Counter | `surface` | A row marked as encrypted contained plaintext. The read succeeds, but the writer or rollout needs investigation. |
 | `ratchet.encryption.envelope.version_skew` | Counter | `version_gap` | A newer envelope reached this node. `next`, `multiple_versions_ahead`, and `not_newer` keep the diagnostic bounded; Ratchet releases valid newer jobs for an upgraded peer. |
 
@@ -98,7 +99,7 @@ topk(5, sum by (family) (rate(ratchet_jobs_failed_total[5m])))
 
 ### Custom `MetricsCollector`
 
-If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. Its 22 callbacks cover job outcomes, success finalization, claims and gates, wakeups and executor routing, callback and signal events, store timing, the poller breaker, and encryption integrity/version signals.
+If you need different metric names, additional tags, or a non-Micrometer backend, implement the `MetricsCollector` SPI. Its callbacks cover job outcomes, success finalization, claims and gates, wakeups and executor routing, callback and signal events, store timing, circuit breakers, and encryption integrity/version signals.
 
 The example below is intentionally partial: it records two basic job outcomes and drops every other signal. Extending `NoOpMetricsCollector` is convenient when that is what you want. For a production replacement, review every callback in [Metrics Collection](../advanced/metrics-collection.md#metricscollector-spi) and either export it or delegate it to a complete collector.
 

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -36,6 +36,11 @@ public MeterRegistry meterRegistry() {
 
 The `MicrometerMetricsCollector` is annotated `@Alternative @Priority(1000)`, so it automatically overrides the default `NoOpMetricsCollector` when the module is on the classpath.
 
+You can install `ratchet-otel` beside `ratchet-micrometer`. In that combination, OpenTelemetry's
+priority-1100 adapter handles tracing while Micrometer continues to publish metrics. If both
+modules are present, Ratchet deliberately chooses direct OpenTelemetry tracing instead of the
+Micrometer tracing bridge. A custom tracing collector with a priority above 1100 overrides both.
+
 ### Published metrics
 
 | Metric | Type | Tags | Description |

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -345,43 +345,17 @@ WHERE terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')
 
 ### Micrometer integration
 
-Wire the `MetricsCollector` SPI to Micrometer for dashboarding:
+Add the `ratchet-micrometer` module instead of maintaining a lifecycle-only collector:
 
-```java
-@ApplicationScoped
-public class MicrometerCollector implements MetricsCollector {
-
-  @Inject
-  MeterRegistry registry;
-
-  @Override
-  public void jobStarted(UUID jobId, JobType type, JobPriority priority) {
-    registry.counter("ratchet.jobs.started",
-        "type", type.name(),
-        "priority", priority.name())
-        .increment();
-  }
-
-  @Override
-  public void jobCompleted(UUID jobId, JobType type, long executionTimeMs) {
-    registry.counter("ratchet.jobs.completed",
-        "type", type.name())
-        .increment();
-
-    registry.timer("ratchet.jobs.duration",
-        "type", type.name())
-        .record(executionTimeMs, TimeUnit.MILLISECONDS);
-  }
-
-  @Override
-  public void jobFailed(UUID jobId, JobType type, Throwable cause, int attempt) {
-    registry.counter("ratchet.jobs.failed",
-        "type", type.name(),
-        "exception", cause.getClass().getSimpleName())
-        .increment();
-  }
-}
+```xml
+<dependency>
+  <groupId>run.ratchet</groupId>
+  <artifactId>ratchet-micrometer</artifactId>
+  <version>${ratchet.version}</version>
+</dependency>
 ```
+
+The bundled adapter covers all 22 `MetricsCollector` callbacks, including store-finalization fallbacks, claim-breaker state, and encryption rollout signals. See [Monitoring](./monitoring.md#published-metrics) for the meter catalog and setup.
 
 ### Useful dashboard queries
 

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -355,7 +355,7 @@ Add the `ratchet-micrometer` module instead of maintaining a lifecycle-only coll
 </dependency>
 ```
 
-The bundled adapter covers all 22 `MetricsCollector` callbacks, including store-finalization fallbacks, claim-breaker state, and encryption rollout signals. See [Monitoring](./monitoring.md#published-metrics) for the meter catalog and setup.
+The bundled adapter covers the full `MetricsCollector` surface, including store-finalization fallbacks, claim and application circuit-breaker state, and encryption rollout signals. See [Monitoring](./monitoring.md#published-metrics) for the meter catalog and setup.
 
 ### Useful dashboard queries
 


### PR DESCRIPTION
## Summary

This is PR 2 of 5 in the review-remediation stack.

- Publish state-change events only after their transaction commits.
- Fence stale half-open circuit-breaker probes.
- Complete encryption metrics, tracing attributes, and application-breaker gauges.
- Make observability adapter selection deterministic.
- Document the expanded metrics and circuit-breaker contracts.

## Testing

- [ ] `mvn clean test -B`
- [ ] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl :ratchet-testsuite,:ratchet-coverage -am`
- [ ] `cd website && npm ci && npm run build`
- [x] `mvn -B -ntp verify` (31-module reactor at the stack tip)
- [x] Focused API, reference implementation, and observability suites
- [x] Focused circuit-breaker transition tests

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed
- [ ] No docs update needed

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

## Additional Context

Base: `work/review-release-foundations` (PR #132). PR 3 targets this branch.

The new collector callback reports application circuit-breaker transitions. Event delivery remains at-most-once and now matches the transaction outcome.