### PR TITLE
Start 0.3.1-SNAPSHOT development

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: version
     attributes:
       label: Ratchet version or commit SHA
-      placeholder: 0.3.0-SNAPSHOT or a commit SHA
+      placeholder: 0.3.1-SNAPSHOT or a commit SHA
     validations:
       required: true
   - type: input

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Swap the retry logic, circuit-breaker behavior, polling cadence, thread/executor
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -175,7 +175,7 @@ mvn spotless:apply       # auto-format (Google Java Format)
 
 ## Project Status
 
-Ratchet is in **0.3.0-SNAPSHOT**. The API is stabilizing; interfaces marked `@Incubating` may change between alpha releases. Feedback and contributions are welcome.
+Ratchet is in **0.3.1-SNAPSHOT**. The API is stabilizing; interfaces marked `@Incubating` may change between alpha releases. Feedback and contributions are welcome.
 
 ## Community
 

--- a/coordinators/ratchet-coordinator-common/pom.xml
+++ b/coordinators/ratchet-coordinator-common/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-hazelcast/pom.xml
+++ b/coordinators/ratchet-coordinator-hazelcast/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-infinispan/pom.xml
+++ b/coordinators/ratchet-coordinator-infinispan/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-jms/pom.xml
+++ b/coordinators/ratchet-coordinator-jms/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/coordinators/ratchet-coordinator-postgresql/pom.xml
+++ b/coordinators/ratchet-coordinator-postgresql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/infra/loadtest/Dockerfile
+++ b/infra/loadtest/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p \
 COPY --from=build /drivers/postgresql.jar /opt/jboss/ratchet/drivers/postgresql.jar
 COPY --from=build /drivers/mysql.jar /opt/jboss/ratchet/drivers/mysql.jar
 COPY infra/loadtest/wildfly/${STORE}.cli /opt/jboss/ratchet/store.cli
-COPY --from=build /workspace/testing/ratchet-loadtest/target/ratchet-loadtest-0.3.0-SNAPSHOT.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
+COPY --from=build /workspace/testing/ratchet-loadtest/target/ratchet-loadtest-0.3.1-SNAPSHOT.war /opt/jboss/wildfly/standalone/deployments/ROOT.war
 RUN chown -R jboss:root /opt/jboss/ratchet /opt/jboss/wildfly/standalone \
     && chmod -R ug+rwX /opt/jboss/ratchet /opt/jboss/wildfly/standalone \
     && /opt/jboss/wildfly/bin/jboss-cli.sh --file=/opt/jboss/ratchet/store.cli \

--- a/integrations/ratchet-quarkus/core-deployment/pom.xml
+++ b/integrations/ratchet-quarkus/core-deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus-core-deployment</artifactId>

--- a/integrations/ratchet-quarkus/core/pom.xml
+++ b/integrations/ratchet-quarkus/core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus-core</artifactId>

--- a/integrations/ratchet-quarkus/deployment/pom.xml
+++ b/integrations/ratchet-quarkus/deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus-deployment</artifactId>

--- a/integrations/ratchet-quarkus/integration-tests/pom.xml
+++ b/integrations/ratchet-quarkus/integration-tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus-integration-tests</artifactId>

--- a/integrations/ratchet-quarkus/mongodb-deployment/pom.xml
+++ b/integrations/ratchet-quarkus/mongodb-deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus-mongodb-deployment</artifactId>

--- a/integrations/ratchet-quarkus/mongodb/pom.xml
+++ b/integrations/ratchet-quarkus/mongodb/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus-mongodb</artifactId>

--- a/integrations/ratchet-quarkus/pom.xml
+++ b/integrations/ratchet-quarkus/pom.xml
@@ -7,13 +7,13 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-quarkus-parent</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Ratchet :: Quarkus Extension :: Parent</name>
 

--- a/integrations/ratchet-quarkus/runtime/pom.xml
+++ b/integrations/ratchet-quarkus/runtime/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-quarkus-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-quarkus</artifactId>

--- a/observability/ratchet-micrometer/pom.xml
+++ b/observability/ratchet-micrometer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/observability/ratchet-otel/pom.xml
+++ b/observability/ratchet-otel/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-parent</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
+  <version>0.3.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Ratchet</name>
@@ -78,7 +78,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Reproducible builds: two builds of the same tag produce identical jar hashes.
          maven-release-plugin refreshes this on each release:prepare. -->
