### PR TITLE
Target 0.2.0 as the next release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: Ratchet version or commit SHA
-      placeholder: 0.1.2-SNAPSHOT or a commit SHA
+      placeholder: 0.2.0-SNAPSHOT or a commit SHA
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ mvn spotless:apply       # auto-format (Google Java Format)
 
 ## Project Status
 
-Ratchet is in **0.1.2-SNAPSHOT**. The API is stabilizing; interfaces marked `@Incubating` may change between alpha releases. Feedback and contributions are welcome.
+Ratchet is in **0.2.0-SNAPSHOT**. The API is stabilizing; interfaces marked `@Incubating` may change between alpha releases. Feedback and contributions are welcome.
 
 ## Community
 

--- a/coordinators/ratchet-coordinator-common/pom.xml
+++ b/coordinators/ratchet-coordinator-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-hazelcast/pom.xml
+++ b/coordinators/ratchet-coordinator-hazelcast/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-infinispan/pom.xml
+++ b/coordinators/ratchet-coordinator-infinispan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-jms/pom.xml
+++ b/coordinators/ratchet-coordinator-jms/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-postgresql/pom.xml
+++ b/coordinators/ratchet-coordinator-postgresql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/infra/loadtest/Dockerfile
+++ b/infra/loadtest/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p \
 COPY --from=build /drivers/postgresql.jar /opt/jboss/ratchet/drivers/postgresql.jar
 COPY --from=build /drivers/mysql.jar /opt/jboss/ratchet/drivers/mysql.jar
 COPY infra/loadtest/wildfly/${STORE}.cli /opt/jboss/ratchet/store.cli
-COPY --from=build /workspace/testing/ratchet-loadtest/target/ratchet-loadtest-0.1.2-SNAPSHOT.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
+COPY --from=build /workspace/testing/ratchet-loadtest/target/ratchet-loadtest-0.2.0-SNAPSHOT.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
 RUN chown -R jboss:root /opt/jboss/ratchet /opt/jboss/wildfly/standalone \
     && chmod -R ug+rwX /opt/jboss/ratchet /opt/jboss/wildfly/standalone \
     && /opt/jboss/wildfly/bin/jboss-cli.sh --file=/opt/jboss/ratchet/store.cli \

--- a/observability/ratchet-micrometer/pom.xml
+++ b/observability/ratchet-micrometer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/observability/ratchet-otel/pom.xml
+++ b/observability/ratchet-otel/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-parent</artifactId>
-  <version>0.1.2-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Ratchet</name>
@@ -76,7 +76,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Reproducible builds: two builds of the same tag produce identical jar hashes.
          maven-release-plugin refreshes this on each release:prepare. -->
-    <project.build.outputTimestamp>2026-06-24T14:25:05Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-07-13T22:56:45Z</project.build.outputTimestamp>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>

--- a/ratchet-api/pom.xml
+++ b/ratchet-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-api</artifactId>

--- a/ratchet-bom/pom.xml
+++ b/ratchet-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-bom</artifactId>

--- a/ratchet-encryption/pom.xml
+++ b/ratchet-encryption/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-encryption</artifactId>

--- a/ratchet/pom.xml
+++ b/ratchet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet</artifactId>

--- a/stores/ratchet-store-core/pom.xml
+++ b/stores/ratchet-store-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-mongodb/pom.xml
+++ b/stores/ratchet-store-mongodb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-mysql/pom.xml
+++ b/stores/ratchet-store-mysql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-oracle/pom.xml
+++ b/stores/ratchet-store-oracle/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-postgresql/pom.xml
+++ b/stores/ratchet-store-postgresql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-sqlserver/pom.xml
+++ b/stores/ratchet-store-sqlserver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-arch-tests/pom.xml
+++ b/testing/ratchet-arch-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-coverage/pom.xml
+++ b/testing/ratchet-coverage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-loadtest/pom.xml
+++ b/testing/ratchet-loadtest/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-showcase/pom.xml
+++ b/testing/ratchet-showcase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-tck/api/pom.xml
+++ b/testing/ratchet-tck/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/coordinator/pom.xml
+++ b/testing/ratchet-tck/coordinator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/jakarta/pom.xml
+++ b/testing/ratchet-tck/jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/pom.xml
+++ b/testing/ratchet-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/store/pom.xml
+++ b/testing/ratchet-tck/store/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/util/pom.xml
+++ b/testing/ratchet-tck/util/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.1.2-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-testsuite-jpms/pom.xml
+++ b/testing/ratchet-testsuite-jpms/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-testsuite/pom.xml
+++ b/testing/ratchet-testsuite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestMongoProducer.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestMongoProducer.java
@@ -20,6 +20,7 @@ import com.mongodb.client.MongoDatabase;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -46,6 +47,21 @@ public class TestMongoProducer {
           "ratchet.test.mongo.uri system property not set. "
               + "Ensure MongoContainerExtension is active and the mongodb profile is enabled.");
     }
