### PR TITLE
Make recurring child lineage durable

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobCancellationEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobCancellationEvent.java
@@ -34,13 +34,14 @@ public abstract class AbstractJobCancellationEvent extends AbstractJobSchedulerE
   protected AbstractJobCancellationEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       String previousStatus,
       Long executionTimeMs) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.previousStatus = EventContract.requireNonBlank(previousStatus, "previousStatus");
     this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
@@ -54,12 +55,13 @@ public abstract class AbstractJobCancellationEvent extends AbstractJobSchedulerE
   protected AbstractJobCancellationEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String previousStatus,
       Long executionTimeMs) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.previousStatus = EventContract.requireNonBlank(previousStatus, "previousStatus");
     this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobSchedulerEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/AbstractJobSchedulerEvent.java
@@ -27,8 +27,9 @@ import run.ratchet.api.JobType;
  * Base class for per-job lifecycle events published by Ratchet.
  *
  * <p>Subclasses carry a snapshot of public job metadata at the time the event is created. Fields
- * such as {@code businessKey}, {@code jobType}, {@code priority}, and {@code nodeId} may be {@code
- * null} when Ratchet can no longer load the job row after a successful state transition.
+ * such as {@code businessKey}, {@code recurringMasterId}, {@code jobType}, {@code priority}, and
+ * {@code nodeId} may be {@code null} when Ratchet can no longer load the job row after a successful
+ * state transition.
  */
 @Incubating
 public abstract class AbstractJobSchedulerEvent implements Serializable {
@@ -37,6 +38,7 @@ public abstract class AbstractJobSchedulerEvent implements Serializable {
 
   private final UUID jobId;
   private final String businessKey;
+  private final UUID recurringMasterId;
   private final JobType jobType;
   private final JobPriority priority;
   private final String nodeId;
@@ -45,12 +47,14 @@ public abstract class AbstractJobSchedulerEvent implements Serializable {
   protected AbstractJobSchedulerEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp) {
     this.jobId = EventContract.requireNonNull(jobId, "jobId");
     this.businessKey = businessKey;
+    this.recurringMasterId = recurringMasterId;
     this.jobType = jobType;
     this.priority = priority;
     this.nodeId = nodeId;
@@ -64,8 +68,13 @@ public abstract class AbstractJobSchedulerEvent implements Serializable {
    * constructor that accepts an explicit {@link Instant}.
    */
   protected AbstractJobSchedulerEvent(
-      UUID jobId, String businessKey, JobType jobType, JobPriority priority, String nodeId) {
-    this(jobId, businessKey, jobType, priority, nodeId, Instant.now());
+      UUID jobId,
+      String businessKey,
+      UUID recurringMasterId,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId) {
+    this(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, Instant.now());
   }
 
   /** Returns the job id affected by this event. */
@@ -76,6 +85,17 @@ public abstract class AbstractJobSchedulerEvent implements Serializable {
   /** Returns the business key captured for the job, or {@code null} when unavailable. */
   public String getBusinessKey() {
     return businessKey;
+  }
+
+  /**
+   * Returns the recurring master id that owns this job's lineage, or {@code null} for jobs that
+   * were not fired from a recurring definition or when lineage metadata was unavailable.
+   *
+   * <p>The id remains usable after the recurring definition is canceled or exhausted and can be
+   * resolved through the recurring-job archive.
+   */
+  public UUID getRecurringMasterId() {
+    return recurringMasterId;
   }
 
   /** Returns the public job type captured for the job, or {@code null} when unavailable. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchChunkFailureEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchChunkFailureEvent.java
@@ -44,6 +44,7 @@ public class BatchChunkFailureEvent extends AbstractJobSchedulerEvent {
   public BatchChunkFailureEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -51,7 +52,7 @@ public class BatchChunkFailureEvent extends AbstractJobSchedulerEvent {
       int chunkIndex,
       int chunkSize,
       String failureReason) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.chunkIndex = chunkIndex;
     this.chunkSize = chunkSize;
     this.failureReason = failureReason;
@@ -60,13 +61,14 @@ public class BatchChunkFailureEvent extends AbstractJobSchedulerEvent {
   public BatchChunkFailureEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       int chunkIndex,
       int chunkSize,
       String failureReason) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.chunkIndex = chunkIndex;
     this.chunkSize = chunkSize;
     this.failureReason = failureReason;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletedEvent.java
@@ -41,6 +41,7 @@ public class BatchCompletedEvent extends AbstractJobSchedulerEvent {
   public BatchCompletedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -48,7 +49,7 @@ public class BatchCompletedEvent extends AbstractJobSchedulerEvent {
       int totalItems,
       int completedItems,
       int failedItems) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;
@@ -58,13 +59,14 @@ public class BatchCompletedEvent extends AbstractJobSchedulerEvent {
   public BatchCompletedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       int totalItems,
       int completedItems,
       int failedItems) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/BatchCompletingEvent.java
@@ -44,6 +44,7 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
   public BatchCompletingEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -51,7 +52,7 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
       int totalItems,
       int completedItems,
       int failedItems) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;
@@ -68,13 +69,14 @@ public class BatchCompletingEvent extends AbstractJobSchedulerEvent {
   public BatchCompletingEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       int totalItems,
       int completedItems,
       int failedItems) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     EventContract.requireBatchCounts(totalItems, completedItems, failedItems);
     this.totalItems = totalItems;
     this.completedItems = completedItems;

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainCompletedEvent.java
@@ -38,23 +38,25 @@ public class ChainCompletedEvent extends AbstractJobSchedulerEvent {
   public ChainCompletedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       UUID parentJobId) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 
   public ChainCompletedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       UUID parentJobId) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainFailedEvent.java
@@ -40,13 +40,14 @@ public class ChainFailedEvent extends AbstractJobSchedulerEvent {
   public ChainFailedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       UUID parentJobId,
       String errorMessage) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
     this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
   }
@@ -60,12 +61,13 @@ public class ChainFailedEvent extends AbstractJobSchedulerEvent {
   public ChainFailedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       UUID parentJobId,
       String errorMessage) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
     this.errorMessage = EventContract.requireNonBlank(errorMessage, "errorMessage");
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/ChainStartedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/ChainStartedEvent.java
@@ -38,23 +38,25 @@ public class ChainStartedEvent extends AbstractJobSchedulerEvent {
   public ChainStartedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       UUID parentJobId) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 
   public ChainStartedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       UUID parentJobId) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.parentJobId = EventContract.requireNonNull(parentJobId, "parentJobId");
   }
 

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCallbackFailedEvent.java
@@ -41,6 +41,7 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
   public JobCallbackFailedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -49,7 +50,7 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       String causeClassName,
       int callbackAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.callbackType = EventContract.requireNonNull(callbackType, "callbackType");
     this.errorMessage = errorMessage;
     this.causeClassName = EventContract.requireNonBlank(causeClassName, "causeClassName");
@@ -65,6 +66,7 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
   public JobCallbackFailedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -72,7 +74,7 @@ public class JobCallbackFailedEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       String causeClassName,
       int callbackAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.callbackType = EventContract.requireNonNull(callbackType, "callbackType");
     this.errorMessage = errorMessage;
     this.causeClassName = EventContract.requireNonBlank(causeClassName, "causeClassName");

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCancelledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCancelledEvent.java
@@ -35,6 +35,7 @@ public class JobCancelledEvent extends AbstractJobCancellationEvent {
   public JobCancelledEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -42,17 +43,34 @@ public class JobCancelledEvent extends AbstractJobCancellationEvent {
       String previousStatus,
       Long executionTimeMs) {
     super(
-        jobId, businessKey, jobType, priority, nodeId, timestamp, previousStatus, executionTimeMs);
+        jobId,
+        businessKey,
+        recurringMasterId,
+        jobType,
+        priority,
+        nodeId,
+        timestamp,
+        previousStatus,
+        executionTimeMs);
   }
 
   public JobCancelledEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String previousStatus,
       Long executionTimeMs) {
-    super(jobId, businessKey, jobType, priority, nodeId, previousStatus, executionTimeMs);
+    super(
+        jobId,
+        businessKey,
+        recurringMasterId,
+        jobType,
+        priority,
+        nodeId,
+        previousStatus,
+        executionTimeMs);
   }
 }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobCompletedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobCompletedEvent.java
@@ -39,12 +39,13 @@ public class JobCompletedEvent extends AbstractJobSchedulerEvent {
   public JobCompletedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       Long executionTimeMs) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
 
@@ -60,11 +61,12 @@ public class JobCompletedEvent extends AbstractJobSchedulerEvent {
   public JobCompletedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Long executionTimeMs) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.executionTimeMs = EventContract.requireNonNegative(executionTimeMs, "executionTimeMs");
   }
 

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobDlqEvent.java
@@ -40,13 +40,14 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
   public JobDlqEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       String errorMessage,
       int retryAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.errorMessage = errorMessage;
     this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }
@@ -63,12 +64,13 @@ public class JobDlqEvent extends AbstractJobSchedulerEvent {
   public JobDlqEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String errorMessage,
       int retryAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.errorMessage = errorMessage;
     this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobExecutionTimedOutEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobExecutionTimedOutEvent.java
@@ -50,6 +50,7 @@ public class JobExecutionTimedOutEvent extends AbstractJobSchedulerEvent {
   public JobExecutionTimedOutEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -57,7 +58,7 @@ public class JobExecutionTimedOutEvent extends AbstractJobSchedulerEvent {
       Duration executionTimeout,
       Duration elapsedTime,
       int retryAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.executionTimeout = EventContract.requirePositive(executionTimeout, "executionTimeout");
     this.elapsedTime = EventContract.requireNonNegative(elapsedTime, "elapsedTime");
     this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
@@ -73,6 +74,7 @@ public class JobExecutionTimedOutEvent extends AbstractJobSchedulerEvent {
   public JobExecutionTimedOutEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -82,6 +84,7 @@ public class JobExecutionTimedOutEvent extends AbstractJobSchedulerEvent {
     this(
         jobId,
         businessKey,
+        recurringMasterId,
         jobType,
         priority,
         nodeId,

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobFailedEvent.java
@@ -46,13 +46,14 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
   public JobFailedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       String errorMessage,
       int retryAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.errorMessage = errorMessage;
     this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }
@@ -66,12 +67,13 @@ public class JobFailedEvent extends AbstractJobSchedulerEvent {
   public JobFailedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String errorMessage,
       int retryAttempt) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.errorMessage = errorMessage;
     this.retryAttempt = EventContract.requireNonNegative(retryAttempt, "retryAttempt");
   }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobPausedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobPausedEvent.java
@@ -31,15 +31,21 @@ public class JobPausedEvent extends AbstractJobSchedulerEvent {
   public JobPausedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
   }
 
   public JobPausedEvent(
-      UUID jobId, String businessKey, JobType jobType, JobPriority priority, String nodeId) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+      UUID jobId,
+      String businessKey,
+      UUID recurringMasterId,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId) {
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
   }
 }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobResumedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobResumedEvent.java
@@ -31,15 +31,21 @@ public class JobResumedEvent extends AbstractJobSchedulerEvent {
   public JobResumedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
   }
 
   public JobResumedEvent(
-      UUID jobId, String businessKey, JobType jobType, JobPriority priority, String nodeId) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+      UUID jobId,
+      String businessKey,
+      UUID recurringMasterId,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId) {
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
   }
 }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobRetryingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobRetryingEvent.java
@@ -43,6 +43,7 @@ public class JobRetryingEvent extends AbstractJobSchedulerEvent {
   public JobRetryingEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -50,7 +51,7 @@ public class JobRetryingEvent extends AbstractJobSchedulerEvent {
       String errorMessage,
       int retryAttempt,
       Instant scheduledTime) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.errorMessage = errorMessage;
     this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
     this.scheduledTime = EventContract.requireNonNull(scheduledTime, "scheduledTime");
@@ -70,13 +71,14 @@ public class JobRetryingEvent extends AbstractJobSchedulerEvent {
   public JobRetryingEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String errorMessage,
       int retryAttempt,
       Instant scheduledTime) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.errorMessage = errorMessage;
     this.retryAttempt = EventContract.requirePositive(retryAttempt, "retryAttempt");
     this.scheduledTime = EventContract.requireNonNull(scheduledTime, "scheduledTime");

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalTimedOutEvent.java
@@ -41,13 +41,14 @@ public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
   public JobSignalTimedOutEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       String signalKey,
       Duration signalTimeout) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
     this.signalTimeout = EventContract.requireNonNull(signalTimeout, "signalTimeout");
   }
@@ -61,12 +62,22 @@ public class JobSignalTimedOutEvent extends AbstractJobSchedulerEvent {
   public JobSignalTimedOutEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String signalKey,
       Duration signalTimeout) {
-    this(jobId, businessKey, jobType, priority, nodeId, Instant.now(), signalKey, signalTimeout);
+    this(
+        jobId,
+        businessKey,
+        recurringMasterId,
+        jobType,
+        priority,
+        nodeId,
+        Instant.now(),
+        signalKey,
+        signalTimeout);
   }
 
   /** Returns the signal key the job was waiting on. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalWaitingEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignalWaitingEvent.java
@@ -40,13 +40,14 @@ public class JobSignalWaitingEvent extends AbstractJobSchedulerEvent {
   public JobSignalWaitingEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       String signalKey,
       Duration signalTimeout) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
     this.signalTimeout = signalTimeout;
   }
@@ -54,12 +55,22 @@ public class JobSignalWaitingEvent extends AbstractJobSchedulerEvent {
   public JobSignalWaitingEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String signalKey,
       Duration signalTimeout) {
-    this(jobId, businessKey, jobType, priority, nodeId, Instant.now(), signalKey, signalTimeout);
+    this(
+        jobId,
+        businessKey,
+        recurringMasterId,
+        jobType,
+        priority,
+        nodeId,
+        Instant.now(),
+        signalKey,
+        signalTimeout);
   }
 
   /** Returns the signal key the job is waiting on. */

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobSignaledEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobSignaledEvent.java
@@ -51,6 +51,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
   public JobSignaledEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -59,6 +60,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
     this(
         jobId,
         businessKey,
+        recurringMasterId,
         jobType,
         priority,
         nodeId,
@@ -80,6 +82,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
   public JobSignaledEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -88,7 +91,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
       String signalDeliveredBy,
       SignalDecision.Outcome outcome,
       String rejectionReason) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.signalKey = EventContract.requireNonBlank(signalKey, "signalKey");
     this.signalDeliveredBy = EventContract.requireNonBlank(signalDeliveredBy, "signalDeliveredBy");
     this.outcome = EventContract.requireNonNull(outcome, "outcome");
@@ -110,6 +113,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
   public JobSignaledEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
@@ -120,6 +124,7 @@ public class JobSignaledEvent extends AbstractJobSchedulerEvent {
     this(
         jobId,
         businessKey,
+        recurringMasterId,
         jobType,
         priority,
         nodeId,

--- a/ratchet-api/src/main/java/run/ratchet/api/event/JobStartedEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/JobStartedEvent.java
@@ -38,16 +38,22 @@ public class JobStartedEvent extends AbstractJobSchedulerEvent {
   public JobStartedEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
   }
 
   /** Creates a start event using the current system clock instant. */
   public JobStartedEvent(
-      UUID jobId, String businessKey, JobType jobType, JobPriority priority, String nodeId) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+      UUID jobId,
+      String businessKey,
+      UUID recurringMasterId,
+      JobType jobType,
+      JobPriority priority,
+      String nodeId) {
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
   }
 }

--- a/ratchet-api/src/main/java/run/ratchet/api/event/WorkflowBranchTriggeredEvent.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/event/WorkflowBranchTriggeredEvent.java
@@ -45,13 +45,14 @@ public class WorkflowBranchTriggeredEvent extends AbstractJobSchedulerEvent {
   public WorkflowBranchTriggeredEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       Instant timestamp,
       String branchCondition,
       UUID nextJobId) {
-    super(jobId, businessKey, jobType, priority, nodeId, timestamp);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId, timestamp);
     this.branchCondition = EventContract.requireNonBlank(branchCondition, "branchCondition");
     this.nextJobId = EventContract.requireNonNull(nextJobId, "nextJobId");
   }
@@ -65,12 +66,13 @@ public class WorkflowBranchTriggeredEvent extends AbstractJobSchedulerEvent {
   public WorkflowBranchTriggeredEvent(
       UUID jobId,
       String businessKey,
+      UUID recurringMasterId,
       JobType jobType,
       JobPriority priority,
       String nodeId,
       String branchCondition,
       UUID nextJobId) {
-    super(jobId, businessKey, jobType, priority, nodeId);
+    super(jobId, businessKey, recurringMasterId, jobType, priority, nodeId);
     this.branchCondition = EventContract.requireNonBlank(branchCondition, "branchCondition");
     this.nextJobId = EventContract.requireNonNull(nextJobId, "nextJobId");
   }

--- a/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/event/EventApiContractTest.java
@@ -32,6 +32,8 @@ class EventApiContractTest {
 
   private static final UUID JOB_ID = UUID.fromString("018f0000-0000-7000-8000-000000000001");
   private static final UUID NEXT_JOB_ID = UUID.fromString("018f0000-0000-7000-8000-000000000002");
+  private static final UUID RECURRING_MASTER_ID =
+      UUID.fromString("018f0000-0000-7000-8000-000000000003");
   private static final Instant TIMESTAMP = Instant.parse("2026-05-10T12:00:00Z");
 
   @Test
@@ -59,6 +61,7 @@ class EventApiContractTest {
         new JobExecutionTimedOutEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.HIGH,
             "node-a",
@@ -79,6 +82,7 @@ class EventApiContractTest {
         new JobDlqEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.NORMAL,
             "node-a",
@@ -95,16 +99,20 @@ class EventApiContractTest {
   void perJobEventsRequireJobIdAndTimestamp() {
     assertThrows(
         NullPointerException.class,
-        () -> new JobStartedEvent(null, "business-key", JobType.SINGLE, JobPriority.NORMAL, null));
+        () ->
+            new JobStartedEvent(
+                null, "business-key", null, JobType.SINGLE, JobPriority.NORMAL, null));
     assertThrows(
         NullPointerException.class,
         () ->
             new JobStartedEvent(
-                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, null, null));
+                JOB_ID, "business-key", null, JobType.SINGLE, JobPriority.NORMAL, null, null));
 
-    JobStartedEvent event = new JobStartedEvent(JOB_ID, null, null, null, null, TIMESTAMP);
+    JobStartedEvent event =
+        new JobStartedEvent(JOB_ID, null, RECURRING_MASTER_ID, null, null, null, TIMESTAMP);
 
     assertEquals(JOB_ID, event.getJobId());
+    assertEquals(RECURRING_MASTER_ID, event.getRecurringMasterId());
     assertEquals(TIMESTAMP, event.getTimestamp());
   }
 
@@ -114,6 +122,7 @@ class EventApiContractTest {
         new JobSignalWaitingEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.NORMAL,
             "node-a",
@@ -124,6 +133,7 @@ class EventApiContractTest {
         new JobSignalTimedOutEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.NORMAL,
             "node-a",
@@ -134,6 +144,7 @@ class EventApiContractTest {
         new JobSignaledEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.NORMAL,
             "node-a",
@@ -154,13 +165,14 @@ class EventApiContractTest {
         NullPointerException.class,
         () ->
             new ChainStartedEvent(
-                JOB_ID, "business-key", JobType.CHAIN, JobPriority.NORMAL, "node-a", null));
+                JOB_ID, "business-key", null, JobType.CHAIN, JobPriority.NORMAL, "node-a", null));
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new ChainFailedEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.CHAIN,
                 JobPriority.NORMAL,
                 "node-a",
@@ -172,6 +184,7 @@ class EventApiContractTest {
             new WorkflowBranchTriggeredEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.WORKFLOW,
                 JobPriority.NORMAL,
                 "node-a",
@@ -183,6 +196,7 @@ class EventApiContractTest {
             new WorkflowBranchTriggeredEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.WORKFLOW,
                 JobPriority.NORMAL,
                 "node-a",
@@ -192,13 +206,21 @@ class EventApiContractTest {
         IllegalArgumentException.class,
         () ->
             new JobSignalWaitingEvent(
-                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", " ", null));
+                JOB_ID,
+                "business-key",
+                null,
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                " ",
+                null));
     assertThrows(
         NullPointerException.class,
         () ->
             new JobSignalTimedOutEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -210,6 +232,7 @@ class EventApiContractTest {
             new JobExecutionTimedOutEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -222,6 +245,7 @@ class EventApiContractTest {
             new JobExecutionTimedOutEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -234,6 +258,7 @@ class EventApiContractTest {
             new JobExecutionTimedOutEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -244,7 +269,14 @@ class EventApiContractTest {
         IllegalArgumentException.class,
         () ->
             new JobCancelledEvent(
-                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", " ", null));
+                JOB_ID,
+                "business-key",
+                null,
+                JobType.SINGLE,
+                JobPriority.NORMAL,
+                "node-a",
+                " ",
+                null));
   }
 
   @Test
@@ -253,15 +285,38 @@ class EventApiContractTest {
         IllegalArgumentException.class,
         () ->
             new BatchCompletedEvent(
-                JOB_ID, "business-key", JobType.BATCH, JobPriority.NORMAL, "node-a", 0, 0, 0));
+                JOB_ID,
+                "business-key",
+                null,
+                JobType.BATCH,
+                JobPriority.NORMAL,
+                "node-a",
+                0,
+                0,
+                0));
     assertThrows(
         IllegalArgumentException.class,
         () ->
             new BatchCompletingEvent(
-                JOB_ID, "business-key", JobType.BATCH, JobPriority.NORMAL, "node-a", 3, 2, 2));
+                JOB_ID,
+                "business-key",
+                null,
+                JobType.BATCH,
+                JobPriority.NORMAL,
+                "node-a",
+                3,
+                2,
+                2));
     JobFailedEvent firstAttemptFailure =
         new JobFailedEvent(
-            JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", "failed", 0);
+            JOB_ID,
+            "business-key",
+            null,
+            JobType.SINGLE,
+            JobPriority.NORMAL,
+            "node-a",
+            "failed",
+            0);
     assertEquals(0, firstAttemptFailure.getRetryAttempt());
     assertThrows(
         IllegalArgumentException.class,
@@ -269,6 +324,7 @@ class EventApiContractTest {
             new JobFailedEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -280,6 +336,7 @@ class EventApiContractTest {
             new JobCallbackFailedEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -293,6 +350,7 @@ class EventApiContractTest {
             new JobRetryingEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -303,7 +361,7 @@ class EventApiContractTest {
         IllegalArgumentException.class,
         () ->
             new JobCompletedEvent(
-                JOB_ID, "business-key", JobType.SINGLE, JobPriority.NORMAL, "node-a", -1L));
+                JOB_ID, "business-key", null, JobType.SINGLE, JobPriority.NORMAL, "node-a", -1L));
     assertThrows(
         IllegalArgumentException.class, () -> new JobsBulkCancelledEvent("tag-a", 0, TIMESTAMP));
     assertThrows(
@@ -321,6 +379,7 @@ class EventApiContractTest {
             new JobSignaledEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -334,6 +393,7 @@ class EventApiContractTest {
             new JobSignaledEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -347,6 +407,7 @@ class EventApiContractTest {
             new JobSignaledEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -360,6 +421,7 @@ class EventApiContractTest {
             new JobSignaledEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -373,6 +435,7 @@ class EventApiContractTest {
             new JobSignaledEvent(
                 JOB_ID,
                 "business-key",
+                null,
                 JobType.SINGLE,
                 JobPriority.NORMAL,
                 "node-a",
@@ -385,6 +448,7 @@ class EventApiContractTest {
         new JobSignaledEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.NORMAL,
             "node-a",
@@ -464,6 +528,7 @@ class EventApiContractTest {
         WorkflowBranchTriggeredEvent.class.getConstructor(
             UUID.class,
             String.class,
+            UUID.class,
             JobType.class,
             JobPriority.class,
             String.class,
@@ -475,6 +540,7 @@ class EventApiContractTest {
         constructor.newInstance(
             JOB_ID,
             "business-key",
+            null,
             JobType.WORKFLOW,
             JobPriority.HIGH,
             "node-a",

--- a/ratchet-api/src/test/java/run/ratchet/api/event/JobCancellationEventTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/event/JobCancellationEventTest.java
@@ -35,6 +35,7 @@ class JobCancellationEventTest {
         new JobCancelledEvent(
             JOB_ID,
             "business-key",
+            null,
             JobType.SINGLE,
             JobPriority.HIGH,
             "node-a",
@@ -50,7 +51,14 @@ class JobCancellationEventTest {
     Instant before = Instant.now();
     JobCancelledEvent event =
         new JobCancelledEvent(
-            JOB_ID, "business-key", JobType.SINGLE, JobPriority.HIGH, "node-a", "PENDING", 7L);
+            JOB_ID,
+            "business-key",
+            null,
+            JobType.SINGLE,
+            JobPriority.HIGH,
+            "node-a",
+            "PENDING",
+            7L);
     Instant after = Instant.now();
 
     assertEquals(JOB_ID, event.getJobId());

--- a/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/BatchService.java
@@ -438,6 +438,7 @@ public class BatchService {
         new BatchCompletingEvent(
             batch.getId(),
             parent.getBusinessKey(),
+            parent.getRecurringMasterId(),
             parent.getPublicJobType(),
             parent.getPriority(),
             parent.getPickedBy(),
@@ -448,6 +449,7 @@ public class BatchService {
         new BatchCompletedEvent(
             batch.getId(),
             parent.getBusinessKey(),
+            parent.getRecurringMasterId(),
             parent.getPublicJobType(),
             parent.getPriority(),
             parent.getPickedBy(),
@@ -459,6 +461,7 @@ public class BatchService {
           new JobCompletedEvent(
               parent.getId(),
               parent.getBusinessKey(),
+              parent.getRecurringMasterId(),
               parent.getPublicJobType(),
               parent.getPriority(),
               parent.getPickedBy(),
@@ -471,6 +474,7 @@ public class BatchService {
         new JobFailedEvent(
             parent.getId(),
             parent.getBusinessKey(),
+            parent.getRecurringMasterId(),
             parent.getPublicJobType(),
             parent.getPriority(),
             parent.getPickedBy(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -871,6 +871,7 @@ class DefaultJobCreationService
               new BatchChunkFailureEvent(
                   parentId,
                   null,
+                  null,
                   JobType.BATCH,
                   JobPriority.NORMAL,
                   null,
@@ -1112,6 +1113,7 @@ class DefaultJobCreationService
         new JobSignalWaitingEvent(
             saved.getId(),
             saved.getBusinessKey(),
+            saved.getRecurringMasterId(),
             saved.getPublicJobType(),
             saved.getPriority(),
             null,

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -788,9 +788,9 @@ public class DefaultJobSchedulerService
 
   /**
    * Publishes a {@link JobCancelledEvent} for a successful cancellation CAS. Uses the pre-CAS
-   * entity snapshot to populate businessKey / jobType / priority / nodeId on the event so
-   * downstream observers (audit logs, monitoring) get the same shape for each cancellable source
-   * state.
+   * entity snapshot to populate businessKey / recurringMasterId / jobType / priority / nodeId on
+   * the event so downstream observers (audit logs, monitoring) get the same shape for each
+   * cancellable source state.
    */
   private void publishCancelledEvent(UUID jobId, JobStatus previousStatus, JobEntity job) {
     Instant timestamp = effective().instant();
@@ -799,10 +799,11 @@ public class DefaultJobSchedulerService
             // Race: job was deleted between CAS and our lookup. Fire a minimal event so observers
             // at least know the cancellation happened.
             ? new JobCancelledEvent(
-                jobId, null, null, null, null, timestamp, previousStatus.name(), null)
+                jobId, null, null, null, null, null, timestamp, previousStatus.name(), null)
             : new JobCancelledEvent(
                 jobId,
                 job.getBusinessKey(),
+                job.getRecurringMasterId(),
                 job.getPublicJobType(),
                 job.getPriority(),
                 job.getPickedBy(),
@@ -823,6 +824,7 @@ public class DefaultJobSchedulerService
         new JobCancelledEvent(
             jobId,
             def.businessKey(),
+            null,
             run.ratchet.api.JobType.RECURRING,
             JobPriorityMapper.fromPersistedCode(def.priority()),
             null,
@@ -840,10 +842,11 @@ public class DefaultJobSchedulerService
     if (eventPublisher != null) {
       JobRetryingEvent event =
           job == null
-              ? new JobRetryingEvent(jobId, null, null, null, null, retryAt, null, 1, retryAt)
+              ? new JobRetryingEvent(jobId, null, null, null, null, null, retryAt, null, 1, retryAt)
               : new JobRetryingEvent(
                   jobId,
                   job.getBusinessKey(),
+                  job.getRecurringMasterId(),
                   job.getPublicJobType(),
                   job.getPriority(),
                   job.getPickedBy(),
@@ -897,6 +900,7 @@ public class DefaultJobSchedulerService
         new JobPausedEvent(
             jobId,
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -912,6 +916,7 @@ public class DefaultJobSchedulerService
         new JobResumedEvent(
             jobId,
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -927,6 +932,7 @@ public class DefaultJobSchedulerService
         new JobPausedEvent(
             jobId,
             def.businessKey(),
+            null,
             run.ratchet.api.JobType.RECURRING,
             JobPriorityMapper.fromPersistedCode(def.priority()),
             null,
@@ -942,6 +948,7 @@ public class DefaultJobSchedulerService
         new JobResumedEvent(
             jobId,
             def.businessKey(),
+            null,
             run.ratchet.api.JobType.RECURRING,
             JobPriorityMapper.fromPersistedCode(def.priority()),
             null,
@@ -1162,6 +1169,7 @@ public class DefaultJobSchedulerService
         new JobSignaledEvent(
             jobId,
             job != null ? job.getBusinessKey() : null,
+            job != null ? job.getRecurringMasterId() : null,
             job != null ? job.getPublicJobType() : null,
             job != null ? job.getPriority() : null,
             null,

--- a/ratchet/src/main/java/run/ratchet/ri/core/JobCascadeService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/JobCascadeService.java
@@ -209,6 +209,7 @@ class JobCascadeService {
         new JobPausedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -224,6 +225,7 @@ class JobCascadeService {
         new JobResumedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/ChainScheduler.java
@@ -195,6 +195,7 @@ public class ChainScheduler {
         new ChainStartedEvent(
             child.getId(),
             child.getBusinessKey(),
+            child.getRecurringMasterId(),
             child.getPublicJobType(),
             child.getPriority(),
             child.getPickedBy(),
@@ -209,6 +210,7 @@ public class ChainScheduler {
         new ChainCompletedEvent(
             finished.getId(),
             finished.getBusinessKey(),
+            finished.getRecurringMasterId(),
             finished.getPublicJobType(),
             finished.getPriority(),
             finished.getPickedBy(),
@@ -223,6 +225,7 @@ public class ChainScheduler {
         new ChainFailedEvent(
             failed.getId(),
             failed.getBusinessKey(),
+            failed.getRecurringMasterId(),
             failed.getPublicJobType(),
             failed.getPriority(),
             failed.getPickedBy(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/DeadLetterService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/DeadLetterService.java
@@ -249,6 +249,7 @@ public class DeadLetterService {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -259,6 +260,7 @@ public class DeadLetterService {
         new JobDlqEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -284,6 +286,7 @@ public class DeadLetterService {
         new JobDlqEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTask.java
@@ -282,6 +282,7 @@ public class JobTask implements Callable<Void> {
           new JobStartedEvent(
               jobEntity.getId(),
               jobEntity.getBusinessKey(),
+              jobEntity.getRecurringMasterId(),
               jobEntity.getPublicJobType(),
               jobEntity.getPriority(),
               jobEntity.getPickedBy(),
@@ -800,6 +801,7 @@ public class JobTask implements Callable<Void> {
         new JobCompletedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -888,6 +890,7 @@ public class JobTask implements Callable<Void> {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -906,6 +909,7 @@ public class JobTask implements Callable<Void> {
           new JobFailedEvent(
               job.getId(),
               job.getBusinessKey(),
+              job.getRecurringMasterId(),
               job.getPublicJobType(),
               job.getPriority(),
               job.getPickedBy(),
@@ -953,6 +957,7 @@ public class JobTask implements Callable<Void> {
             new JobCallbackFailedEvent(
                 job.getId(),
                 job.getBusinessKey(),
+                job.getRecurringMasterId(),
                 job.getPublicJobType(),
                 job.getPriority(),
                 job.getPickedBy(),
@@ -1058,6 +1063,7 @@ public class JobTask implements Callable<Void> {
           new JobRetryingEvent(
               job.getId(),
               job.getBusinessKey(),
+              job.getRecurringMasterId(),
               job.getPublicJobType(),
               job.getPriority(),
               job.getPickedBy(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobTimeoutHandler.java
@@ -481,6 +481,7 @@ public class JobTimeoutHandler {
         new JobSignalTimedOutEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -491,6 +492,7 @@ public class JobTimeoutHandler {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -529,6 +531,7 @@ public class JobTimeoutHandler {
         new JobRetryingEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -555,6 +558,7 @@ public class JobTimeoutHandler {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -569,6 +573,7 @@ public class JobTimeoutHandler {
     return new JobExecutionTimedOutEvent(
         job.getId(),
         job.getBusinessKey(),
+        job.getRecurringMasterId(),
         job.getPublicJobType(),
         job.getPriority(),
         job.getPickedBy(),
@@ -587,6 +592,7 @@ public class JobTimeoutHandler {
         new JobRetryingEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/WorkflowScheduler.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/WorkflowScheduler.java
@@ -316,6 +316,7 @@ public class WorkflowScheduler extends ChainScheduler {
         new WorkflowBranchTriggeredEvent(
             parentJob.getId(),
             parentJob.getBusinessKey(),
+            parentJob.getRecurringMasterId(),
             parentJob.getPublicJobType(),
             parentJob.getPriority(),
             parentJob.getPickedBy(),

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceRecurringReconciliationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceRecurringReconciliationTest.java
@@ -43,6 +43,7 @@ import run.ratchet.ri.payload.DefaultJobInvocationResolver;
 import run.ratchet.ri.security.JobPayloadInputValidator;
 import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.JobBatchStatusStore;
 import run.ratchet.store.spi.JobBulkStore;
@@ -407,6 +408,11 @@ class DefaultJobCreationServiceRecurringReconciliationTest {
 
     @Override
     public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
       throw new UnsupportedOperationException();
     }
 

--- a/ratchet/src/test/java/run/ratchet/ri/core/RecurringJobExecutorGraceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/RecurringJobExecutorGraceTest.java
@@ -441,6 +441,27 @@ class RecurringJobExecutorGraceTest {
     return children.getValue().stream().map(JobEntity::getScheduledTime).toList();
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void exhaustedMasterIsArchivedAndFinalChildIsBulkInserted() {
+    state.markRegistrationComplete(Set.of("known-key"));
+
+    RecurringJobDefinition exhausted =
+        recurringMasterWithFire(19L, "known-key", "0 0 12 12 5 ? 2026", FIXED_NOW);
+    when(recurringJobStore.claimDueRecurring(anyInt(), anyString(), any()))
+        .thenReturn(List.of(exhausted));
+
+    int fired = executor.process(10, "node-A");
+
+    assertEquals(1, fired);
+    verify(recurringJobStore).cancelRecurringAndArchive(exhausted.id(), ArchiveReason.EXHAUSTED);
+    verify(recurringJobStore, never()).advanceNextFire(eq(exhausted.id()), any(Instant.class));
+    ArgumentCaptor<List<JobEntity>> childrenCaptor = ArgumentCaptor.forClass(List.class);
+    verify(jobBulkStore).bulkInsert(childrenCaptor.capture());
+    assertEquals(1, childrenCaptor.getValue().size());
+    assertEquals(exhausted.id(), childrenCaptor.getValue().get(0).getRecurringMasterId());
+  }
+
   private static RecurringJobDefinition recurringMaster(long id, String businessKey) {
     return recurringMasterWithFire(id, businessKey, "0 0 12 * * ?", FIXED_NOW.plusSeconds(60));
   }

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/DeadLetterServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/DeadLetterServiceTest.java
@@ -260,6 +260,7 @@ class DeadLetterServiceTest {
         new JobExecutionTimedOutEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -271,6 +272,7 @@ class DeadLetterServiceTest {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -303,6 +305,7 @@ class DeadLetterServiceTest {
         new JobSignalTimedOutEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -313,6 +316,7 @@ class DeadLetterServiceTest {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -341,6 +345,7 @@ class DeadLetterServiceTest {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -366,6 +371,7 @@ class DeadLetterServiceTest {
         new JobSignalTimedOutEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),
@@ -376,6 +382,7 @@ class DeadLetterServiceTest {
         new JobFailedEvent(
             job.getId(),
             job.getBusinessKey(),
+            job.getRecurringMasterId(),
             job.getPublicJobType(),
             job.getPriority(),
             job.getPickedBy(),

--- a/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/internal/JobTaskTest.java
@@ -936,6 +936,8 @@ class JobTaskTest {
       throws Exception {
     JobTask fixedClockTask = newJobTaskWithClock(FIXED_CLOCK);
     JobEntity job = createTestJob();
+    UUID recurringMasterId = UUID.fromString("019c1f33-09c0-7000-8000-000000000125");
+    job.setRecurringMasterId(recurringMasterId);
     job.setOnSuccessPayload(
         new JobPayload(JobTaskTest.class.getName(), "failingCallback", "()V", true, List.of()));
     initJobTaskWithDefaultStubs(fixedClockTask, job);
@@ -951,6 +953,12 @@ class JobTaskTest {
 
     ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
     verify(observabilityFacade, atLeastOnce()).publishEvent(eventCaptor.capture());
+    JobStartedEvent startedEvent =
+        eventCaptor.getAllValues().stream()
+            .filter(JobStartedEvent.class::isInstance)
+            .map(JobStartedEvent.class::cast)
+            .findFirst()
+            .orElseThrow();
     JobCompletedEvent completedEvent =
         eventCaptor.getAllValues().stream()
             .filter(JobCompletedEvent.class::isInstance)
@@ -964,6 +972,9 @@ class JobTaskTest {
             .findFirst()
             .orElseThrow();
 
+    Assertions.assertEquals(recurringMasterId, startedEvent.getRecurringMasterId());
+    Assertions.assertEquals(recurringMasterId, completedEvent.getRecurringMasterId());
+    Assertions.assertEquals(recurringMasterId, callbackEvent.getRecurringMasterId());
     Assertions.assertEquals(FIXED_NOW, completedEvent.getTimestamp());
     Assertions.assertEquals(FIXED_NOW, callbackEvent.getTimestamp());
     Assertions.assertEquals(1, callbackEvent.getCallbackAttempt());

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/entity/JobEntity.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/entity/JobEntity.java
@@ -45,6 +45,7 @@ import run.ratchet.store.converter.JobPayloadConverter;
 import run.ratchet.store.converter.JobPriorityConverter;
 import run.ratchet.store.converter.JsonMapConverter;
 import run.ratchet.store.id.UuidV7EntityListener;
+import run.ratchet.store.spi.RecurringJobStore;
 
 /** Persisted record of a scheduled task. @see JobStatus @see JobExecutionType */
 @Entity
@@ -195,8 +196,9 @@ public class JobEntity implements UuidV7EntityListener.UuidV7Assignable {
   private UUID supersededBy;
 
   /**
-   * Set on child rows spawned by a recurring master. Points to the master's id in {@code
-   * scheduler_recurring_job} via FK with {@code ON DELETE SET NULL}.
+   * Durable lineage reference set on child rows spawned by a recurring master. The value
+   * intentionally survives master cancellation or exhaustion and remains resolvable through {@link
+   * RecurringJobStore#findArchivedRecurring(UUID)} after the live master ends.
    */
   @Column(name = "recurring_master_id")
   private UUID recurringMasterId;

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/ArchivedRecurringJob.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/ArchivedRecurringJob.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.store.spi;
+
+import java.time.Instant;
+import java.util.UUID;
+import run.ratchet.api.Incubating;
+import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
+
+/**
+ * Immutable correlation projection of an archived recurring definition. Payload templates are
+ * intentionally omitted: this type resolves durable recurring lineage and is not a replay surface.
+ *
+ * @param id archived recurring-master primary key; never {@code null}
+ * @param businessKey business key that identified the recurring definition, or {@code null} when
+ *     none was configured
+ * @param cronExpr cron expression that drove the recurring definition; never {@code null} or blank
+ * @param zoneId IANA zone id used to evaluate {@code cronExpr}; never {@code null} or blank
+ * @param executionTarget execution-target label used by fired child jobs, or {@code null} when the
+ *     deployment default applied
+ * @param callerPrincipal caller principal captured at registration, or {@code null} when no
+ *     security context was present
+ * @param createdAt instant the recurring definition was registered; never {@code null}
+ * @param archivedAt instant the recurring definition was archived; never {@code null}
+ * @param archiveReason reason the recurring definition was archived; never {@code null}
+ */
+@Incubating
+public record ArchivedRecurringJob(
+    UUID id,
+    String businessKey,
+    String cronExpr,
+    String zoneId,
+    String executionTarget,
+    String callerPrincipal,
+    Instant createdAt,
+    Instant archivedAt,
+    ArchiveReason archiveReason) {}

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/RecurringJobDefinition.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/RecurringJobDefinition.java
@@ -50,7 +50,9 @@ import run.ratchet.store.entity.JobPayload;
  * @param onSuccessPayload optional success-callback payload, or {@code null} when none configured
  * @param onFailurePayload optional failure-callback payload, or {@code null} when none configured
  * @param businessKey active-unique identity of the recurring master, or {@code null} when none
- *     configured; fired child jobs do not inherit it
+ *     configured; fired child jobs do not inherit it. Children reference the master through {@code
+ *     recurringMasterId}, which lifecycle events publish and callers can resolve after the master
+ *     ends through {@link RecurringJobStore#findArchivedRecurring(UUID)}
  * @param resourceName resource permit name required by fired child jobs, or {@code null} when no
  *     resource gate applies
  * @param executionTarget execution-target label copied to fired child jobs, or {@code null} to

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/RecurringJobStore.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/spi/RecurringJobStore.java
@@ -128,6 +128,17 @@ public interface RecurringJobStore {
   boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason);
 
   /**
+   * Resolves an archived recurring definition by its durable master id. Archived definitions remain
+   * available after cancellation or natural exhaustion so fired child jobs can retain a stable
+   * lineage reference. Transaction attribute: {@code SUPPORTS}.
+   *
+   * @param id recurring master id to resolve; never {@code null}
+   * @return the archived recurring definition, or {@link Optional#empty()} when {@code id} has not
+   *     been archived
+   */
+  Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id);
+
+  /**
    * Node-startup cleanup. Cancels (with reason {@link ArchiveReason#CANCELED}) every recurring
    * master whose {@code business_key} no longer appears in the supplied {@code knownBusinessKeys}
    * set AND was created before {@code nodeStartTime}. Used to retire {@code @Recurring} annotation

--- a/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/RecurringJobRows.java
+++ b/stores/ratchet-store-core/src/main/java/run/ratchet/store/util/RecurringJobRows.java
@@ -22,12 +22,13 @@ import run.ratchet.api.RecurringMisfirePolicy;
 import run.ratchet.spi.ProtectedSurface;
 import run.ratchet.store.converter.JobPayloadConverter;
 import run.ratchet.store.entity.JobPayload;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.RecurringJobDefinition;
+import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
 
 /**
- * Shared hydration of {@link RecurringJobDefinition} from a {@code scheduler_recurring_job}
- * projection. The column order matches {@code SELECT_COLUMNS} in the per-store recurring
- * operations.
+ * Shared hydration of recurring definitions from live and archive projections. Column order matches
+ * the corresponding select-column constants in the per-store recurring operations.
  */
 public final class RecurringJobRows {
 
@@ -92,6 +93,24 @@ public final class RecurringJobRows {
         callerPrincipal,
         encryptedPayload,
         misfirePolicy);
+  }
+
+  /**
+   * Maps a recurring archive correlation projection in this order: id, business key, cron
+   * expression, zone id, execution target, caller principal, created time, archived time, archive
+   * reason.
+   */
+  public static ArchivedRecurringJob hydrateArchived(Object[] row) {
+    return new ArchivedRecurringJob(
+        RowValues.uuidOrNull(row[0]),
+        RowValues.stringOrNull(row[1]),
+        RowValues.stringOrNull(row[2]),
+        RowValues.stringOrNull(row[3]),
+        RowValues.stringOrNull(row[4]),
+        RowValues.stringOrNull(row[5]),
+        RowValues.instantOrNull(row[6]),
+        RowValues.instantOrNull(row[7]),
+        ArchiveReason.valueOf(RowValues.stringOrNull(row[8])));
   }
 
   /**

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoJobStoreImpl.java
@@ -52,6 +52,7 @@ import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.NodeEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
 import run.ratchet.store.id.UuidV7EntityListener;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 
 /**
@@ -887,6 +888,11 @@ class MongoJobStoreImpl implements MongoJobStore {
   public boolean cancelRecurringAndArchive(
       UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
     return recurringJobs.cancelRecurringAndArchive(id, reason);
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    return recurringJobs.findArchivedRecurring(id);
   }
 
   @Override

--- a/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoRecurringJobOperations.java
+++ b/stores/ratchet-store-mongodb/src/main/java/run/ratchet/store/mongodb/MongoRecurringJobOperations.java
@@ -69,6 +69,7 @@ import org.bson.conversions.Bson;
 import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.util.JobEncryption;
@@ -224,6 +225,12 @@ final class MongoRecurringJobOperations implements RecurringJobStore {
             return Boolean.TRUE;
           });
     }
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    Document doc = ctx.recurringJobArchive().find(eq(ID, id)).first();
+    return doc == null ? Optional.empty() : Optional.of(hydrateArchived(doc));
   }
 
   @Override
@@ -402,5 +409,18 @@ final class MongoRecurringJobOperations implements RecurringJobStore {
 
   private static RecurringJobDefinition hydrate(Document doc) {
     return DocumentMapper.toRecurringJobDefinition(doc);
+  }
+
+  private static ArchivedRecurringJob hydrateArchived(Document doc) {
+    return new ArchivedRecurringJob(
+        doc.get(ID, UUID.class),
+        doc.getString(BUSINESS_KEY),
+        doc.getString(CRON_EXPR),
+        doc.getString(ZONE_ID),
+        doc.getString(EXECUTION_TARGET),
+        doc.getString(CALLER_PRINCIPAL),
+        DocumentMapper.toInstant(doc.getDate(CREATED_AT)),
+        DocumentMapper.toInstant(doc.getDate(ARCHIVED_AT)),
+        ArchiveReason.valueOf(doc.getString(ARCHIVE_REASON)));
   }
 }

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlJobStoreImpl.java
@@ -45,6 +45,7 @@ import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.NodeEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
 import run.ratchet.store.util.IsolationCheck;
@@ -846,6 +847,11 @@ class MysqlJobStoreImpl implements MysqlJobStore {
   public boolean cancelRecurringAndArchive(
       UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
     return recurringJobs.cancelRecurringAndArchive(id, reason);
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    return recurringJobs.findArchivedRecurring(id);
   }
 
   // cancelOrphanedRecurringAnnotationJobs / cancelRecurringJobsByTag /

--- a/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlRecurringJobOperations.java
+++ b/stores/ratchet-store-mysql/src/main/java/run/ratchet/store/mysql/MysqlRecurringJobOperations.java
@@ -28,6 +28,7 @@ import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
 import run.ratchet.store.mysql.converter.UuidByteArrayConverter;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
@@ -50,6 +51,11 @@ final class MysqlRecurringJobOperations implements RecurringJobStore {
           + " zone_id, next_fire, is_paused, paused_at, payload, on_success_payload,"
           + " on_failure_payload, business_key, resource_name, execution_target, created_at,"
           + " caller_principal, encrypted_payload, misfire_policy, max_catch_up_executions";
+
+  // language=MySQL
+  private static final String ARCHIVE_SELECT_COLUMNS =
+      "id, business_key, cron_expr, zone_id, execution_target, caller_principal, created_at,"
+          + " archived_at, archive_reason";
 
   private final MysqlStoreContext ctx;
   private final MysqlBusinessKeyReservations reservations;
@@ -147,6 +153,23 @@ final class MysqlRecurringJobOperations implements RecurringJobStore {
   @Override
   public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
     return archiveAndDelete(List.of(id), reason) > 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    // language=MySQL
+    String sql =
+        "SELECT " + ARCHIVE_SELECT_COLUMNS + " FROM scheduler_recurring_job_archive WHERE id = ?";
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(RecurringJobRows.hydrateArchived(rows.get(0)));
   }
 
   @Override

--- a/stores/ratchet-store-mysql/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
+++ b/stores/ratchet-store-mysql/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
@@ -1,0 +1,21 @@
+-- Drops the recurring-master foreign key from scheduler_job. Its ON DELETE SET NULL erased
+-- recurring_master_id from every historical child row when a master ended, and its immediate
+-- check failed the final child insert of a naturally exhausted master (the executor archives
+-- the master in the same transaction, before the post-loop bulk insert). The lineage id now
+-- survives master archival and resolves through scheduler_recurring_job_archive. The explicit
+-- idx_job_recurring_master_id index backing the constraint stays. MySQL 8.0 has no DROP
+-- FOREIGN KEY IF EXISTS, so guard through information_schema; this also lets the migrator
+-- adopt a current consolidated schema whose version ledger is empty.
+
+SET @ratchet_drop_recurring_fk_ddl =
+    (SELECT IF(COUNT(*) > 0,
+               'ALTER TABLE scheduler_job DROP FOREIGN KEY fk_job_recurring_master',
+               'SELECT 1')
+       FROM information_schema.table_constraints
+      WHERE constraint_schema = DATABASE()
+        AND table_name = 'scheduler_job'
+        AND constraint_name = 'fk_job_recurring_master'
+        AND constraint_type = 'FOREIGN KEY');
+PREPARE ratchet_drop_recurring_fk_statement FROM @ratchet_drop_recurring_fk_ddl;
+EXECUTE ratchet_drop_recurring_fk_statement;
+DEALLOCATE PREPARE ratchet_drop_recurring_fk_statement;

--- a/stores/ratchet-store-mysql/src/main/resources/ddl/mysql-schema.sql
+++ b/stores/ratchet-store-mysql/src/main/resources/ddl/mysql-schema.sql
@@ -183,8 +183,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job
     result_type           VARCHAR(100)                                                                                                        NULL,
     -- Recurring-child lineage pointer. Set for child rows spawned by a recurring master; NULL
     -- for all other rows. depends_on is reserved for chain / batch / workflow same-table parent
-    -- pointers. ON DELETE SET NULL so cancel of the master does not cascade-delete in-flight
-    -- children.
+    -- pointers. Intentionally unconstrained so the lineage id survives master cancellation or
+    -- exhaustion and remains resolvable through scheduler_recurring_job_archive.
     recurring_master_id   BINARY(16)                                                                                                          NULL,
     -- Per-row payload-encryption metadata (cleartext by design). encrypted_payload marks whether
     -- this row's protected surfaces are ciphertext; encryption_key_id records the key the
@@ -195,7 +195,6 @@ CREATE TABLE IF NOT EXISTS scheduler_job
     PRIMARY KEY (job_id),
     UNIQUE KEY uk_idempotency_key (idempotency_key),
     CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4),
-    CONSTRAINT fk_job_recurring_master FOREIGN KEY (recurring_master_id) REFERENCES scheduler_recurring_job (id) ON DELETE SET NULL,
     -- Lookup/relationship indexes.
     INDEX idx_job_depends_on (depends_on),
     INDEX idx_job_superseded_by (superseded_by),

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigrationDialectTest.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigrationDialectTest.java
@@ -118,7 +118,7 @@ class MysqlSchemaMigrationDialectTest {
             .orElseThrow();
 
     assertEquals(
-        List.of("001", "002", "003", "004", "005"),
+        List.of("001", "002", "003", "004", "005", "006"),
         migrations.stream().map(script -> script.version()).toList());
     assertEquals(
         "0b339e555cddc589c0844184a04e2eff8f803bc7d1ef18a695b02dacb1224112", v001.checksum());

--- a/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigratorIT.java
+++ b/stores/ratchet-store-mysql/src/test/java/run/ratchet/store/mysql/MysqlSchemaMigratorIT.java
@@ -190,7 +190,7 @@ class MysqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
 
     SchemaMigrator.MigrationResult result = migrator.migrate();
 
-    assertEquals(List.of("002", "003", "004", "005"), versions(result.applied()));
+    assertEquals(List.of("002", "003", "004", "005", "006"), versions(result.applied()));
     assertEquals(List.of("001"), versions(result.skipped()));
     assertExtensionSchemaExists();
     assertSchemaVersionRowsMatch(migrator.discoverMigrations());
@@ -204,7 +204,7 @@ class MysqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
 
     SchemaMigrator.MigrationResult result = migrator.migrate();
 
-    assertEquals(List.of("001", "002", "003", "004", "005"), versions(result.applied()));
+    assertEquals(List.of("001", "002", "003", "004", "005", "006"), versions(result.applied()));
     assertEquals(List.of(), result.skipped());
     assertExtensionSchemaExists();
     assertSchemaVersionRowsMatch(migrator.discoverMigrations());

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStoreImpl.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleJobStoreImpl.java
@@ -45,6 +45,7 @@ import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.NodeEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
 import run.ratchet.store.util.IsolationCheck;
@@ -857,6 +858,11 @@ class OracleJobStoreImpl implements OracleJobStore {
   public boolean cancelRecurringAndArchive(
       UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
     return recurringJobs.cancelRecurringAndArchive(id, reason);
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    return recurringJobs.findArchivedRecurring(id);
   }
 
   // cancelOrphanedRecurringAnnotationJobs / cancelRecurringJobsByTag /

--- a/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleRecurringJobOperations.java
+++ b/stores/ratchet-store-oracle/src/main/java/run/ratchet/store/oracle/OracleRecurringJobOperations.java
@@ -29,6 +29,7 @@ import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
 import run.ratchet.store.oracle.converter.UuidRawConverter;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
@@ -51,6 +52,11 @@ final class OracleRecurringJobOperations implements RecurringJobStore {
           + " zone_id, next_fire, is_paused, paused_at, payload, on_success_payload,"
           + " on_failure_payload, business_key, resource_name, execution_target, created_at,"
           + " caller_principal, encrypted_payload, misfire_policy, max_catch_up_executions";
+
+  // language=Oracle
+  private static final String ARCHIVE_SELECT_COLUMNS =
+      "id, business_key, cron_expr, zone_id, execution_target, caller_principal, created_at,"
+          + " archived_at, archive_reason";
 
   private final OracleStoreContext ctx;
   private final OracleBusinessKeyReservations reservations;
@@ -184,6 +190,23 @@ final class OracleRecurringJobOperations implements RecurringJobStore {
   @Override
   public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
     return archiveAndDelete(List.of(id), reason) > 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    // language=Oracle
+    String sql =
+        "SELECT " + ARCHIVE_SELECT_COLUMNS + " FROM scheduler_recurring_job_archive WHERE id = ?";
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidRawConverter.toBytes(id))
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(RecurringJobRows.hydrateArchived(rows.get(0)));
   }
 
   @Override

--- a/stores/ratchet-store-oracle/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
+++ b/stores/ratchet-store-oracle/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
@@ -1,0 +1,14 @@
+-- ratchet:single-statement
+BEGIN
+    -- Drops the recurring-master foreign key from scheduler_job. Its ON DELETE SET NULL erased
+    -- recurring_master_id from every historical child row when a master ended, and its immediate
+    -- check failed the final child insert of a naturally exhausted master (the executor archives
+    -- the master in the same transaction, before the post-loop bulk insert). The lineage id now
+    -- survives master archival and resolves through scheduler_recurring_job_archive.
+    EXECUTE IMMEDIATE 'ALTER TABLE scheduler_job DROP CONSTRAINT fk_job_recurring_master';
+EXCEPTION
+    WHEN OTHERS THEN
+        IF SQLCODE != -2443 THEN
+            RAISE;
+        END IF;
+END;

--- a/stores/ratchet-store-oracle/src/main/resources/ddl/oracle-schema.sql
+++ b/stores/ratchet-store-oracle/src/main/resources/ddl/oracle-schema.sql
@@ -175,9 +175,7 @@ CREATE TABLE IF NOT EXISTS scheduler_job
                                     'CHAIN_STEP', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
     CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4),
     CONSTRAINT chk_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL')),
-    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
-    CONSTRAINT fk_job_recurring_master FOREIGN KEY (recurring_master_id)
-        REFERENCES scheduler_recurring_job (id) ON DELETE SET NULL
+    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED'))
 );
 
 -- 4a. Hot authoritative queue state for executable jobs.

--- a/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleSchemaMigrationDiscoveryTest.java
+++ b/stores/ratchet-store-oracle/src/test/java/run/ratchet/store/oracle/OracleSchemaMigrationDiscoveryTest.java
@@ -34,7 +34,7 @@ class OracleSchemaMigrationDiscoveryTest {
     SchemaMigrator.MigrationScript v001 = migrations.get(0);
 
     assertEquals(
-        List.of("001", "002", "003", "004", "005"),
+        List.of("001", "002", "003", "004", "005", "006"),
         migrations.stream().map(script -> script.version()).toList());
     assertEquals(
         "2862e471ae72a3e9c6d5182b6d1819d1af9e9055fbac0ee405bbedd0277ef5a2", v001.checksum());

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlJobStoreImpl.java
@@ -45,6 +45,7 @@ import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.NodeEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
 import run.ratchet.store.util.IsolationCheck;
@@ -850,6 +851,11 @@ class PostgresqlJobStoreImpl implements PostgresqlJobStore {
   public boolean cancelRecurringAndArchive(
       UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
     return recurringJobs.cancelRecurringAndArchive(id, reason);
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    return recurringJobs.findArchivedRecurring(id);
   }
 
   @Override

--- a/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlRecurringJobOperations.java
+++ b/stores/ratchet-store-postgresql/src/main/java/run/ratchet/store/postgresql/PostgresqlRecurringJobOperations.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
@@ -49,6 +50,11 @@ final class PostgresqlRecurringJobOperations implements RecurringJobStore {
           + " on_success_payload::text, on_failure_payload::text, business_key, resource_name,"
           + " execution_target, created_at, caller_principal, encrypted_payload,"
           + " misfire_policy, max_catch_up_executions";
+
+  // language=PostgreSQL
+  private static final String ARCHIVE_SELECT_COLUMNS =
+      "id, business_key, cron_expr, zone_id, execution_target, caller_principal, created_at,"
+          + " archived_at, archive_reason";
 
   private final PostgresqlStoreContext ctx;
   private final PostgresqlBusinessKeyReservations reservations;
@@ -144,6 +150,19 @@ final class PostgresqlRecurringJobOperations implements RecurringJobStore {
   @Override
   public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
     return archiveAndDelete(List.of(id), reason) > 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    // language=PostgreSQL
+    String sql =
+        "SELECT " + ARCHIVE_SELECT_COLUMNS + " FROM scheduler_recurring_job_archive WHERE id = ?";
+    List<Object[]> rows = ctx.em().createNativeQuery(sql).setParameter(1, id).getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(RecurringJobRows.hydrateArchived(rows.get(0)));
   }
 
   @Override

--- a/stores/ratchet-store-postgresql/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
+++ b/stores/ratchet-store-postgresql/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
@@ -1,0 +1,6 @@
+-- Drops the recurring-master foreign key from scheduler_job. Its ON DELETE SET NULL erased
+-- recurring_master_id from every historical child row when a master ended, and its immediate
+-- check failed the final child insert of a naturally exhausted master (the executor archives
+-- the master in the same transaction, before the post-loop bulk insert). The lineage id now
+-- survives master archival and resolves through scheduler_recurring_job_archive.
+ALTER TABLE scheduler_job DROP CONSTRAINT IF EXISTS fk_job_recurring_master;

--- a/stores/ratchet-store-postgresql/src/main/resources/ddl/postgresql-schema.sql
+++ b/stores/ratchet-store-postgresql/src/main/resources/ddl/postgresql-schema.sql
@@ -175,8 +175,8 @@ CREATE TABLE IF NOT EXISTS scheduler_job
     job_result JSONB,
     result_type           VARCHAR(100),
     -- Recurring-child lineage pointer. Set for child rows spawned by a recurring master; NULL
-    -- elsewhere. ON DELETE SET NULL so cancel of a master does not cascade-delete in-flight
-    -- children.
+    -- elsewhere. Intentionally unconstrained so the lineage id survives master cancellation or
+    -- exhaustion and remains resolvable through scheduler_recurring_job_archive.
     recurring_master_id   uuid,
     -- Per-row payload-encryption metadata (cleartext by design). encrypted_payload marks whether
     -- this row's protected surfaces are ciphertext; encryption_key_id records the key the
@@ -191,9 +191,7 @@ CREATE TABLE IF NOT EXISTS scheduler_job
                                     'CHAIN_STEP', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
     CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4),
     CONSTRAINT chk_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL')),
-    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
-    CONSTRAINT fk_job_recurring_master FOREIGN KEY (recurring_master_id)
-        REFERENCES scheduler_recurring_job (id) ON DELETE SET NULL
+    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED'))
 );
 
 -- 4a. Hot authoritative queue state for executable jobs.

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigrationDialectTest.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigrationDialectTest.java
@@ -82,7 +82,7 @@ class PostgresqlSchemaMigrationDialectTest {
             .orElseThrow();
 
     assertEquals(
-        List.of("001", "002", "003", "004", "005"),
+        List.of("001", "002", "003", "004", "005", "006"),
         migrations.stream().map(script -> script.version()).toList());
     assertEquals(
         "de49b983ef0b9110af22f59047a9e91fd1b37efdf7a790241b8297f82c857160", v001.checksum());

--- a/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigratorIT.java
+++ b/stores/ratchet-store-postgresql/src/test/java/run/ratchet/store/postgresql/PostgresqlSchemaMigratorIT.java
@@ -156,7 +156,7 @@ class PostgresqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
 
     SchemaMigrator.MigrationResult result = migrator.migrate();
 
-    assertEquals(List.of("002", "003", "004", "005"), versions(result.applied()));
+    assertEquals(List.of("002", "003", "004", "005", "006"), versions(result.applied()));
     assertEquals(List.of("001"), versions(result.skipped()));
     assertExtensionSchemaExists();
     assertSchemaVersionRowsMatch(migrator.discoverMigrations());
@@ -170,7 +170,7 @@ class PostgresqlSchemaMigratorIT extends AbstractSchemaMigratorContract {
 
     SchemaMigrator.MigrationResult result = migrator.migrate();
 
-    assertEquals(List.of("001", "002", "003", "004", "005"), versions(result.applied()));
+    assertEquals(List.of("001", "002", "003", "004", "005", "006"), versions(result.applied()));
     assertEquals(List.of(), result.skipped());
     assertExtensionSchemaExists();
     assertSchemaVersionRowsMatch(migrator.discoverMigrations());

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverJobStoreImpl.java
@@ -45,6 +45,7 @@ import run.ratchet.store.entity.JobExecutionType;
 import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.NodeEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.ExecutionTargetFilter;
 import run.ratchet.store.spi.RatchetEntityManagerProvider;
 import run.ratchet.store.util.IsolationCheck;
@@ -863,6 +864,11 @@ class SqlserverJobStoreImpl implements SqlserverJobStore {
   public boolean cancelRecurringAndArchive(
       UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
     return recurringJobs.cancelRecurringAndArchive(id, reason);
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    return recurringJobs.findArchivedRecurring(id);
   }
 
   @Override

--- a/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
+++ b/stores/ratchet-store-sqlserver/src/main/java/run/ratchet/store/sqlserver/SqlserverRecurringJobOperations.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import run.ratchet.api.NodeTagFilter;
 import run.ratchet.api.exception.RatchetTransientStoreException;
 import run.ratchet.spi.ProtectedSurface;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.RecurringJobStore.ArchiveReason;
@@ -51,6 +52,11 @@ final class SqlserverRecurringJobOperations implements RecurringJobStore {
           + " on_success_payload, on_failure_payload, business_key, resource_name,"
           + " execution_target, created_at, caller_principal, encrypted_payload,"
           + " misfire_policy, max_catch_up_executions";
+
+  // language=SQL Server
+  private static final String ARCHIVE_SELECT_COLUMNS =
+      "id, business_key, cron_expr, zone_id, execution_target, caller_principal, created_at,"
+          + " archived_at, archive_reason";
 
   private final SqlserverStoreContext ctx;
   private final SqlserverBusinessKeyReservations reservations;
@@ -147,6 +153,23 @@ final class SqlserverRecurringJobOperations implements RecurringJobStore {
   @Override
   public boolean cancelRecurringAndArchive(UUID id, ArchiveReason reason) {
     return archiveAndDelete(List.of(id), reason) > 0;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    // language=SQL Server
+    String sql =
+        "SELECT " + ARCHIVE_SELECT_COLUMNS + " FROM scheduler_recurring_job_archive WHERE id = ?";
+    List<Object[]> rows =
+        ctx.em()
+            .createNativeQuery(sql)
+            .setParameter(1, UuidByteArrayConverter.toBytes(id))
+            .getResultList();
+    if (rows.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(RecurringJobRows.hydrateArchived(rows.get(0)));
   }
 
   @Override

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/migrations/V006__drop_recurring_master_fk.sql
@@ -1,0 +1,6 @@
+-- Drops the recurring-master foreign key from scheduler_job. Its ON DELETE SET NULL erased
+-- recurring_master_id from every historical child row when a master ended, and its immediate
+-- check failed the final child insert of a naturally exhausted master (the executor archives
+-- the master in the same transaction, before the post-loop bulk insert). The lineage id now
+-- survives master archival and resolves through scheduler_recurring_job_archive.
+ALTER TABLE scheduler_job DROP CONSTRAINT IF EXISTS fk_job_recurring_master;

--- a/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-schema.sql
+++ b/stores/ratchet-store-sqlserver/src/main/resources/ddl/sqlserver-schema.sql
@@ -187,9 +187,7 @@ CREATE TABLE scheduler_job
                                     'CHAIN_STEP', 'WORKFLOW_BRANCH', 'WORKFLOW_JOIN')),
     CONSTRAINT chk_job_priority CHECK (priority BETWEEN 0 AND 4),
     CONSTRAINT chk_backoff_policy CHECK (backoff_policy IN ('NONE', 'FIXED', 'EXPONENTIAL')),
-    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED')),
-    CONSTRAINT fk_job_recurring_master FOREIGN KEY (recurring_master_id)
-        REFERENCES scheduler_recurring_job (id) ON DELETE SET NULL
+    CONSTRAINT chk_terminal_status CHECK (terminal_status IS NULL OR terminal_status IN ('SUCCEEDED', 'FAILED', 'CANCELED'))
 );
 
 -- 4a. Hot authoritative queue state for executable jobs.

--- a/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigrationDialectTest.java
+++ b/stores/ratchet-store-sqlserver/src/test/java/run/ratchet/store/sqlserver/SqlserverSchemaMigrationDialectTest.java
@@ -103,7 +103,7 @@ class SqlserverSchemaMigrationDialectTest {
     SchemaMigrator.MigrationScript v001 = migrations.get(0);
 
     assertEquals(
-        List.of("001", "002", "003", "004", "005"),
+        List.of("001", "002", "003", "004", "005", "006"),
         migrations.stream().map(script -> script.version()).toList());
     assertEquals(
         "1dd8f2d437ef11447c7f74ef5601aa90d531475568d01349a12d56d4393fbd87", v001.checksum());

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractRecurringJobStoreContract.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/AbstractRecurringJobStoreContract.java
@@ -242,11 +242,9 @@ public abstract class AbstractRecurringJobStoreContract {
   }
 
   /**
-   * TCK 5b — archive snapshot correctness: the row that lands in the archive carries the same
-   * identifying state the live row had. The implementor projects every column relevant to a
-   * post-mortem (id, businessKey, cron, archive reason, principal). The contract verifies the
-   * smallest visible projection: businessKey survives the archive write, and a re-create with the
-   * same businessKey succeeds because the bkres slot is freed by the same cancel.
+   * TCK 5b — archive snapshot correctness: the row that lands in the archive exposes the original
+   * business key and archive reason through the correlation read API. Re-creating the same key also
+   * proves the bkres slot is freed by the same cancel.
    */
   @Test
   void cancelRecurringAndArchive_archivedRowMatchesLiveSnapshot() {
@@ -258,6 +256,10 @@ public abstract class AbstractRecurringJobStoreContract {
 
     assertTrue(recurringStore().cancelRecurringAndArchive(first, ArchiveReason.CANCELED));
     assertTrue(recurringStore().findRecurringByBusinessKey(key).isEmpty());
+    var archived = recurringStore().findArchivedRecurring(first).orElseThrow();
+    assertEquals(first, archived.id());
+    assertEquals(key, archived.businessKey());
+    assertEquals(ArchiveReason.CANCELED, archived.archiveReason());
 
     // Re-registering the same key on a fresh id must succeed because the archive snapshot
     // does NOT keep the bkres slot occupied — that's the whole point of moving the row off the
@@ -266,6 +268,12 @@ public abstract class AbstractRecurringJobStoreContract {
     assertNotNull(
         recurringStore()
             .createRecurring(definitionWithBusinessKey(second, key, "0 0 * * * ?", Instant.now())));
+  }
+
+  /** TCK 5c — archive lookup of an unknown master id is empty. */
+  @Test
+  void findArchivedRecurring_unknownIdReturnsEmpty() {
+    assertTrue(recurringStore().findArchivedRecurring(UuidV7Factory.create()).isEmpty());
   }
 
   /** TCK 6 — orphan-absence: the bkres entry is removed in the same cancel transaction. */
@@ -291,9 +299,9 @@ public abstract class AbstractRecurringJobStoreContract {
    * TCK 7 — child lineage (master half): the recurring master's id round-trips so the executor has
    * the value it needs to stamp onto every spawned child's {@code recurring_master_id} column. The
    * child-side half of this contract — actually writing a {@link JobEntity} with {@code
-   * recurringMasterId} set and re-reading it through the cold-table mapper — lives in {@link
-   * #create_persistsRecurringMasterIdOnChildJob}: it needs both this capability (to create the
-   * master the child's foreign key references) and the core {@code create}/{@code findById}
+   * recurringMasterId} set after the master is archived, then re-reading it through the cold-table
+   * mapper — lives in {@link #bulkInsert_preservesRecurringMasterIdAfterMasterIsArchived}. It needs
+   * both the recurring archive capability and the core {@code bulkInsert}/{@code findById}
    * round-trip.
    */
   @Test
@@ -642,22 +650,22 @@ public abstract class AbstractRecurringJobStoreContract {
   }
 
   /**
-   * A child job created with a {@code recurringMasterId} must persist that link and read it back.
-   * The child references a live master through a foreign key on SQL stores, so this contract
-   * belongs to the recurring capability rather than the core CRUD contract — it needs both a
-   * created master and the core {@code create}/{@code findById} round-trip.
+   * A child job created after its recurring master is archived must retain the durable lineage id.
+   * This mirrors natural cron exhaustion: the executor archives the exhausted master before it
+   * bulk-inserts the final child occurrence.
    */
   @Test
-  void create_persistsRecurringMasterIdOnChildJob() {
+  void bulkInsert_preservesRecurringMasterIdAfterMasterIsArchived() {
     UUID masterId = UuidV7Factory.create();
     recurringStore()
         .createRecurring(definition(masterId, "0 * * * * ?", Instant.now().plusSeconds(3600)));
+    assertTrue(recurringStore().cancelRecurringAndArchive(masterId, ArchiveReason.EXHAUSTED));
 
     JobEntity child = jobFixture().newPendingJob();
     child.setRecurringMasterId(masterId);
-    JobEntity created = jobFixture().store().create(child);
+    jobFixture().store().bulkInsert(List.of(child));
 
-    JobEntity reread = jobFixture().store().findById(created.getId()).orElseThrow();
+    JobEntity reread = jobFixture().store().findById(child.getId()).orElseThrow();
     assertEquals(
         masterId,
         reread.getRecurringMasterId(),

--- a/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/schema/RatchetSchemaCatalog.java
+++ b/testing/ratchet-tck/store/src/main/java/run/ratchet/tck/store/schema/RatchetSchemaCatalog.java
@@ -116,13 +116,6 @@ public final class RatchetSchemaCatalog {
         .column(required("encrypted_payload", BOOLEAN))
         .column(nullable("encryption_key_id", TEXT))
         .primaryKey("job_id")
-        .foreignKey(
-            new ForeignKey(
-                "fk_job_recurring_master",
-                "recurring_master_id",
-                "scheduler_recurring_job",
-                "id",
-                OnDeleteAction.SET_NULL))
         .index(Index.unique("uk_idempotency_key", "idempotency_key"))
         .index(Index.of("idx_job_depends_on", "depends_on"))
         .index(Index.of("idx_job_superseded_by", "superseded_by"))

--- a/testing/ratchet-tck/store/src/test/java/run/ratchet/tck/store/schema/RatchetSchemaCatalogTest.java
+++ b/testing/ratchet-tck/store/src/test/java/run/ratchet/tck/store/schema/RatchetSchemaCatalogTest.java
@@ -85,18 +85,9 @@ class RatchetSchemaCatalogTest {
         columns.contains("trace_context"),
         "scheduler_job should declare trace_context (W3C TraceContext captured at enqueue)");
 
-    ForeignKey fk =
-        job.foreignKeys().stream()
-            .filter(f -> f.name().equals("fk_job_recurring_master"))
-            .findFirst()
-            .orElseThrow();
-    assertEquals("recurring_master_id", fk.column());
-    assertEquals("scheduler_recurring_job", fk.refTable());
-    assertEquals("id", fk.refColumn());
-    assertEquals(
-        OnDeleteAction.SET_NULL,
-        fk.onDelete(),
-        "recurring-master FK must be ON DELETE SET NULL to match the DDL");
+    assertTrue(
+        job.foreignKeys().stream().noneMatch(f -> f.column().equals("recurring_master_id")),
+        "recurring_master_id must remain unconstrained so lineage survives master archival");
 
     assertEquals(
         List.of("recurring_master_id"),

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/clocked/ThrowingJobStoreBase.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/tck/clocked/ThrowingJobStoreBase.java
@@ -38,6 +38,7 @@ import run.ratchet.store.entity.JobLogEntity;
 import run.ratchet.store.entity.NodeEntity;
 import run.ratchet.store.entity.WorkflowConditionEntity;
 import run.ratchet.store.spi.ArchiveStore;
+import run.ratchet.store.spi.ArchivedRecurringJob;
 import run.ratchet.store.spi.BatchStore;
 import run.ratchet.store.spi.JobAnalyticsStore;
 import run.ratchet.store.spi.JobAuditStore;
@@ -755,6 +756,11 @@ public abstract class ThrowingJobStoreBase
   public boolean cancelRecurringAndArchive(
       UUID id, run.ratchet.store.spi.RecurringJobStore.ArchiveReason reason) {
     return fail("cancelRecurringAndArchive");
+  }
+
+  @Override
+  public Optional<ArchivedRecurringJob> findArchivedRecurring(UUID id) {
+    return fail("findArchivedRecurring");
   }
 
   @Override


### PR DESCRIPTION
Fixes #125.

## The business-key half

`RecurringJobDefinition` promised the business key was "carried into fired child jobs", but `createChildFromMaster` never copied it — and it can't. Every store reserves an active business key exclusively (SQL stores through `scheduler_business_key_reservation`, Mongo through a partial unique index), and the recurring master already holds that reservation. Overlapping firings also mean several children can be live at once, so children could never hold a reserved key.

This lands option 2 from the issue discussion: children stay keyless, the Javadoc now states the real contract, and consumers get a correlation handle that actually works:

- Every per-job lifecycle event now carries `recurringMasterId` (null for non-recurring jobs). The child entity has it in hand at publish time, so this costs no extra store read.
- New `RecurringJobStore.findArchivedRecurring(UUID)` resolves an ended master's `ArchivedRecurringJob` (business key included) from the archive, on all five stores. Without this, the id went dark the moment a master was canceled or exhausted — which is eventually every master.

## The exhausted-master half (second bug in #125's comments)

When a Quartz cron runs out, `process()` archives-and-deletes the master in the loop but bulk-inserts that master's final child after the loop. The child's `recurring_master_id` then referenced a deleted row, so `fk_job_recurring_master` failed the insert on every natural exhaustion — and since the whole cycle is one transaction, the rollback revived the master and poisoned every master batched with it. Separately, the FK's `ON DELETE SET NULL` erased lineage from all historical children whenever a master ended.

The FK is the root cause of both, so migration V006 drops it on all four SQL stores (V001 stays the immutable baseline; the consolidated schemas and the TCK schema catalog drop it too). `recurring_master_id` is now a durable lineage reference that survives master archival and stays resolvable through the archive.

## Validation

- Full reactor `mvn clean test`: green.
- `mvn clean verify` on all five store modules with real containers: green, including the migrator ITs running the V001–V006 chain and the ledgerless consolidated-schema adoption path (MySQL guards the FK drop through `information_schema` since it lacks `DROP FOREIGN KEY IF EXISTS`).
- New TCK contracts: archived masters resolve by id with their key and reason; unknown ids return empty; a child bulk-inserted after its master is archived keeps its lineage id (this one fails on the old schema).
- RI tests cover event enrichment and the exhaustion path.