-    <project.build.outputTimestamp>2026-07-29T19:16:04Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-07-31T13:23:12Z</project.build.outputTimestamp>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
     <maven.compiler.release>17</maven.compiler.release>

--- a/ratchet-api/pom.xml
+++ b/ratchet-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-api</artifactId>

--- a/ratchet-bom/pom.xml
+++ b/ratchet-bom/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-bom</artifactId>

--- a/ratchet-encryption/pom.xml
+++ b/ratchet-encryption/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>ratchet-encryption</artifactId>

--- a/ratchet-security-jakarta/pom.xml
+++ b/ratchet-security-jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet-security-jakarta</artifactId>

--- a/ratchet/pom.xml
+++ b/ratchet/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>ratchet</artifactId>

--- a/stores/ratchet-store-core/pom.xml
+++ b/stores/ratchet-store-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-mongodb/pom.xml
+++ b/stores/ratchet-store-mongodb/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-mysql/pom.xml
+++ b/stores/ratchet-store-mysql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-oracle/pom.xml
+++ b/stores/ratchet-store-oracle/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-postgresql/pom.xml
+++ b/stores/ratchet-store-postgresql/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/stores/ratchet-store-sqlserver/pom.xml
+++ b/stores/ratchet-store-sqlserver/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-arch-tests/pom.xml
+++ b/testing/ratchet-arch-tests/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-coverage/pom.xml
+++ b/testing/ratchet-coverage/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-loadtest/pom.xml
+++ b/testing/ratchet-loadtest/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-showcase/pom.xml
+++ b/testing/ratchet-showcase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-tck/api/pom.xml
+++ b/testing/ratchet-tck/api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/coordinator/pom.xml
+++ b/testing/ratchet-tck/coordinator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/jakarta/pom.xml
+++ b/testing/ratchet-tck/jakarta/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/pom.xml
+++ b/testing/ratchet-tck/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/store/pom.xml
+++ b/testing/ratchet-tck/store/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-tck/util/pom.xml
+++ b/testing/ratchet-tck/util/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>run.ratchet</groupId>
         <artifactId>ratchet-parent</artifactId>
-        <version>0.3.0-SNAPSHOT</version>
+        <version>0.3.1-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
 

--- a/testing/ratchet-testsuite-jpms/pom.xml
+++ b/testing/ratchet-testsuite-jpms/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-testsuite/pom.xml
+++ b/testing/ratchet-testsuite/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/testing/ratchet-version-compatibility/pom.xml
+++ b/testing/ratchet-version-compatibility/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-parent</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.3.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/website/docs/advanced/metrics-collection.md
+++ b/website/docs/advanced/metrics-collection.md
@@ -39,7 +39,7 @@ The `ratchet-micrometer` module provides a Micrometer adapter that publishes job
 <dependency>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-micrometer</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
 </dependency>
 ```
 

--- a/website/docs/advanced/spi-implementation.md
+++ b/website/docs/advanced/spi-implementation.md
@@ -922,7 +922,7 @@ Compatible" label. API and Jakarta-runtime compatibility are separate tiers; fol
 <dependency>
     <groupId>run.ratchet</groupId>
     <artifactId>ratchet-tck-store</artifactId>
-    <version>0.2.1</version>
+    <version>0.3.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/website/docs/concepts/overview.md
+++ b/website/docs/concepts/overview.md
@@ -355,7 +355,7 @@ Add Ratchet to your Jakarta EE application:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/conformance/adopting-the-tck.md
+++ b/website/docs/conformance/adopting-the-tck.md
@@ -46,7 +46,7 @@ Import the Ratchet BOM so the TCK, API, and store artifacts use one version:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/deployment/database-setup.md
+++ b/website/docs/deployment/database-setup.md
@@ -39,7 +39,7 @@ The DDL file is at `stores/ratchet-store-postgresql/src/main/resources/ddl/postg
 psql -U ratchet -d ratchet -f stores/ratchet-store-postgresql/src/main/resources/ddl/postgresql-schema.sql
 
 # Or extract from the JAR
-jar xf ratchet-store-postgresql-0.2.1.jar ddl/postgresql-schema.sql
+jar xf ratchet-store-postgresql-0.3.0.jar ddl/postgresql-schema.sql
 psql -U ratchet -d ratchet -f ddl/postgresql-schema.sql
 ```
 
@@ -162,7 +162,7 @@ FLUSH PRIVILEGES;
 mysql -u ratchet -p ratchet < stores/ratchet-store-mysql/src/main/resources/ddl/mysql-schema.sql
 
 # Or extract from the JAR
-jar xf ratchet-store-mysql-0.2.1.jar ddl/mysql-schema.sql
+jar xf ratchet-store-mysql-0.3.0.jar ddl/mysql-schema.sql
 mysql -u ratchet -p ratchet < ddl/mysql-schema.sql
 ```
 

