### PR TITLE
Add a caller-principal configuration seam and boot-time SPI diagnostics

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+import run.ratchet.spi.CallerPrincipalResolver;
 
 /**
  * Immutable CDI-producible runtime options for Ratchet.
@@ -54,6 +55,7 @@ public class RatchetOptions {
   private final StoreOptions store;
   private final CircuitBreakerOptions circuitBreaker;
   private final EncryptionOptions encryption;
+  private final CallerPrincipalResolver callerPrincipalResolver;
 
   /**
    * No-arg constructor used only by CDI to generate the client proxy subclass. Sets all fields to
@@ -75,6 +77,7 @@ public class RatchetOptions {
     this.store = null;
     this.circuitBreaker = null;
     this.encryption = null;
+    this.callerPrincipalResolver = null;
   }
 
   public RatchetOptions(
@@ -91,6 +94,38 @@ public class RatchetOptions {
       StoreOptions store,
       CircuitBreakerOptions circuitBreaker,
       EncryptionOptions encryption) {
+    this(
+        polling,
+        execution,
+        node,
+        recurring,
+        retryBuffer,
+        timeout,
+        maintenance,
+        schema,
+        payload,
+        security,
+        store,
+        circuitBreaker,
+        encryption,
+        /* callerPrincipalResolver */ null);
+  }
+
+  private RatchetOptions(
+      PollingOptions polling,
+      ExecutionOptions execution,
+      NodeOptions node,
+      RecurringOptions recurring,
+      RetryBufferOptions retryBuffer,
+      TimeoutOptions timeout,
+      MaintenanceOptions maintenance,
+      SchemaOptions schema,
+      PayloadOptions payload,
+      SecurityOptions security,
+      StoreOptions store,
+      CircuitBreakerOptions circuitBreaker,
+      EncryptionOptions encryption,
+      CallerPrincipalResolver callerPrincipalResolver) {
     this.polling = Objects.requireNonNull(polling, "polling must not be null");
     this.execution = Objects.requireNonNull(execution, "execution must not be null");
     this.node = Objects.requireNonNull(node, "node must not be null");
@@ -104,6 +139,7 @@ public class RatchetOptions {
     this.store = Objects.requireNonNull(store, "store must not be null");
     this.circuitBreaker = Objects.requireNonNull(circuitBreaker, "circuitBreaker must not be null");
     this.encryption = Objects.requireNonNull(encryption, "encryption must not be null");
+    this.callerPrincipalResolver = callerPrincipalResolver;
   }
 
   public static RatchetOptions defaults() {
@@ -267,6 +303,56 @@ public class RatchetOptions {
   @Incubating
   public EncryptionOptions encryption() {
     return encryption;
+  }
+
+  /**
+   * Returns the application-supplied caller-principal resolver, or {@code null} if none is
+   * configured. When {@code null}, caller-principal resolution falls back to {@code
+   * run.ratchet.ri.security.CallerPrincipalProvider} — today's behavior.
+   *
+   * @see CallerPrincipalResolver for the proxy-discipline contract an application MUST follow when
+   *     supplying one.
+   */
+  @Incubating
+  public @Nullable CallerPrincipalResolver callerPrincipalResolver() {
+    return callerPrincipalResolver;
+  }
+
+  /**
+   * Returns a new instance identical to this one except with the caller-principal resolver set to
+   * {@code resolver}. This instance is left unchanged.
+   *
+   * <p>{@link RatchetOptionsFactory#fromEnvironment} returns a finished, immutable {@code
+   * RatchetOptions} rather than a {@link Builder}, so it has no way to accept a resolver — a
+   * resolver is code, not environment-sourced configuration, and cannot travel through the
+   * factory's config-source chain. This method is the attachment point for that case:
+   *
+   * <pre>{@code
+   * RatchetOptionsFactory.fromEnvironment(overlay)
+   *     .withCallerPrincipalResolver(() ->
+   *         currentUser.isSet() ? Optional.of(currentUser.get()) : Optional.empty());
+   * }</pre>
+   *
+   * @see CallerPrincipalResolver for the proxy-discipline contract the supplied resolver MUST
+   *     follow.
+   */
+  @Incubating
+  public RatchetOptions withCallerPrincipalResolver(CallerPrincipalResolver resolver) {
+    return new RatchetOptions(
+        polling,
+        execution,
+        node,
+        recurring,
+        retryBuffer,
+        timeout,
+        maintenance,
+        schema,
+        payload,
+        security,
+        store,
+        circuitBreaker,
+        encryption,
+        resolver);
   }
 
   public enum IsolationCheckMode {
@@ -646,6 +732,7 @@ public class RatchetOptions {
     private final StoreBuilder store = new StoreBuilder();
     private final CircuitBreakerBuilder circuitBreaker = new CircuitBreakerBuilder();
     private final EncryptionBuilder encryption = new EncryptionBuilder();
+    private CallerPrincipalResolver callerPrincipalResolver;
 
     private Builder() {}
 
@@ -716,6 +803,20 @@ public class RatchetOptions {
       return this;
     }
 
+    /**
+     * Sets the application-supplied caller-principal resolver. Leave unset (the default) to resolve
+     * the caller principal via {@code run.ratchet.ri.security.CallerPrincipalProvider} instead —
+     * today's behavior.
+     *
+     * @see CallerPrincipalResolver for the proxy-discipline contract the supplied resolver MUST
+     *     follow.
+     */
+    @Incubating
+    public Builder callerPrincipalResolver(CallerPrincipalResolver callerPrincipalResolver) {
+      this.callerPrincipalResolver = callerPrincipalResolver;
+      return this;
+    }
+
     public RatchetOptions build() {
       return new RatchetOptions(
           polling.build(),
@@ -730,7 +831,8 @@ public class RatchetOptions {
           security.build(),
           store.build(),
           circuitBreaker.build(),
-          encryption.build());
+          encryption.build(),
+          callerPrincipalResolver);
     }
   }
 

--- a/ratchet-api/src/main/java/run/ratchet/spi/CallerPrincipalResolver.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/CallerPrincipalResolver.java
@@ -29,6 +29,21 @@ import run.ratchet.api.Incubating;
  * {@code @Alternative @Priority(APPLICATION) CallerPrincipalProvider} override, so this seam exists
  * as a fallback path that does not depend on CDI alternative resolution at all.
  *
+ * <h2>Authentication mechanism and the default capture</h2>
+ *
+ * <p>The reference default reads {@code jakarta.security.enterprise.SecurityContext}, which a
+ * container registers only when the deployment activates Jakarta Security — an {@code
+ * HttpAuthenticationMechanism}, {@code IdentityStore}, or a
+ * {@code @…AuthenticationMechanismDefinition}. Some integrations authenticate the caller fully
+ * without activating Jakarta Security, so no {@code SecurityContext} bean is registered and the
+ * default capture records no principal even for an authenticated request. WildFly's native Elytron
+ * OIDC ({@code web.xml} {@code auth-method=OIDC} via the {@code elytron-oidc-client} subsystem) is
+ * one such case: {@code HttpServletRequest.getUserPrincipal()} and {@code @RolesAllowed} work, but
+ * {@code SecurityContext} is never resolvable. Under such a mechanism, supply this resolver and
+ * read an identity source the mechanism actually populates — {@code
+ * HttpServletRequest.getUserPrincipal()} or the Elytron {@code SecurityIdentity} — rather than
+ * relying on the default {@code SecurityContext}-based capture.
+ *
  * <h2>Proxy discipline</h2>
  *
  * <p>{@link #resolve()} is invoked per submission or authorization check, but the {@code

--- a/ratchet-api/src/main/java/run/ratchet/spi/CallerPrincipalResolver.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/CallerPrincipalResolver.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.spi;
+
+import java.util.Optional;
+import run.ratchet.api.Incubating;
+
+/**
+ * Application-supplied seam for resolving the current caller principal through configuration the
+ * application already controls, bypassing CDI {@code @Alternative} bean resolution entirely.
+ *
+ * <p>Configured via {@code RatchetOptions.Builder#callerPrincipalResolver}. When set, it takes
+ * precedence over {@code run.ratchet.ri.security.CallerPrincipalProvider} — the reference
+ * implementation's CDI-alternative-based default. Leaving it unset reproduces today's behavior
+ * exactly: some EAR containers silently ignore an application's
+ * {@code @Alternative @Priority(APPLICATION) CallerPrincipalProvider} override, so this seam exists
+ * as a fallback path that does not depend on CDI alternative resolution at all.
+ *
+ * <h2>Proxy discipline</h2>
+ *
+ * <p>{@link #resolve()} is invoked per submission or authorization check, but the {@code
+ * CallerPrincipalResolver} instance itself is captured only <strong>once</strong> — when the
+ * application's {@code @ApplicationScoped RatchetOptions} producer method runs. An application MUST
+ * close this functional interface over a normal-scoped CDI proxy (or call {@code Instance<T>.get()}
+ * from inside {@link #resolve()} on every invocation), and MUST NOT close over a directly-injected
+ * {@code @Dependent} reference. A {@code @Dependent} reference is resolved once, at the moment the
+ * producer method runs, and would freeze whatever principal was live at container start —
+ * reproducing the exact bug this seam exists to fix.
+ *
+ * <p>{@code run.ratchet.ri.security.CallerPrincipalProvider} is the worked example of the correct
+ * pattern: it holds an {@code Instance<SecurityContext>} and calls {@code
+ * Instance.getHandle()}/{@code get()} inside its own {@code currentPrincipal()} method on every
+ * invocation, rather than injecting {@code SecurityContext} directly. An application's resolver
+ * should follow the same shape — inject {@code Instance<MyRequestScopedActor>} into its producer
+ * and call {@code .get()} from inside the lambda passed to {@code callerPrincipalResolver(...)}.
+ */
+@Incubating
+@FunctionalInterface
+public interface CallerPrincipalResolver {
+
+  /**
+   * Resolves the current caller principal.
+   *
+   * <p>May be invoked from a background or materializer thread (chain-step continuation,
+   * workflow-branch creation, batch-child creation) where a request-scoped proxy is not active. In
+   * that situation, prefer returning {@link Optional#empty()}; a thrown {@link RuntimeException} is
+   * also tolerated by the framework's resolution helper, which logs a warning and degrades to
+   * {@link Optional#empty()} rather than failing the submission.
+   *
+   * @return the resolved principal name, or {@link Optional#empty()} if none is available
+   */
+  Optional<String> resolve();
+}

--- a/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
@@ -17,14 +17,18 @@ package run.ratchet.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import run.ratchet.spi.CallerPrincipalResolver;
 
 class RatchetOptionsTest {
 
@@ -209,6 +213,27 @@ class RatchetOptionsTest {
                         circuitBreaker.profile(
                             CircuitBreakerProfile.DEFAULT,
                             profile -> profile.failureRateThreshold(Float.POSITIVE_INFINITY))));
+  }
+
+  @Test
+  void withCallerPrincipalResolverCopiesEveryOtherFieldAndLeavesOriginalUnchanged() {
+    RatchetOptions original =
+        RatchetOptions.builder()
+            .node(node -> node.heartbeatIntervalSeconds(42L))
+            .polling(polling -> polling.batchSize(77))
+            .security(security -> security.maskPayloads(true))
+            .execution(execution -> execution.jobExecutorJndi("java:app/concurrent/CustomExecutor"))
+            .build();
+    CallerPrincipalResolver resolver = () -> Optional.of("test-user");
+
+    RatchetOptions withResolver = original.withCallerPrincipalResolver(resolver);
+
+    assertSame(resolver, withResolver.callerPrincipalResolver());
+    assertEquals(42L, withResolver.node().heartbeatIntervalSeconds());
+    assertEquals(77, withResolver.polling().batchSize());
+    assertTrue(withResolver.security().maskPayloads());
+    assertEquals("java:app/concurrent/CustomExecutor", withResolver.execution().jobExecutorJndi());
+    assertNull(original.callerPrincipalResolver());
   }
 
   @Test

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/SpiBindingLogger.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/SpiBindingLogger.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.cdi;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Initialized;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
+import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.spi.ClassPolicy;
+import run.ratchet.spi.ErrorSanitizer;
+import run.ratchet.spi.ExecutorProvider;
+import run.ratchet.spi.JobAuthorizationPolicy;
+import run.ratchet.spi.MetricsCollector;
+import run.ratchet.spi.NodeIdentityProvider;
+import run.ratchet.spi.PayloadEncryption;
+import run.ratchet.spi.PayloadSerializer;
+import run.ratchet.spi.ResilienceStrategy;
+import run.ratchet.spi.RetryPolicy;
+import run.ratchet.spi.TracingCollector;
+import run.ratchet.store.spi.RatchetEntityManagerProvider;
+
+/**
+ * Logs, at application startup, which implementation actually won CDI resolution for every
+ * application-overridable Ratchet SPI seam.
+ *
+ * <p>An application {@code @Alternative @Priority(APPLICATION)} bean can silently fail to apply
+ * (for example a sibling EAR module the RI's classloader cannot see), and today there is no way to
+ * tell which implementation is actually active short of attaching a debugger. This bean prints one
+ * INFO line naming the resolved class per seam, turning that mis-selection into a log read instead
+ * of a multi-week investigation.
+ *
+ * <p>Resolution problems are caught and recorded as a state string rather than thrown — a
+ * diagnostic must never itself break startup.
+ */
+@ApplicationScoped
+public class SpiBindingLogger {
+
+  private static final Logger log = Logger.getLogger(SpiBindingLogger.class);
+
+  private static final String UNSATISFIED = "<none>";
+  private static final String AMBIGUOUS = "<ambiguous>";
+  private static final String ERROR = "<error>";
+
+  /**
+   * Seams resolved to a single winner. {@link PayloadEncryption} is reported separately below since
+   * several engines may legitimately be installed at once (algorithm rotation), so "the resolved
+   * bean" is not a meaningful question for it. {@code LambdaAnalyzer} is deliberately excluded:
+   * {@code AsmLambdaAnalyzer} is invoked as a static utility ({@code
+   * AsmLambdaAnalyzer.inspect(...)}), never through CDI resolution, so it has no binding to report.
+   */
+  private static final List<Class<?>> SINGLE_RESOLUTION_SEAMS =
+      List.of(
+          CallerPrincipalProvider.class,
+          JobAuthorizationPolicy.class,
+          ClassPolicy.class,
+          RatchetEntityManagerProvider.class,
+          PayloadSerializer.class,
+          ResilienceStrategy.class,
+          ErrorSanitizer.class,
+          MetricsCollector.class,
+          TracingCollector.class,
+          NodeIdentityProvider.class,
+          ExecutorProvider.class,
+          RetryPolicy.class);
+
+  private final BeanManager beanManager;
+
+  /**
+   * No-arg constructor so Weld can instantiate the client-proxy subclass (CDI 4.0 §3.15); never
+   * used for a real instance.
+   */
+  protected SpiBindingLogger() {
+    this.beanManager = null;
+  }
+
+  @Inject
+  public SpiBindingLogger(BeanManager beanManager) {
+    this.beanManager = beanManager;
+  }
+
+  void logBindings(@Observes @Initialized(ApplicationScoped.class) Object event) {
+    if (beanManager == null) {
+      return;
+    }
+    StringBuilder message = new StringBuilder("Ratchet SPI bindings: ");
+    for (int i = 0; i < SINGLE_RESOLUTION_SEAMS.size(); i++) {
+      if (i > 0) {
+        message.append(", ");
+      }
+      Class<?> seam = SINGLE_RESOLUTION_SEAMS.get(i);
+      message.append(seam.getSimpleName()).append('=').append(resolveBinding(seam));
+    }
+    message.append(", PayloadEncryption=").append(resolveEncryptionEngines());
+    log.info(message.toString());
+  }
+
+  /**
+   * Resolves the single bean CDI would hand out for {@code seamType} without instantiating it.
+   * {@link BeanManager#getBeans(java.lang.reflect.Type, java.lang.annotation.Annotation...)} with
+   * no qualifiers implies {@code @Default}, which matches every seam listed above.
+   */
+  private String resolveBinding(Class<?> seamType) {
+    try {
+      Set<Bean<?>> beans = beanManager.getBeans(seamType);
+      if (beans.isEmpty()) {
+        return UNSATISFIED;
+      }
+      Bean<?> winner = beanManager.resolve(beans);
+      return winner.getBeanClass().getName();
+    } catch (AmbiguousResolutionException e) {
+      return AMBIGUOUS;
+    } catch (RuntimeException e) {
+      log.warnf(e, "Failed to resolve SPI binding for %s", seamType.getName());
+      return ERROR;
+    }
+  }
+
+  /**
+   * {@link PayloadEncryption} is a multi-engine seam by design (an old algorithm stays installed to
+   * decrypt not-yet-drained rows during rotation), so every installed engine is reported rather
+   * than a single resolved winner.
+   */
+  private String resolveEncryptionEngines() {
+    try {
+      Set<Bean<?>> beans = beanManager.getBeans(PayloadEncryption.class);
+      if (beans.isEmpty()) {
+        return UNSATISFIED;
+      }
+      return beans.stream()
+          .map(bean -> bean.getBeanClass().getName())
+          .sorted()
+          .collect(Collectors.joining("+"));
+    } catch (RuntimeException e) {
+      log.warnf(e, "Failed to enumerate PayloadEncryption engines");
+      return ERROR;
+    }
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/SpiBindingLogger.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/SpiBindingLogger.java
@@ -19,6 +19,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.context.Initialized;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
@@ -116,13 +117,12 @@ public class SpiBindingLogger {
   }
 
   /**
-   * Resolves the single bean CDI would hand out for {@code seamType} without instantiating it.
-   * {@link BeanManager#getBeans(java.lang.reflect.Type, java.lang.annotation.Annotation...)} with
-   * no qualifiers implies {@code @Default}, which matches every seam listed above.
+   * Resolves the {@code @Default} bean for {@code seamType} without instantiating it, mirroring an
+   * unqualified {@code @Inject} injection point of that seam type.
    */
   private String resolveBinding(Class<?> seamType) {
     try {
-      Set<Bean<?>> beans = beanManager.getBeans(seamType);
+      Set<Bean<?>> beans = beanManager.getBeans(seamType, Default.Literal.INSTANCE);
       if (beans.isEmpty()) {
         return UNSATISFIED;
       }

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -42,6 +42,7 @@ import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobStatus;
 import run.ratchet.api.JobSubmitter;
 import run.ratchet.api.JobType;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.SerializableCheckedRunnable;
 import run.ratchet.api.SerializableFunction;
 import run.ratchet.api.SerializablePredicate;
@@ -57,7 +58,9 @@ import run.ratchet.ri.core.internal.JobWakeupService;
 import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.ri.payload.JobPayloadFactory;
 import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.ri.security.CallerPrincipalResolution;
 import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.spi.CallerPrincipalResolver;
 import run.ratchet.spi.ClassPolicy;
 import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.JobInvocation;
@@ -107,6 +110,7 @@ class DefaultJobCreationService
   private final JobInvocationResolver jobInvocationResolver;
   private final JobPayloadInputValidator payloadValidator;
   private final CallerPrincipalProvider callerPrincipalProvider;
+  private final CallerPrincipalResolver callerPrincipalResolver;
   private final TracingCollector tracingCollector;
   private final JobAuthorizationPolicy authorizationPolicy;
   private final ClassPolicy classPolicy;
@@ -132,6 +136,7 @@ class DefaultJobCreationService
     this.jobInvocationResolver = null;
     this.payloadValidator = null;
     this.callerPrincipalProvider = null;
+    this.callerPrincipalResolver = null;
     this.tracingCollector = null;
     this.authorizationPolicy = null;
     this.classPolicy = null;
@@ -164,7 +169,8 @@ class DefaultJobCreationService
       ClassPolicy classPolicy,
       InternalEventPublisher eventPublisher,
       MetricsCollector metricsCollector,
-      Clock clock) {
+      Clock clock,
+      RatchetOptions options) {
     this(
         jobBatchStatusStore,
         jobTerminalStore,
@@ -186,13 +192,15 @@ class DefaultJobCreationService
         metricsCollector,
         clock,
         signalStore.isResolvable(),
-        resourcePermitStore.isResolvable());
+        resourcePermitStore.isResolvable(),
+        options != null ? options.callerPrincipalResolver() : null);
   }
 
   /**
    * Constructor for tests that supply stores directly. Signal-waiting job creation is permitted
    * (assumes the {@code SignalStore} capability is present); pass through the {@code @Inject}
-   * constructor to model an absent capability.
+   * constructor to model an absent capability. No {@link CallerPrincipalResolver} is configured;
+   * use the overload below to exercise resolver-precedence behavior.
    */
   public DefaultJobCreationService(
       JobBatchStatusStore jobBatchStatusStore,
@@ -234,8 +242,58 @@ class DefaultJobCreationService
         eventPublisher,
         metricsCollector,
         clock,
+        null);
+  }
+
+  /**
+   * Constructor for tests that need an application-supplied {@link CallerPrincipalResolver} in
+   * addition to directly-supplied stores. See the no-resolver overload above for the default
+   * (unconfigured) case.
+   */
+  public DefaultJobCreationService(
+      JobBatchStatusStore jobBatchStatusStore,
+      JobTerminalStore jobTerminalStore,
+      JobCrudStore jobCrudStore,
+      JobBulkStore jobBulkStore,
+      BatchStore batchStore,
+      TagStore tagStore,
+      WorkflowConditionStore workflowConditionStore,
+      RecurringJobStore recurringJobStore,
+      JobWakeupService wakeupService,
+      RecurringScheduler recurringScheduler,
+      JobInvocationResolver jobInvocationResolver,
+      JobPayloadInputValidator payloadValidator,
+      CallerPrincipalProvider callerPrincipalProvider,
+      TracingCollector tracingCollector,
+      JobAuthorizationPolicy authorizationPolicy,
+      ClassPolicy classPolicy,
+      InternalEventPublisher eventPublisher,
+      MetricsCollector metricsCollector,
+      Clock clock,
+      CallerPrincipalResolver callerPrincipalResolver) {
+    this(
+        jobBatchStatusStore,
+        jobTerminalStore,
+        jobCrudStore,
+        jobBulkStore,
+        batchStore,
+        tagStore,
+        workflowConditionStore,
+        recurringJobStore,
+        wakeupService,
+        recurringScheduler,
+        jobInvocationResolver,
+        payloadValidator,
+        callerPrincipalProvider,
+        tracingCollector,
+        authorizationPolicy,
+        classPolicy,
+        eventPublisher,
+        metricsCollector,
+        clock,
         true,
-        true);
+        true,
+        callerPrincipalResolver);
   }
 
   private DefaultJobCreationService(
@@ -259,7 +317,8 @@ class DefaultJobCreationService
       MetricsCollector metricsCollector,
       Clock clock,
       boolean signalCapabilityAvailable,
-      boolean resourcePermitCapabilityAvailable) {
+      boolean resourcePermitCapabilityAvailable,
+      CallerPrincipalResolver callerPrincipalResolver) {
     this.jobBatchStatusStore = jobBatchStatusStore;
     this.jobTerminalStore = jobTerminalStore;
     this.jobCrudStore = jobCrudStore;
@@ -273,6 +332,7 @@ class DefaultJobCreationService
     this.jobInvocationResolver = jobInvocationResolver;
     this.payloadValidator = payloadValidator;
     this.callerPrincipalProvider = callerPrincipalProvider;
+    this.callerPrincipalResolver = callerPrincipalResolver;
     this.tracingCollector = tracingCollector;
     this.authorizationPolicy = authorizationPolicy;
     this.classPolicy = classPolicy;
@@ -790,9 +850,8 @@ class DefaultJobCreationService
   }
 
   private String resolveCallerPrincipal() {
-    return callerPrincipalProvider == null
-        ? null
-        : callerPrincipalProvider.currentPrincipal().orElse(null);
+    return CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+        .orElse(null);
   }
 
   private void applyOptions(JobEntity job, JobOptions opts) {
@@ -1088,10 +1147,8 @@ class DefaultJobCreationService
   }
 
   private void stampCallerPrincipal(JobEntity job) {
-    if (callerPrincipalProvider == null) {
-      return;
-    }
-    callerPrincipalProvider.currentPrincipal().ifPresent(job::setCallerPrincipal);
+    CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+        .ifPresent(job::setCallerPrincipal);
   }
 
   private void checkCreateAuthorization(JobEntity job) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobQueryService.java
@@ -40,7 +40,9 @@ import run.ratchet.api.QueueHealthSnapshot;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.ri.security.CallerPrincipalResolution;
 import run.ratchet.ri.security.PayloadMasker;
+import run.ratchet.spi.CallerPrincipalResolver;
 import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.MaskingContext;
 import run.ratchet.spi.ProtectedSurface;
@@ -71,6 +73,7 @@ class DefaultJobQueryService implements JobQueryService {
   private final Clock clock;
   private final boolean maskPayloads;
   private final JobExtensionStore extensionStore;
+  private final CallerPrincipalResolver callerPrincipalResolver;
 
   protected DefaultJobQueryService() {
     this.queryStore = null;
@@ -83,6 +86,7 @@ class DefaultJobQueryService implements JobQueryService {
     this.clock = null;
     this.maskPayloads = false;
     this.extensionStore = null;
+    this.callerPrincipalResolver = null;
   }
 
   public DefaultJobQueryService(
@@ -194,6 +198,7 @@ class DefaultJobQueryService implements JobQueryService {
     this.clock = clock;
     this.maskPayloads = options != null && options.security().maskPayloads();
     this.extensionStore = extensionStore;
+    this.callerPrincipalResolver = options != null ? options.callerPrincipalResolver() : null;
   }
 
   /**
@@ -544,7 +549,8 @@ class DefaultJobQueryService implements JobQueryService {
   }
 
   private String currentPrincipal() {
-    return principalProvider != null ? principalProvider.currentPrincipal().orElse(null) : null;
+    return CallerPrincipalResolution.resolve(callerPrincipalResolver, principalProvider)
+        .orElse(null);
   }
 
   private Clock effective() {

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobSchedulerService.java
@@ -41,6 +41,7 @@ import run.ratchet.api.JobOptions;
 import run.ratchet.api.JobPriority;
 import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.JobStatus;
+import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.RecurringJobBuilder;
 import run.ratchet.api.SerializableCheckedRunnable;
 import run.ratchet.api.SignalDecision;
@@ -58,6 +59,8 @@ import run.ratchet.ri.core.internal.JobWakeupService;
 import run.ratchet.ri.core.internal.JobWakeupService.AfterCommitRegistrationResult;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.ri.security.CallerPrincipalResolution;
+import run.ratchet.spi.CallerPrincipalResolver;
 import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.JobInvocationResolver;
 import run.ratchet.spi.MetricsCollector;
@@ -108,6 +111,7 @@ public class DefaultJobSchedulerService
   private final JobInvocationResolver jobInvocationResolver;
   private final DefaultJobCreationService jobCreationService;
   private final CallerPrincipalProvider callerPrincipalProvider;
+  private final CallerPrincipalResolver callerPrincipalResolver;
   private final JobAuthorizationPolicy authorizationPolicy;
   private final SignalStore signalStore;
   private final PayloadSerializer payloadSerializer;
@@ -134,6 +138,7 @@ public class DefaultJobSchedulerService
     this.jobInvocationResolver = null;
     this.jobCreationService = null;
     this.callerPrincipalProvider = null;
+    this.callerPrincipalResolver = null;
     this.authorizationPolicy = null;
     this.signalStore = null;
     this.payloadSerializer = null;
@@ -247,7 +252,8 @@ public class DefaultJobSchedulerService
       Instance<SignalStore> signalStore,
       PayloadSerializer payloadSerializer,
       MetricsCollector metricsCollector,
-      Clock clock) {
+      Clock clock,
+      RatchetOptions options) {
     this(
         eventPublisher,
         jobBatchStatusStore,
@@ -268,9 +274,15 @@ public class DefaultJobSchedulerService
         signalStore.isResolvable() ? signalStore.get() : null,
         payloadSerializer,
         metricsCollector,
-        clock);
+        clock,
+        options != null ? options.callerPrincipalResolver() : null);
   }
 
+  /**
+   * Convenience constructor for tests that supply stores directly. No {@link
+   * CallerPrincipalResolver} is configured; use the overload below to exercise resolver-precedence
+   * behavior.
+   */
   DefaultJobSchedulerService(
       InternalEventPublisher eventPublisher,
       JobBatchStatusStore jobBatchStatusStore,
@@ -292,6 +304,57 @@ public class DefaultJobSchedulerService
       PayloadSerializer payloadSerializer,
       MetricsCollector metricsCollector,
       Clock clock) {
+    this(
+        eventPublisher,
+        jobBatchStatusStore,
+        jobPauseStore,
+        jobRetryStore,
+        jobTerminalStore,
+        jobCrudStore,
+        batchStore,
+        tagStore,
+        workflowConditionStore,
+        recurringJobStore,
+        wakeupService,
+        recurringScheduler,
+        jobInvocationResolver,
+        jobCreationService,
+        callerPrincipalProvider,
+        authorizationPolicy,
+        signalStore,
+        payloadSerializer,
+        metricsCollector,
+        clock,
+        null);
+  }
+
+  /**
+   * Full constructor for tests that need an application-supplied {@link CallerPrincipalResolver} in
+   * addition to directly-supplied stores. See the no-resolver overload above for the default
+   * (unconfigured) case.
+   */
+  DefaultJobSchedulerService(
+      InternalEventPublisher eventPublisher,
+      JobBatchStatusStore jobBatchStatusStore,
+      JobPauseStore jobPauseStore,
+      JobRetryStore jobRetryStore,
+      JobTerminalStore jobTerminalStore,
+      JobCrudStore jobCrudStore,
+      BatchStore batchStore,
+      TagStore tagStore,
+      WorkflowConditionStore workflowConditionStore,
+      RecurringJobStore recurringJobStore,
+      JobWakeupService wakeupService,
+      RecurringScheduler recurringScheduler,
+      JobInvocationResolver jobInvocationResolver,
+      DefaultJobCreationService jobCreationService,
+      CallerPrincipalProvider callerPrincipalProvider,
+      JobAuthorizationPolicy authorizationPolicy,
+      SignalStore signalStore,
+      PayloadSerializer payloadSerializer,
+      MetricsCollector metricsCollector,
+      Clock clock,
+      CallerPrincipalResolver callerPrincipalResolver) {
     this.eventPublisher = eventPublisher;
     this.jobBatchStatusStore = jobBatchStatusStore;
     this.jobPauseStore = jobPauseStore;
@@ -307,6 +370,7 @@ public class DefaultJobSchedulerService
     this.jobInvocationResolver = jobInvocationResolver;
     this.jobCreationService = jobCreationService;
     this.callerPrincipalProvider = callerPrincipalProvider;
+    this.callerPrincipalResolver = callerPrincipalResolver;
     this.authorizationPolicy = authorizationPolicy;
     this.signalStore = signalStore;
     this.payloadSerializer = payloadSerializer;
@@ -330,9 +394,8 @@ public class DefaultJobSchedulerService
       // and the CAS below, ownerPrincipal will be null — the policy must tolerate null.
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : recurringOwner;
       String currentPrincipal =
-          callerPrincipalProvider != null
-              ? callerPrincipalProvider.currentPrincipal().orElse(null)
-              : null;
+          CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+              .orElse(null);
       authorizationPolicy.checkCancel(jobId, ownerPrincipal, currentPrincipal);
     }
 
@@ -479,9 +542,8 @@ public class DefaultJobSchedulerService
                 () -> new IllegalArgumentException("Job not found for replacement: " + jobId));
     if (authorizationPolicy != null) {
       String currentPrincipal =
-          callerPrincipalProvider != null
-              ? callerPrincipalProvider.currentPrincipal().orElse(null)
-              : null;
+          CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+              .orElse(null);
       authorizationPolicy.checkCancel(jobId, existing.getCallerPrincipal(), currentPrincipal);
     }
     if (existing.getSupersededBy() != null) {
@@ -546,9 +608,8 @@ public class DefaultJobSchedulerService
     if (recurring.isPresent()) {
       if (authorizationPolicy != null) {
         String currentPrincipal =
-            callerPrincipalProvider != null
-                ? callerPrincipalProvider.currentPrincipal().orElse(null)
-                : null;
+            CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+                .orElse(null);
         authorizationPolicy.checkPause(jobId, recurring.get().callerPrincipal(), currentPrincipal);
       }
       if (recurring.get().paused()) {
@@ -572,9 +633,8 @@ public class DefaultJobSchedulerService
     }
     if (authorizationPolicy != null) {
       String currentPrincipal =
-          callerPrincipalProvider != null
-              ? callerPrincipalProvider.currentPrincipal().orElse(null)
-              : null;
+          CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+              .orElse(null);
       authorizationPolicy.checkPause(jobId, job.getCallerPrincipal(), currentPrincipal);
     }
     JobStatus current = job.getStatus();
@@ -608,9 +668,8 @@ public class DefaultJobSchedulerService
     if (recurring.isPresent()) {
       if (authorizationPolicy != null) {
         String currentPrincipal =
-            callerPrincipalProvider != null
-                ? callerPrincipalProvider.currentPrincipal().orElse(null)
-                : null;
+            CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+                .orElse(null);
         authorizationPolicy.checkResume(jobId, recurring.get().callerPrincipal(), currentPrincipal);
       }
       if (recurringJobStore.resumeRecurring(jobId)) {
@@ -630,9 +689,8 @@ public class DefaultJobSchedulerService
     }
     if (authorizationPolicy != null) {
       String currentPrincipal =
-          callerPrincipalProvider != null
-              ? callerPrincipalProvider.currentPrincipal().orElse(null)
-              : null;
+          CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+              .orElse(null);
       authorizationPolicy.checkResume(jobId, job.getCallerPrincipal(), currentPrincipal);
     }
 
@@ -659,9 +717,8 @@ public class DefaultJobSchedulerService
       // and the CAS below, ownerPrincipal will be null — the policy must tolerate null.
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
       String currentPrincipal =
-          callerPrincipalProvider != null
-              ? callerPrincipalProvider.currentPrincipal().orElse(null)
-              : null;
+          CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+              .orElse(null);
       authorizationPolicy.checkRetry(jobId, ownerPrincipal, currentPrincipal);
     }
 
@@ -997,9 +1054,8 @@ public class DefaultJobSchedulerService
     }
     JobEntity job = jobCrudStore.findById(jobId).orElse(null);
     String principal =
-        callerPrincipalProvider != null
-            ? callerPrincipalProvider.currentPrincipal().orElse(null)
-            : null;
+        CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+            .orElse(null);
     if (authorizationPolicy != null) {
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
       authorizationPolicy.checkDeliverSignal(jobId, ownerPrincipal, principal);
@@ -1033,9 +1089,8 @@ public class DefaultJobSchedulerService
     }
     JobEntity job = jobCrudStore.findById(jobId).orElse(null);
     String principal =
-        callerPrincipalProvider != null
-            ? callerPrincipalProvider.currentPrincipal().orElse(null)
-            : null;
+        CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+            .orElse(null);
     if (authorizationPolicy != null) {
       String ownerPrincipal = job != null ? job.getCallerPrincipal() : null;
       authorizationPolicy.checkDeliverSignal(jobId, ownerPrincipal, principal);
@@ -1070,9 +1125,8 @@ public class DefaultJobSchedulerService
       return 0;
     }
     String principal =
-        callerPrincipalProvider != null
-            ? callerPrincipalProvider.currentPrincipal().orElse(null)
-            : null;
+        CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+            .orElse(null);
     if (authorizationPolicy != null) {
       authorizationPolicy.checkDeliverSignal(signalKey, principal);
     }
@@ -1109,9 +1163,8 @@ public class DefaultJobSchedulerService
       return 0;
     }
     String principal =
-        callerPrincipalProvider != null
-            ? callerPrincipalProvider.currentPrincipal().orElse(null)
-            : null;
+        CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
+            .orElse(null);
     if (authorizationPolicy != null) {
       authorizationPolicy.checkDeliverSignal(signalKey, principal);
     }

--- a/ratchet/src/main/java/run/ratchet/ri/security/CallerPrincipalResolution.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/CallerPrincipalResolution.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.security;
+
+import java.util.Optional;
+import org.jboss.logging.Logger;
+import run.ratchet.spi.CallerPrincipalResolver;
+
+/**
+ * Central precedence rule for caller-principal resolution: an application-supplied {@link
+ * CallerPrincipalResolver} (read from {@code RatchetOptions#callerPrincipalResolver()}) takes
+ * precedence over the CDI-alternative-based {@link CallerPrincipalProvider} default. Every call
+ * site that needs the current caller principal goes through {@link #resolve} rather than
+ * re-implementing this precedence and its safety net inline.
+ */
+public final class CallerPrincipalResolution {
+
+  private static final Logger log = Logger.getLogger(CallerPrincipalResolution.class);
+
+  private CallerPrincipalResolution() {}
+
+  /**
+   * Resolves the current caller principal, preferring {@code optionResolver} when one is
+   * configured.
+   *
+   * <p>{@code optionResolver} may be invoked off a background or materializer thread (chain-step
+   * continuation, workflow-branch creation, batch-child creation) where a request-scoped proxy is
+   * not active and throws (for example {@code ContextNotActiveException}). Any {@link
+   * RuntimeException} it throws — and a {@code null} {@link Optional} return — degrade to {@link
+   * Optional#empty()} here rather than failing the submission or authorization check.
+   *
+   * @param optionResolver the application-supplied resolver from {@code
+   *     RatchetOptions#callerPrincipalResolver()}; may be {@code null} when unconfigured
+   * @param provider the CDI-alternative-based default provider; may be {@code null} in test wiring
+   * @return the resolved principal, or {@link Optional#empty()} if neither source yields one
+   */
+  public static Optional<String> resolve(
+      CallerPrincipalResolver optionResolver, CallerPrincipalProvider provider) {
+    if (optionResolver != null) {
+      try {
+        Optional<String> resolved = optionResolver.resolve();
+        return resolved != null ? resolved : Optional.empty();
+      } catch (RuntimeException e) {
+        log.warnf(e, "CallerPrincipalResolver threw; capturing null caller principal");
+        return Optional.empty();
+      }
+    }
+    return provider != null ? provider.currentPrincipal() : Optional.empty();
+  }
+}

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/SpiBindingLoggerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/SpiBindingLoggerTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.cdi;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.spi.PayloadEncryption;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class SpiBindingLoggerTest {
+
+  @Mock private BeanManager beanManager;
+
+  @Test
+  void nullBeanManager_noArgConstructor_neverLogs() {
+    SpiBindingLogger logger = new SpiBindingLogger();
+
+    CapturingHandler handler = attachHandler();
+    try {
+      logger.logBindings(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    assertTrue(handler.records.isEmpty());
+  }
+
+  @Test
+  void unsatisfiedSeams_areLoggedAsNone() {
+    SpiBindingLogger logger = new SpiBindingLogger(beanManager);
+
+    CapturingHandler handler = attachHandler();
+    try {
+      logger.logBindings(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    String line = handler.onlyMessage();
+    assertTrue(line.startsWith("Ratchet SPI bindings: "), line);
+    assertTrue(line.contains("CallerPrincipalProvider=<none>"), line);
+    assertTrue(line.contains("PayloadEncryption=<none>"), line);
+  }
+
+  @Test
+  void resolvedSeam_logsWinningImplementationClassName() {
+    Bean<?> winner = mockBean(CallerPrincipalProvider.class);
+    Set<Bean<?>> beans = Set.of(winner);
+    doReturn(beans).when(beanManager).getBeans(CallerPrincipalProvider.class);
+    doReturn(winner).when(beanManager).resolve(beans);
+
+    SpiBindingLogger logger = new SpiBindingLogger(beanManager);
+    CapturingHandler handler = attachHandler();
+    try {
+      logger.logBindings(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    assertTrue(
+        handler
+            .onlyMessage()
+            .contains("CallerPrincipalProvider=run.ratchet.ri.security.CallerPrincipalProvider"));
+  }
+
+  @Test
+  void ambiguousSeam_logsAmbiguousMarker() {
+    Set<Bean<?>> beans = Set.of(mockBean(CallerPrincipalProvider.class), mockBean(Object.class));
+    doReturn(beans).when(beanManager).getBeans(CallerPrincipalProvider.class);
+    doThrow(new AmbiguousResolutionException("two beans")).when(beanManager).resolve(beans);
+
+    SpiBindingLogger logger = new SpiBindingLogger(beanManager);
+    CapturingHandler handler = attachHandler();
+    try {
+      logger.logBindings(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    assertTrue(handler.onlyMessage().contains("CallerPrincipalProvider=<ambiguous>"));
+  }
+
+  @Test
+  void resolutionFailure_isCaught_andRecordedAsError() {
+    doThrow(new IllegalStateException("boom"))
+        .when(beanManager)
+        .getBeans(CallerPrincipalProvider.class);
+
+    SpiBindingLogger logger = new SpiBindingLogger(beanManager);
+    CapturingHandler handler = attachHandler();
+    try {
+      logger.logBindings(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    assertTrue(handler.onlyMessage().contains("CallerPrincipalProvider=<error>"));
+  }
+
+  @Test
+  void payloadEncryption_listsEveryInstalledEngine_sortedByClassName() {
+    Set<Bean<?>> beans = Set.of(mockBean(EngineB.class), mockBean(EngineA.class));
+    doReturn(beans).when(beanManager).getBeans(PayloadEncryption.class);
+
+    SpiBindingLogger logger = new SpiBindingLogger(beanManager);
+    CapturingHandler handler = attachHandler();
+    try {
+      logger.logBindings(new Object());
+    } finally {
+      detachHandler(handler);
+    }
+
+    assertTrue(
+        handler
+            .onlyMessage()
+            .contains(
+                "PayloadEncryption=" + EngineA.class.getName() + "+" + EngineB.class.getName()));
+  }
+
+  private static Bean<?> mockBean(Class<?> beanClass) {
+    Bean<?> bean = mock(Bean.class);
+    doReturn(beanClass).when(bean).getBeanClass();
+    return bean;
+  }
+
+  private static CapturingHandler attachHandler() {
+    Logger logger = Logger.getLogger(SpiBindingLogger.class.getName());
+    logger.setLevel(Level.ALL);
+    CapturingHandler handler = new CapturingHandler();
+    logger.addHandler(handler);
+    return handler;
+  }
+
+  private static void detachHandler(CapturingHandler handler) {
+    Logger.getLogger(SpiBindingLogger.class.getName()).removeHandler(handler);
+  }
+
+  /** Collects log records so a test can assert on the single emitted line. */
+  private static final class CapturingHandler extends Handler {
+    private final CopyOnWriteArrayList<LogRecord> records = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+      records.add(record);
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() {}
+
+    /**
+     * Returns the single "Ratchet SPI bindings: ..." summary line, ignoring any WARN records the
+     * failure-path tests also trigger on this same logger.
+     */
+    String onlyMessage() {
+      var summaryLines =
+          records.stream()
+              .map(LogRecord::getMessage)
+              .filter(m -> m.startsWith("Ratchet SPI bindings: "))
+              .toList();
+      assertEquals(1, summaryLines.size());
+      return summaryLines.get(0);
+    }
+  }
+
+  /** Marker type standing in for an installed encryption engine's bean class. */
+  private static final class EngineA {}
+
+  /** Marker type standing in for a second installed encryption engine's bean class. */
+  private static final class EngineB {}
+}

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/SpiBindingLoggerTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/SpiBindingLoggerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import java.util.Set;
@@ -80,7 +81,9 @@ class SpiBindingLoggerTest {
   void resolvedSeam_logsWinningImplementationClassName() {
     Bean<?> winner = mockBean(CallerPrincipalProvider.class);
     Set<Bean<?>> beans = Set.of(winner);
-    doReturn(beans).when(beanManager).getBeans(CallerPrincipalProvider.class);
+    doReturn(beans)
+        .when(beanManager)
+        .getBeans(CallerPrincipalProvider.class, Default.Literal.INSTANCE);
     doReturn(winner).when(beanManager).resolve(beans);
 
     SpiBindingLogger logger = new SpiBindingLogger(beanManager);
@@ -100,7 +103,9 @@ class SpiBindingLoggerTest {
   @Test
   void ambiguousSeam_logsAmbiguousMarker() {
     Set<Bean<?>> beans = Set.of(mockBean(CallerPrincipalProvider.class), mockBean(Object.class));
-    doReturn(beans).when(beanManager).getBeans(CallerPrincipalProvider.class);
+    doReturn(beans)
+        .when(beanManager)
+        .getBeans(CallerPrincipalProvider.class, Default.Literal.INSTANCE);
     doThrow(new AmbiguousResolutionException("two beans")).when(beanManager).resolve(beans);
 
     SpiBindingLogger logger = new SpiBindingLogger(beanManager);
@@ -118,7 +123,7 @@ class SpiBindingLoggerTest {
   void resolutionFailure_isCaught_andRecordedAsError() {
     doThrow(new IllegalStateException("boom"))
         .when(beanManager)
-        .getBeans(CallerPrincipalProvider.class);
+        .getBeans(CallerPrincipalProvider.class, Default.Literal.INSTANCE);
 
     SpiBindingLogger logger = new SpiBindingLogger(beanManager);
     CapturingHandler handler = attachHandler();

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
@@ -59,6 +59,7 @@ import run.ratchet.ri.core.internal.JobWakeupService;
 import run.ratchet.ri.payload.DefaultJobInvocationResolver;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.ri.security.JobPayloadInputValidator;
+import run.ratchet.spi.CallerPrincipalResolver;
 import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.MetricsCollector;
 import run.ratchet.spi.TracingCollector;
@@ -160,6 +161,31 @@ class DefaultJobCreationServiceAuthorizationTest {
         eventPublisher,
         metricsCollector,
         clock);
+  }
+
+  private DefaultJobCreationService serviceWithResolver(
+      CallerPrincipalProvider principalProvider, CallerPrincipalResolver callerPrincipalResolver) {
+    return new DefaultJobCreationService(
+        jobBatchStatusStore,
+        jobTerminalStore,
+        jobCrudStore,
+        jobBulkStore,
+        batchStore,
+        tagStore,
+        workflowConditionStore,
+        recurringJobStore,
+        wakeupService,
+        recurringScheduler,
+        new DefaultJobInvocationResolver(),
+        new JobPayloadInputValidator(),
+        principalProvider,
+        tracingCollector,
+        authorizationPolicy,
+        null,
+        eventPublisher,
+        metricsCollector,
+        Clock.systemUTC(),
+        callerPrincipalResolver);
   }
 
   private DefaultJobCreationService serviceWithoutAuthorizationPolicy() {
@@ -324,6 +350,61 @@ class DefaultJobCreationServiceAuthorizationTest {
     verify(jobCrudStore).create(jobCaptor.capture());
     verify(authorizationPolicy).checkCreate(any(UUID.class), isNull());
     assertNull(jobCaptor.getValue().getCallerPrincipal());
+  }
+
+  @Test
+  void checkCreate_configuredResolverTakesPrecedenceOverProvider() {
+    DefaultJobCreationService resolverService =
+        serviceWithResolver(
+            principalProviderReturning("provider-principal"),
+            () -> Optional.of("resolver-principal"));
+
+    JobEntity saved = savedEntity();
+    when(jobCrudStore.findByIdempotencyKey(anyString())).thenReturn(Optional.empty());
+    when(jobCrudStore.create(any(JobEntity.class))).thenReturn(saved);
+
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                resolverService,
+                DefaultJobCreationServiceAuthorizationTest::noopTask,
+                Duration.ZERO);
+
+    resolverService.submit(builder);
+
+    ArgumentCaptor<JobEntity> jobCaptor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).create(jobCaptor.capture());
+    assertEquals("resolver-principal", jobCaptor.getValue().getCallerPrincipal());
+    verify(authorizationPolicy).checkCreate(any(UUID.class), Mockito.eq("resolver-principal"));
+  }
+
+  @Test
+  void checkCreate_throwingResolverDegradesToNullPrincipal_doesNotFailSubmission() {
+    DefaultJobCreationService resolverService =
+        serviceWithResolver(
+            principalProviderReturning("provider-principal"),
+            () -> {
+              throw new IllegalStateException("ContextNotActiveException-like failure");
+            });
+
+    JobEntity saved = savedEntity();
+    when(jobCrudStore.findByIdempotencyKey(anyString())).thenReturn(Optional.empty());
+    when(jobCrudStore.create(any(JobEntity.class))).thenReturn(saved);
+
+    DefaultJobBuilder builder =
+        (DefaultJobBuilder)
+            DefaultJobBuilder.create(
+                resolverService,
+                DefaultJobCreationServiceAuthorizationTest::noopTask,
+                Duration.ZERO);
+
+    JobHandle handle = resolverService.submit(builder);
+
+    assertNotNull(handle, "A throwing resolver must not fail submission");
+    ArgumentCaptor<JobEntity> jobCaptor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).create(jobCaptor.capture());
+    assertNull(jobCaptor.getValue().getCallerPrincipal());
+    verify(authorizationPolicy).checkCreate(any(UUID.class), isNull());
   }
 
   // ---- recurring job ----

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceAuthorizationTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
@@ -43,6 +44,7 @@ import run.ratchet.api.exception.JobAuthorizationException;
 import run.ratchet.ri.core.internal.InternalEventPublisher;
 import run.ratchet.ri.core.internal.JobWakeupService;
 import run.ratchet.ri.security.CallerPrincipalProvider;
+import run.ratchet.spi.CallerPrincipalResolver;
 import run.ratchet.spi.JobAuthorizationPolicy;
 import run.ratchet.spi.JobInvocationResolver;
 import run.ratchet.store.entity.JobEntity;
@@ -137,6 +139,76 @@ class DefaultJobSchedulerServiceAuthorizationTest {
     service.cancelJob(JOB_ID);
 
     verify(authorizationPolicy).checkCancel(eq(JOB_ID), eq(OWNER), eq(CALLER));
+  }
+
+  private DefaultJobSchedulerService serviceWithResolver(
+      CallerPrincipalProvider principalProvider, CallerPrincipalResolver callerPrincipalResolver) {
+    return new DefaultJobSchedulerService(
+        eventPublisher,
+        jobBatchStatusStore,
+        jobPauseStore,
+        jobRetryStore,
+        jobTerminalStore,
+        jobCrudStore,
+        batchStore,
+        tagStore,
+        workflowConditionStore,
+        recurringJobStore,
+        wakeupService,
+        recurringScheduler,
+        jobInvocationResolver,
+        jobCreationService,
+        principalProvider,
+        authorizationPolicy,
+        null,
+        null,
+        null,
+        Clock.systemUTC(),
+        callerPrincipalResolver);
+  }
+
+  @Test
+  void cancelJob_configuredResolverTakesPrecedenceOverProvider() {
+    DefaultJobSchedulerService resolverService =
+        serviceWithResolver(
+            new CallerPrincipalProvider(null) {
+              @Override
+              public Optional<String> currentPrincipal() {
+                return Optional.of(CALLER);
+              }
+            },
+            () -> Optional.of("resolver-caller"));
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(ownerJob()));
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), eq(JobStatus.PENDING), eq(JobStatus.CANCELED), any()))
+        .thenReturn(true);
+
+    resolverService.cancelJob(JOB_ID);
+
+    verify(authorizationPolicy).checkCancel(eq(JOB_ID), eq(OWNER), eq("resolver-caller"));
+  }
+
+  @Test
+  void cancelJob_throwingResolverDegradesToNullCurrentPrincipal() {
+    DefaultJobSchedulerService resolverService =
+        serviceWithResolver(
+            new CallerPrincipalProvider(null) {
+              @Override
+              public Optional<String> currentPrincipal() {
+                return Optional.of(CALLER);
+              }
+            },
+            () -> {
+              throw new IllegalStateException("ContextNotActiveException-like failure");
+            });
+    when(jobCrudStore.findById(JOB_ID)).thenReturn(Optional.of(ownerJob()));
+    when(jobBatchStatusStore.compareAndSwapStatus(
+            eq(JOB_ID), eq(JobStatus.PENDING), eq(JobStatus.CANCELED), any()))
+        .thenReturn(true);
+
+    resolverService.cancelJob(JOB_ID);
+
+    verify(authorizationPolicy).checkCancel(eq(JOB_ID), eq(OWNER), eq(null));
   }
 
   // ---- pauseJob ----

--- a/ratchet/src/test/java/run/ratchet/ri/security/CallerPrincipalResolutionTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/security/CallerPrincipalResolutionTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.ri.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class CallerPrincipalResolutionTest {
+
+  @Test
+  void resolve_resolverPresent_takesPrecedenceOverProvider() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
+
+    Optional<String> result =
+        CallerPrincipalResolution.resolve(() -> Optional.of("resolver-principal"), provider);
+
+    assertEquals(Optional.of("resolver-principal"), result);
+    verify(provider, never()).currentPrincipal();
+  }
+
+  @Test
+  void resolve_resolverThrows_degradesToEmptyWithoutConsultingProvider() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+
+    Optional<String> result =
+        CallerPrincipalResolution.resolve(
+            () -> {
+              throw new IllegalStateException("ContextNotActiveException-like failure");
+            },
+            provider);
+
+    assertTrue(result.isEmpty(), "A throwing resolver must degrade to empty, not propagate");
+    verify(provider, never()).currentPrincipal();
+  }
+
+  @Test
+  void resolve_resolverReturnsNullOptional_isTreatedAsEmpty() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+
+    Optional<String> result = CallerPrincipalResolution.resolve(() -> null, provider);
+
+    assertTrue(result.isEmpty(), "A resolver returning a null Optional must be treated as empty");
+    verify(provider, never()).currentPrincipal();
+  }
+
+  @Test
+  void resolve_resolverNull_fallsBackToProvider() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
+
+    Optional<String> result = CallerPrincipalResolution.resolve(null, provider);
+
+    assertEquals(Optional.of("provider-principal"), result);
+  }
+
+  @Test
+  void resolve_resolverAndProviderNull_yieldsEmpty() {
+    Optional<String> result = CallerPrincipalResolution.resolve(null, null);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void resolve_resolverNullAndProviderEmpty_yieldsEmpty() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.empty());
+
+    Optional<String> result = CallerPrincipalResolution.resolve(null, provider);
+
+    assertTrue(result.isEmpty());
+  }
+}

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/EjbModuleCallerPrincipalProvider.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/EjbModuleCallerPrincipalProvider.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.interceptor.Interceptor.Priority;
+import java.util.Optional;
+import run.ratchet.ri.security.CallerPrincipalProvider;
+
+/**
+ * {@link CallerPrincipalProvider} {@code @Alternative} packaged in an EJB-jar subdeployment
+ * (mirroring the {@code nets-ejb} module) rather than in {@code EAR/lib}, to verify whether an
+ * application-level alternative declared in a subdeployment reaches Ratchet's injection points when
+ * Ratchet itself is deployed from {@code EAR/lib}.
+ */
+@Alternative
+@jakarta.annotation.Priority(Priority.APPLICATION)
+@ApplicationScoped
+public class EjbModuleCallerPrincipalProvider extends CallerPrincipalProvider {
+
+  public static final String STUB_PRINCIPAL = "ejb-module-caller";
+
+  public EjbModuleCallerPrincipalProvider() {
+    super();
+  }
+
+  @Override
+  public Optional<String> currentPrincipal() {
+    return Optional.of(STUB_PRINCIPAL);
+  }
+}

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/EjbModuleMarkerBean.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/EjbModuleMarkerBean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import jakarta.ejb.Singleton;
+
+/**
+ * Trivial {@code @Singleton} session bean whose only purpose is to make its jar a genuine EJB
+ * module, mirroring the {@code nets-ejb} subdeployment. An ejb-jar with no session beans is an edge
+ * case some containers handle differently, so this bean keeps the subdeployment realistic.
+ */
+@Singleton
+public class EjbModuleMarkerBean {
+
+  public void noop() {}
+}

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/ear/EarEjbSubmoduleOverrideIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/ear/EarEjbSubmoduleOverrideIT.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.ear;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.Testable;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobHandle;
+import run.ratchet.store.entity.JobEntity;
+import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.app.DocumentStorePerformanceTestHelper;
+import run.ratchet.testsuite.app.DocumentStoreTestCleanupStrategy;
+import run.ratchet.testsuite.app.DocumentStoreTestDataManipulator;
+import run.ratchet.testsuite.app.EjbModuleCallerPrincipalProvider;
+import run.ratchet.testsuite.app.EjbModuleMarkerBean;
+import run.ratchet.testsuite.app.JpaPerformanceTestHelper;
+import run.ratchet.testsuite.app.JpaTestCleanupStrategy;
+import run.ratchet.testsuite.app.JpaTestDataManipulator;
+import run.ratchet.testsuite.app.PerformanceTestHelper;
+import run.ratchet.testsuite.app.SimpleJob;
+import run.ratchet.testsuite.app.SqlDialectTestSupportProvider;
+import run.ratchet.testsuite.app.TestCleanupStrategy;
+import run.ratchet.testsuite.app.TestDataManipulator;
+import run.ratchet.testsuite.app.TestEntityManagerProvider;
+import run.ratchet.testsuite.app.TestJobService;
+import run.ratchet.testsuite.app.TestMongoProducer;
+import run.ratchet.testsuite.app.TestRatchetOptionsProducer;
+import run.ratchet.testsuite.app.TestRuntimeConfig;
+import run.ratchet.testsuite.infra.JdbcContainerExtension;
+import run.ratchet.testsuite.util.BaseRatchetIT;
+import run.ratchet.testsuite.util.DataSourceStrategy;
+import run.ratchet.testsuite.util.DataSourceStrategyFactory;
+import run.ratchet.testsuite.util.GlassFishDataSourceStrategy;
+import run.ratchet.testsuite.util.JobAssertions;
+import run.ratchet.testsuite.util.PayaraDataSourceStrategy;
+import run.ratchet.testsuite.util.PollerControl;
+import run.ratchet.testsuite.util.RatchetArchiveBuilder;
+import run.ratchet.testsuite.util.TestClassPolicy;
+
+/**
+ * Documents that a {@code CallerPrincipalProvider} {@code @Alternative} override packaged in a
+ * separate EJB-jar subdeployment — mirroring the {@code nets-ejb} module — rather than alongside
+ * Ratchet in {@code EAR/lib}, is honored only on WildFly-family servers and Open Liberty, and NOT
+ * on Payara or GlassFish.
+ *
+ * <p>The EAR deploys and the job reaches {@code COMPLETED} identically on all five managed servers;
+ * only visibility of the subdeployment {@code @Alternative} differs:
+ *
+ * <ul>
+ *   <li>Honored ({@code JobEntity.getCallerPrincipal()} equals {@link
+ *       EjbModuleCallerPrincipalProvider#STUB_PRINCIPAL}): {@code wildfly-managed}, {@code
+ *       wildfly-ee11-managed}, {@code openliberty-managed}.
+ *   <li>Not honored ({@code JobEntity.getCallerPrincipal()} is {@code null} — the default
+ *       provider's result in this unauthenticated test context): {@code payara-managed}, {@code
+ *       glassfish-managed}.
+ * </ul>
+ *
+ * <p>This is spec-compliant, not a Ratchet defect: a subdeployment {@code @Alternative} is not
+ * guaranteed visible to Ratchet's EAR/lib injection points, and Payara/GlassFish's stricter Weld
+ * resolution does not expose it there. Portable code should either package {@code
+ * CallerPrincipalProvider} overrides in {@code EAR/lib} alongside Ratchet — see {@link
+ * run.ratchet.testsuite.security.EarCallerPrincipalCaptureIT}, green on all servers — or use {@code
+ * RatchetOptions.withCallerPrincipalResolver} / the {@code CallerPrincipalResolver} seam, which
+ * bypasses CDI {@code @Alternative} resolution entirely.
+ */
+class EarEjbSubmoduleOverrideIT extends BaseRatchetIT {
+
+  /**
+   * Server profiles on which a subdeployment {@code @Alternative} override is empirically honored.
+   * Measured against a live 5-server run (mysql); see class Javadoc.
+   */
+  private static final Set<String> SUBMODULE_ALTERNATIVE_HONORING_PROFILES =
+      Set.of("wildfly-managed", "wildfly-ee11-managed", "openliberty-managed");
+
+  @Inject private TestJobService jobService;
+
+  @Inject private JobCrudStore jobCrudStore;
+
+  @Deployment
+  public static EnterpriseArchive createDeployment() {
+    String dbType = System.getProperty("ratchet.test.db.type", "mysql");
+    String profile = System.getProperty("testsuite.profile", "wildfly-managed");
+    DataSourceStrategy strategy = DataSourceStrategyFactory.create();
+    boolean sql = !"mongodb".equals(dbType);
+    boolean earLevelDataSource =
+        sql
+            && (strategy instanceof PayaraDataSourceStrategy
+                || strategy instanceof GlassFishDataSourceStrategy);
+
+    Map<String, String> executorOverrides =
+        profile.startsWith("wildfly")
+            ? Map.of(
+                "ratchet.worker.job-executor-jndi",
+                "java:jboss/ee/concurrency/executor/default",
+                "ratchet.worker.scheduled-executor-jndi",
+                "java:jboss/ee/concurrency/scheduler/default",
+                "ratchet.coordinator.thread-factory-jndi",
+                "java:jboss/ee/concurrency/factory/default")
+            : Map.of();
+
+    // EAR/lib support jar carries only the config producers and runtime props. The
+    // CallerPrincipalProvider override deliberately does NOT live here — it is isolated in the
+    // ejb-jar subdeployment below.
+    JavaArchive supportJar =
+        ShrinkWrap.create(JavaArchive.class, "ejb-submodule-support.jar")
+            .addClasses(
+                SimpleJob.class,
+                TestRatchetOptionsProducer.class,
+                TestRuntimeConfig.class,
+                TestClassPolicy.class)
+            // Ratchet's EAR-level startup observers run outside any component namespace. On
+            // WildFly, java:comp/* therefore does not resolve, so the global
+            // java:jboss/ee/concurrency/* bindings are required. Other Jakarta EE 10+ containers
+            // (Payara, GlassFish, and Open Liberty) bind the portable
+            // java:comp/DefaultManagedExecutorService and
+            // java:comp/DefaultManagedScheduledExecutorService names even for EAR-level observers,
+            // so an empty override map lets DefaultExecutorProvider use the RI defaults there.
+            .addAsResource(
+                new StringAsset(
+                    RatchetArchiveBuilder.testRuntimeConfigContent(dbType, executorOverrides)),
+                "ratchet-testsuite.properties")
+            .addAsManifestResource(new StringAsset(allModeBeansXml()), "beans.xml");
+
+    JavaArchive persistenceUnitJar = null;
+    if (sql) {
+      supportJar.addClass(TestEntityManagerProvider.class);
+      persistenceUnitJar =
+          ShrinkWrap.create(JavaArchive.class, "ejb-submodule-pu.jar")
+              .addAsManifestResource(
+                  new StringAsset(
+                      RatchetArchiveBuilder.persistenceXmlContent(
+                          dbType, strategy.jtaDataSourceName())),
+                  "persistence.xml");
+    } else {
+      supportJar.addClass(TestMongoProducer.class);
+    }
+
+    // The override lives ONLY in this EJB-jar subdeployment, never in EAR/lib. A trivial
+    // @Singleton bean makes the jar a genuine ejb-jar, mirroring the nets-ejb module.
+    JavaArchive overrideEjbJar =
+        ShrinkWrap.create(JavaArchive.class, "override-ejb.jar")
+            .addClasses(EjbModuleCallerPrincipalProvider.class, EjbModuleMarkerBean.class)
+            .addAsManifestResource(new StringAsset(allModeBeansXml()), "beans.xml");
+
+    WebArchive war =
+        ShrinkWrap.create(WebArchive.class, "ejb-submodule-test.war")
+            .addClasses(
+                EarEjbSubmoduleOverrideIT.class,
+                TestJobService.class,
+                BaseRatchetIT.class,
+                JobAssertions.class,
+                PollerControl.class,
+                TestCleanupStrategy.class,
+                TestDataManipulator.class,
+                PerformanceTestHelper.class)
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+
+    if (sql) {
+      war.addClasses(
+          JpaTestCleanupStrategy.class,
+          JpaTestDataManipulator.class,
+          JpaPerformanceTestHelper.class,
+          SqlDialectTestSupportProvider.class);
+      RatchetArchiveBuilder warBuilder =
+          RatchetArchiveBuilder.forArchive(war).addSqlDialectTestSupport();
+      if (!earLevelDataSource) {
+        warBuilder.addDataSource(strategy);
+      }
+    } else {
+      war.addClasses(
+          DocumentStoreTestCleanupStrategy.class,
+          DocumentStoreTestDataManipulator.class,
+          DocumentStorePerformanceTestHelper.class);
+    }
+
+    EnterpriseArchive ear =
+        ShrinkWrap.create(EnterpriseArchive.class, "ejb-submodule-override.ear")
+            .addAsLibraries(RatchetArchiveBuilder.ratchetDependencyFiles(profile, dbType))
+            .addAsLibraries(RatchetArchiveBuilder.awaitilityFiles())
+            .addAsLibraries(supportJar)
+            .addAsModule(overrideEjbJar)
+            .addAsModule(Testable.archiveToTest(war))
+            .addAsManifestResource(new StringAsset(applicationXmlContent()), "application.xml");
+
+    if (persistenceUnitJar != null) {
+      ear.addAsLibraries(persistenceUnitJar);
+    }
+
+    if (earLevelDataSource) {
+      strategy.configureEnterpriseArchive(ear, JdbcContainerExtension.getConfig());
+    }
+
+    return ear;
+  }
+
+  @BeforeEach
+  void resetSimpleJobCount() {
+    SimpleJob.resetCount();
+  }
+
+  private static boolean honorsSubmoduleAlternative() {
+    String profile = System.getProperty("testsuite.profile", "wildfly-managed");
+    return SUBMODULE_ALTERNATIVE_HONORING_PROFILES.contains(profile);
+  }
+
+  @Test
+  void scheduledJob_honorsEjbSubmoduleAlternativeOnlySupportedServers() {
+    boolean honored = honorsSubmoduleAlternative();
+
+    JobHandle handle = jobService.schedule(Duration.ofSeconds(2), SimpleJob::execute).submit();
+
+    assertNotNull(handle);
+    JobEntity beforeExecution =
+        jobCrudStore
+            .findById(handle.id())
+            .orElseThrow(() -> new AssertionError("Job not found after submit"));
+
+    if (honored) {
+      assertEquals(
+          EjbModuleCallerPrincipalProvider.STUB_PRINCIPAL,
+          beforeExecution.getCallerPrincipal(),
+          "Framework MUST persist the principal returned by the EJB-jar subdeployment "
+              + "alternative on servers that honor it");
+    } else {
+      assertNull(
+          beforeExecution.getCallerPrincipal(),
+          "Server does not honor a subdeployment @Alternative; the default provider must yield "
+              + "no principal in this unauthenticated test context");
+    }
+
+    JobAssertions.assertJobCompleted(jobCrudStore, handle);
+
+    JobEntity afterExecution =
+        jobCrudStore
+            .findById(handle.id())
+            .orElseThrow(() -> new AssertionError("Job not found after completion"));
+
+    assertEquals(
+        beforeExecution.getCallerPrincipal(),
+        afterExecution.getCallerPrincipal(),
+        "Execution must not overwrite the caller principal stamped at job creation");
+  }
+
+  private static String allModeBeansXml() {
+    return """
+        <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                   https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+               version="4.0"
+               bean-discovery-mode="all">
+        </beans>
+        """;
+  }
+
+  private static String applicationXmlContent() {
+    return """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                         https://jakarta.ee/xml/ns/jakartaee/application_10.xsd"
+                     version="10">
+          <module>
+            <web>
+              <web-uri>ejb-submodule-test.war</web-uri>
+              <context-root>/ejb-submodule-test</context-root>
+            </web>
+          </module>
+          <module>
+            <ejb>override-ejb.jar</ejb>
+          </module>
+        </application>
+        """;
+  }
+}

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -325,7 +325,7 @@ public class AppClassPolicy implements ClassPolicy {
 
 ## Caller principal resolution
 
-By default, Ratchet captures the caller principal through `CallerPrincipalProvider`, a CDI bean resolved via `Instance<SecurityContext>`. Applications override the default by supplying an `@Alternative @Priority(APPLICATION) CallerPrincipalProvider` bean.
+By default, Ratchet captures the caller principal through `CallerPrincipalProvider`, a CDI bean that reads `jakarta.security.enterprise.SecurityContext` through an injected `Instance<SecurityContext>`. Applications override the default by supplying an `@Alternative @Priority(APPLICATION) CallerPrincipalProvider` bean.
 
 CDI `@Alternative` visibility can vary by container and deployment topology. An override packaged in `EAR/lib` alongside Ratchet is broadly honored, but the same override packaged in a separate subdeployment (an EJB-jar, for example) is not guaranteed visible to Ratchet's injection points on every container — WildFly-family servers and Open Liberty honor a subdeployment `@Alternative`, while Payara and GlassFish do not.
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -329,6 +329,12 @@ By default, Ratchet captures the caller principal through `CallerPrincipalProvid
 
 CDI `@Alternative` visibility can vary by container and deployment topology. An override packaged in `EAR/lib` alongside Ratchet is broadly honored, but the same override packaged in a separate subdeployment (an EJB-jar, for example) is not guaranteed visible to Ratchet's injection points on every container — WildFly-family servers and Open Liberty honor a subdeployment `@Alternative`, while Payara and GlassFish do not.
 
+### Caller capture and the authentication mechanism
+
+The default `CallerPrincipalProvider` reads `jakarta.security.enterprise.SecurityContext`, which a container registers only when the deployment activates **Jakarta Security** — an `HttpAuthenticationMechanism`, `IdentityStore`, or a `@…AuthenticationMechanismDefinition`. Some authentication integrations fully authenticate the caller without activating Jakarta Security, so `SecurityContext` is never registered and the default capture records **no principal even for an authenticated caller**. WildFly's native Elytron OIDC (`web.xml` `auth-method=OIDC` via the `elytron-oidc-client` subsystem) is one such case: `HttpServletRequest.getUserPrincipal()` and `@RolesAllowed` work normally, but `SecurityContext` is not resolvable.
+
+If your deployment authenticates through a mechanism like this, use the `CallerPrincipalResolver` seam below and read an identity source your mechanism populates — `HttpServletRequest.getUserPrincipal()` or the Elytron `SecurityIdentity` — instead of relying on the default `SecurityContext`-based capture.
+
 For applications that want to supply the caller principal without relying on a CDI `@Alternative` override at all, `RatchetOptions` exposes a second, independent path:
 
 ```java

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -323,6 +323,68 @@ public class AppClassPolicy implements ClassPolicy {
 | `RatchetEntityManagerProvider` | Store default provider | Specific SQL persistence unit |
 | `NodeIdentityProvider` | Hostname-based with heartbeat | Cloud-specific node identity |
 
+## Caller principal resolution
+
+By default, Ratchet captures the caller principal through `CallerPrincipalProvider`, a CDI bean resolved via `Instance<SecurityContext>`. Applications override the default by supplying an `@Alternative @Priority(APPLICATION) CallerPrincipalProvider` bean.
+
+CDI `@Alternative` visibility can vary by container and deployment topology. An override packaged in `EAR/lib` alongside Ratchet is broadly honored, but the same override packaged in a separate subdeployment (an EJB-jar, for example) is not guaranteed visible to Ratchet's injection points on every container — WildFly-family servers and Open Liberty honor a subdeployment `@Alternative`, while Payara and GlassFish do not.
+
+For applications that want to supply the caller principal without relying on a CDI `@Alternative` override at all, `RatchetOptions` exposes a second, independent path:
+
+```java
+@FunctionalInterface
+public interface CallerPrincipalResolver {
+    Optional<String> resolve();
+}
+```
+
+Configure it through the builder:
+
+```java
+RatchetOptions.builder()
+    .callerPrincipalResolver(myResolver)
+    .build();
+```
+
+When configured, it takes precedence over `CallerPrincipalProvider` at every call site. Leaving it unset (the default) preserves the CDI-based resolution described above.
+
+If your producer builds `RatchetOptions` through `RatchetOptionsFactory.fromEnvironment(...)` instead of the builder, attach the resolver afterward with `withCallerPrincipalResolver`, since `fromEnvironment` returns a finished instance rather than a `Builder`:
+
+```java
+RatchetOptionsFactory.fromEnvironment(overlay)
+    .withCallerPrincipalResolver(() ->
+        currentUser.isSet() ? Optional.of(currentUser.get()) : Optional.empty());
+```
+
+### Proxy discipline
+
+`resolve()` is called once per job submission, cancellation, pause, resume, retry, signal delivery, or read — but the `CallerPrincipalResolver` instance itself is captured only **once**, when your `@ApplicationScoped RatchetOptions` producer method runs. If you close the lambda over a directly-injected `@Dependent` bean, you freeze whatever value was live at container startup, reproducing the exact bug this seam exists to fix.
+
+Close over a normal-scoped CDI proxy, or inject `Instance<T>` and call `.get()` from inside `resolve()`, so every invocation re-resolves the live actor — the same pattern `CallerPrincipalProvider` itself uses with `Instance<SecurityContext>`:
+
+```java
+@ApplicationScoped
+public class SchedulerConfiguration {
+
+    @Inject Instance<CurrentUserContext> currentUserContext;
+
+    @Produces
+    @ApplicationScoped
+    RatchetOptions ratchetOptions() {
+        return RatchetOptions.builder()
+            .callerPrincipalResolver(() ->
+                currentUserContext.isResolvable()
+                    ? Optional.ofNullable(currentUserContext.get().userId())
+                    : Optional.empty())
+            .build();
+    }
+}
+```
+
+`CurrentUserContext` here is an application-defined, narrowly-scoped bean (`@RequestScoped` or similar); `Instance<T>.get()` re-resolves it on every call instead of freezing it at startup.
+
+A resolver may be invoked from a background or materializer thread (chain-step continuation, workflow-branch creation, batch-child creation) where a request-scoped proxy is not active. Ratchet treats a thrown `RuntimeException` — and a `null` `Optional` return — as `Optional.empty()` rather than failing the submission, but a resolver that legitimately has no caller identity available should prefer returning `Optional.empty()` directly.
+
 ## ClassPolicy
 
 The default `PackagePrefixClassPolicy` has an empty allowlist. Ratchet refuses to start until you provide a real allowlist, because jobs execute application code by design.


### PR DESCRIPTION
## What

- **Boot-time SPI log** (`SpiBindingLogger`): one INFO line at startup naming the selected implementation for each pluggable SPI (`ClassPolicy`, `CallerPrincipalProvider`, `JobAuthorizationPolicy`, and the rest). A silently mis-selected `@Alternative` now shows up in the boot log instead of staying invisible.
- **Configuration seam for caller-principal capture** (`RatchetOptions.callerPrincipalResolver` / `withCallerPrincipalResolver`): lets an application supply the caller principal directly, bypassing CDI `@Alternative` resolution. Threaded through job creation, scheduling, and query, with the resolver call wrapped so a throw degrades to "no principal" rather than failing the submission.
- **Cross-server matrix IT** (`EarEjbSubmoduleOverrideIT`): records which managed servers honor a `CallerPrincipalProvider` `@Alternative` packaged in an EJB subdeployment. WildFly-family and Open Liberty honor it; Payara and GlassFish fall back to the default, which is spec-compliant.
- **Docs**: the default `CallerPrincipalProvider` reads `jakarta.security.enterprise.SecurityContext`, which a container registers only when the deployment activates Jakarta Security. Some mechanisms authenticate the caller without activating it — WildFly's native Elytron OIDC is the notable case — so the default capture records no principal even for an authenticated request. The Javadoc and configuration guide now point applications at `getUserPrincipal()` or the Elytron `SecurityIdentity` through the resolver seam.

## Why

An application that overrides `CallerPrincipalProvider` from an EJB subdeployment, or authenticates through native OIDC, can persist a null `caller_principal`. The resolver seam gives a container-independent way to supply the principal regardless of how the override resolves or which auth mechanism is in play, and the startup SPI log turns an invisible mis-selection into a one-line diagnosis.
