### PR TITLE
Update netty and postcss, suppress a dependency-check false positive

### DIFF
--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -73,4 +73,18 @@
         <cpe>cpe:/a:prometheus:prometheus</cpe>
     </suppress>
 
+    <suppress>
+        <notes><![CDATA[
+        False positive: CVE-2019-3826 is a stored DOM-based XSS in the Prometheus
+        SERVER's web UI, fixed in Prometheus server 2.7.1. micrometer-registry-prometheus
+        is the io.micrometer client library that only emits metrics; it has no web UI
+        and is not the Prometheus server. Matched by file path, not packageUrl: this
+        scan reaches the jar nested inside testing/ratchet-loadtest's WAR (WEB-INF/lib),
+        where Dependency-Check assigns the server CPE from the name but no Maven PURL,
+        so packageUrl/cpe rules never match (mirrors the CVE-2026-42154 entry above).
+        ]]></notes>
+        <filePath regex="true">.*/micrometer-registry-prometheus-[^/]+\.jar$</filePath>
+        <cve>CVE-2019-3826</cve>
+    </suppress>
+
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <mssql-jdbc.version>12.8.2.jre11</mssql-jdbc.version>
     <jakarta.jms-api.version>3.1.0</jakarta.jms-api.version>
     <artemis.version>2.54.0</artemis.version>
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <jackson-core.version>2.22.1</jackson-core.version>
     <infinispan.version>15.1.7.Final</infinispan.version>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2087,9 +2087,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2186,9 +2186,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -2206,7 +2206,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Triage of the open Security and quality findings. This PR takes the three low-risk ones. The large netty cluster in the Quarkus modules is deliberately left out and handled separately, since it carries native-image risk.

## netty 4.1.135 -> 4.1.136

Ten open advisories name 4.1.136.Final as first-patched. This pin only reaches `ratchet-coordinator-jms`, where netty arrives test-scope under the embedded Artemis broker, so there is no consumer-facing change.

Verified: `mvn dependency:tree '-Dincludes=io.netty:*' -pl coordinators/ratchet-coordinator-jms -am` resolves every io.netty artifact to 4.1.136.Final. Module tests pass, 46/46, broker boots.

Note that `integrations/ratchet-quarkus/*` still resolves netty 4.1.130.Final and is unaffected by this bump. That pom imports quarkus-bom, and a module's own dependencyManagement outranks anything inherited from the parent, so the root pin never reaches it. That is the subject of the follow-up.

## postcss 8.5.15 -> 8.5.25

Dev dependency of vite and `@vue/compiler-sfc` in the docs site. Advisory needs >= 8.5.18. Plain `npm update postcss`, no `overrides` entry required. `nanoid` moves 3.3.12 -> 3.3.16 alongside it because postcss depends on it. Only `package-lock.json` changed. Docs site builds clean.

## Suppress CVE-2019-3826

Dependency-check reports this against `micrometer-registry-prometheus-1.14.4.jar` inside the loadtest WAR. It is a false positive: CVE-2019-3826 is a stored DOM XSS in the Prometheus *server's* web UI, fixed in server 2.7.1. The micrometer registry is a client library that emits metrics and has no UI.

The suppression file already carries a `packageUrl` rule for this artifact plus the Prometheus server CPE, and it cannot match here. The scan reaches the jar nested inside WEB-INF/lib, where dependency-check assigns the server CPE from the artifact name but no Maven PURL. The new entry matches on file path instead, mirroring the existing CVE-2026-42154 block directly above it.

Both alert 34 and 35 are this same finding counted twice, once for the exploded `target/` directory and once for the `.war` beside it.

## Still open after this

- 113 netty/vertx alerts in the Quarkus modules. Follow-up PR pins netty-bom in the Quarkus parent's own dependencyManagement.
- 2 plexus-utils alerts, test scope, transitive from Quarkus's own maven-resolver stack. Nothing to fix here; will dismiss as used-in-tests.
