### PR TITLE
Expose the env-seeded options builder for typed overrides

### DIFF
--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -157,7 +157,10 @@ public class RatchetOptions {
    *
    * @return a new builder seeded from this instance
    */
+  // Instances reachable through builder(), toBuilder(), or the public constructor have non-null
+  // option groups; CDI intercepts the sole null-valued proxy and delegates without reading them.
   @Incubating
+  @SuppressWarnings("DataFlowIssue")
   public Builder toBuilder() {
     Builder builder = new Builder();
 

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptions.java
@@ -150,6 +150,106 @@ public class RatchetOptions {
     return new Builder();
   }
 
+  /**
+   * Returns an independent builder seeded from this instance. Mutating the returned builder never
+   * affects this instance, and building it without changes yields an instance whose option-group
+   * records equal this instance's.
+   *
+   * @return a new builder seeded from this instance
+   */
+  @Incubating
+  public Builder toBuilder() {
+    Builder builder = new Builder();
+
+    builder.polling.batchSize = polling.batchSize();
+    builder.polling.burstDelayMs = polling.burstDelayMs();
+    builder.polling.minDelayMs = polling.minDelayMs();
+    builder.polling.maxDelayMs = polling.maxDelayMs();
+    builder.polling.deepIdleDelayMs = polling.deepIdleDelayMs();
+    builder.polling.deepIdleThresholdMs = polling.deepIdleThresholdMs();
+    builder.polling.idleThreshold = polling.idleThreshold();
+    builder.polling.claimHeadroomFactor = polling.claimHeadroomFactor();
+
+    builder.execution.defaultThreadingMode = execution.defaultThreadingMode();
+    builder.execution.queueSize = execution.queueSize();
+    builder.execution.maxConcurrency.clear();
+    builder.execution.maxConcurrency.putAll(execution.maxConcurrency());
+    builder.execution.virtualThreadLimits.clear();
+    builder.execution.virtualThreadLimits.putAll(execution.virtualThreadLimits());
+    builder.execution.rateLimitsPerMinute.clear();
+    builder.execution.rateLimitsPerMinute.putAll(execution.rateLimitsPerMinute());
+    builder.execution.jobExecutorJndi = execution.jobExecutorJndi();
+    builder.execution.scheduledExecutorJndi = execution.scheduledExecutorJndi();
+    builder.execution.coordinatorThreadFactoryJndi = execution.coordinatorThreadFactoryJndi();
+    builder.execution.virtualExecutorJndi = execution.virtualExecutorJndi();
+    builder.execution.virtualCounterAccounting = execution.virtualCounterAccounting();
+
+    builder.node.nodeId = node.nodeId();
+    builder.node.heartbeatIntervalSeconds = node.heartbeatIntervalSeconds();
+    builder.node.orphanGraceSeconds = node.orphanGraceSeconds();
+    builder.node.orphanScanIntervalMinutes = node.orphanScanIntervalMinutes();
+    builder.node.dynamicHeartbeatEnabled = node.dynamicHeartbeatEnabled();
+    builder.node.requireTags = List.copyOf(node.requireTags());
+    builder.node.excludeTags = List.copyOf(node.excludeTags());
+
+    builder.recurring.batchLimit = recurring.batchLimit();
+    builder.recurring.pollMs = recurring.pollMs();
+    builder.recurring.maxPollMs = recurring.maxPollMs();
+    builder.recurring.startupGraceSeconds = recurring.startupGraceSeconds();
+    builder.recurring.convergenceWindowSeconds = recurring.convergenceWindowSeconds();
+
+    builder.retryBuffer.drainIntervalMs = retryBuffer.drainIntervalMs();
+
+    builder.timeout.softTimeoutPercent = timeout.softTimeoutPercent();
+    builder.timeout.defaultSlaSeconds = timeout.defaultSlaSeconds();
+    builder.timeout.signalTimeoutBatchSize = timeout.signalTimeoutBatchSize();
+
+    builder.maintenance.dlqPurgeEnabled = maintenance.dlqPurgeEnabled();
+    builder.maintenance.dlqPurgeCron = maintenance.dlqPurgeCron();
+    builder.maintenance.dlqPurgeDays = maintenance.dlqPurgeDays();
+    builder.maintenance.jobArchiveEnabled = maintenance.jobArchiveEnabled();
+    builder.maintenance.jobArchiveCron = maintenance.jobArchiveCron();
+    builder.maintenance.jobRetentionDays = maintenance.jobRetentionDays();
+    builder.maintenance.jobArchiveBatchSize = maintenance.jobArchiveBatchSize();
+    builder.maintenance.logPurgeEnabled = maintenance.logPurgeEnabled();
+    builder.maintenance.logPurgeCron = maintenance.logPurgeCron();
+    builder.maintenance.logRetentionDays = maintenance.logRetentionDays();
+
+    builder.schema.autoMigrate = schema.autoMigrate();
+    builder.schema.migrationDialect = schema.migrationDialect();
+    builder.schema.migrationPrefix = schema.migrationPrefix();
+
+    builder.payload.maxPayloadKb = payload.maxPayloadKb();
+    builder.payload.maxResultBytes = payload.maxResultBytes();
+
+    builder.security.allowEmptyClassPolicy = security.allowEmptyClassPolicy();
+    builder.security.redactEmails = security.redactEmails();
+    builder.security.maskPayloads = security.maskPayloads();
+
+    builder.store.isolationCheckMode = store.isolationCheckMode();
+    builder.store.priorityBoostIntervalMinutes = store.priorityBoostIntervalMinutes();
+
+    builder.circuitBreaker.enabled = circuitBreaker.enabled();
+    builder.circuitBreaker.profiles.clear();
+    for (Map.Entry<CircuitBreakerProfile, CircuitBreakerProfileOptions> entry :
+        circuitBreaker.profiles().entrySet()) {
+      CircuitBreakerProfileOptions profile = entry.getValue();
+      builder.circuitBreaker.profiles.put(
+          entry.getKey(),
+          circuitBreakerProfile(
+              profile.failureRateThreshold(),
+              profile.slidingWindowSize(),
+              profile.waitDurationMs(),
+              profile.permittedCallsInHalfOpen(),
+              profile.minimumCalls()));
+    }
+
+    builder.encryption.enabled = encryption.enabled();
+    builder.encryption.writeAlgorithm = encryption.writeAlgorithm();
+    builder.callerPrincipalResolver = callerPrincipalResolver;
+    return builder;
+  }
+
   private static Map<String, Integer> defaultConcurrency() {
     Map<String, Integer> defaults = new HashMap<>();
     // Keys are JobExecutionType.name() values, but ratchet-api intentionally does not depend on
@@ -184,11 +284,11 @@ public class RatchetOptions {
       int permittedCallsInHalfOpen,
       int minimumCalls) {
     CircuitBreakerProfileBuilder builder = new CircuitBreakerProfileBuilder();
-    builder.failureRateThreshold(failureRateThreshold);
-    builder.slidingWindowSize(slidingWindowSize);
-    builder.waitDurationMs(waitDurationMs);
-    builder.permittedCallsInHalfOpen(permittedCallsInHalfOpen);
-    builder.minimumCalls(minimumCalls);
+    builder.failureRateThreshold = failureRateThreshold;
+    builder.slidingWindowSize = slidingWindowSize;
+    builder.waitDurationMs = waitDurationMs;
+    builder.permittedCallsInHalfOpen = permittedCallsInHalfOpen;
+    builder.minimumCalls = minimumCalls;
     return builder;
   }
 
@@ -406,7 +506,12 @@ public class RatchetOptions {
       long deepIdleDelayMs,
       long deepIdleThresholdMs,
       int idleThreshold,
-      int claimHeadroomFactor) {}
+      int claimHeadroomFactor) {
+
+    public PollingOptions {
+      requireNotGreater("minDelayMs", minDelayMs, "maxDelayMs", maxDelayMs);
+    }
+  }
 
   /**
    * Execution-pool wiring: target executor JNDI names, queue size, and per-execution-type
@@ -554,7 +659,12 @@ public class RatchetOptions {
       long pollMs,
       long maxPollMs,
       long startupGraceSeconds,
-      long convergenceWindowSeconds) {}
+      long convergenceWindowSeconds) {
+
+    public RecurringOptions {
+      requireNotGreater("pollMs", pollMs, "maxPollMs", maxPollMs);
+    }
+  }
 
   /**
    * Tuning for the in-memory retry buffer that batches failed-job retry inserts.

--- a/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
+++ b/ratchet-api/src/main/java/run/ratchet/api/RatchetOptionsFactory.java
@@ -21,6 +21,7 @@ import run.ratchet.api.internal.DefaultRatchetConfig;
 import run.ratchet.api.internal.EnvironmentRatchetConfigSource;
 import run.ratchet.api.internal.MicroProfileRatchetConfigSource;
 import run.ratchet.api.internal.RatchetConfigKeys;
+import run.ratchet.spi.CallerPrincipalResolver;
 import run.ratchet.spi.RatchetConfigKey;
 import run.ratchet.spi.RatchetConfigSource;
 
@@ -40,6 +41,10 @@ public final class RatchetOptionsFactory {
   private RatchetOptionsFactory() {}
 
   static RatchetOptions from(DefaultRatchetConfig config) {
+    return builderFrom(config).build();
+  }
+
+  static RatchetOptions.Builder builderFrom(DefaultRatchetConfig config) {
     return RatchetOptions.builder()
         .polling(
             polling ->
@@ -131,8 +136,7 @@ public final class RatchetOptionsFactory {
               for (CircuitBreakerProfile profile : CircuitBreakerProfile.values()) {
                 configureCircuitBreakerProfile(config, circuitBreaker, profile);
               }
-            })
-        .build();
+            });
   }
 
   /**
@@ -163,6 +167,48 @@ public final class RatchetOptionsFactory {
    */
   @Incubating
   public static RatchetOptions fromEnvironment(RatchetConfigSource... additional) {
+    return builderFromEnvironment(additional).build();
+  }
+
+  /**
+   * Returns a fully seeded {@link RatchetOptions.Builder} by reading the ambient configuration
+   * chain (MicroProfile Config when present, then environment variables), optionally overlaid with
+   * caller-supplied {@link RatchetConfigSource} instances.
+   *
+   * <p>Intended for use inside a CDI producer method when typed bootstrap overrides are required:
+   *
+   * <pre>{@code
+   * @Produces
+   * @ApplicationScoped
+   * public RatchetOptions ratchetOptions() {
+   *   return RatchetOptionsFactory.builderFromEnvironment()
+   *       .schema(s -> s.autoMigrate(false))
+   *       .store(s -> s.isolationCheckMode(RatchetOptions.IsolationCheckMode.WARN))
+   *       .execution(e -> e.jobExecutorJndi("java:jboss/ee/concurrency/executor/default")
+   *           .scheduledExecutorJndi("java:jboss/ee/concurrency/scheduler/default"))
+   *       .build();
+   * }
+   * }</pre>
+   *
+   * <p>Calling with no arguments reads exclusively from MicroProfile Config and environment
+   * variables, applying compiled-in defaults for keys absent from those sources. Caller-supplied
+   * sources take precedence over the ambient chain.
+   *
+   * <p>The returned builder is fully seeded from that source chain. Subsequent typed setters
+   * override values read from environment variables and MicroProfile Config. The builder is mutable
+   * and intended for single-threaded customization during bootstrap. It also provides the natural
+   * pre-build point for attaching a caller-principal resolver via {@link
+   * RatchetOptions.Builder#callerPrincipalResolver(CallerPrincipalResolver)}.
+   *
+   * <p>The surrounding producer method should be {@code @ApplicationScoped} so sources are read
+   * once at bootstrap rather than on every injection.
+   *
+   * @param additional optional overlay sources consulted before MicroProfile Config / env vars;
+   *     null elements are ignored
+   * @return a fully seeded, mutable {@link RatchetOptions.Builder}
+   */
+  @Incubating
+  public static RatchetOptions.Builder builderFromEnvironment(RatchetConfigSource... additional) {
     List<RatchetConfigSource> sources = new ArrayList<>();
     if (additional != null) {
       for (RatchetConfigSource source : additional) {
@@ -173,7 +219,7 @@ public final class RatchetOptionsFactory {
     }
     MicroProfileRatchetConfigSource.create().ifPresent(sources::add);
     sources.add(new EnvironmentRatchetConfigSource());
-    return from(new DefaultRatchetConfig(sources));
+    return builderFrom(new DefaultRatchetConfig(sources));
   }
 
   private static void configureExecution(

--- a/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsFactoryTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsFactoryTest.java
@@ -132,6 +132,68 @@ class RatchetOptionsFactoryTest {
   }
 
   @Test
+  void builderFromEnvironmentTreatsNullAdditionalArrayAsNoOverlays() {
+    RatchetOptions options =
+        RatchetOptionsFactory.builderFromEnvironment((RatchetConfigSource[]) null).build();
+
+    assertMatchesDefaults(RatchetOptions.defaults(), options);
+  }
+
+  @Test
+  void typedOverridesWinOverEnvironmentSourcedValues() {
+    RatchetOptions options =
+        RatchetOptionsFactory.builderFrom(
+                new DefaultRatchetConfig(
+                    List.of(
+                        new MapRatchetConfigSource(
+                            Map.of(
+                                "ratchet.schema.auto-migrate", "true",
+                                "ratchet.isolation-check", "fail",
+                                "ratchet.worker.job-executor-jndi", "java:env/concurrency/executor",
+                                "ratchet.worker.scheduled-executor-jndi",
+                                    "java:env/concurrency/scheduler",
+                                "ratchet.poller.batch-size", "456"),
+                            Map.of()))))
+            .schema(schema -> schema.autoMigrate(false))
+            .store(store -> store.isolationCheckMode(RatchetOptions.IsolationCheckMode.WARN))
+            .execution(
+                execution ->
+                    execution
+                        .jobExecutorJndi("java:jboss/ee/concurrency/executor/default")
+                        .scheduledExecutorJndi("java:jboss/ee/concurrency/scheduler/default"))
+            .build();
+
+    assertFalse(options.schema().autoMigrate());
+    assertEquals(RatchetOptions.IsolationCheckMode.WARN, options.store().isolationCheckMode());
+    assertEquals(
+        "java:jboss/ee/concurrency/executor/default", options.execution().jobExecutorJndi());
+    assertEquals(
+        "java:jboss/ee/concurrency/scheduler/default", options.execution().scheduledExecutorJndi());
+    assertEquals(456, options.polling().batchSize());
+  }
+
+  @Test
+  void builderFromSeedsBuilderFromSourceValues() {
+    RatchetOptions options =
+        RatchetOptionsFactory.builderFrom(
+                new DefaultRatchetConfig(
+                    List.of(
+                        new MapRatchetConfigSource(
+                            Map.of(
+                                "ratchet.poller.batch-size", "73",
+                                "ratchet.node.id", "seeded-node",
+                                "ratchet.timeout.default-sla-seconds", "91",
+                                "ratchet.security.mask-payloads", "true"),
+                            Map.of()))))
+            .build();
+
+    assertEquals(73, options.polling().batchSize());
+    assertEquals(Optional.of("seeded-node"), options.node().explicitNodeId());
+    assertEquals(91L, options.timeout().defaultSlaSeconds());
+    assertTrue(options.security().maskPayloads());
+  }
+
+  @Test
   void mapsRepresentativeConfigurationKeysAcrossOptionGroups() {
     RatchetOptions options =
         optionsFrom(
@@ -365,6 +427,37 @@ class RatchetOptionsFactoryTest {
         System.clearProperty(property);
       } else {
         System.setProperty(property, previous);
+      }
+    }
+  }
+
+  @Test
+  void builderFromEnvironmentReadsSystemPropertiesAndTypedOverridesWin() {
+    String batchSizeProperty = "ratchet.poller.batch-size";
+    String autoMigrateProperty = "ratchet.schema.auto-migrate";
+    String previousBatchSize = System.getProperty(batchSizeProperty);
+    String previousAutoMigrate = System.getProperty(autoMigrateProperty);
+    try {
+      System.setProperty(batchSizeProperty, "321");
+      System.setProperty(autoMigrateProperty, "true");
+
+      RatchetOptions options =
+          RatchetOptionsFactory.builderFromEnvironment()
+              .schema(schema -> schema.autoMigrate(false))
+              .build();
+
+      assertEquals(321, options.polling().batchSize());
+      assertFalse(options.schema().autoMigrate());
+    } finally {
+      if (previousBatchSize == null) {
+        System.clearProperty(batchSizeProperty);
+      } else {
+        System.setProperty(batchSizeProperty, previousBatchSize);
+      }
+      if (previousAutoMigrate == null) {
+        System.clearProperty(autoMigrateProperty);
+      } else {
+        System.setProperty(autoMigrateProperty, previousAutoMigrate);
       }
     }
   }

--- a/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
+++ b/ratchet-api/src/test/java/run/ratchet/api/RatchetOptionsTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -213,6 +214,196 @@ class RatchetOptionsTest {
                         circuitBreaker.profile(
                             CircuitBreakerProfile.DEFAULT,
                             profile -> profile.failureRateThreshold(Float.POSITIVE_INFINITY))));
+  }
+
+  @Test
+  void toBuilderRoundTripsFullyPopulatedInstance() {
+    CallerPrincipalResolver resolver = () -> Optional.of("round-trip-user");
+    RatchetOptions original =
+        RatchetOptions.builder()
+            .polling(
+                polling ->
+                    polling
+                        .batchSize(51)
+                        .burstDelayMs(501L)
+                        .minDelayMs(2001L)
+                        .maxDelayMs(10001L)
+                        .deepIdleDelayMs(30001L)
+                        .deepIdleThresholdMs(60001L)
+                        .idleThreshold(4)
+                        .claimHeadroomFactor(1))
+            .execution(
+                execution ->
+                    execution
+                        .defaultThreadingMode(RatchetOptions.ThreadingMode.VIRTUAL)
+                        .queueSize(101)
+                        .maxConcurrency("SINGLE", 21)
+                        .virtualThreadLimit("RECURRING", 22)
+                        .rateLimitPerMinute("BATCH_CHILD", 23)
+                        .jobExecutorJndi("java:app/concurrent/JobExecutor")
+                        .scheduledExecutorJndi("java:app/concurrent/ScheduledExecutor")
+                        .coordinatorThreadFactoryJndi("java:app/concurrent/CoordinatorFactory")
+                        .virtualExecutorJndi("java:app/concurrent/VirtualExecutor")
+                        .virtualCounterAccounting(true))
+            .node(
+                node ->
+                    node.nodeId("node-a")
+                        .heartbeatIntervalSeconds(11L)
+                        .orphanGraceSeconds(61L)
+                        .orphanScanIntervalMinutes(6L)
+                        .dynamicHeartbeatEnabled(false)
+                        .requireTags("blue", "primary")
+                        .excludeTags("draining"))
+            .recurring(
+                recurring ->
+                    recurring
+                        .batchLimit(21)
+                        .pollMs(1001L)
+                        .maxPollMs(60001L)
+                        .startupGraceSeconds(61L)
+                        .convergenceWindowSeconds(1L))
+            .retryBuffer(retryBuffer -> retryBuffer.drainIntervalMs(1001L))
+            .timeout(
+                timeout ->
+                    timeout
+                        .softTimeoutPercent(81)
+                        .defaultSlaSeconds(1801L)
+                        .signalTimeoutBatchSize(501))
+            .maintenance(
+                maintenance ->
+                    maintenance
+                        .dlqPurgeEnabled(false)
+                        .dlqPurgeCron("0 1 2 * * ?")
+                        .dlqPurgeDays(91L)
+                        .jobArchiveEnabled(false)
+                        .jobArchiveCron("0 1 1 * * ?")
+                        .jobRetentionDays(91L)
+                        .jobArchiveBatchSize(1001)
+                        .logPurgeEnabled(false)
+                        .logPurgeCron("0 31 2 * * ?")
+                        .logRetentionDays(31L))
+            .schema(
+                schema ->
+                    schema
+                        .autoMigrate(true)
+                        .migrationDialect("postgresql")
+                        .migrationPrefix("ddl/custom"))
+            .payload(payload -> payload.maxPayloadKb(101).maxResultBytes(65537L))
+            .security(
+                security ->
+                    security.allowEmptyClassPolicy(true).redactEmails(false).maskPayloads(true))
+            .store(
+                store ->
+                    store
+                        .isolationCheckMode(RatchetOptions.IsolationCheckMode.WARN)
+                        .priorityBoostIntervalMinutes(16))
+            .circuitBreaker(
+                circuitBreaker ->
+                    circuitBreaker
+                        .enabled(false)
+                        .profile(
+                            CircuitBreakerProfile.DEFAULT,
+                            profile ->
+                                profile
+                                    .failureRateThreshold(51.0f)
+                                    .slidingWindowSize(101)
+                                    .waitDurationMs(30001L)
+                                    .permittedCallsInHalfOpen(4)
+                                    .minimumCalls(6)))
+            .encryption(encryption -> encryption.enabled(true).writeAlgorithm("AES/GCM/NoPadding"))
+            .callerPrincipalResolver(resolver)
+            .build();
+
+    RatchetOptions roundTripped = original.toBuilder().build();
+
+    assertEquals(original.polling(), roundTripped.polling());
+    assertEquals(original.execution(), roundTripped.execution());
+    assertEquals(original.node(), roundTripped.node());
+    assertEquals(original.recurring(), roundTripped.recurring());
+    assertEquals(original.retryBuffer(), roundTripped.retryBuffer());
+    assertEquals(original.timeout(), roundTripped.timeout());
+    assertEquals(original.maintenance(), roundTripped.maintenance());
+    assertEquals(original.schema(), roundTripped.schema());
+    assertEquals(original.payload(), roundTripped.payload());
+    assertEquals(original.security(), roundTripped.security());
+    assertEquals(original.store(), roundTripped.store());
+    assertEquals(original.circuitBreaker(), roundTripped.circuitBreaker());
+    assertEquals(original.encryption(), roundTripped.encryption());
+    assertSame(original.callerPrincipalResolver(), roundTripped.callerPrincipalResolver());
+  }
+
+  @Test
+  void toBuilderPreservesSubsetMapsWithoutDefaultLeakBack() {
+    Map<String, Integer> maxConcurrency = Map.of("SINGLE", 2, "RECURRING", 3);
+    RatchetOptions.ExecutionOptions execution =
+        new RatchetOptions.ExecutionOptions(
+            RatchetOptions.ThreadingMode.PLATFORM,
+            17,
+            maxConcurrency,
+            Map.of(),
+            Map.of(),
+            "java:app/concurrent/JobExecutor",
+            "java:app/concurrent/ScheduledExecutor",
+            "java:app/concurrent/CoordinatorFactory",
+            null,
+            false);
+    RatchetOptions.CircuitBreakerProfileOptions profile =
+        new RatchetOptions.CircuitBreakerProfileOptions(40.0f, 10, 5000L, 2, 3);
+    RatchetOptions.CircuitBreakerOptions circuitBreaker =
+        new RatchetOptions.CircuitBreakerOptions(true, Map.of(CircuitBreakerProfile.FAST, profile));
+    RatchetOptions defaults = RatchetOptions.defaults();
+    RatchetOptions original =
+        new RatchetOptions(
+            defaults.polling(),
+            execution,
+            defaults.node(),
+            defaults.recurring(),
+            defaults.retryBuffer(),
+            defaults.timeout(),
+            defaults.maintenance(),
+            defaults.schema(),
+            defaults.payload(),
+            defaults.security(),
+            defaults.store(),
+            circuitBreaker,
+            defaults.encryption());
+
+    RatchetOptions roundTripped = original.toBuilder().build();
+
+    assertEquals(maxConcurrency, roundTripped.execution().maxConcurrency());
+    assertEquals(Map.of(), roundTripped.execution().virtualThreadLimits());
+    assertEquals(Map.of(), roundTripped.execution().rateLimitsPerMinute());
+    assertEquals(
+        Map.of(CircuitBreakerProfile.FAST, profile), roundTripped.circuitBreaker().profiles());
+  }
+
+  @Test
+  void toBuilderModificationsDoNotAffectOriginal() {
+    RatchetOptions original =
+        RatchetOptions.builder().polling(polling -> polling.batchSize(77)).build();
+    RatchetOptions.PollingOptions originalPolling = original.polling();
+    RatchetOptions.Builder builder = original.toBuilder();
+
+    builder.polling(polling -> polling.batchSize(88));
+    RatchetOptions modified = builder.build();
+
+    assertEquals(originalPolling, original.polling());
+    assertEquals(77, original.polling().batchSize());
+    assertEquals(88, modified.polling().batchSize());
+  }
+
+  @Test
+  void pollingOptionsRejectsMinDelayGreaterThanMaxDelay() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new RatchetOptions.PollingOptions(1, 0L, 2L, 1L, 0L, 0L, 0, 0));
+  }
+
+  @Test
+  void recurringOptionsRejectsPollGreaterThanMaxPoll() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new RatchetOptions.RecurringOptions(1, 2L, 1L, 0L, 0L));
   }
 
   @Test