--- a/website/docs/deployment/docker.md
+++ b/website/docs/deployment/docker.md
@@ -229,7 +229,7 @@ To extract the DDL from the Ratchet JAR:
 
 ```bash
 # Extract from the store module JAR
-jar xf ratchet-store-postgresql-0.2.1.jar ddl/postgresql-schema.sql
+jar xf ratchet-store-postgresql-0.3.0.jar ddl/postgresql-schema.sql
 cp ddl/postgresql-schema.sql schema/
 ```
 

--- a/website/docs/deployment/mongodb.md
+++ b/website/docs/deployment/mongodb.md
@@ -30,7 +30,7 @@ or sharded cluster even when an application does not currently assign business k
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-store-mongodb</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 

--- a/website/docs/deployment/monitoring.md
+++ b/website/docs/deployment/monitoring.md
@@ -18,7 +18,7 @@ Add the Micrometer module:
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-micrometer</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 

--- a/website/docs/deployment/overview.md
+++ b/website/docs/deployment/overview.md
@@ -45,7 +45,7 @@ All versions are managed through the `ratchet-bom`:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/deployment/performance-tuning.md
+++ b/website/docs/deployment/performance-tuning.md
@@ -351,7 +351,7 @@ Add the `ratchet-micrometer` module instead of maintaining a lifecycle-only coll
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-micrometer</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
 </dependency>
 ```
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -22,7 +22,7 @@ The Bill of Materials (BOM) ensures all Ratchet modules use the same version. Im
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/getting-started/introduction.md
+++ b/website/docs/getting-started/introduction.md
@@ -164,7 +164,7 @@ On Quarkus, the `ratchet-quarkus` extension runs the engine on the JVM and as a 
 
 ## Project status
 
-Ratchet is currently at version **0.3.0-SNAPSHOT**. The core API is stabilizing, but interfaces marked with `@Incubating` (such as `CircuitBreakerProtected` and `CircuitBreakerProfile`) may change in future releases. Feedback and contributions are welcome.
+Ratchet is currently at version **0.3.1-SNAPSHOT**. The core API is stabilizing, but interfaces marked with `@Incubating` (such as `CircuitBreakerProtected` and `CircuitBreakerProfile`) may change in future releases. Feedback and contributions are welcome.
 
 ## What's next
 

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -27,7 +27,7 @@ If you haven't done steps 3 and 4 yet, here's the minimum `pom.xml` setup:
     <dependency>
       <groupId>run.ratchet</groupId>
       <artifactId>ratchet-bom</artifactId>
-      <version>0.2.1</version>
+      <version>0.3.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>

--- a/website/docs/use-cases/bulk-batch-jobs.md
+++ b/website/docs/use-cases/bulk-batch-jobs.md
@@ -12,7 +12,7 @@ Roll that yourself and you end up writing the same ledger every time. A counter 
 A batch is Ratchet's name for that ledger. You hand it the items and the work; it enqueues one child job each, counts completions and failures as they land, and hands every progress hook an immutable snapshot. When the batch finishes, you branch on what actually happened.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.3.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `BatchStore` capability.
+The Java on this page compiles against `ratchet-api` `0.3.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `BatchStore` capability.
 :::
 
 ## Fan out, track progress, branch on the result

