### PR TITLE
Keep signed-commit payloads out of argv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
         run: scripts/test-materialize-runtime-conformance-reports.sh
       - name: Test release version synchronization
         run: scripts/test-sync-version.sh
+      - name: Test signed commit request generation
+        run: scripts/test-gh-signed-commit.sh
 
   # Detects whether a pull request touches anything other than documentation, so
   # the heavy integration matrix, the EE 11 lane, and CodeQL can be skipped on

--- a/scripts/gh-signed-commit.sh
+++ b/scripts/gh-signed-commit.sh
@@ -23,7 +23,7 @@
 #                      including the Signed-off-by trailer); pass /dev/null for
 #                      no body
 #
-# Requires: gh (authenticated), jq, git. Reads the changed files from
+# Requires: gh (authenticated), jq, git, base64. Reads the changed files from
 # `git diff --name-only HEAD` plus `git diff --name-only --cached`.
 #
 # Prints the new commit oid on stdout.
@@ -35,6 +35,14 @@ BRANCH="$2"
 EXPECTED_HEAD_OID="$3"
 HEADLINE="$4"
 BODY_FILE="${5:-/dev/null}"
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ratchet-gh-signed-commit.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+ADDITIONS_FILE="${TMP_ROOT}/additions.jsonl"
+DELETIONS_FILE="${TMP_ROOT}/deletions.jsonl"
+REQUEST_FILE="${TMP_ROOT}/request.json"
+: > "${ADDITIONS_FILE}"
+: > "${DELETIONS_FILE}"
 
 # Collect every TRACKED path that differs from HEAD — modifications, staged
 # changes, and deletions (`git diff HEAD` plus `--cached`). Untracked files are
@@ -55,23 +63,21 @@ if [[ -z "$CHANGED_LIST" ]]; then
   exit 1
 fi
 
-# Build the additions/deletions arrays in one pass. A file still present in the
-# working tree is an addition carrying its base64 contents (base64 -w0 keeps
-# each blob on one line); a path that has vanished is a deletion.
-ADDITIONS='[]'
-DELETIONS='[]'
+# Build the additions/deletions as JSON-object-per-line temp files in one pass.
+# A file still present in the working tree is an addition carrying its base64
+# contents (base64 -w0 keeps each blob on one line); a path that has vanished
+# is a deletion. Blob contents flow through stdin into jq and then into a file,
+# so neither individual blobs nor the accumulated payload ever ride in argv.
 while IFS= read -r path; do
   [[ -n "$path" ]] || continue
   if [[ -f "$path" ]]; then
-    b64="$(base64 -w0 < "$path")"
-    ADDITIONS="$(jq -c --arg p "$path" --arg c "$b64" \
-      '. + [{path: $p, contents: $c}]' <<<"$ADDITIONS")"
+    base64 -w0 < "$path" \
+      | jq -Rsc --arg p "$path" '{path: $p, contents: .}' \
+      >> "${ADDITIONS_FILE}"
   else
-    DELETIONS="$(jq -c --arg p "$path" '. + [{path: $p}]' <<<"$DELETIONS")"
+    jq -cn --arg p "$path" '{path: $p}' >> "${DELETIONS_FILE}"
   fi
 done <<<"$CHANGED_LIST"
-
-BODY="$(cat "$BODY_FILE")"
 
 MUTATION='mutation($input: CreateCommitOnBranchInput!) {
   createCommitOnBranch(input: $input) {
@@ -79,20 +85,20 @@ MUTATION='mutation($input: CreateCommitOnBranchInput!) {
   }
 }'
 
-# Assemble the COMPLETE GraphQL request body ({query, variables}) with jq so
-# nothing is shell-interpolated into the payload. `gh api graphql --input -`
-# reads the whole body from stdin, so query and variables both ride along
-# rather than being passed as flat field flags (which can't express a nested
-# input object). The message is {headline, body}; an empty body is allowed.
-REQUEST="$(jq -n \
+# Assemble the complete GraphQL request body ({query, variables}) in a temp
+# file. `--slurpfile` turns each JSONL file into an array (including [] for an
+# empty file), while `--rawfile` reads the message body without putting its
+# contents in argv. Passing that request file to gh preserves the nested input
+# object without holding the multi-megabyte payload in a shell variable.
+jq -n \
   --arg query "$MUTATION" \
   --arg repo "$REPO" \
   --arg branch "$BRANCH" \
   --arg oid "$EXPECTED_HEAD_OID" \
   --arg headline "$HEADLINE" \