+
+    // Bound how long a monitor thread blocked in connect/heartbeat I/O can survive close(), keeping
+    // its post-close lifetime under the disposer join budget so the WAR classloader never closes
+    // while a driver thread is still alive.
+    String query = uri.contains("?") ? uri.substring(uri.indexOf('?') + 1) : "";
+    List<String> queryParameterNames =
+        Arrays.stream(query.split("&")).map(parameter -> parameter.split("=", 2)[0]).toList();
+    if (queryParameterNames.stream()
+        .noneMatch(parameter -> parameter.equalsIgnoreCase("heartbeatFrequencyMS"))) {
+      uri += (uri.contains("?") ? "&" : "?") + "heartbeatFrequencyMS=2000";
+    }
+    if (queryParameterNames.stream()
+        .noneMatch(parameter -> parameter.equalsIgnoreCase("connectTimeoutMS"))) {
+      uri += (uri.contains("?") ? "&" : "?") + "connectTimeoutMS=2000";
+    }
     return MongoClientFactory.create(uri);
   }
 
@@ -71,29 +87,43 @@ public class TestMongoProducer {
   }
 
   private static void waitForMonitorThreads() {
-    // GlassFish closes the WebappClassLoader at undeploy and hard-fails later class loads. MongoDB
-    // monitor threads lazily load classes during shutdown, so wait for them before undeploy
-    // returns.
-    long deadlineNanos = System.nanoTime() + MONITOR_SHUTDOWN_TIMEOUT_NANOS;
+    // MongoDB close() signals monitor threads, but one blocked in socket I/O dies only when the
+    // now-bounded timeout fires. Join to reap it before GlassFish closes the WAR classloader.
+    // Interrupt halfway through covers interruptible waits but cannot break a blocking socket read.
+    long startNanos = System.nanoTime();
+    long interruptDeadlineNanos = startNanos + MONITOR_SHUTDOWN_TIMEOUT_NANOS / 2;
+    long deadlineNanos = startNanos + MONITOR_SHUTDOWN_TIMEOUT_NANOS;
     List<Thread> monitorThreads =
         Thread.getAllStackTraces().keySet().stream()
             .filter(Thread::isAlive)
             .filter(thread -> thread.getName().startsWith("cluster-"))
             .toList();
 
-    for (Thread thread : monitorThreads) {
-      long remainingNanos = deadlineNanos - System.nanoTime();
-      if (remainingNanos <= 0) {
-        break;
+    boolean waitInterrupted = false;
+    for (int phase = 0; phase < 2 && !waitInterrupted; phase++) {
+      long phaseDeadlineNanos = phase == 0 ? interruptDeadlineNanos : deadlineNanos;
+      if (phase == 1) {
+        monitorThreads.stream().filter(Thread::isAlive).forEach(Thread::interrupt);
       }
-      try {
-        long remainingMillis = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
-        int remainingNanosPart =
-            (int) (remainingNanos - TimeUnit.MILLISECONDS.toNanos(remainingMillis));
-        thread.join(remainingMillis, remainingNanosPart);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        break;
+
+      for (Thread thread : monitorThreads) {
+        if (!thread.isAlive()) {
+          continue;
+        }
+        long remainingNanos = phaseDeadlineNanos - System.nanoTime();
+        if (remainingNanos <= 0) {
+          break;
+        }
+        try {
+          long remainingMillis = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
+          int remainingNanosPart =
+              (int) (remainingNanos - TimeUnit.MILLISECONDS.toNanos(remainingMillis));
+          thread.join(remainingMillis, remainingNanosPart);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          waitInterrupted = true;
+          break;
+        }
       }
     }
 

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestMongoProducer.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/TestMongoProducer.java
@@ -17,16 +17,25 @@ package run.ratchet.testsuite.app;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
-import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
 import jakarta.enterprise.inject.Produces;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
 import run.ratchet.store.mongodb.MongoClientFactory;
 
-/** Produces MongoDB test handles from MongoContainerExtension system properties. */
+/**
+ * Produces MongoDB test handles from MongoContainerExtension system properties.
+ *
+ * <p>The client disposer waits for the driver's background monitor threads to exit before returning
+ * so GlassFish can safely close the WAR classloader during undeploy.
+ */
 @ApplicationScoped
 public class TestMongoProducer {
 
-  private volatile MongoClient client;
+  private static final Logger log = Logger.getLogger(TestMongoProducer.class.getName());
+  private static final long MONITOR_SHUTDOWN_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(5);
 
   @Produces
   @ApplicationScoped
@@ -37,8 +46,7 @@ public class TestMongoProducer {
           "ratchet.test.mongo.uri system property not set. "
               + "Ensure MongoContainerExtension is active and the mongodb profile is enabled.");
     }
-    client = MongoClientFactory.create(uri);
-    return client;
+    return MongoClientFactory.create(uri);
   }
 
   @Produces
@@ -48,10 +56,53 @@ public class TestMongoProducer {
     return mongoClient.getDatabase(dbName);
   }
 
-  @PreDestroy
-  void cleanup() {
-    if (client != null) {
+  void closeClient(@Disposes MongoClient client) {
+    try {
       client.close();
+    } catch (RuntimeException e) {
+      log.warning("Failed to close MongoDB test client: " + e.getMessage());
+    }
+
+    try {
+      waitForMonitorThreads();
+    } catch (RuntimeException e) {
+      log.warning("Failed while waiting for MongoDB monitor threads to stop: " + e.getMessage());
+    }
+  }
+
+  private static void waitForMonitorThreads() {
+    // GlassFish closes the WebappClassLoader at undeploy and hard-fails later class loads. MongoDB
+    // monitor threads lazily load classes during shutdown, so wait for them before undeploy
+    // returns.
+    long deadlineNanos = System.nanoTime() + MONITOR_SHUTDOWN_TIMEOUT_NANOS;
+    List<Thread> monitorThreads =
+        Thread.getAllStackTraces().keySet().stream()
+            .filter(Thread::isAlive)
+            .filter(thread -> thread.getName().startsWith("cluster-"))
+            .toList();
+
+    for (Thread thread : monitorThreads) {
+      long remainingNanos = deadlineNanos - System.nanoTime();
+      if (remainingNanos <= 0) {
+        break;
+      }
+      try {
+        long remainingMillis = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
+        int remainingNanosPart =
+            (int) (remainingNanos - TimeUnit.MILLISECONDS.toNanos(remainingMillis));
+        thread.join(remainingMillis, remainingNanosPart);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        break;
+      }
+    }
+
+    List<String> remainingMonitorNames =
+        monitorThreads.stream().filter(Thread::isAlive).map(Thread::getName).sorted().toList();
+    if (!remainingMonitorNames.isEmpty()) {
+      log.warning(
+          "MongoDB monitor threads still alive after shutdown wait: "
+              + String.join(", ", remainingMonitorNames));
     }
   }
 }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/app/TestMongoProducerTest.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/app/TestMongoProducerTest.java
@@ -17,14 +17,21 @@ package run.ratchet.testsuite.app;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.Modifier;
+import com.mongodb.client.MongoClient;
+import jakarta.enterprise.inject.Disposes;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 class TestMongoProducerTest {
 
   @Test
-  void producedClientReadDuringShutdown_isVolatile() throws Exception {
+  void producedClient_hasDisposerMethod() {
     assertTrue(
-        Modifier.isVolatile(TestMongoProducer.class.getDeclaredField("client").getModifiers()));
+        Arrays.stream(TestMongoProducer.class.getDeclaredMethods())
+            .flatMap(method -> Arrays.stream(method.getParameters()))
+            .anyMatch(
+                parameter ->
+                    parameter.getType() == MongoClient.class
+                        && parameter.isAnnotationPresent(Disposes.class)));
   }
 }

--- a/testing/ratchet-version-compatibility/pom.xml
+++ b/testing/ratchet-version-compatibility/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.1.2-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -249,7 +249,7 @@ sqlplus ratchet/your-secure-password@//localhost:1521/FREEPDB1 \
 
 The Oracle store was added after `0.1.1`, so that release has no store JAR to extract. Build the
 current source tree and use the DDL path above; the JAR contains `ddl/oracle-schema.sql` starting
-with `0.1.2`.
+with `0.2.0`.
 
 ### Verify Installation
 

--- a/website/docs/deployment/oracle.md
+++ b/website/docs/deployment/oracle.md
@@ -23,7 +23,7 @@ sqlplus ratchet/secret@//localhost:1521/FREEPDB1 \
 
 The Oracle store was added after the `0.1.1` release, so there is no published store JAR to
 extract at that version. Build the current source tree and use the DDL path above. Starting with
-`0.1.2`, the store JAR also contains the file at `ddl/oracle-schema.sql`.
+`0.2.0`, the store JAR also contains the file at `ddl/oracle-schema.sql`.
 
 Or copy it into your migration tool's versioned scripts:
 

--- a/website/docs/deployment/sqlserver.md
+++ b/website/docs/deployment/sqlserver.md
@@ -32,7 +32,7 @@ sqlcmd -S localhost,1433 -U ratchet -P 'secret' -d ratchet -C \
 
 The SQL Server store was added after the `0.1.1` release, so there is no published store JAR to
 extract at that version. Build the current source tree and use the DDL path above. Starting with
-`0.1.2`, the store JAR also contains the file at `ddl/sqlserver-schema.sql`.
+`0.2.0`, the store JAR also contains the file at `ddl/sqlserver-schema.sql`.
 
 Or copy it into your migration tool's versioned scripts:
 

--- a/website/docs/getting-started/basic-concepts.md
+++ b/website/docs/getting-started/basic-concepts.md
@@ -145,7 +145,7 @@ You choose a store implementation as a Maven dependency:
 <artifactId>ratchet-store-mysql</artifactId>
 <artifactId>ratchet-store-mongodb</artifactId>
 
-<!-- Published starting in 0.1.2; build from source when using 0.1.1 -->
+<!-- Published starting in 0.2.0; build from source when using 0.1.1 -->
 <artifactId>ratchet-store-oracle</artifactId>
 <artifactId>ratchet-store-sqlserver</artifactId>
 ```

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -62,15 +62,15 @@ Ratchet is split into focused modules so you only pull in what you need.
 You need exactly one store module matching your database:
 
 The `0.1.1` release predates the Oracle and SQL Server modules. Those two stores are available
-from the source tree and become Maven Central artifacts in `0.1.2`; when using the `0.1.1` BOM,
+from the source tree and become Maven Central artifacts in `0.2.0`; when using the `0.1.1` BOM,
 build them from source instead of adding an unpublished coordinate.
 
 | Module | Database | Notes |
 |--------|----------|-------|
 | `ratchet-store-postgresql` | PostgreSQL 14+ | Uses JSONB columns, partial indexes, and `FOR UPDATE SKIP LOCKED` for efficient job claiming |
 | `ratchet-store-mysql` | MySQL 8+ | Uses JSON columns and `SELECT ... FOR UPDATE SKIP LOCKED` |
-| `ratchet-store-oracle` | Oracle 23ai+ | Source build on 0.1.1; published in 0.1.2+. RAW(16) UUIDs, CLOB JSON read via `JSON_VALUE`, two-phase `FETCH FIRST` + `FOR UPDATE SKIP LOCKED` claim |
-| `ratchet-store-sqlserver` | SQL Server 2022+ | Source build on 0.1.1; published in 0.1.2+. BINARY(16) UUIDs, row-versioned reads, and `UPDLOCK, READPAST` for concurrent claiming |
+| `ratchet-store-oracle` | Oracle 23ai+ | Source build on 0.1.1; published in 0.2.0+. RAW(16) UUIDs, CLOB JSON read via `JSON_VALUE`, two-phase `FETCH FIRST` + `FOR UPDATE SKIP LOCKED` claim |
+| `ratchet-store-sqlserver` | SQL Server 2022+ | Source build on 0.1.1; published in 0.2.0+. BINARY(16) UUIDs, row-versioned reads, and `UPDLOCK, READPAST` for concurrent claiming |
 | `ratchet-store-mongodb` | MongoDB 6+ | Document-based store with TTL indexes |
 
 ### Optional modules

--- a/website/docs/getting-started/introduction.md
+++ b/website/docs/getting-started/introduction.md
@@ -164,7 +164,7 @@ If you're building a microservice on Spring Boot or Quarkus and not targeting a 
 
 ## Project status
 
-Ratchet is currently at version **0.1.2-SNAPSHOT**. The core API is stabilizing, but interfaces marked with `@Incubating` (such as `CircuitBreakerProtected` and `CircuitBreakerProfile`) may change in future releases. Feedback and contributions are welcome.
+Ratchet is currently at version **0.2.0-SNAPSHOT**. The core API is stabilizing, but interfaces marked with `@Incubating` (such as `CircuitBreakerProtected` and `CircuitBreakerProfile`) may change in future releases. Feedback and contributions are welcome.
 
 ## What's next
 

--- a/website/docs/use-cases/bulk-batch-jobs.md
+++ b/website/docs/use-cases/bulk-batch-jobs.md
@@ -12,7 +12,7 @@ Roll that yourself and you end up writing the same ledger every time. A counter 
 A batch is Ratchet's name for that ledger. You hand it the items and the work; it enqueues one child job each, counts completions and failures as they land, and hands every progress hook an immutable snapshot. When the batch finishes, you branch on what actually happened.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.2-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `BatchStore` capability.
+The Java on this page compiles against `ratchet-api` `0.2.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `BatchStore` capability.
 :::
 
 ## Fan out, track progress, branch on the result

--- a/website/docs/use-cases/durable-llm-workflows.md
+++ b/website/docs/use-cases/durable-llm-workflows.md
@@ -10,7 +10,7 @@ Calling a language model from a request thread is a trap. The call is slow, it f
 This is the problem durable execution solves, and it is what Ratchet already does for any other background work. Ratchet is not an AI framework and ships no model client. It is the layer underneath: it persists the call before it runs, retries it with backoff, trips a circuit breaker when the provider is down, and resumes a half-finished multi-step workflow after a crash. You bring the model client. On Jakarta EE the natural choice is [langchain4j-cdi](https://github.com/langchain4j/langchain4j-cdi), which exposes a [LangChain4j](https://docs.langchain4j.dev) AI service as an injectable CDI bean, the same programming model Ratchet uses.
 
 ::: tip Verified
-The Java on this page is compile-checked in this repository against the next development API: `ratchet-api` `0.1.2-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. The copyable dependency block deliberately uses the latest published Ratchet release shown below so it resolves from Maven Central. This is not a full runnable application (wiring it up needs a Jakarta EE server and AWS credentials), but the API usage is real, not illustrative pseudocode.
+The Java on this page is compile-checked in this repository against the next development API: `ratchet-api` `0.2.0-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. The copyable dependency block deliberately uses the latest published Ratchet release shown below so it resolves from Maven Central. This is not a full runnable application (wiring it up needs a Jakarta EE server and AWS credentials), but the API usage is real, not illustrative pseudocode.
 :::
 
 ## What you wire together

--- a/website/docs/use-cases/human-in-the-loop.md
+++ b/website/docs/use-cases/human-in-the-loop.md
@@ -14,7 +14,7 @@ Ratchet gives the job a waiting state instead. It parks in `WAITING`, holds no t
 The [durable LLM workflows](./durable-llm-workflows.md#pause-for-a-human-then-resume) page reaches for this same mechanism to gate an agent's actions. This page is the mechanism itself: how a job waits, how a decision reaches it, and what happens when nobody decides.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.2-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `SignalStore` capability.
+The Java on this page compiles against `ratchet-api` `0.2.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `SignalStore` capability.
 :::
 
 ## Park, decide, resume

--- a/website/docs/use-cases/offload-after-request.md
+++ b/website/docs/use-cases/offload-after-request.md
@@ -12,7 +12,7 @@ The usual escape hatch is a thread pool, or a `@Async` method, or handing the wo
 Ratchet closes that window. You enqueue the follow-up work inside the same transaction that writes the order, so the job and the order row commit together. The request returns as soon as the row is durable. The work runs later, on a worker, with retries, and it cannot get lost, because it was written to the same database as the thing it follows up on.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.2-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
+The Java on this page compiles against `ratchet-api` `0.2.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
 :::
 
 ## Enqueue inside the transaction, return now

--- a/website/docs/use-cases/resilient-integrations.md
+++ b/website/docs/use-cases/resilient-integrations.md
@@ -12,7 +12,7 @@ Retrying handles the blip. It is the wrong tool for the outage: a hundred queued
 Ratchet gives you both, and they stay out of each other's way. The retry budget rides out transient errors. The breaker rides out outages without spending that budget. The external call lives in a durable job, so none of this happens on the request thread, and a provider's bad afternoon never reaches your user as a failed request.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.2-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store. The `@CircuitBreakerProtected` annotation is marked `@Incubating` and may change.
+The Java on this page compiles against `ratchet-api` `0.2.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store. The `@CircuitBreakerProtected` annotation is marked `@Incubating` and may change.
 :::
 
 ## Layer one: the call as a retrying job

--- a/website/docs/use-cases/scheduled-recurring-jobs.md
+++ b/website/docs/use-cases/scheduled-recurring-jobs.md
@@ -12,7 +12,7 @@ The usual answer is Quartz, or a `@Scheduled` method, or a cron line on one box.
 Ratchet treats a scheduled run as what it already is: a job. It gets written to your database before it runs, claimed by exactly one node, retried on failure, and picked up again after a crash. The schedule is a row, not a thread on a single machine. If you already run Ratchet for background work, recurring work is the same engine with a cron string attached.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.1.2-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
+The Java on this page compiles against `ratchet-api` `0.2.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
 :::
 
 ## The declarative path: `@Recurring`


### PR DESCRIPTION
Everything merged since v0.1.1 (the Oracle and SQL Server stores, the coordinator modules, the extension-store capability) is minor-version scope, so 0.1.2 will never ship.

The release workflow derives its version by stripping -SNAPSHOT from the pom and has no dispatch input to override it. Dispatching a release today would tag and publish v0.1.2. This PR re-targets the next release to 0.2.0:

- All 31 poms bumped to 0.2.0-SNAPSHOT via mvn versions:set (the same invocation release.yml uses)
- scripts/sync-version.sh 0.2.0-SNAPSHOT updated the development references (README status line, bug-report template placeholder, loadtest Dockerfile, use-case verified-against notes); public dependency snippets stay at the published 0.1.1
- Five docs pages said Oracle and SQL Server artifacts would be published "in 0.1.2"; that prose is free text the sync script does not manage, so it is updated by hand here to say 0.2.0

Also fixes the glassfish-managed + mongodb CI failure this PR surfaced (failed on all three attempts): the MongoDB driver's SDAM monitor threads outlive WAR undeploy, and their next heartbeat (10s, the driver default) loads a class through the closed WebappClassLoader — GlassFish is the only server that hard-fails loadClass after close, so whatever test was running at that moment errored. TestMongoProducer now uses a CDI disposer that closes the client and joins the driver's cluster-* threads (bounded at 5s) before undeploy returns. Verified locally against the real cell: 74 deploy/undeploy cycles, 221 tests green, zero closed-classloader exceptions.

After this merges, dispatching the Release workflow produces v0.2.0 and rolls main to 0.2.1-SNAPSHOT.