--- a/website/docs/use-cases/durable-llm-workflows.md
+++ b/website/docs/use-cases/durable-llm-workflows.md
@@ -10,7 +10,7 @@ Calling a language model from a request thread is a trap. The call is slow, it f
 This is the problem durable execution solves, and it is what Ratchet already does for any other background work. Ratchet is not an AI framework and ships no model client. It is the layer underneath: it persists the call before it runs, retries it with backoff, trips a circuit breaker when the provider is down, and resumes a half-finished multi-step workflow after a crash. You bring the model client. On Jakarta EE the natural choice is [langchain4j-cdi](https://github.com/langchain4j/langchain4j-cdi), which exposes a [LangChain4j](https://docs.langchain4j.dev) AI service as an injectable CDI bean, the same programming model Ratchet uses.
 
 ::: tip Verified
-The Java on this page is compile-checked in this repository against the next development API: `ratchet-api` `0.3.0-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. The copyable dependency block deliberately uses the latest published Ratchet release shown below so it resolves from Maven Central. This is not a full runnable application (wiring it up needs a Jakarta EE server and AWS credentials), but the API usage is real, not illustrative pseudocode.
+The Java on this page is compile-checked in this repository against the next development API: `ratchet-api` `0.3.1-SNAPSHOT`, `langchain4j-cdi-portable-ext` `1.3.3`, and `langchain4j-bedrock` `1.0.0-beta5`. The copyable dependency block deliberately uses the latest published Ratchet release shown below so it resolves from Maven Central. This is not a full runnable application (wiring it up needs a Jakarta EE server and AWS credentials), but the API usage is real, not illustrative pseudocode.
 :::
 
 ## What you wire together
@@ -20,12 +20,12 @@ The Java on this page is compile-checked in this repository against the next dev
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
 </dependency>
 <dependency>
   <groupId>run.ratchet</groupId>
   <artifactId>ratchet-store-postgresql</artifactId>
-  <version>0.2.1</version>
+  <version>0.3.0</version>
 </dependency>
 
 <!-- langchain4j-cdi: AI services as CDI beans on WildFly, Liberty, Payara, GlassFish -->

--- a/website/docs/use-cases/human-in-the-loop.md
+++ b/website/docs/use-cases/human-in-the-loop.md
@@ -14,7 +14,7 @@ Ratchet gives the job a waiting state instead. It parks in `WAITING`, holds no t
 The [durable LLM workflows](./durable-llm-workflows.md#pause-for-a-human-then-resume) page reaches for this same mechanism to gate an agent's actions. This page is the mechanism itself: how a job waits, how a decision reaches it, and what happens when nobody decides.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.3.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `SignalStore` capability.
+The Java on this page compiles against `ratchet-api` `0.3.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a store that advertises the `SignalStore` capability.
 :::
 
 ## Park, decide, resume

--- a/website/docs/use-cases/offload-after-request.md
+++ b/website/docs/use-cases/offload-after-request.md
@@ -12,7 +12,7 @@ The usual escape hatch is a thread pool, or a `@Async` method, or handing the wo
 Ratchet closes that window. You enqueue the follow-up work inside the same transaction that writes the order, so the job and the order row commit together. The request returns as soon as the row is durable. The work runs later, on a worker, with retries, and it cannot get lost, because it was written to the same database as the thing it follows up on.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.3.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
+The Java on this page compiles against `ratchet-api` `0.3.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
 :::
 
 ## Enqueue inside the transaction, return now

--- a/website/docs/use-cases/resilient-integrations.md
+++ b/website/docs/use-cases/resilient-integrations.md
@@ -12,7 +12,7 @@ Retrying handles the blip. It is the wrong tool for the outage: a hundred queued
 Ratchet gives you both, and they stay out of each other's way. The retry budget rides out transient errors. The breaker rides out outages without spending that budget. The external call lives in a durable job, so none of this happens on the request thread, and a provider's bad afternoon never reaches your user as a failed request.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.3.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store. The `@CircuitBreakerProtected` annotation is marked `@Incubating` and may change.
+The Java on this page compiles against `ratchet-api` `0.3.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store. The `@CircuitBreakerProtected` annotation is marked `@Incubating` and may change.
 :::
 
 ## Layer one: the call as a retrying job

--- a/website/docs/use-cases/scheduled-recurring-jobs.md
+++ b/website/docs/use-cases/scheduled-recurring-jobs.md
@@ -12,7 +12,7 @@ The usual answer is Quartz, or a `@Scheduled` method, or a cron line on one box.
 Ratchet treats a scheduled run as what it already is: a job. It gets written to your database before it runs, claimed by exactly one node, retried on failure, and picked up again after a crash. The schedule is a row, not a thread on a single machine. If you already run Ratchet for background work, recurring work is the same engine with a cron string attached.
 
 ::: tip Verified
-The Java on this page compiles against `ratchet-api` `0.3.0-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
+The Java on this page compiles against `ratchet-api` `0.3.1-SNAPSHOT`. It shows real API usage, not pseudocode. The running app needs a Jakarta EE server and a configured store.
 :::
 
 ## The declarative path: `@Recurring`


### PR DESCRIPTION
Automated reactor bump to 0.3.1-SNAPSHOT after the v0.3.0 release. Opened by hand because the release workflow's RELEASE_TOKEN lacks pull-request permission (the workflow pushed the Verified bump commit before failing on PR creation).