--- a/website/docs/getting-started/configuration.md
+++ b/website/docs/getting-started/configuration.md
@@ -79,6 +79,35 @@ public class SchedulerConfiguration {
 
 With zero arguments, `fromEnvironment()` reads exclusively from MicroProfile Config and environment variables, applying compiled-in defaults for keys absent from those sources. See [Source Chain](#source-chain) below to overlay custom `RatchetConfigSource` implementations.
 
+### Typed overrides on top of the environment
+
+When most settings should remain environment-tunable but a few deployment values are known in code, start from the environment-backed builder and override only those values:
+
+```java
+import run.ratchet.api.RatchetOptions;
+import run.ratchet.api.RatchetOptionsFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class SchedulerConfiguration {
+
+    @Produces
+    @ApplicationScoped
+    RatchetOptions ratchetOptions() {
+        return RatchetOptionsFactory.builderFromEnvironment()
+            .schema(s -> s.autoMigrate(false))
+            .store(s -> s.isolationCheckMode(RatchetOptions.IsolationCheckMode.WARN))
+            .execution(e -> e
+                .jobExecutorJndi("java:jboss/ee/concurrency/executor/default")
+                .scheduledExecutorJndi("java:jboss/ee/concurrency/scheduler/default"))
+            .build();
+    }
+}
+```
+
+Everything else stays environment-tunable. Typed overrides win over environment and MicroProfile Config values.
+
 ### Option B: Programmatic producer
 
 For applications that want compile-time-checked configuration without env-var round-tripping, use the builder directly:
@@ -284,6 +313,8 @@ public class PlatformRatchetConfigSource implements RatchetConfigSource {
     }
 }
 ```
+
+For simple known-value pins, prefer typed calls on `builderFromEnvironment()` over a custom `RatchetConfigSource`; they are compile-checked and survive configuration-key renames.
 
 The env lookup recognizes canonical `ratchet.*` property names and `RATCHET_*` environment variable names. The source-derived [Configuration reference](/deployment/configuration-reference) lists every fixed pair and its default; the website build fails if that table falls behind the typed catalog.
 


### PR DESCRIPTION
## Summary

`RatchetOptionsFactory.fromEnvironment(...)` returns a finished immutable `RatchetOptions`, so a host that wants everything env-tunable except a few code-pinned safety values had to overlay a string-keyed `RatchetConfigSource`. Those magic keys silently stop applying when a key is renamed.

This closes the composition gap in the supported API without making the internal key catalog public:

- `RatchetOptionsFactory.builderFromEnvironment(RatchetConfigSource...)` (`@Incubating`) returns the env-seeded `RatchetOptions.Builder` instead of a built instance. The existing seeding chain was split at its `.build()` boundary; `fromEnvironment` now delegates to it, so there is one seeding path. Typed setter calls on the returned builder win over env and MicroProfile values:

  ```java
  RatchetOptionsFactory.builderFromEnvironment()
      .schema(s -> s.autoMigrate(false))
      .store(s -> s.isolationCheckMode(RatchetOptions.IsolationCheckMode.WARN))
      .execution(e -> e.jobExecutorJndi("java:jboss/ee/concurrency/executor/default")
          .scheduledExecutorJndi("java:jboss/ee/concurrency/scheduler/default"))
      .build();
  ```

- `RatchetOptions.toBuilder()` (`@Incubating`) seeds a fresh builder from a built instance. Map-typed builder state is cleared before copying so a record built directly with a subset map round-trips without the compiled defaults leaking back; nullable fields bypass the validating setters; `callerPrincipalResolver` carries through.

- `PollingOptions` and `RecurringOptions` gained compact constructors enforcing the same min/max cross-checks as their builders, so every constructible instance survives `toBuilder().build()` instead of failing late.

No new config keys, no env-parsing changes, `RatchetConfigKeys` stays internal, and `configuration-reference.md` is untouched.

## Testing

- [x] `mvn clean test -B`
- [x] `mvn spotless:check -B`
- [ ] `mvn verify -P wildfly-managed,postgresql -B -pl :ratchet-testsuite,:ratchet-coverage -am`
- [x] `cd website && npm ci && npm run build`

New coverage: typed overrides beat env-sourced values while untouched env values survive; builder seeding asserts concrete values across groups; system-property path through `builderFromEnvironment`; full-population `toBuilder` round-trip (every group plus resolver identity); subset-map leak-back guard; builder independence from the original instance; new record cross-field validations.

The server-matrix cell was not run: the change is confined to `ratchet-api` value types with no store, container, or wiring impact.

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed

`configuration.md` gained a "Typed overrides on top of the environment" subsection and the Source chain section now points known-value pinning at typed overrides instead of a custom source. `configuration-reference.md` has zero diff by design.

## Review Notes

- [ ] Breaking change
- [x] Public API or SPI change
- [ ] Security-sensitive change
- [ ] Follow-up work remains

Strictly speaking the compact constructors narrow `PollingOptions`/`RecurringOptions`: direct construction with inverted min/max bounds now throws where it previously produced a broken-but-accepted instance. Not marked breaking since no valid configuration is affected and this is pre-release.

## Additional Context

The design (builder exposure over per-setting withers, and the `toBuilder` seeding approach) went through a two-AI adversarial review before implementation; the compact-constructor hardening and the subset-map test came out of that review.