### PR TITLE
Fetch the release tag before building release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,9 @@ jobs:
         # into the script via ${{ }}, so a crafted commit message cannot inject commands.
         run: |
           set -euo pipefail
+          # The tag step creates RELEASE_TAG remotely through the API after this job's
+          # checkout already fetched tags, so the local clone doesn't have it yet.
+          git fetch --quiet origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           PREV_TAG=$(git describe --tags --abbrev=0 "${RELEASE_TAG}^" 2>/dev/null || echo "")
           if [ -n "$PREV_TAG" ]; then
             COMMITS=$(git log "${PREV_TAG}..${RELEASE_TAG}" --pretty=format:"- %s" \


### PR DESCRIPTION
Release attempt 2 got past the tag step (the argv fix in #140 held) and died one step later: the tag is created remotely via the API after checkout has already fetched tags, so 'git describe'/'git log' in the release-notes step reference a tag the runner's clone doesn't have. One-line fix: fetch the tag ref at the top of the step.

Recovery plan after merge: delete the orphaned v0.2.0 tag (nothing references it; no GitHub release exists), re-dispatch Release, and discard the two stale staged bundles in the Central Portal when publishing.