### PR TITLE
Inherit the caller principal from the executing job's context

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/JobContext.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobContext.java
@@ -24,6 +24,11 @@ import run.ratchet.spi.JobLogger;
 /**
  * Thread-local context for the executing job.
  *
+ * <p>This is a plain {@link ThreadLocal}. Job code that hands work to another thread, for example
+ * with {@code CompletableFuture.supplyAsync(...)}, does not carry this context with it. Submissions
+ * that should inherit the executing job's caller principal must be made on the job execution thread
+ * while the context is bound.
+ *
  * @since 0.1
  */
 @Incubating
@@ -35,21 +40,32 @@ public final class JobContext {
   private final JobLogger logger;
   private final Map<String, String> params;
   private final Serializable signalPayload;
+  private final @Nullable String callerPrincipal;
 
   private JobContext(UUID jobId, JobLogger logger) {
-    this(jobId, logger, Collections.emptyMap(), null);
+    this(jobId, logger, Collections.emptyMap(), null, null);
   }
 
   private JobContext(UUID jobId, JobLogger logger, Map<String, String> params) {
-    this(jobId, logger, params, null);
+    this(jobId, logger, params, null, null);
   }
 
   private JobContext(
       UUID jobId, JobLogger logger, Map<String, String> params, Serializable signalPayload) {
+    this(jobId, logger, params, signalPayload, null);
+  }
+
+  private JobContext(
+      UUID jobId,
+      JobLogger logger,
+      Map<String, String> params,
+      @Nullable Serializable signalPayload,
+      @Nullable String callerPrincipal) {
     this.jobId = jobId;
     this.logger = logger;
     this.params = params != null ? Collections.unmodifiableMap(params) : Collections.emptyMap();
     this.signalPayload = signalPayload;
+    this.callerPrincipal = callerPrincipal;
   }
 
   /**
@@ -84,6 +100,23 @@ public final class JobContext {
     return ctx;
   }
 
+  /**
+   * Binds a new context with parameters, the captured caller principal, and a pre-deserialized
+   * signal payload. Called by the job executor for persisted jobs; {@code callerPrincipal} is the
+   * immutable principal captured when the job was created, or {@code null} when none was captured.
+   * Always pair with {@link #clear()} in a finally block.
+   */
+  public static JobContext bind(
+      UUID jobId,
+      JobLogger logger,
+      Map<String, String> params,
+      @Nullable String callerPrincipal,
+      @Nullable Serializable signalPayload) {
+    JobContext ctx = new JobContext(jobId, logger, params, signalPayload, callerPrincipal);
+    TL.set(ctx);
+    return ctx;
+  }
+
   /** Removes the context bound to the current thread. */
   public static void clear() {
     TL.remove();
@@ -101,6 +134,13 @@ public final class JobContext {
     return ctx;
   }
 
+  /**
+   * @return the context bound to the current thread, or {@code null} if no context is bound
+   */
+  public static @Nullable JobContext currentOrNull() {
+    return TL.get();
+  }
+
   /** Returns the UUID of the executing job. */
   public UUID jobId() {
     return jobId;
@@ -109,6 +149,14 @@ public final class JobContext {
   /** Returns the job-scoped logger (automatically includes job ID in all entries). */
   public JobLogger logger() {
     return logger;
+  }
+
+  /**
+   * Returns the caller principal captured when this job was created, or {@code null} when no
+   * principal was captured.
+   */
+  public @Nullable String callerPrincipal() {
+    return callerPrincipal;
   }
 
   /**

--- a/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/JobSchedulerService.java
@@ -59,11 +59,13 @@ import run.ratchet.spi.JobAuthorizationPolicy;
  *
  * <h2>Security context capture</h2>
  *
- * <p>Implementations MUST capture the caller principal at job creation when a container security
- * context is available and store it on the job entity. When no security context is active or the
- * context provides no authenticated principal, implementations MUST store null. The captured
- * principal MUST be immutable once set — subsequent job mutations (status transitions, retries,
- * rescheduling) MUST NOT overwrite the original capture.
+ * <p>Implementations MUST capture the caller principal at job creation when one is available from
+ * the implementation's configured caller-principal resolution sources and store it on the job
+ * entity. When no source provides a principal, implementations MUST store null. A null capture
+ * means no principal was captured, such as a background or system-initiated submission; Ratchet
+ * does not invent a literal system principal. The captured principal MUST be immutable once set —
+ * subsequent job mutations (status transitions, retries, rescheduling) MUST NOT overwrite the
+ * original capture.
  *
  * <p>Authorization is delegated to the {@link run.ratchet.spi.JobAuthorizationPolicy} SPI. The
  * default reference implementation ({@code PermitAllJobAuthorizationPolicy}) permits all

--- a/ratchet-api/src/main/java/run/ratchet/spi/CallerPrincipalResolver.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/CallerPrincipalResolver.java
@@ -23,11 +23,17 @@ import run.ratchet.api.Incubating;
  * application already controls, bypassing CDI {@code @Alternative} bean resolution entirely.
  *
  * <p>Configured via {@code RatchetOptions.Builder#callerPrincipalResolver}. When set, it takes
- * precedence over {@code run.ratchet.ri.security.CallerPrincipalProvider} — the reference
- * implementation's CDI-alternative-based default. Leaving it unset reproduces today's behavior
- * exactly: some EAR containers silently ignore an application's
+ * first precedence in the reference implementation's resolution cascade. If this resolver returns
+ * {@link Optional#empty()}, returns {@code null}, or throws a {@link RuntimeException}, Ratchet
+ * treats this source as empty and continues to the next source: the executing {@code JobContext}'s
+ * captured caller principal, then {@code run.ratchet.ri.security.CallerPrincipalProvider}, then no
+ * principal. Some EAR containers silently ignore an application's
  * {@code @Alternative @Priority(APPLICATION) CallerPrincipalProvider} override, so this seam exists
- * as a fallback path that does not depend on CDI alternative resolution at all.
+ * as a path that does not depend on CDI alternative resolution at all.
+ *
+ * <p>Ratchet never invents a principal. A persisted {@code null} {@code caller_principal} means no
+ * principal was captured, such as a background or system-initiated submission. Applications that
+ * want a literal stamp such as {@code "system"} must return that value from this resolver.
  *
  * <h2>Authentication mechanism and the default capture</h2>
  *
@@ -72,8 +78,8 @@ public interface CallerPrincipalResolver {
    * <p>May be invoked from a background or materializer thread (chain-step continuation,
    * workflow-branch creation, batch-child creation) where a request-scoped proxy is not active. In
    * that situation, prefer returning {@link Optional#empty()}; a thrown {@link RuntimeException} is
-   * also tolerated by the framework's resolution helper, which logs a warning and degrades to
-   * {@link Optional#empty()} rather than failing the submission.
+   * also tolerated by the framework's resolution helper, which logs a warning, treats this source
+   * as empty, and continues the resolution cascade rather than failing the submission.
    *
    * @return the resolved principal name, or {@link Optional#empty()} if none is available
    */

--- a/ratchet-api/src/test/java/run/ratchet/api/JobContextTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/JobContextTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class JobContextTest {
+
+  @AfterEach
+  void clearContext() {
+    JobContext.clear();
+  }
+
+  @Test
+  void currentOrNullReturnsNullWhenUnbound() {
+    assertNull(JobContext.currentOrNull());
+    assertThrows(IllegalStateException.class, JobContext::current);
+  }
+
+  @Test
+  void bindWithCallerPrincipalExposesCallerPrincipal() {
+    UUID jobId = UUID.randomUUID();
+
+    JobContext bound = JobContext.bind(jobId, null, Map.of("tenant", "west"), "alice", null);
+
+    assertSame(bound, JobContext.currentOrNull());
+    assertEquals(jobId, JobContext.current().jobId());
+    assertEquals("west", JobContext.current().param("tenant"));
+    assertEquals("alice", JobContext.current().callerPrincipal());
+  }
+
+  @Test
+  void existingBindOverloadsExposeNullCallerPrincipal() {
+    JobContext.bind(UUID.randomUUID(), null, Map.of());
+
+    assertNull(JobContext.current().callerPrincipal());
+  }
+}

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultJobCreationService.java
@@ -407,6 +407,7 @@ class DefaultJobCreationService
     Instant now = effective().instant();
 
     JobOptions opts = builder.opts();
+    String callerPrincipal = resolveCallerPrincipal();
     JobEntity job = new JobEntity();
     job.setJobType(JobExecutionType.SINGLE);
     job.setStatus(isSignalWaiting ? JobStatus.WAITING : JobStatus.PENDING);
@@ -430,7 +431,7 @@ class DefaultJobCreationService
     if (state.onFailure() != null) {
       job.setOnFailurePayload(payload(state.onFailure()));
     }
-    stampCallerPrincipal(job);
+    stampCallerPrincipal(job, callerPrincipal);
     captureTraceContext(job);
     applyOptions(job, opts);
     if (!builder.params().isEmpty()) {
@@ -477,12 +478,19 @@ class DefaultJobCreationService
 
     List<SerializableCheckedRunnable> chainTasks = state.chainTasks();
     if (!chainTasks.isEmpty()) {
-      createChainSteps(jobId, chainTasks, opts, state.executionTarget(), state.encryptedPayload());
+      createChainSteps(
+          jobId,
+          chainTasks,
+          opts,
+          state.executionTarget(),
+          state.encryptedPayload(),
+          callerPrincipal);
     }
 
     List<WorkflowBranch> branches = builder.workflowBranches();
     if (!branches.isEmpty()) {
-      createWorkflowBranches(jobId, branches, state.executionTarget(), saved.isEncryptedPayload());
+      createWorkflowBranches(
+          jobId, branches, state.executionTarget(), saved.isEncryptedPayload(), callerPrincipal);
     }
 
     boolean shouldWakeup =
@@ -512,7 +520,8 @@ class DefaultJobCreationService
 
   private JobHandle submitPrepared(DefaultBatchBuilder builder) {
     requireBatchCapability();
-    JobEntity parent = newBatchParent();
+    String callerPrincipal = resolveCallerPrincipal();
+    JobEntity parent = newBatchParent(callerPrincipal);
     parent.setExecutionTarget(builder.executionTarget());
     checkCreateAuthorization(parent);
     JobEntity savedParent = createJob(parent);
@@ -548,7 +557,7 @@ class DefaultJobCreationService
       childJob.setDependsOn(parentId);
       childJob.setExecutionTarget(builder.executionTarget());
       applyOptions(childJob, builder.childOptions());
-      stampCallerPrincipal(childJob);
+      stampCallerPrincipal(childJob, callerPrincipal);
       checkCreateAuthorization(childJob);
       childJobs.add(childJob);
     }
@@ -558,7 +567,8 @@ class DefaultJobCreationService
         parentId,
         builder.workflowBranches(),
         builder.executionTarget(),
-        savedParent.isEncryptedPayload());
+        savedParent.isEncryptedPayload(),
+        callerPrincipal);
 
     wakeupService.notifyIfNeeded(
         JobExecutionType.BATCH_PARENT,
@@ -592,7 +602,8 @@ class DefaultJobCreationService
     requireBatchCapability();
     builder.validateReady();
 
-    JobEntity parent = newBatchParent();
+    String callerPrincipal = resolveCallerPrincipal();
+    JobEntity parent = newBatchParent(callerPrincipal);
     parent.setExecutionTarget(builder.executionTarget());
     checkCreateAuthorization(parent);
     JobEntity savedParent = createJob(parent);
@@ -616,7 +627,7 @@ class DefaultJobCreationService
       while (iterator.hasNext()) {
         chunk.add(iterator.next());
         if (chunk.size() >= builder.chunkSize()) {
-          totalItems += createChildChunk(parentId, builder, chunk, chunksInserted);
+          totalItems += createChildChunk(parentId, builder, chunk, chunksInserted, callerPrincipal);
           chunksInserted++;
           builder.invokeLocalProgressHook(parentId, totalItems, chunksInserted);
           chunk.clear();
@@ -624,7 +635,7 @@ class DefaultJobCreationService
       }
 
       if (!chunk.isEmpty()) {
-        totalItems += createChildChunk(parentId, builder, chunk, chunksInserted);
+        totalItems += createChildChunk(parentId, builder, chunk, chunksInserted, callerPrincipal);
         chunksInserted++;
         builder.invokeLocalProgressHook(parentId, totalItems, chunksInserted);
       }
@@ -637,7 +648,8 @@ class DefaultJobCreationService
         parentId,
         builder.workflowBranches(),
         builder.executionTarget(),
-        savedParent.isEncryptedPayload());
+        savedParent.isEncryptedPayload(),
+        callerPrincipal);
 
     wakeupService.notifyIfNeeded(
         JobExecutionType.BATCH_PARENT,
@@ -861,7 +873,7 @@ class DefaultJobCreationService
     job.setTimeoutSec(opts.timeoutSec());
   }
 
-  private JobEntity newBatchParent() {
+  private JobEntity newBatchParent(String callerPrincipal) {
     JobEntity parent = new JobEntity();
     parent.setJobType(JobExecutionType.BATCH_PARENT);
     parent.setStatus(JobStatus.PENDING);
@@ -869,7 +881,7 @@ class DefaultJobCreationService
     parent.setScheduledTime(effective().instant());
     parent.setPayload(validate(JobPayloadFactory.noop()));
     parent.setIdempotencyKey(UUID.randomUUID().toString());
-    stampCallerPrincipal(parent);
+    stampCallerPrincipal(parent, callerPrincipal);
     return parent;
   }
 
@@ -886,7 +898,8 @@ class DefaultJobCreationService
       List<SerializableCheckedRunnable> chainTasks,
       JobOptions opts,
       String executionTarget,
-      boolean parentEncrypted) {
+      boolean parentEncrypted,
+      String callerPrincipal) {
     UUID prevId = predecessorId;
     for (SerializableCheckedRunnable chainTask : chainTasks) {
       JobEntity step = new JobEntity();
@@ -905,7 +918,7 @@ class DefaultJobCreationService
       step.setDependsOn(prevId);
       step.setExecutionTarget(executionTarget);
       applyOptions(step, opts);
-      stampCallerPrincipal(step);
+      stampCallerPrincipal(step, callerPrincipal);
       captureTraceContext(step);
       checkCreateAuthorization(step);
 
@@ -920,10 +933,15 @@ class DefaultJobCreationService
    * rolls the whole submission back).
    */
   private <T extends Serializable> int createChildChunk(
-      UUID parentId, DefaultStreamingBatchBuilder<T> builder, List<T> chunk, int chunkIndex) {
+      UUID parentId,
+      DefaultStreamingBatchBuilder<T> builder,
+      List<T> chunk,
+      int chunkIndex,
+      String callerPrincipal) {
     if (builder instanceof InvocationStreamingState<T> invocationBuilder) {
       try {
-        return createInvocationStreamingChildJobs(parentId, invocationBuilder, chunk);
+        return createInvocationStreamingChildJobs(
+            parentId, invocationBuilder, chunk, callerPrincipal);
       } catch (RuntimeException e) {
         if (eventPublisher != null) {
           eventPublisher.publish(
@@ -941,29 +959,38 @@ class DefaultJobCreationService
         throw e;
       }
     }
-    return createStreamingChildJobs(parentId, builder, chunk);
+    return createStreamingChildJobs(parentId, builder, chunk, callerPrincipal);
   }
 
   private <T extends Serializable> int createInvocationStreamingChildJobs(
-      UUID parentId, InvocationStreamingState<T> builder, List<T> items) {
+      UUID parentId, InvocationStreamingState<T> builder, List<T> items, String callerPrincipal) {
     return createStreamingChildJobs(
         parentId,
         builder,
         items,
+        callerPrincipal,
         item ->
             validate(JobPayloadFactory.fromInvocation(builder.invocationFactory().apply(item))));
-  }
-
-  private <T extends Serializable> int createStreamingChildJobs(
-      UUID parentId, DefaultStreamingBatchBuilder<T> builder, List<T> items) {
-    return createStreamingChildJobs(
-        parentId, builder, items, item -> payload(builder.action(), List.of(item)));
   }
 
   private <T extends Serializable> int createStreamingChildJobs(
       UUID parentId,
       DefaultStreamingBatchBuilder<T> builder,
       List<T> items,
+      String callerPrincipal) {
+    return createStreamingChildJobs(
+        parentId,
+        builder,
+        items,
+        callerPrincipal,
+        item -> payload(builder.action(), List.of(item)));
+  }
+
+  private <T extends Serializable> int createStreamingChildJobs(
+      UUID parentId,
+      DefaultStreamingBatchBuilder<T> builder,
+      List<T> items,
+      String callerPrincipal,
       Function<T, JobPayload> payloadFactory) {
     List<JobEntity> children = new ArrayList<>(items.size());
     for (T item : items) {
@@ -977,7 +1004,7 @@ class DefaultJobCreationService
       child.setDependsOn(parentId);
       child.setExecutionTarget(builder.executionTarget());
       applyOptions(child, builder.childOptions());
-      stampCallerPrincipal(child);
+      stampCallerPrincipal(child, callerPrincipal);
       checkCreateAuthorization(child);
       children.add(child);
     }
@@ -998,7 +1025,8 @@ class DefaultJobCreationService
       UUID parentId,
       List<WorkflowBranch> branches,
       String executionTarget,
-      boolean parentEncrypted) {
+      boolean parentEncrypted,
+      String callerPrincipal) {
     if (workflowConditionStore == null && !branches.isEmpty()) {
       throw new UnsupportedOperationException(
           "Workflow branch scheduling requires a store advertising the WorkflowConditionStore"
@@ -1010,7 +1038,8 @@ class DefaultJobCreationService
           branches.get(definitionOrder),
           definitionOrder,
           executionTarget,
-          parentEncrypted);
+          parentEncrypted,
+          callerPrincipal);
     }
   }
 
@@ -1019,7 +1048,8 @@ class DefaultJobCreationService
       WorkflowBranch branch,
       int definitionOrder,
       String executionTarget,
-      boolean parentEncrypted) {
+      boolean parentEncrypted,
+      String callerPrincipal) {
     JobEntity branchJob = new JobEntity();
     branchJob.setJobType(JobExecutionType.WORKFLOW_BRANCH);
     branchJob.setStatus(JobStatus.PENDING);
@@ -1030,7 +1060,7 @@ class DefaultJobCreationService
     branchJob.setIdempotencyKey(UUID.randomUUID().toString());
     branchJob.setDependsOn(parentId);
     branchJob.setExecutionTarget(executionTarget);
-    stampCallerPrincipal(branchJob);
+    stampCallerPrincipal(branchJob, callerPrincipal);
     checkCreateAuthorization(branchJob);
     JobEntity savedBranch = createJob(branchJob);
 
@@ -1146,9 +1176,10 @@ class DefaultJobCreationService
     JOB_PAYLOAD_CONVERTER.discardPreparedSerialization(payload);
   }
 
-  private void stampCallerPrincipal(JobEntity job) {
-    CallerPrincipalResolution.resolve(callerPrincipalResolver, callerPrincipalProvider)
-        .ifPresent(job::setCallerPrincipal);
+  private void stampCallerPrincipal(JobEntity job, String callerPrincipal) {
+    if (callerPrincipal != null) {
+      job.setCallerPrincipal(callerPrincipal);
+    }
   }
 
   private void checkCreateAuthorization(JobEntity job) {

--- a/ratchet/src/main/java/run/ratchet/ri/core/internal/JobMdcContext.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/internal/JobMdcContext.java
@@ -110,7 +110,7 @@ final class JobMdcContext {
       String jobCreator,
       String jobType,
       Serializable signalPayload) {
-    JobContext.bind(jobId, logger, params, signalPayload);
+    JobContext.bind(jobId, logger, params, jobCreator, signalPayload);
     if (jobId != null) {
       MDC.put(MDC_JOB_ID, String.valueOf(jobId));
     }

--- a/ratchet/src/main/java/run/ratchet/ri/security/CallerPrincipalProvider.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/CallerPrincipalProvider.java
@@ -28,6 +28,18 @@ import org.jboss.logging.Logger;
  * container, and returns an empty Optional otherwise. Stamped onto {@code
  * JobEntity.callerPrincipal} at job creation for audit.
  *
+ * <p>The provider is the third source in the reference implementation's caller-principal cascade:
+ * configured {@code run.ratchet.spi.CallerPrincipalResolver}, bound {@code JobContext} caller
+ * principal, this provider, then empty. The bound {@code JobContext} source intentionally outranks
+ * this provider so jobs that submit children on their execution thread inherit the parent's
+ * persisted principal even when an application provider falls back to a worker-thread service
+ * account.
+ *
+ * <p>Ratchet never invents a principal. A persisted {@code null} {@code caller_principal} means no
+ * principal was captured, such as a background or system-initiated submission. Applications that
+ * want a literal stamp such as {@code "system"} must supply it through {@code
+ * run.ratchet.spi.CallerPrincipalResolver} or an overriding provider.
+ *
  * <p>The default bean is supplied by a {@code @Produces @Default} producer on {@link
  * run.ratchet.ri.cdi.RatchetProducer}. Applications override it with a CDI
  * {@code @Alternative @Priority(APPLICATION) CallerPrincipalProvider} bean.

--- a/ratchet/src/main/java/run/ratchet/ri/security/CallerPrincipalResolution.java
+++ b/ratchet/src/main/java/run/ratchet/ri/security/CallerPrincipalResolution.java
@@ -17,14 +17,15 @@ package run.ratchet.ri.security;
 
 import java.util.Optional;
 import org.jboss.logging.Logger;
+import run.ratchet.api.JobContext;
 import run.ratchet.spi.CallerPrincipalResolver;
 
 /**
- * Central precedence rule for caller-principal resolution: an application-supplied {@link
- * CallerPrincipalResolver} (read from {@code RatchetOptions#callerPrincipalResolver()}) takes
- * precedence over the CDI-alternative-based {@link CallerPrincipalProvider} default. Every call
- * site that needs the current caller principal goes through {@link #resolve} rather than
- * re-implementing this precedence and its safety net inline.
+ * Central precedence rule for caller-principal resolution. Resolution cascades through an
+ * application-supplied {@link CallerPrincipalResolver}, the executing job's bound {@link
+ * JobContext#callerPrincipal()}, and finally the CDI-alternative-based {@link
+ * CallerPrincipalProvider} default. Every call site that needs the current caller principal goes
+ * through {@link #resolve} rather than re-implementing this precedence and its safety net inline.
  */
 public final class CallerPrincipalResolution {
 
@@ -33,31 +34,65 @@ public final class CallerPrincipalResolution {
   private CallerPrincipalResolution() {}
 
   /**
-   * Resolves the current caller principal, preferring {@code optionResolver} when one is
-   * configured.
+   * Resolves the current caller principal.
    *
-   * <p>{@code optionResolver} may be invoked off a background or materializer thread (chain-step
-   * continuation, workflow-branch creation, batch-child creation) where a request-scoped proxy is
-   * not active and throws (for example {@code ContextNotActiveException}). Any {@link
-   * RuntimeException} it throws — and a {@code null} {@link Optional} return — degrade to {@link
-   * Optional#empty()} here rather than failing the submission or authorization check.
+   * <p>Resolution order is:
+   *
+   * <ol>
+   *   <li>{@code optionResolver}, when configured
+   *   <li>the caller principal bound to the current {@link JobContext}
+   *   <li>{@code provider}
+   *   <li>{@link Optional#empty()}
+   * </ol>
+   *
+   * <p>{@code optionResolver} may be invoked off a background or materializer thread where a
+   * request-scoped proxy is not active and throws (for example {@code ContextNotActiveException}).
+   * Any {@link RuntimeException} thrown by the resolver or provider — and a {@code null} {@link
+   * Optional} return — degrades that source to {@link Optional#empty()} here rather than failing
+   * the submission or authorization check.
    *
    * @param optionResolver the application-supplied resolver from {@code
    *     RatchetOptions#callerPrincipalResolver()}; may be {@code null} when unconfigured
    * @param provider the CDI-alternative-based default provider; may be {@code null} in test wiring
-   * @return the resolved principal, or {@link Optional#empty()} if neither source yields one
+   * @return the resolved principal, or {@link Optional#empty()} if no source yields one
    */
   public static Optional<String> resolve(
       CallerPrincipalResolver optionResolver, CallerPrincipalProvider provider) {
+    Optional<String> resolved = resolveFromOption(optionResolver);
+    if (resolved.isPresent()) {
+      return resolved;
+    }
+
+    JobContext context = JobContext.currentOrNull();
+    if (context != null && context.callerPrincipal() != null) {
+      return Optional.of(context.callerPrincipal());
+    }
+
+    return resolveFromProvider(provider);
+  }
+
+  private static Optional<String> resolveFromOption(CallerPrincipalResolver optionResolver) {
     if (optionResolver != null) {
       try {
         Optional<String> resolved = optionResolver.resolve();
         return resolved != null ? resolved : Optional.empty();
       } catch (RuntimeException e) {
-        log.warnf(e, "CallerPrincipalResolver threw; capturing null caller principal");
-        return Optional.empty();
+        log.warnf(e, "CallerPrincipalResolver threw; treating this source as empty");
       }
     }
-    return provider != null ? provider.currentPrincipal() : Optional.empty();
+    return Optional.empty();
+  }
+
+  private static Optional<String> resolveFromProvider(CallerPrincipalProvider provider) {
+    if (provider == null) {
+      return Optional.empty();
+    }
+    try {
+      Optional<String> resolved = provider.currentPrincipal();
+      return resolved != null ? resolved : Optional.empty();
+    } catch (RuntimeException e) {
+      log.warnf(e, "CallerPrincipalProvider threw; treating this source as empty");
+      return Optional.empty();
+    }
   }
 }

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobCreationServiceAuthorizationTest.java
@@ -39,6 +39,7 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -379,7 +380,7 @@ class DefaultJobCreationServiceAuthorizationTest {
   }
 
   @Test
-  void checkCreate_throwingResolverDegradesToNullPrincipal_doesNotFailSubmission() {
+  void checkCreate_throwingResolverFallsBackToProvider_doesNotFailSubmission() {
     DefaultJobCreationService resolverService =
         serviceWithResolver(
             principalProviderReturning("provider-principal"),
@@ -403,8 +404,8 @@ class DefaultJobCreationServiceAuthorizationTest {
     assertNotNull(handle, "A throwing resolver must not fail submission");
     ArgumentCaptor<JobEntity> jobCaptor = ArgumentCaptor.forClass(JobEntity.class);
     verify(jobCrudStore).create(jobCaptor.capture());
-    assertNull(jobCaptor.getValue().getCallerPrincipal());
-    verify(authorizationPolicy).checkCreate(any(UUID.class), isNull());
+    assertEquals("provider-principal", jobCaptor.getValue().getCallerPrincipal());
+    verify(authorizationPolicy).checkCreate(any(UUID.class), Mockito.eq("provider-principal"));
   }
 
   // ---- recurring job ----
@@ -589,6 +590,34 @@ class DefaultJobCreationServiceAuthorizationTest {
     verify(jobBulkStore).bulkInsert(childrenCaptor.capture());
     assertEquals(3, childrenCaptor.getValue().size());
     verify(jobCrudStore, times(1)).create(any(JobEntity.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void batchSubmit_resolvesCallerPrincipalOnceForParentAndChildren() {
+    AtomicInteger resolves = new AtomicInteger();
+    DefaultJobCreationService resolverService =
+        serviceWithResolver(
+            principalProviderReturning("provider-principal"),
+            () -> Optional.of("caller-" + resolves.incrementAndGet()));
+    when(jobCrudStore.create(any())).thenAnswer(inv -> savedEntity());
+
+    DefaultBatchBuilder builder = new DefaultBatchBuilder("test-batch", resolverService);
+    builder.forEach(
+        List.of("one", "two", "three"), DefaultJobCreationServiceAuthorizationTest::consumeString);
+
+    resolverService.submit(builder);
+
+    ArgumentCaptor<JobEntity> parentCaptor = ArgumentCaptor.forClass(JobEntity.class);
+    verify(jobCrudStore).create(parentCaptor.capture());
+    ArgumentCaptor<List<JobEntity>> childrenCaptor = ArgumentCaptor.forClass(List.class);
+    verify(jobBulkStore).bulkInsert(childrenCaptor.capture());
+
+    assertEquals(1, resolves.get(), "A single batch submission must resolve its principal once");
+    assertEquals("caller-1", parentCaptor.getValue().getCallerPrincipal());
+    for (JobEntity child : childrenCaptor.getValue()) {
+      assertEquals("caller-1", child.getCallerPrincipal());
+    }
   }
 
   @Test

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceAuthorizationTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultJobSchedulerServiceAuthorizationTest.java
@@ -189,7 +189,7 @@ class DefaultJobSchedulerServiceAuthorizationTest {
   }
 
   @Test
-  void cancelJob_throwingResolverDegradesToNullCurrentPrincipal() {
+  void cancelJob_throwingResolverFallsBackToProvider() {
     DefaultJobSchedulerService resolverService =
         serviceWithResolver(
             new CallerPrincipalProvider(null) {
@@ -208,7 +208,7 @@ class DefaultJobSchedulerServiceAuthorizationTest {
 
     resolverService.cancelJob(JOB_ID);
 
-    verify(authorizationPolicy).checkCancel(eq(JOB_ID), eq(OWNER), eq(null));
+    verify(authorizationPolicy).checkCancel(eq(JOB_ID), eq(OWNER), eq(CALLER));
   }
 
   // ---- pauseJob ----

--- a/ratchet/src/test/java/run/ratchet/ri/security/CallerPrincipalResolutionTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/security/CallerPrincipalResolutionTest.java
@@ -22,15 +22,26 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import run.ratchet.api.JobContext;
 
 class CallerPrincipalResolutionTest {
 
+  @AfterEach
+  void clearJobContext() {
+    JobContext.clear();
+  }
+
   @Test
-  void resolve_resolverPresent_takesPrecedenceOverProvider() {
+  void resolve_resolverPresent_takesPrecedenceOverJobContextAndProvider() {
     CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
     when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
+    JobContext.bind(
+        UUID.randomUUID(), null, Map.of(), "job-context-principal", /* signalPayload */ null);
 
     Optional<String> result =
         CallerPrincipalResolution.resolve(() -> Optional.of("resolver-principal"), provider);
@@ -40,38 +51,63 @@ class CallerPrincipalResolutionTest {
   }
 
   @Test
-  void resolve_resolverThrows_degradesToEmptyWithoutConsultingProvider() {
+  void resolve_resolverEmpty_fallsBackToJobContextBeforeProvider() {
     CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
+    JobContext.bind(
+        UUID.randomUUID(), null, Map.of(), "job-context-principal", /* signalPayload */ null);
 
-    Optional<String> result =
-        CallerPrincipalResolution.resolve(
-            () -> {
-              throw new IllegalStateException("ContextNotActiveException-like failure");
-            },
-            provider);
+    Optional<String> result = CallerPrincipalResolution.resolve(Optional::empty, provider);
 
-    assertTrue(result.isEmpty(), "A throwing resolver must degrade to empty, not propagate");
+    assertEquals(Optional.of("job-context-principal"), result);
     verify(provider, never()).currentPrincipal();
   }
 
   @Test
-  void resolve_resolverReturnsNullOptional_isTreatedAsEmpty() {
+  void resolve_resolverReturnsNullOptional_fallsBackToJobContext() {
     CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    JobContext.bind(
+        UUID.randomUUID(), null, Map.of(), "job-context-principal", /* signalPayload */ null);
 
     Optional<String> result = CallerPrincipalResolution.resolve(() -> null, provider);
 
-    assertTrue(result.isEmpty(), "A resolver returning a null Optional must be treated as empty");
+    assertEquals(
+        Optional.of("job-context-principal"),
+        result,
+        "A resolver returning a null Optional must be treated as empty");
     verify(provider, never()).currentPrincipal();
   }
 
   @Test
-  void resolve_resolverNull_fallsBackToProvider() {
+  void resolve_jobContextEmpty_fallsBackToProvider() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
+    JobContext.bind(UUID.randomUUID(), null, Map.of(), null, /* signalPayload */ null);
+
+    Optional<String> result = CallerPrincipalResolution.resolve(null, provider);
+
+    assertEquals(Optional.of("provider-principal"), result);
+  }
+
+  @Test
+  void resolve_noJobContext_fallsBackToProvider() {
     CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
     when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
 
     Optional<String> result = CallerPrincipalResolution.resolve(null, provider);
 
     assertEquals(Optional.of("provider-principal"), result);
+  }
+
+  @Test
+  void resolve_allSourcesEmpty_yieldsEmpty() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.empty());
+    JobContext.bind(UUID.randomUUID(), null, Map.of(), null, /* signalPayload */ null);
+
+    Optional<String> result = CallerPrincipalResolution.resolve(Optional::empty, provider);
+
+    assertTrue(result.isEmpty());
   }
 
   @Test
@@ -82,12 +118,47 @@ class CallerPrincipalResolutionTest {
   }
 
   @Test
-  void resolve_resolverNullAndProviderEmpty_yieldsEmpty() {
+  void resolve_throwingResolver_degradesToJobContext() {
     CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
-    when(provider.currentPrincipal()).thenReturn(Optional.empty());
+    JobContext.bind(
+        UUID.randomUUID(), null, Map.of(), "job-context-principal", /* signalPayload */ null);
+
+    Optional<String> result =
+        CallerPrincipalResolution.resolve(
+            () -> {
+              throw new IllegalStateException("ContextNotActiveException-like failure");
+            },
+            provider);
+
+    assertEquals(
+        Optional.of("job-context-principal"),
+        result,
+        "A throwing resolver must degrade to the next source, not propagate");
+    verify(provider, never()).currentPrincipal();
+  }
+
+  @Test
+  void resolve_throwingResolverWithNoJobContext_degradesToProvider() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenReturn(Optional.of("provider-principal"));
+
+    Optional<String> result =
+        CallerPrincipalResolution.resolve(
+            () -> {
+              throw new IllegalStateException("ContextNotActiveException-like failure");
+            },
+            provider);
+
+    assertEquals(Optional.of("provider-principal"), result);
+  }
+
+  @Test
+  void resolve_throwingProvider_degradesToEmpty() {
+    CallerPrincipalProvider provider = mock(CallerPrincipalProvider.class);
+    when(provider.currentPrincipal()).thenThrow(new IllegalStateException("provider failure"));
 
     Optional<String> result = CallerPrincipalResolution.resolve(null, provider);
 
-    assertTrue(result.isEmpty());
+    assertTrue(result.isEmpty(), "A throwing provider must degrade to empty, not propagate");
   }
 }

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/CallerPrincipalInheritanceJob.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/CallerPrincipalInheritanceJob.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.testsuite.app;
+
+import jakarta.enterprise.inject.spi.CDI;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import run.ratchet.api.JobContext;
+import run.ratchet.api.JobHandle;
+import run.ratchet.api.JobSchedulerService;
+
+/** Job bodies and callbacks used by caller-principal inheritance integration tests. */
+public class CallerPrincipalInheritanceJob {
+
+  private static final AtomicReference<UUID> CHILD_ID = new AtomicReference<>();
+  private static final AtomicReference<String> SUCCESS_CALLBACK_PRINCIPAL = new AtomicReference<>();
+  private static final AtomicReference<String> FAILURE_CALLBACK_PRINCIPAL = new AtomicReference<>();
+
+  public static void submitChildOnWorkerThread() {
+    JobSchedulerService scheduler = CDI.current().select(JobSchedulerService.class).get();
+    JobHandle child = scheduler.enqueue(CallerPrincipalInheritanceJob::child).submit();
+    CHILD_ID.set(child.id());
+  }
+
+  public static void child() {}
+
+  public static void succeed() {}
+
+  public static void fail() {
+    throw new IllegalStateException("intentional failure for callback context test");
+  }
+
+  public static void captureSuccessCallbackContext() {
+    JobContext context = JobContext.currentOrNull();
+    SUCCESS_CALLBACK_PRINCIPAL.set(context != null ? context.callerPrincipal() : null);
+  }
+
+  public static void captureFailureCallbackContext() {
+    JobContext context = JobContext.currentOrNull();
+    FAILURE_CALLBACK_PRINCIPAL.set(context != null ? context.callerPrincipal() : null);
+  }
+
+  public static UUID childId() {
+    return CHILD_ID.get();
+  }
+
+  public static String successCallbackPrincipal() {
+    return SUCCESS_CALLBACK_PRINCIPAL.get();
+  }
+
+  public static String failureCallbackPrincipal() {
+    return FAILURE_CALLBACK_PRINCIPAL.get();
+  }
+
+  public static void reset() {
+    CHILD_ID.set(null);
+    SUCCESS_CALLBACK_PRINCIPAL.set(null);
+    FAILURE_CALLBACK_PRINCIPAL.set(null);
+  }
+}

--- a/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/StubCallerPrincipalProvider.java
+++ b/testing/ratchet-testsuite/src/main/java/run/ratchet/testsuite/app/StubCallerPrincipalProvider.java
@@ -19,6 +19,7 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Alternative;
 import java.util.Optional;
+import run.ratchet.api.JobContext;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 
 /**
@@ -33,6 +34,7 @@ import run.ratchet.ri.security.CallerPrincipalProvider;
 public class StubCallerPrincipalProvider extends CallerPrincipalProvider {
 
   public static final String STUB_PRINCIPAL = "it-caller";
+  public static final String WORKER_FALLBACK_PRINCIPAL = "worker-service-account";
 
   public StubCallerPrincipalProvider() {
     super();
@@ -40,6 +42,9 @@ public class StubCallerPrincipalProvider extends CallerPrincipalProvider {
 
   @Override
   public Optional<String> currentPrincipal() {
+    if (JobContext.currentOrNull() != null) {
+      return Optional.of(WORKER_FALLBACK_PRINCIPAL);
+    }
     return Optional.of(STUB_PRINCIPAL);
   }
 }

--- a/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/security/CallerPrincipalCaptureIT.java
+++ b/testing/ratchet-testsuite/src/test/java/run/ratchet/testsuite/security/CallerPrincipalCaptureIT.java
@@ -15,18 +15,22 @@
  */
 package run.ratchet.testsuite.security;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import jakarta.inject.Inject;
 import java.time.Duration;
+import java.util.UUID;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import run.ratchet.api.JobHandle;
 import run.ratchet.ri.security.CallerPrincipalProvider;
 import run.ratchet.store.entity.JobEntity;
 import run.ratchet.store.spi.JobCrudStore;
+import run.ratchet.testsuite.app.CallerPrincipalInheritanceJob;
 import run.ratchet.testsuite.app.SimpleJob;
 import run.ratchet.testsuite.app.StubCallerPrincipalProvider;
 import run.ratchet.testsuite.app.TestJobService;
@@ -57,10 +61,19 @@ class CallerPrincipalCaptureIT extends BaseRatchetIT {
 
     return RatchetArchiveBuilder.create()
         .addRatchetDependencies(profile, dbType)
-        .addClasses(StubCallerPrincipalProvider.class, SimpleJob.class, TestJobService.class)
+        .addClasses(
+            StubCallerPrincipalProvider.class,
+            SimpleJob.class,
+            CallerPrincipalInheritanceJob.class,
+            TestJobService.class)
         .addStoreInfrastructure()
         .addBeansXml()
         .build();
+  }
+
+  @BeforeEach
+  void resetFixtures() {
+    CallerPrincipalInheritanceJob.reset();
   }
 
   @Test
@@ -89,5 +102,68 @@ class CallerPrincipalCaptureIT extends BaseRatchetIT {
         beforeExecution.getCallerPrincipal(),
         afterExecution.getCallerPrincipal(),
         "Execution must not overwrite the caller principal stamped at job creation");
+  }
+
+  @Test
+  void runtimeChildSubmittedOnWorkerThread_inheritsParentCallerPrincipal() {
+    JobHandle parent =
+        jobService.enqueueNow(CallerPrincipalInheritanceJob::submitChildOnWorkerThread);
+
+    JobAssertions.assertJobCompleted(jobCrudStore, parent);
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .until(() -> CallerPrincipalInheritanceJob.childId() != null);
+
+    UUID childId = CallerPrincipalInheritanceJob.childId();
+    JobEntity child =
+        jobCrudStore
+            .findById(childId)
+            .orElseThrow(() -> new AssertionError("Child job not found after runtime submit"));
+
+    assertEquals(
+        StubCallerPrincipalProvider.STUB_PRINCIPAL,
+        child.getCallerPrincipal(),
+        "Child submissions made on the worker thread must inherit the parent's captured principal");
+    JobAssertions.assertJobCompleted(jobCrudStore, () -> childId);
+  }
+
+  @Test
+  void onSuccessCallbackRunsInsideJobContextBindWindow() {
+    JobHandle handle =
+        jobService
+            .enqueue(CallerPrincipalInheritanceJob::succeed)
+            .onSuccess(ctx -> CallerPrincipalInheritanceJob.captureSuccessCallbackContext())
+            .submit();
+
+    JobAssertions.assertJobCompleted(jobCrudStore, handle);
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    StubCallerPrincipalProvider.STUB_PRINCIPAL,
+                    CallerPrincipalInheritanceJob.successCallbackPrincipal()));
+  }
+
+  @Test
+  void onFailureCallbackRunsInsideJobContextBindWindow() {
+    JobHandle handle =
+        jobService
+            .enqueue(CallerPrincipalInheritanceJob::fail)
+            .withMaxRetries(0)
+            .onFailure(
+                (ctx, failure) -> CallerPrincipalInheritanceJob.captureFailureCallbackContext())
+            .submit();
+
+    JobAssertions.assertJobFailed(jobCrudStore, handle);
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertEquals(
+                    StubCallerPrincipalProvider.STUB_PRINCIPAL,
+                    CallerPrincipalInheritanceJob.failureCallbackPrincipal()));
   }
 }

--- a/website/docs/api-reference/job-context.md
+++ b/website/docs/api-reference/job-context.md
@@ -25,6 +25,8 @@ void processOrder(long orderId) {
 }
 ```
 
+`JobContext` is a plain thread-local. Work handed to another thread with `CompletableFuture.supplyAsync(...)` or a separate executor does not inherit it. If a job submits another job and expects caller-principal inheritance, make that submission on the Ratchet execution thread while the context is bound.
+
 ## Static methods
 
 ### current
@@ -43,6 +45,14 @@ Retrieves the `JobContext` bound to the current thread.
 JobContext ctx = JobContext.current();
 UUID id = ctx.jobId();
 ```
+
+### currentOrNull
+
+```java
+public static JobContext currentOrNull()
+```
+
+Retrieves the `JobContext` bound to the current thread, or returns `null` when called outside a Ratchet-managed job execution.
 
 ### bind
 
@@ -108,6 +118,19 @@ Binds a context with both job parameters and a pre-deserialized signal payload. 
 
 Most application code should not call this directly except in unit tests for signal-aware job methods.
 
+### bind (with caller principal)
+
+```java
+public static JobContext bind(
+    UUID jobId,
+    JobLogger logger,
+    Map<String, String> params,
+    String callerPrincipal,
+    Serializable signalPayload)
+```
+
+Binds a context with parameters, the persisted caller principal, and an optional signal payload. Ratchet calls this overload internally while executing persisted jobs. `callerPrincipal` may be `null` when no principal was captured at creation.
+
 ### clear
 
 ```java
@@ -164,6 +187,14 @@ log.info("Progress milestone");
 log.warn("Potential issue");
 log.error("Failure occurred");
 ```
+
+### callerPrincipal
+
+```java
+public String callerPrincipal()
+```
+
+Returns the principal captured when this job was created, or `null` when no principal was captured. A `null` value means Ratchet did not capture a principal; it is not a synthetic `"system"` value.
 
 ### param
 

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -352,7 +352,16 @@ RatchetOptions.builder()
     .build();
 ```
 
-When configured, it takes precedence over `CallerPrincipalProvider` at every call site. Leaving it unset (the default) preserves the CDI-based resolution described above.
+Caller-principal resolution cascades in this order:
+
+1. The configured `CallerPrincipalResolver`, if present.
+2. The caller principal bound to the running job's `JobContext`.
+3. The CDI `CallerPrincipalProvider`.
+4. No principal.
+
+`Optional.empty()`, a `null` `Optional`, or a thrown `RuntimeException` from a resolver/provider makes only that source empty; Ratchet continues to the next source instead of failing submission. This is important for worker threads: a child job submitted from inside a running job inherits the parent's captured principal from `JobContext`, and that inherited value outranks a provider that would otherwise return a worker-thread service account fallback.
+
+Ratchet never invents a principal. A `NULL` `caller_principal` means no principal was captured, such as a background or system-initiated submission. If your application wants a literal value like `"system"`, return that value from the resolver.
 
 If your producer builds `RatchetOptions` through `RatchetOptionsFactory.fromEnvironment(...)` instead of the builder, attach the resolver afterward with `withCallerPrincipalResolver`, since `fromEnvironment` returns a finished instance rather than a `Builder`:
 
@@ -364,7 +373,7 @@ RatchetOptionsFactory.fromEnvironment(overlay)
 
 ### Proxy discipline
 
-`resolve()` is called once per job submission, cancellation, pause, resume, retry, signal delivery, or read — but the `CallerPrincipalResolver` instance itself is captured only **once**, when your `@ApplicationScoped RatchetOptions` producer method runs. If you close the lambda over a directly-injected `@Dependent` bean, you freeze whatever value was live at container startup, reproducing the exact bug this seam exists to fix.
+For public submission calls, the reference implementation resolves the principal once and stamps that same value on every node created by that submission: the parent job, batch children, chain steps, workflow branches, and gates. `resolve()` is also called for cancellation, pause, resume, retry, signal delivery, or read authorization checks — but the `CallerPrincipalResolver` instance itself is captured only **once**, when your `@ApplicationScoped RatchetOptions` producer method runs. If you close the lambda over a directly-injected `@Dependent` bean, you freeze whatever value was live at container startup, reproducing the exact bug this seam exists to fix.
 
 Close over a normal-scoped CDI proxy, or inject `Instance<T>` and call `.get()` from inside `resolve()`, so every invocation re-resolves the live actor — the same pattern `CallerPrincipalProvider` itself uses with `Instance<SecurityContext>`:
 
@@ -390,6 +399,8 @@ public class SchedulerConfiguration {
 `CurrentUserContext` here is an application-defined, narrowly-scoped bean (`@RequestScoped` or similar); `Instance<T>.get()` re-resolves it on every call instead of freezing it at startup.
 
 A resolver may be invoked from a background or materializer thread (chain-step continuation, workflow-branch creation, batch-child creation) where a request-scoped proxy is not active. Ratchet treats a thrown `RuntimeException` — and a `null` `Optional` return — as `Optional.empty()` rather than failing the submission, but a resolver that legitimately has no caller identity available should prefer returning `Optional.empty()` directly.
+
+`JobContext` is a plain thread-local, not an inheritable context. If job code uses `CompletableFuture.supplyAsync(...)`, a manually managed executor, or another thread handoff and submits a job there, that submission does not inherit the parent job's principal from `JobContext`. Inheriting submissions must happen on the job execution thread while Ratchet's `JobContext` bind is active.
 
 ## ClassPolicy
 


### PR DESCRIPTION
## What

- `JobContext` now carries the executing job's persisted caller principal: a new `bind` overload stores it, `callerPrincipal()` reads it, and `currentOrNull()` gives non-throwing access. The executor already threaded the value into the MDC; the same call now populates the context.
- `CallerPrincipalResolution` cascades instead of short-circuiting. Order: configured `CallerPrincipalResolver`, then the bound `JobContext` principal, then the CDI `CallerPrincipalProvider`. A source that returns empty or throws hands off to the next one. Previously a configured resolver's `Optional.empty()` suppressed the provider entirely.
- `DefaultJobCreationService` resolves the principal once per submission and stamps the same value on every node of the graph (batch parent and children, chain steps, workflow branches, gates).
- Docs: the configuration guide and `JobContext` reference describe the resolution order and pin the contract that Ratchet never invents a principal. A null `caller_principal` means no principal was captured.

## Why

A job that submits another job from its own body runs on a worker thread with no request or actor context, so the child persisted a null `caller_principal` even when a user triggered the parent. The audit column lost the attribution chain at the first hop, and the authorization policy judged those children with no identity. With the context carrying the parent's persisted principal, inheritance holds at arbitrary depth because every child row is stamped and every execution rebinds.

The bound `JobContext` principal deliberately outranks the provider: a provider that falls back to a service account on worker threads must not mask the parent's identity.

## Testing

- Unit: full precedence matrix for the cascade, throw-degradation per source, batch-children-identical-principal test (1,764 tests green across touched modules).
- Testsuite (wildfly-managed/mysql, 4/4 green): runtime child submission inherits the parent principal, with the stub provider returning a distinct service-account value on worker threads so the test fails if inheritance loses precedence; `onSuccess`/`onFailure` callbacks proven to run inside the `JobContext` bind window.