-  --arg body "$BODY" \
-  --argjson additions "$ADDITIONS" \
-  --argjson deletions "$DELETIONS" \
+  --rawfile body "$BODY_FILE" \
+  --slurpfile additions "$ADDITIONS_FILE" \
+  --slurpfile deletions "$DELETIONS_FILE" \
   '{
     query: $query,
     variables: {
@@ -103,11 +109,10 @@ REQUEST="$(jq -n \
         fileChanges: { additions: $additions, deletions: $deletions }
       }
     }
-  }')"
+  }' > "$REQUEST_FILE"
 
 # Capture the new commit oid for the caller.
-NEW_OID="$(printf '%s' "$REQUEST" \
-  | gh api graphql --input - \
+NEW_OID="$(gh api graphql --input "$REQUEST_FILE" \
   | jq -r '.data.createCommitOnBranch.commit.oid')"
 
 if [[ -z "$NEW_OID" || "$NEW_OID" == "null" ]]; then

--- a/scripts/test-gh-signed-commit.sh
+++ b/scripts/test-gh-signed-commit.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SIGNED_COMMIT_SCRIPT="${ROOT}/scripts/gh-signed-commit.sh"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/ratchet-gh-signed-commit-test.XXXXXX")"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+FIXTURE_REPO="${TMP_ROOT}/repo"
+SHIM_DIR="${TMP_ROOT}/bin"
+CAPTURED_REQUEST="${TMP_ROOT}/request.json"
+STDERR_FILE="${TMP_ROOT}/stderr"
+BODY_FILE="${TMP_ROOT}/body.txt"
+DECODED_FILE="${TMP_ROOT}/decoded.txt"
+ADDITION_COUNT=60
+DELETION_COUNT=3
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+mkdir -p "${FIXTURE_REPO}/tracked" "${FIXTURE_REPO}/deleted" "${SHIM_DIR}"
+git -C "${FIXTURE_REPO}" init -q
+
+# Sixty 40 KiB files become a request larger than typical ARG_MAX limits once
+# base64-encoded. This is deliberately release-sized so the former --argjson
+# handoff fails before the gh shim can be reached.
+dd if=/dev/zero bs=1024 count=40 2>/dev/null \
+  | LC_ALL=C tr '\000' 'a' > "${TMP_ROOT}/original-40k.txt"
+dd if=/dev/zero bs=1024 count=40 2>/dev/null \
+  | LC_ALL=C tr '\000' 'b' > "${TMP_ROOT}/modified-40k.txt"
+
+for ((i = 1; i <= ADDITION_COUNT; i++)); do
+  path="$(printf 'tracked/file-%03d.txt' "${i}")"
+  cp "${TMP_ROOT}/original-40k.txt" "${FIXTURE_REPO}/${path}"
+done
+
+for ((i = 1; i <= DELETION_COUNT; i++)); do
+  path="$(printf 'deleted/file-%03d.txt' "${i}")"
+  printf 'delete fixture %03d\n' "${i}" > "${FIXTURE_REPO}/${path}"
+done
+
+git -C "${FIXTURE_REPO}" add tracked deleted
+git -C "${FIXTURE_REPO}" \
+  -c user.name='Ratchet Test' \
+  -c user.email='ratchet-test@example.invalid' \
+  -c commit.gpgsign=false \
+  -c core.hooksPath=/dev/null \
+  commit -qm 'fixture baseline'
+
+for ((i = 1; i <= ADDITION_COUNT; i++)); do
+  path="$(printf 'tracked/file-%03d.txt' "${i}")"
+  cp "${TMP_ROOT}/modified-40k.txt" "${FIXTURE_REPO}/${path}"
+done
+rm "${FIXTURE_REPO}"/deleted/*.txt
+
+actual_changed_count="$(git -C "${FIXTURE_REPO}" diff --name-only HEAD | wc -l | tr -d ' ')"
+expected_changed_count=$(( ADDITION_COUNT + DELETION_COUNT ))
+[[ "${actual_changed_count}" -eq "${expected_changed_count}" ]] \
+  || fail "expected ${expected_changed_count} changed paths, found ${actual_changed_count}"
+
+cat > "${SHIM_DIR}/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 4 || "$1" != 'api' || "$2" != 'graphql' || "$3" != '--input' ]]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 2
+fi
+if [[ "$4" == '-' ]]; then
+  echo 'expected gh --input to name a request file' >&2
+  exit 2
+fi
+
+cp "$4" "${GH_CAPTURE_FILE}"
+printf '%s\n' '{"data":{"createCommitOnBranch":{"commit":{"oid":"deadbeef"}}}}'
+EOF
+chmod +x "${SHIM_DIR}/gh"
+
+# The production runner uses GNU base64. Make the same `base64 -w0` interface
+# available when this test is run on macOS, whose system base64 is BSD-based.
+REAL_BASE64="$(command -v base64)"
+export REAL_BASE64
+cat > "${SHIM_DIR}/base64" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == '-w0' ]]; then
+  shift
+  "${REAL_BASE64}" "$@" | tr -d '\n'
+else
+  exec "${REAL_BASE64}" "$@"
+fi
+EOF
+chmod +x "${SHIM_DIR}/base64"
+
+printf '%s\n' 'Fixture body' 'Signed-off-by: Ratchet Test <ratchet-test@example.invalid>' \
+  > "${BODY_FILE}"
+expected_head_oid="$(git -C "${FIXTURE_REPO}" rev-parse HEAD)"
+
+if stdout="$(
+  cd "${FIXTURE_REPO}"
+  GH_CAPTURE_FILE="${CAPTURED_REQUEST}" \
+    PATH="${SHIM_DIR}:${PATH}" \
+    "${SIGNED_COMMIT_SCRIPT}" \
+      'ratchet-run/ratchet' \
+      'release-fixture' \
+      "${expected_head_oid}" \
+      'Exercise release-sized signed commit' \
+      "${BODY_FILE}"
+)" 2> "${STDERR_FILE}"; then
+  :
+else
+  status=$?
+  cat "${STDERR_FILE}" >&2
+  fail "gh-signed-commit.sh exited ${status}"
+fi
+
+[[ "${stdout}" == 'deadbeef' ]] \
+  || fail "expected stdout to be deadbeef, got: ${stdout}"
+[[ -s "${CAPTURED_REQUEST}" ]] || fail 'gh shim did not capture a request'
+jq empty "${CAPTURED_REQUEST}" || fail 'captured request is not valid JSON'
+
+actual_additions="$(jq -r '.variables.input.fileChanges.additions | length' "${CAPTURED_REQUEST}")"
+actual_deletions="$(jq -r '.variables.input.fileChanges.deletions | length' "${CAPTURED_REQUEST}")"
+[[ "${actual_additions}" -eq "${ADDITION_COUNT}" ]] \
+  || fail "expected ${ADDITION_COUNT} additions, found ${actual_additions}"
+[[ "${actual_deletions}" -eq "${DELETION_COUNT}" ]] \
+  || fail "expected ${DELETION_COUNT} deletions, found ${actual_deletions}"
+
+round_trip_path='tracked/file-037.txt'
+jq -j --arg path "${round_trip_path}" \
+  '.variables.input.fileChanges.additions[]
+   | select(.path == $path)
+   | .contents
+   | @base64d' \
+  "${CAPTURED_REQUEST}" > "${DECODED_FILE}"
+cmp "${FIXTURE_REPO}/${round_trip_path}" "${DECODED_FILE}" \
+  || fail "base64 contents did not round-trip for ${round_trip_path}"
+
+for ((i = 1; i <= DELETION_COUNT; i++)); do
+  path="$(printf 'deleted/file-%03d.txt' "${i}")"
+  jq -e --arg path "${path}" \
+    '.variables.input.fileChanges.deletions | any(.path == $path)' \
+    "${CAPTURED_REQUEST}" > /dev/null \
+    || fail "captured request is missing deletion ${path}"
+done
+
+payload_bytes="$(wc -c < "${CAPTURED_REQUEST}" | tr -d ' ')"
+[[ "${payload_bytes}" -gt 3000000 ]] \
+  || fail "expected a regression payload larger than 3 MB, found ${payload_bytes} bytes"
+
+echo "PASS: signed commit request contains ${ADDITION_COUNT} additions and ${DELETION_COUNT} deletions"
+echo "PASS: ${payload_bytes}-byte request parses and file contents round-trip"


### PR DESCRIPTION
The v0.2.0 release run failed at the tag step: gh-signed-commit.sh passed the accumulated additions array (base64 of every changed file) to jq as one argv element, and a real release commit rewrites ~55 files, exceeding ARG_MAX. Exit 126, no tag, no GitHub release. The Central bundle had already staged, so autoPublish=false contained the damage.

The fix streams blob contents through stdin into JSONL temp files, assembles the request with --slurpfile/--rawfile, and hands gh the finished request as a file. A new regression test (wired into workflow-lint) pushes 60 files of 40KB through a stubbed gh and asserts the 3MB request parses and round-trips — the old implementation fails it on argv overflow.

After this merges: delete the leftover release-tag/v0.2.0 temp branch and re-dispatch the Release workflow.