### PR TITLE
Fix @Recurring in native images and support capturing lambdas

### DIFF
--- a/integrations/ratchet-quarkus/core-deployment/src/main/java/run/ratchet/quarkus/deployment/RatchetProcessor.java
+++ b/integrations/ratchet-quarkus/core-deployment/src/main/java/run/ratchet/quarkus/deployment/RatchetProcessor.java
@@ -26,10 +26,16 @@ import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.SystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.LambdaCapturingTypeBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.NativeImageResourceBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageSystemPropertyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveMethodBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
@@ -39,6 +45,7 @@ import run.ratchet.quarkus.runtime.QuarkusPrincipalSource;
 import run.ratchet.quarkus.runtime.QuarkusRatchetExecutorProvider;
 import run.ratchet.quarkus.runtime.RatchetRuntimeProducers;
 import run.ratchet.quarkus.runtime.RatchetStartupTrigger;
+import run.ratchet.quarkus.runtime.RegisterJobSubmitter;
 import run.ratchet.ri.cdi.RatchetRuntimeStart;
 import run.ratchet.ri.cdi.RecurringMethodInvoker;
 import run.ratchet.ri.util.JobPlaceholders;
@@ -52,6 +59,9 @@ class RatchetProcessor {
   private static final String FEATURE = "ratchet";
   private static final DotName JOB_SCHEDULER_SERVICE =
       DotName.createSimple("run.ratchet.api.JobSchedulerService");
+
+  private static final DotName REGISTER_JOB_SUBMITTER =
+      DotName.createSimple(RegisterJobSubmitter.class.getName());
 
   @BuildStep
   FeatureBuildItem feature() {
@@ -168,7 +178,9 @@ class RatchetProcessor {
     if (applicationClasses.length > 0) {
       reflective.produce(
           ReflectiveClassBuildItem.builder(applicationClasses)
-              .constructors(false)
+              // JSON-B reconstructs captured POJO receivers and arguments at execution. Registering
+              // application constructors costs image size, but is required for that native path.
+              .constructors(true)
               .methods(true)
               .build());
     }
@@ -183,11 +195,43 @@ class RatchetProcessor {
   @BuildStep
   void lambdaCapturingTypes(
       CombinedIndexBuildItem index, BuildProducer<LambdaCapturingTypeBuildItem> lambdas) {
+    for (ClassInfo candidate : lambdaCapturingClasses(index)) {
+      lambdas.produce(new LambdaCapturingTypeBuildItem(candidate.name().toString()));
+    }
+  }
+
+  /**
+   * Ship bytecode only for lambda-capturing classes: {@code AsmLambdaAnalyzer} reads these class
+   * resources at runtime for inline lambdas. Restricting the set bounds the native image-size cost.
+   */
+  @BuildStep
+  void lambdaCapturingClassResources(
+      CombinedIndexBuildItem index, BuildProducer<NativeImageResourceBuildItem> resources) {
+    for (ClassInfo candidate : lambdaCapturingClasses(index)) {
+      String internalName = candidate.name().toString().replace('.', '/');
+      resources.produce(new NativeImageResourceBuildItem(internalName + ".class"));
+    }
+  }
+
+  /**
+   * Classes that may declare an inline lambda body the engine has to resolve: those injecting
+   * {@link run.ratchet.api.JobSchedulerService}, plus those opting in with {@link
+   * RegisterJobSubmitter} because they obtain the scheduler some other way.
+   */
+  private static List<ClassInfo> lambdaCapturingClasses(CombinedIndexBuildItem index) {
+    Map<DotName, ClassInfo> selected = new LinkedHashMap<>();
     for (ClassInfo candidate : index.getIndex().getKnownClasses()) {
       if (injectsJobScheduler(candidate)) {
-        lambdas.produce(new LambdaCapturingTypeBuildItem(candidate.name().toString()));
+        selected.put(candidate.name(), candidate);
       }
     }
+    for (AnnotationInstance annotation : index.getIndex().getAnnotations(REGISTER_JOB_SUBMITTER)) {
+      if (annotation.target().kind() == AnnotationTarget.Kind.CLASS) {
+        ClassInfo annotated = annotation.target().asClass();
+        selected.put(annotated.name(), annotated);
+      }
+    }
+    return List.copyOf(selected.values());
   }
 
   private static boolean injectsJobScheduler(ClassInfo candidate) {

--- a/integrations/ratchet-quarkus/core/src/main/java/run/ratchet/quarkus/runtime/RegisterJobSubmitter.java
+++ b/integrations/ratchet-quarkus/core/src/main/java/run/ratchet/quarkus/runtime/RegisterJobSubmitter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.quarkus.runtime;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class that submits Ratchet jobs, so the extension registers it for lambda-capture
+ * serialization and ships its bytecode into the native image.
+ *
+ * <p>Submitting an inline lambda such as {@code () -> service.work(value)} requires reading the
+ * lambda body's bytecode at runtime to resolve the invocation it stands for. A native image ships
+ * no class files by default, so the extension registers each submitting class explicitly.
+ *
+ * <p>The extension finds submitters automatically when the class declares a {@link
+ * run.ratchet.api.JobSchedulerService} field or method parameter, which covers ordinary injection.
+ * Annotate a class with {@code @RegisterJobSubmitter} when it submits jobs but obtains the
+ * scheduler some other way — most commonly {@code CDI.current().select(...)}, a lookup helper, or a
+ * base class submitting on behalf of subclasses. Without it, such a class fails in native at
+ * submission time with {@code IllegalStateException: Bytecode not found}.
+ *
+ * <p>This annotation only affects native-image builds; it is a no-op in JVM mode, where class files
+ * are always on the classpath. Job targets submitted as method references need no registration,
+ * because a method reference names its target directly instead of hiding it in a lambda body.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RegisterJobSubmitter {}

--- a/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/DemoArg.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/DemoArg.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.quarkus.it;
+
+/**
+ * Proves POJO/record job arguments rehydrate through the JSON-B payload round-trip, including in
+ * native images.
+ */
+public record DemoArg(String name, int count) {}

--- a/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/ItJobs.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/ItJobs.java
@@ -35,6 +35,9 @@ public class ItJobs {
   private static final Logger LOG = Logger.getLogger(ItJobs.class);
 
   private final AtomicReference<String> executedOnThread = new AtomicReference<>();
+  private final AtomicReference<String> executedValue = new AtomicReference<>();
+  private final AtomicReference<DemoArg> executedArg = new AtomicReference<>();
+  private final AtomicReference<String> executedUnmanaged = new AtomicReference<>();
   private final AtomicBoolean recurringExecuted = new AtomicBoolean();
 
   /** Job body. Submitted as the method reference {@code itJobs::recordRun}. */
@@ -46,6 +49,37 @@ public class ItJobs {
 
   public boolean hasExecuted() {
     return executedOnThread.get() != null;
+  }
+
+  public void recordValue(String value) {
+    executedValue.set(value);
+    LOG.infof("ItJobs.recordValue executed with value %s", value);
+  }
+
+  public String executedValue() {
+    String value = executedValue.get();
+    return value == null ? "none" : value;
+  }
+
+  public void recordArg(DemoArg arg) {
+    executedArg.set(arg);
+    LOG.infof("ItJobs.recordArg executed with argument %s:%s", arg.name(), arg.count());
+  }
+
+  public String executedArg() {
+    DemoArg arg = executedArg.get();
+    return arg == null ? "none" : arg.name() + ":" + arg.count();
+  }
+
+  /** Job body for the lambda submitted by {@link UnmanagedSubmitter}. */
+  public void recordUnmanaged(String value) {
+    executedUnmanaged.set(value);
+    LOG.infof("ItJobs.recordUnmanaged executed with value %s", value);
+  }
+
+  public String executedUnmanaged() {
+    String value = executedUnmanaged.get();
+    return value == null ? "none" : value;
   }
 
   /** Registered via onRuntimeStart() at Quarkus boot; fires every second. */

--- a/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/ItResource.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/ItResource.java
@@ -35,12 +35,42 @@ public class ItResource {
   @Inject JobSchedulerService scheduler;
   @Inject ItJobs jobs;
   @Inject RatchetOptions options;
+  @Inject UnmanagedSubmitter unmanagedSubmitter;
 
   @POST
   @Path("/submit")
   @Produces(MediaType.TEXT_PLAIN)
   public String submit() {
     scheduler.enqueueNow(jobs::recordRun);
+    return "submitted";
+  }
+
+  @POST
+  @Path("/submit-value")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String submitValue() {
+    String captured = valueToCapture();
+    scheduler.enqueueNow(() -> jobs.recordValue(captured));
+    return "submitted";
+  }
+
+  @POST
+  @Path("/submit-arg")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String submitArg() {
+    DemoArg captured = argToCapture();
+    scheduler.enqueueNow(() -> jobs.recordArg(captured));
+    return "submitted";
+  }
+
+  /**
+   * Submits from a class the auto-detection heuristic cannot see; see {@link UnmanagedSubmitter}.
+   */
+  @POST
+  @Path("/submit-unmanaged")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String submitUnmanaged() {
+    unmanagedSubmitter.submit(jobs);
     return "submitted";
   }
 
@@ -74,6 +104,27 @@ public class ItResource {
   }
 
   @GET
+  @Path("/executed-value")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String executedValue() {
+    return jobs.executedValue();
+  }
+
+  @GET
+  @Path("/executed-arg")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String executedArg() {
+    return jobs.executedArg();
+  }
+
+  @GET
+  @Path("/executed-unmanaged")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String executedUnmanaged() {
+    return jobs.executedUnmanaged();
+  }
+
+  @GET
   @Path("/recurring-executed")
   @Produces(MediaType.TEXT_PLAIN)
   public String recurringExecuted() {
@@ -85,5 +136,14 @@ public class ItResource {
   @Produces(MediaType.TEXT_PLAIN)
   public String autoMigrateEnabled() {
     return Boolean.toString(options.schema().autoMigrate());
+  }
+
+  // Resolve captures through method calls so javac cannot fold literals into the lambda bodies.
+  private static String valueToCapture() {
+    return "hello-native";
+  }
+
+  private static DemoArg argToCapture() {
+    return new DemoArg("demo", 7);
   }
 }

--- a/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/UnmanagedSubmitter.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/main/java/run/ratchet/quarkus/it/UnmanagedSubmitter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Ratchet Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package run.ratchet.quarkus.it;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.CDI;
+import run.ratchet.api.JobSchedulerService;
+import run.ratchet.quarkus.runtime.RegisterJobSubmitter;
+
+/**
+ * Submits an inline capturing lambda without ever declaring a {@link JobSchedulerService} field or
+ * method parameter, so the extension's auto-detection heuristic cannot see it. {@link
+ * RegisterJobSubmitter} is the only reason this class's bytecode reaches the native image; drop the
+ * annotation and the submission below fails in native with {@code Bytecode not found}.
+ *
+ * <p>The scheduler is looked up programmatically on purpose. The heuristic inspects fields and
+ * method parameters, and a constructor is a method, so constructor injection would still match it
+ * and this class would prove nothing.
+ */
+@ApplicationScoped
+@RegisterJobSubmitter
+public class UnmanagedSubmitter {
+
+  public void submit(ItJobs jobs) {
+    String captured = valueToCapture();
+    JobSchedulerService scheduler = CDI.current().select(JobSchedulerService.class).get();
+    scheduler.enqueueNow(() -> jobs.recordUnmanaged(captured));
+  }
+
+  // A method call, not a literal, so javac cannot fold the value into the lambda body.
+  private static String valueToCapture() {
+    return "unmanaged-native";
+  }
+}

--- a/integrations/ratchet-quarkus/integration-tests/src/test/java/run/ratchet/quarkus/it/RatchetQuarkusMongoNativeIT.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/test/java/run/ratchet/quarkus/it/RatchetQuarkusMongoNativeIT.java
@@ -50,6 +50,86 @@ class RatchetQuarkusMongoNativeIT {
   }
 
   @Test
+  void capturedStringArgumentJobExecutesInNativeMongoApp() {
+    given().when().post("/jobs/submit-value").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-value")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("hello-native"));
+  }
+
+  @Test
+  void capturedRecordArgumentJobExecutesInNativeMongoApp() {
+    given().when().post("/jobs/submit-arg").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-arg")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("demo:7"));
+  }
+
+  /**
+   * Proves {@code @RegisterJobSubmitter} substitutes for the auto-detection heuristic: {@link
+   * UnmanagedSubmitter} declares no {@code JobSchedulerService} field or parameter, so without the
+   * annotation its bytecode would be absent from the image and submission would fail here.
+   */
+  @Test
+  void unmanagedSubmitterJobExecutesInNativeMongoApp() {
+    given().when().post("/jobs/submit-unmanaged").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-unmanaged")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("unmanaged-native"));
+  }
+
+  /** Guards the native inline-lambda regression in recurring registration. */
+  @Test
+  void recurringJobRegisteredViaOnRuntimeStartExecutesInNativeMongoApp() {
+    Awaitility.await()
+        .atMost(60, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/recurring-executed")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("true"));
+  }
+
+  @Test
   void classPolicyRejectsDisallowedJobTargetInNativeMongoApp() {
     given().when().post("/jobs/reject-class-policy").then().statusCode(200).body(is("rejected"));
   }

--- a/integrations/ratchet-quarkus/integration-tests/src/test/java/run/ratchet/quarkus/it/RatchetQuarkusSmokeTest.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/test/java/run/ratchet/quarkus/it/RatchetQuarkusSmokeTest.java
@@ -57,6 +57,72 @@ class RatchetQuarkusSmokeTest {
                     .equals("true"));
   }
 
+  @Test
+  void capturedStringArgumentJobExecutesOnQuarkus() {
+    given().when().post("/jobs/submit-value").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-value")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("hello-native"));
+  }
+
+  /**
+   * Exercises the JSON-B rehydration path in ArgumentMaterializer: the payload round-trip
+   * re-serializes the captured value and reads it back as the declared parameter type.
+   */
+  @Test
+  void capturedRecordArgumentJobExecutesOnQuarkus() {
+    given().when().post("/jobs/submit-arg").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-arg")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("demo:7"));
+  }
+
+  /**
+   * Submitted from a class with no {@code JobSchedulerService} field or parameter, so only
+   * {@code @RegisterJobSubmitter} makes it work in native. In JVM mode the annotation is inert;
+   * this run proves the wiring, and the native ITs prove the annotation itself.
+   */
+  @Test
+  void unmanagedSubmitterJobExecutesOnQuarkus() {
+    given().when().post("/jobs/submit-unmanaged").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-unmanaged")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("unmanaged-native"));
+  }
+
   /**
    * Registration only happens via {@code RecurringJobProcessor.onRuntimeStart()}, which only fires
    * because the extension's build step defers @Initialized(ApplicationScoped) auto-start and fires

--- a/integrations/ratchet-quarkus/integration-tests/src/test/java/run/ratchet/quarkus/it/RatchetQuarkusSqlNativeIT.java
+++ b/integrations/ratchet-quarkus/integration-tests/src/test/java/run/ratchet/quarkus/it/RatchetQuarkusSqlNativeIT.java
@@ -55,6 +55,86 @@ class RatchetQuarkusSqlNativeIT {
   }
 
   @Test
+  void capturedStringArgumentJobExecutesInNativeSqlApp() {
+    given().when().post("/jobs/submit-value").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-value")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("hello-native"));
+  }
+
+  @Test
+  void capturedRecordArgumentJobExecutesInNativeSqlApp() {
+    given().when().post("/jobs/submit-arg").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-arg")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("demo:7"));
+  }
+
+  /**
+   * Proves {@code @RegisterJobSubmitter} substitutes for the auto-detection heuristic: {@link
+   * UnmanagedSubmitter} declares no {@code JobSchedulerService} field or parameter, so without the
+   * annotation its bytecode would be absent from the image and submission would fail here.
+   */
+  @Test
+  void unmanagedSubmitterJobExecutesInNativeSqlApp() {
+    given().when().post("/jobs/submit-unmanaged").then().statusCode(200).body(is("submitted"));
+
+    Awaitility.await()
+        .atMost(30, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/executed-unmanaged")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("unmanaged-native"));
+  }
+
+  /** Guards the native inline-lambda regression in recurring registration. */
+  @Test
+  void recurringJobRegisteredViaOnRuntimeStartExecutesInNativeSqlApp() {
+    Awaitility.await()
+        .atMost(60, TimeUnit.SECONDS)
+        .pollInterval(Duration.ofMillis(250))
+        .until(
+            () ->
+                given()
+                    .when()
+                    .get("/jobs/recurring-executed")
+                    .then()
+                    .extract()
+                    .body()
+                    .asString()
+                    .equals("true"));
+  }
+
+  @Test
   void classPolicyRejectsDisallowedJobTargetInNativeSqlApp() {
     given().when().post("/jobs/reject-class-policy").then().statusCode(200).body(is("rejected"));
   }

--- a/ratchet-api/src/main/java/run/ratchet/spi/InvocationSubmissionService.java
+++ b/ratchet-api/src/main/java/run/ratchet/spi/InvocationSubmissionService.java
@@ -17,7 +17,9 @@ package run.ratchet.spi;
 
 import java.io.Serializable;
 import java.time.Duration;
+import java.time.ZoneId;
 import run.ratchet.api.Incubating;
+import run.ratchet.api.RecurringJobBuilder;
 import run.ratchet.api.WorkflowCondition;
 
 /**
@@ -54,6 +56,17 @@ public interface InvocationSubmissionService {
    * @return builder for options, chaining, and submission; never {@code null}
    */
   InvocationJobBuilder scheduleInvocation(Duration delay, JobInvocation invocation);
+
+  /**
+   * Starts a builder for a recurring job executing the given invocation on a cron schedule.
+   *
+   * @param cron Quartz cron expression; never {@code null}
+   * @param zone timezone used to evaluate the cron expression; never {@code null}
+   * @param invocation pre-resolved invocation; never {@code null}
+   * @return builder for recurring options and submission; never {@code null}
+   */
+  RecurringJobBuilder scheduleRecurringInvocation(
+      String cron, ZoneId zone, JobInvocation invocation);
 
   /**
    * Starts a builder for a batch whose children are produced by per-item invocation factories.

--- a/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
+++ b/ratchet/src/main/java/run/ratchet/ri/cdi/RecurringJobProcessor.java
@@ -49,13 +49,14 @@ import org.jboss.logging.Logger;
 import run.ratchet.api.JobHandle;
 import run.ratchet.api.JobOptions;
 import run.ratchet.api.JobPriority;
-import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.Recurring;
 import run.ratchet.api.RecurringJobBuilder;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.core.internal.RecurringRegistrationState;
 import run.ratchet.spi.ExecutorProvider;
+import run.ratchet.spi.InvocationSubmissionService;
+import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.StartupCoordinator;
 import run.ratchet.store.spi.JobBatchStatusStore;
 import run.ratchet.store.spi.RecurringJobStore;
@@ -77,13 +78,15 @@ public class RecurringJobProcessor {
   private static final Duration ORPHAN_CLEANUP_LEASE_TTL = Duration.ofMinutes(5);
   private static final long REGISTRATION_RETRY_DELAY_MS = 500;
   private static final int MAX_REGISTRATION_ATTEMPTS = 10;
+  private static final String RECURRING_INVOKE_DESCRIPTOR =
+      "(Ljava/lang/String;Ljava/lang/String;Z)V";
 
   private static final CronParser CRON_PARSER =
       new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
 
   private final Map<String, String> registeredJobIds = new ConcurrentHashMap<>();
 
-  private final JobSchedulerService schedulerService;
+  private final InvocationSubmissionService invocationSubmissionService;
   private final JobBatchStatusStore jobBatchStatusStore;
   private final RecurringAnnotationMaintenanceService recurringAnnotationMaintenanceService;
   private final BeanManager beanManager;
@@ -104,7 +107,7 @@ public class RecurringJobProcessor {
   private final AtomicBoolean registrationFinalized = new AtomicBoolean();
 
   protected RecurringJobProcessor() {
-    this.schedulerService = null;
+    this.invocationSubmissionService = null;
     this.jobBatchStatusStore = null;
     this.recurringAnnotationMaintenanceService = null;
     this.beanManager = null;
@@ -117,7 +120,7 @@ public class RecurringJobProcessor {
   }
 
   RecurringJobProcessor(
-      JobSchedulerService schedulerService,
+      InvocationSubmissionService invocationSubmissionService,
       JobBatchStatusStore jobBatchStatusStore,
       RecurringAnnotationMaintenanceService recurringAnnotationMaintenanceService,
       BeanManager beanManager,
@@ -126,7 +129,7 @@ public class RecurringJobProcessor {
       RecurringRegistrationState registrationState,
       RatchetOptions options) {
     this(
-        schedulerService,
+        invocationSubmissionService,
         jobBatchStatusStore,
         recurringAnnotationMaintenanceService,
         beanManager,
@@ -139,7 +142,7 @@ public class RecurringJobProcessor {
 
   @Inject
   public RecurringJobProcessor(
-      JobSchedulerService schedulerService,
+      InvocationSubmissionService invocationSubmissionService,
       JobBatchStatusStore jobBatchStatusStore,
       RecurringAnnotationMaintenanceService recurringAnnotationMaintenanceService,
       BeanManager beanManager,
@@ -149,7 +152,7 @@ public class RecurringJobProcessor {
       RatchetOptions options,
       Clock clock) {
     this(
-        schedulerService,
+        invocationSubmissionService,
         jobBatchStatusStore,
         recurringAnnotationMaintenanceService,
         beanManager,
@@ -162,7 +165,7 @@ public class RecurringJobProcessor {
   }
 
   RecurringJobProcessor(
-      JobSchedulerService schedulerService,
+      InvocationSubmissionService invocationSubmissionService,
       JobBatchStatusStore jobBatchStatusStore,
       RecurringAnnotationMaintenanceService recurringAnnotationMaintenanceService,
       BeanManager beanManager,
@@ -172,7 +175,7 @@ public class RecurringJobProcessor {
       RatchetOptions options,
       Set<Class<?>> discoveredRecurringBeanClasses) {
     this(
-        schedulerService,
+        invocationSubmissionService,
         jobBatchStatusStore,
         recurringAnnotationMaintenanceService,
         beanManager,
@@ -185,7 +188,7 @@ public class RecurringJobProcessor {
   }
 
   RecurringJobProcessor(
-      JobSchedulerService schedulerService,
+      InvocationSubmissionService invocationSubmissionService,
       JobBatchStatusStore jobBatchStatusStore,
       RecurringAnnotationMaintenanceService recurringAnnotationMaintenanceService,
       BeanManager beanManager,
@@ -195,7 +198,7 @@ public class RecurringJobProcessor {
       RatchetOptions options,
       Set<Class<?>> discoveredRecurringBeanClasses,
       Clock clock) {
-    this.schedulerService = schedulerService;
+    this.invocationSubmissionService = invocationSubmissionService;
     this.jobBatchStatusStore = jobBatchStatusStore;
     this.recurringAnnotationMaintenanceService = recurringAnnotationMaintenanceService;
     this.beanManager = beanManager;
@@ -208,7 +211,7 @@ public class RecurringJobProcessor {
   }
 
   RecurringJobProcessor(
-      JobSchedulerService schedulerService,
+      InvocationSubmissionService invocationSubmissionService,
       JobBatchStatusStore jobBatchStatusStore,
       RecurringAnnotationMaintenanceService recurringAnnotationMaintenanceService,
       BeanManager beanManager,
@@ -216,7 +219,7 @@ public class RecurringJobProcessor {
       StartupCoordinator startupCoordinator,
       RecurringRegistrationState registrationState) {
     this(
-        schedulerService,
+        invocationSubmissionService,
         jobBatchStatusStore,
         recurringAnnotationMaintenanceService,
         beanManager,
@@ -519,10 +522,15 @@ public class RecurringJobProcessor {
     String className = beanClass.getName();
 
     RecurringJobBuilder builder =
-        schedulerService.scheduleRecurring(
+        invocationSubmissionService.scheduleRecurringInvocation(
             annotation.cron(),
             registration.zone(),
-            () -> methodInvoker.invoke(className, methodName, hasJobContextParam));
+            new JobInvocation(
+                RecurringMethodInvoker.class.getName(),
+                "invoke",
+                RECURRING_INVOKE_DESCRIPTOR,
+                false,
+                List.of(className, methodName, hasJobContextParam)));
 
     JobOptions options =
         JobOptions.defaults()

--- a/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationSubmissionService.java
+++ b/ratchet/src/main/java/run/ratchet/ri/core/DefaultInvocationSubmissionService.java
@@ -19,7 +19,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import java.io.Serializable;
 import java.time.Duration;
+import java.time.ZoneId;
 import java.util.Objects;
+import run.ratchet.api.RecurringJobBuilder;
 import run.ratchet.api.WorkflowCondition;
 import run.ratchet.spi.InvocationBatchBuilder;
 import run.ratchet.spi.InvocationJobBuilder;
@@ -65,6 +67,16 @@ public class DefaultInvocationSubmissionService implements InvocationSubmissionS
     Objects.requireNonNull(invocation, "invocation must not be null");
     return new DefaultInvocationJobBuilder(
         DefaultJobBuilder.create(jobCreationService, new InvocationAdapter(invocation), delay));
+  }
+
+  @Override
+  public RecurringJobBuilder scheduleRecurringInvocation(
+      String cron, ZoneId zone, JobInvocation invocation) {
+    Objects.requireNonNull(cron, "cron must not be null");
+    Objects.requireNonNull(zone, "zone must not be null");
+    Objects.requireNonNull(invocation, "invocation must not be null");
+    return new DefaultRecurringJobBuilder(
+        cron, zone, new InvocationAdapter(invocation), jobCreationService);
   }
 
   @Override

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/RecurringJobProcessorDeferredStartTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/RecurringJobProcessorDeferredStartTest.java
@@ -40,11 +40,11 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.Recurring;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.core.internal.RecurringRegistrationState;
 import run.ratchet.spi.ExecutorProvider;
+import run.ratchet.spi.InvocationSubmissionService;
 import run.ratchet.store.spi.JobBatchStatusStore;
 import run.ratchet.store.spi.RecurringJobStore;
 
@@ -64,28 +64,30 @@ class RecurringJobProcessorDeferredStartTest {
   @Test
   void onStartup_whenAutoStartDeferred_doesNotRegisterJobs() {
     System.setProperty(RatchetRuntimeStart.DEFER_PROPERTY, "true");
-    var schedulerService = mock(JobSchedulerService.class);
-    var processor = newProcessor(schedulerService);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
+    var processor = newProcessor(invocationSubmissionService);
 
     processor.onStartup(new Object());
 
-    verifyNoInteractions(schedulerService);
+    verifyNoInteractions(invocationSubmissionService);
   }
 
   @Test
   void onStartup_whenNotDeferred_andNoManagedExecutor_registersInline() throws Exception {
     System.clearProperty(RatchetRuntimeStart.DEFER_PROPERTY);
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
-    var processor = newProcessor(schedulerService);
+    var processor = newProcessor(invocationSubmissionService);
 
     processor.onStartup(new Object());
 
     // No ExecutorProvider is injected via this constructor, matching the documented plain-CDI/SE/
     // unit-test path: registration happens inline on the calling thread, not deferred.
-    verify(schedulerService).scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(invocationSubmissionService)
+        .scheduleRecurringInvocation(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
     verify(recurringJobBuilder).submit();
   }
 
@@ -94,26 +96,29 @@ class RecurringJobProcessorDeferredStartTest {
     // The realistic Quarkus scenario: the defer flag stays true for the whole process lifetime,
     // and RatchetRuntimeStart is the only thing that ever triggers registration.
     System.setProperty(RatchetRuntimeStart.DEFER_PROPERTY, "true");
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
-    var processor = newProcessor(schedulerService);
+    var processor = newProcessor(invocationSubmissionService);
 
     processor.onRuntimeStart(new RatchetRuntimeStart());
 
-    verify(schedulerService).scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(invocationSubmissionService)
+        .scheduleRecurringInvocation(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
     verify(recurringJobBuilder).submit();
   }
 
   @Test
   void onRuntimeStart_whenRegistrationIsNotCommitted_retriesOnManagedScheduler() throws Exception {
     System.setProperty(RatchetRuntimeStart.DEFER_PROPERTY, "true");
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
-    var processor = newProcessor(schedulerService);
+    var processor = newProcessor(invocationSubmissionService);
 
     var managedScheduler = mock(ScheduledExecutorService.class);
     var executorProvider = mock(ExecutorProvider.class);
@@ -134,8 +139,8 @@ class RecurringJobProcessorDeferredStartTest {
 
     retry.getValue().run();
 
-    verify(schedulerService, times(2))
-        .scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(invocationSubmissionService, times(2))
+        .scheduleRecurringInvocation(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
     verify(recurringJobBuilder, times(2)).submit();
     verify(recurringJobStore, times(2)).findRecurringByBusinessKey("leader-gate-job");
   }
@@ -143,11 +148,12 @@ class RecurringJobProcessorDeferredStartTest {
   @Test
   void onRuntimeStart_whenRegistrationNeverCommits_stopsAfterBoundedAttempts() throws Exception {
     System.setProperty(RatchetRuntimeStart.DEFER_PROPERTY, "true");
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
-    var processor = newProcessor(schedulerService);
+    var processor = newProcessor(invocationSubmissionService);
 
     Deque<Runnable> retries = new ArrayDeque<>();
     var managedScheduler = mock(ScheduledExecutorService.class);
@@ -171,20 +177,21 @@ class RecurringJobProcessorDeferredStartTest {
       retries.removeFirst().run();
     }
 
-    verify(schedulerService, times(10))
-        .scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(invocationSubmissionService, times(10))
+        .scheduleRecurringInvocation(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
     verify(recurringJobBuilder, times(10)).submit();
     verify(recurringJobStore, times(10)).findRecurringByBusinessKey("leader-gate-job");
     verify(managedScheduler, times(9))
         .schedule(any(Runnable.class), eq(500L), eq(TimeUnit.MILLISECONDS));
   }
 
-  private RecurringJobProcessor newProcessor(JobSchedulerService schedulerService) {
+  private RecurringJobProcessor newProcessor(
+      InvocationSubmissionService invocationSubmissionService) {
     var beanManager = mock(BeanManager.class);
     Set<Bean<?>> beans = Set.of(beanFor(RecurringBean.class));
     when(beanManager.getBeans(any(), any())).thenReturn(beans);
     return new RecurringJobProcessor(
-        schedulerService,
+        invocationSubmissionService,
         mock(JobBatchStatusStore.class),
         mock(RecurringAnnotationMaintenanceService.class),
         beanManager,

--- a/ratchet/src/test/java/run/ratchet/ri/cdi/RecurringJobProcessorLeaderGateTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/cdi/RecurringJobProcessorLeaderGateTest.java
@@ -38,6 +38,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -46,7 +47,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import run.ratchet.api.JobHandle;
 import run.ratchet.api.JobOptions;
-import run.ratchet.api.JobSchedulerService;
 import run.ratchet.api.RatchetOptions;
 import run.ratchet.api.Recurring;
 import run.ratchet.api.RecurringJobBuilder;
@@ -54,6 +54,8 @@ import run.ratchet.api.RecurringMisfirePolicy;
 import run.ratchet.ri.core.internal.RecurringAnnotationMaintenanceService;
 import run.ratchet.ri.core.internal.RecurringRegistrationState;
 import run.ratchet.ri.payload.JobPayloadFactory;
+import run.ratchet.spi.InvocationSubmissionService;
+import run.ratchet.spi.JobInvocation;
 import run.ratchet.spi.StartupCoordinator;
 import run.ratchet.store.spi.JobBatchStatusStore;
 import run.ratchet.store.spi.RecurringJobDefinition;
@@ -68,13 +70,14 @@ class RecurringJobProcessorLeaderGateTest {
   @Test
   void cleanup_skippedWhenStartupLeaseNotAcquired() throws Exception {
     var maintenance = mock(RecurringAnnotationMaintenanceService.class);
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var jobBatchStatusStore = mock(JobBatchStatusStore.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
     var beanManager = mock(BeanManager.class);
     Set<Bean<?>> beans = Set.of(beanFor(LeaderGateBean.class));
     when(beanManager.getBeans(any(), any())).thenReturn(beans);
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
     var coordinator = mock(StartupCoordinator.class);
     when(coordinator.tryAcquire("recurring-annotation-orphan-cleanup", Duration.ofMinutes(5)))
@@ -83,7 +86,7 @@ class RecurringJobProcessorLeaderGateTest {
 
     var processor =
         new RecurringJobProcessor(
-            schedulerService,
+            invocationSubmissionService,
             jobBatchStatusStore,
             maintenance,
             beanManager,
@@ -93,7 +96,18 @@ class RecurringJobProcessorLeaderGateTest {
 
     processor.registerRecurringJobs();
 
-    verify(schedulerService).scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    ArgumentCaptor<JobInvocation> invocationCaptor = ArgumentCaptor.forClass(JobInvocation.class);
+    verify(invocationSubmissionService)
+        .scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), invocationCaptor.capture());
+    assertEquals(
+        new JobInvocation(
+            RecurringMethodInvoker.class.getName(),
+            "invoke",
+            "(Ljava/lang/String;Ljava/lang/String;Z)V",
+            false,
+            List.of(LeaderGateBean.class.getName(), "run", false)),
+        invocationCaptor.getValue());
     verify(recurringJobBuilder).withBusinessKey("leader-gate-job");
     verify(recurringJobBuilder).submit();
     assertTrue(registrationState.shouldFire("leader-gate-job"));
@@ -105,18 +119,19 @@ class RecurringJobProcessorLeaderGateTest {
   @Test
   void registerRecurringJobs_usesDiscoveredRecurringBeanClassesWhenAvailable() throws Exception {
     var maintenance = mock(RecurringAnnotationMaintenanceService.class);
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var jobBatchStatusStore = mock(JobBatchStatusStore.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
     var beanManager = mock(BeanManager.class);
     Set<Bean<?>> beans = Set.of(beanFor(LeaderGateBean.class));
     when(beanManager.getBeans(eq(LeaderGateBean.class), any())).thenReturn(beans);
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
 
     var processor =
         new RecurringJobProcessor(
-            schedulerService,
+            invocationSubmissionService,
             jobBatchStatusStore,
             maintenance,
             beanManager,
@@ -130,7 +145,8 @@ class RecurringJobProcessorLeaderGateTest {
 
     verify(beanManager).getBeans(eq(LeaderGateBean.class), any());
     verify(beanManager, never()).getBeans(eq(Object.class), any());
-    verify(schedulerService).scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(invocationSubmissionService)
+        .scheduleRecurringInvocation(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
   }
 
   @Test
@@ -145,7 +161,7 @@ class RecurringJobProcessorLeaderGateTest {
 
     var processor =
         new RecurringJobProcessor(
-            mock(JobSchedulerService.class),
+            mock(InvocationSubmissionService.class),
             mock(JobBatchStatusStore.class),
             maintenance,
             beanManager,
@@ -177,7 +193,7 @@ class RecurringJobProcessorLeaderGateTest {
 
     var processor =
         new RecurringJobProcessor(
-            mock(JobSchedulerService.class),
+            mock(InvocationSubmissionService.class),
             mock(JobBatchStatusStore.class),
             maintenance,
             beanManager,
@@ -203,7 +219,7 @@ class RecurringJobProcessorLeaderGateTest {
 
     var processor =
         new RecurringJobProcessor(
-            mock(JobSchedulerService.class),
+            mock(InvocationSubmissionService.class),
             mock(JobBatchStatusStore.class),
             maintenance,
             beanManager,
@@ -222,19 +238,20 @@ class RecurringJobProcessorLeaderGateTest {
   @Test
   void registerRecurringJobs_doesNotCancelExistingJobWhenSubmitFails() throws Exception {
     var maintenance = mock(RecurringAnnotationMaintenanceService.class);
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var jobBatchStatusStore = mock(JobBatchStatusStore.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
     var beanManager = mock(BeanManager.class);
     Set<Bean<?>> beans = Set.of(beanFor(LeaderGateBean.class));
     when(beanManager.getBeans(any(), any())).thenReturn(beans);
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
     when(recurringJobBuilder.submit()).thenThrow(new IllegalStateException("store unavailable"));
 
     var processor =
         new RecurringJobProcessor(
-            schedulerService,
+            invocationSubmissionService,
             jobBatchStatusStore,
             maintenance,
             beanManager,
@@ -252,7 +269,7 @@ class RecurringJobProcessorLeaderGateTest {
   void registerRecurringJobs_submitsExistingBusinessKeySoDefinitionCanBeReconciled()
       throws Exception {
     var maintenance = mock(RecurringAnnotationMaintenanceService.class);
-    var schedulerService = mock(JobSchedulerService.class);
+    var invocationSubmissionService = mock(InvocationSubmissionService.class);
     var jobBatchStatusStore = mock(JobBatchStatusStore.class);
     var recurringJobBuilder = mockRecurringJobBuilder();
     UUID existingId = UUID.randomUUID();
@@ -260,13 +277,14 @@ class RecurringJobProcessorLeaderGateTest {
     var beanManager = mock(BeanManager.class);
     Set<Bean<?>> beans = Set.of(beanFor(LeaderGateBean.class));
     when(beanManager.getBeans(any(), any())).thenReturn(beans);
-    when(schedulerService.scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
+    when(invocationSubmissionService.scheduleRecurringInvocation(
+            eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any()))
         .thenReturn(recurringJobBuilder);
     var registrationState = new RecurringRegistrationState();
 
     var processor =
         new RecurringJobProcessor(
-            schedulerService,
+            invocationSubmissionService,
             jobBatchStatusStore,
             maintenance,
             beanManager,
@@ -280,7 +298,8 @@ class RecurringJobProcessorLeaderGateTest {
 
     assertTrue(processor.registerRecurringJobs());
 
-    verify(schedulerService).scheduleRecurring(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
+    verify(invocationSubmissionService)
+        .scheduleRecurringInvocation(eq("0 0/5 * * * ?"), eq(ZoneId.of("UTC")), any());
     verify(recurringJobBuilder).withBusinessKey("leader-gate-job");
     verify(recurringJobBuilder).submit();
     assertRegisteredJobId(processor, "leader-gate-job", existingId);

--- a/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
+++ b/ratchet/src/test/java/run/ratchet/ri/core/DefaultInvocationSubmissionServiceTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
@@ -54,6 +55,7 @@ import run.ratchet.store.spi.JobBatchStatusStore;
 import run.ratchet.store.spi.JobBulkStore;
 import run.ratchet.store.spi.JobCrudStore;
 import run.ratchet.store.spi.JobTerminalStore;
+import run.ratchet.store.spi.RecurringJobDefinition;
 import run.ratchet.store.spi.RecurringJobStore;
 import run.ratchet.store.spi.TagStore;
 import run.ratchet.store.spi.WorkflowConditionStore;
@@ -99,6 +101,9 @@ class DefaultInvocationSubmissionServiceTest {
     lenient()
         .when(jobCrudStore.create(any(JobEntity.class)))
         .thenAnswer(DefaultInvocationSubmissionServiceTest::persist);
+    lenient()
+        .when(recurringJobStore.createRecurring(any(RecurringJobDefinition.class)))
+        .thenAnswer(invocation -> invocation.<RecurringJobDefinition>getArgument(0).id());
   }
 
   private DefaultJobCreationService newCreationService(ClassPolicy classPolicy) {
@@ -153,6 +158,21 @@ class DefaultInvocationSubmissionServiceTest {
     ArgumentCaptor<JobEntity> captor = ArgumentCaptor.forClass(JobEntity.class);
     verify(jobCrudStore).create(captor.capture());
     assertEquals(Instant.parse("2026-05-27T12:05:00Z"), captor.getValue().getScheduledTime());
+  }
+
+  @Test
+  void scheduleRecurringInvocation_persistsThePreResolvedInvocation() {
+    service
+        .scheduleRecurringInvocation("0 0 12 * * ?", ZoneId.of("UTC"), sendInvoiceInvocation())
+        .submit();
+
+    ArgumentCaptor<RecurringJobDefinition> captor =
+        ArgumentCaptor.forClass(RecurringJobDefinition.class);
+    verify(recurringJobStore).createRecurring(captor.capture());
+    assertEquals(TARGET, captor.getValue().payload().target());
+    assertEquals("sendInvoice", captor.getValue().payload().method());
+    assertEquals("(Ljava/lang/String;)V", captor.getValue().payload().methodDescriptor());
+    assertEquals(List.of("inv_123"), captor.getValue().payload().args());
   }
 
   @Test

--- a/website/docs/deployment/quarkus.md
+++ b/website/docs/deployment/quarkus.md
@@ -201,8 +201,21 @@ schema details.
 ## Submitting jobs
 
 Inject `JobSchedulerService` and submit a method reference, as in the [Quickstart](#quickstart).
-Recurring jobs, signals, and batches work the same as on a Jakarta EE server. Every job target class
-must be permitted by the class allowlist.
+Recurring jobs, signals, and batches work the same as on a Jakarta EE server, on the JVM and in a
+native image. Every job target class must be permitted by the class allowlist.
+
+Lambdas that capture arguments work too, so a job can carry parameters:
+
+```java
+String orderId = order.id();
+scheduler.enqueueNow(() -> shipping.dispatch(orderId));
+```
+
+Captured values are persisted with the job, so they must be JSON-representable. Strings, numbers,
+and booleans round-trip as themselves; your own records and classes are serialized and rebuilt by
+JSON-B, so they need the usual JSON-B shape and must be permitted by the class allowlist. A bound
+method reference on an unmanaged object, `new Report(id)::send`, is not supported — the receiver's
+state has nowhere to live in the persisted job. Capture the values in a lambda instead.
 
 ## MongoDB flavor
 
@@ -245,9 +258,36 @@ mvn package -Pnative -Dquarkus.native.container-build=false
 
 Build on a host GraalVM or Mandrel. The extension registers the reflection, runtime-init, and
 lambda-serialization metadata the engine needs, and it includes the schema migrations in the image,
-so method-reference jobs and `auto-migrate` both work in native. Inline lambdas such as `() ->
-svc.work(arg)` are JVM-only; for a job you want to run in native, pass a method reference or a bean
-method instead.
+so jobs and `auto-migrate` both work in native.
+
+Method references and capturing lambdas both run in a native image. A method reference names its
+target directly, so it needs nothing extra. An inline lambda does not — resolving `() ->
+svc.work(arg)` into a persistable job means reading the lambda body's bytecode, and a native image
+ships no class files by default. The extension therefore includes the bytecode of each class that
+submits jobs, which it finds by looking for a `JobSchedulerService` field or method parameter.
+
+::: warning Submitting without injecting the scheduler
+That detection covers ordinary injection — a field, a setter, or a constructor parameter. It does
+not cover a class that looks the scheduler up instead, such as
+`CDI.current().select(JobSchedulerService.class).get()`, a lookup helper, or a base class
+submitting on behalf of subclasses. An inline lambda submitted from such a class fails at runtime in
+native with `IllegalStateException: Bytecode not found`. Annotate the class with
+`@RegisterJobSubmitter` to register it explicitly:
+
+```java
+import run.ratchet.quarkus.runtime.RegisterJobSubmitter;
+
+@RegisterJobSubmitter
+public class OrderSubmitter {
+  public void submit(String orderId) {
+    JobSchedulerService scheduler = CDI.current().select(JobSchedulerService.class).get();
+    scheduler.enqueueNow(() -> shipping.dispatch(orderId));
+  }
+}
+```
+
+The annotation is a no-op in JVM mode, and method references never need it.
+:::
 
 ## What the extension handles
 
@@ -266,6 +306,9 @@ method instead.
   an authenticated request records that caller. It reads the identity defensively, so submitting from
   a background thread with no active request simply records no caller instead of failing.
 - Keeps Ratchet's beans from being pruned by ArC and registers the native metadata.
+- Registers each job-submitting class for lambda serialization and includes its bytecode in the
+  native image, so capturing lambdas resolve at runtime. Classes that do not inject
+  `JobSchedulerService` opt in with `@RegisterJobSubmitter`.
 
 ## Differences from a Jakarta EE server
 

--- a/website/docs/troubleshooting/common-issues.md
+++ b/website/docs/troubleshooting/common-issues.md
@@ -86,26 +86,43 @@ Verify the datasource is working by checking for connection errors in your serve
 
 **Symptom:** `ClassNotFoundException`, `NoSuchMethodException`, or `IllegalStateException` when jobs try to execute.
 
-### Lambda must be a method reference
+### Job task must be a single method invocation
 
-Ratchet uses ASM bytecode analysis to serialize lambda expressions. This means the lambda you pass to `enqueue()` must be a **single method reference**, not an inline lambda with complex logic:
+Ratchet uses ASM bytecode analysis to turn the task you submit into a stored payload. The task must
+contain **exactly one method invocation** — a method reference, or a lambda whose body is a single
+method call. Multi-statement lambdas and inline logic fail at submission with
+`IllegalArgumentException`:
 
 ```java
-// This works - single method reference
+// This works - method reference
 scheduler.enqueue(myService::processData);
 
-// This works - no-arg runnable
+// This works - lambda wrapping one call
 scheduler.enqueue(() -> myService.processData());
 
-// This may fail - captured variables must be Serializable
+// This works - the captured argument is stored with the job
 String name = "test";
-scheduler.enqueue(() -> myService.processData(name));  // 'name' is captured
+scheduler.enqueue(() -> myService.processData(name));
+
+// This fails - more than one invocation
+scheduler.enqueue(() -> {
+  myService.prepare();
+  myService.processData(name);
+});
 ```
+
+For complex logic, put it in a method on a CDI bean and submit that method instead.
+
+Captured arguments are persisted as JSON, not JDK-serialized, so they must be JSON-representable —
+strings, numbers, and booleans round-trip as themselves, and your own types are serialized and
+rebuilt by the payload serializer. Implementing `java.io.Serializable` is neither required nor
+sufficient.
 
 If you see `IllegalStateException` during serialization, ensure:
 1. The target class is accessible from the thread context classloader
 2. The method is `public`
-3. Any captured arguments implement `java.io.Serializable`
+3. Any captured arguments are JSON-representable, and their types are permitted by the class
+   allowlist
 
 ### Target class not found at execution time
 


### PR DESCRIPTION
## Summary

Two things, both about running Ratchet in a GraalVM native image on Quarkus.

**`@Recurring` never worked in a native image.** `RecurringJobProcessor.registerJob` submitted through an inline capturing lambda, `() -> methodInvoker.invoke(className, methodName, hasJobContextParam)`. Resolving an inline lambda into a stored payload means reading the lambda body's bytecode at runtime through `ClassLoader.getResourceAsStream`, and a native image ships no `.class` files. Registration threw, was caught and logged at `registerRecurringJobs`, retried ten times at 500ms, then stopped. Startup reported healthy. No recurring job ever ran, and because `finalizeRegistration` never executed, recurring orphan cleanup was skipped too. This shipped in 0.3.0; neither native IT asserted recurring, which is why it went unnoticed.

The processor now builds the `JobInvocation` itself and submits it through a new `scheduleRecurringInvocation` on `InvocationSubmissionService`, reusing the `InvocationAdapter` seam that `enqueueInvocation`/`scheduleInvocation` already use to bypass lambda analysis. The persisted invocation is identical to what ASM used to derive: `RecurringMethodInvoker.invoke` with descriptor `(Ljava/lang/String;Ljava/lang/String;Z)V`, whose reflective registration the extension already emitted.

**Capturing lambdas now work in native.** The extension ships the bytecode of each job-submitting class as a native-image resource so the analyzer can read lambda bodies at runtime, and registers application classes with their constructors so JSON-B can rebuild captured arguments. Submitting classes are found by the existing "declares a `JobSchedulerService` field or method parameter" heuristic; a class that obtains the scheduler another way (`CDI.current()`, a lookup helper, a base class submitting for subclasses) opts in with the new `@RegisterJobSubmitter`.

## Testing

- [x] `mvn clean test-compile -Dmaven.compiler.maxErrors=10000` (full reactor; mandatory after the SPI change)
- [x] `mvn -pl ratchet -am test` — 1019 tests, 0 failures
- [x] `mvn -pl integrations/ratchet-quarkus/integration-tests -am verify -P db-postgres -DskipITs` — 74 tests, 0 failures
- [x] `mvn -pl integrations/ratchet-quarkus/integration-tests -am verify -P db-postgres,native-sql` — 8 tests, 0 failures
- [x] `mvn -pl integrations/ratchet-quarkus/integration-tests -am verify -P db-mongo,native-mongo` — 6 tests, 0 failures
- [x] `mvn spotless:apply` (full reactor)
- [x] `cd website && npm ci && npm run build`
- [ ] `mvn verify -P wildfly-managed,postgresql -pl :ratchet-testsuite,:ratchet-coverage -am` — not run locally

Evidence from both native runs, where the same log previously showed `IllegalStateException: Bytecode not found`:

```
0 occurrences of "Bytecode not found"          (was 3+)
Registered recurring job: it-recurring-job with cron: 0/1 * * * * ?
ItJobs.recordValue executed with value hello-native
ItJobs.recordArg executed with argument demo:7
ItJobs.recordUnmanaged executed with value unmanaged-native
```

New integration tests, in `RatchetQuarkusSmokeTest` (JVM) and both native ITs: a captured `String`, a captured record, a submission from a class the heuristic cannot see, and recurring registration. The recurring assertions are the regression guard for the bug above.

## Docs

- [x] Docs updated where behavior, configuration, logs, or examples changed

`deployment/quarkus.md` said inline lambdas were JVM-only, which is no longer true, and said recurring jobs, signals, and batches "work the same as on a Jakarta EE server" with no native caveat, which was wrong. Both corrected, with a capturing-lambda example, the rules for captured values, and a warning callout covering the `@RegisterJobSubmitter` case.

`troubleshooting/common-issues.md` said the task "must be a single method reference, not an inline lambda", and that captured arguments must implement `java.io.Serializable`. The real rule is exactly one method invocation, which `api-reference/functional-interfaces.md` already stated correctly, and captured arguments are persisted as JSON. `JobInvocation`'s own javadoc says they must be JSON-representable "not `Serializable`". Corrected, and the example previously marked "may fail" is the pattern the new tests prove works.

## Review Notes

- [x] Public API or SPI change
- [x] Follow-up work remains

`InvocationSubmissionService` gains `scheduleRecurringInvocation`. It returns the existing `RecurringJobBuilder` rather than a new `Invocation*Builder` wrapper, unlike its `enqueueInvocation`/`scheduleInvocation` siblings; worth a look if that inconsistency matters. Pre-release, so no default method or shim.

## Additional Context

**A bound method reference on an unmanaged receiver, `new Report(id)::send`, is still unsupported** and now documented as such. The receiver's captured state has nowhere to live because `JobInvocation` has no receiver field. An earlier draft of this branch added persisted receivers across the payload engine, keyed on an arity heuristic (`args.size() == descriptor arity + 1`) with a `BeanManager` lookup at submission deciding whether to keep the receiver. That was reverted as out of scope and too subtle to land without its own design review. Capture the values in a lambda instead.

The registration heuristic is the sharp edge worth reviewing. Auto-detection keys on a `JobSchedulerService` field or method parameter, which covers field, setter, and constructor injection, since Jandex treats a constructor as a method. Anything else needs the annotation or fails at runtime in native. `@RegisterJobSubmitter` deliberately has no `targets`/`classNames` member; that can be added if someone needs to register a class they do not own.

Image-size impact of shipping bytecode as resources is not measured.
